### PR TITLE
GridFS bug fix

### DIFF
--- a/lib/mongo/gridfs/grid_io.rb
+++ b/lib/mongo/gridfs/grid_io.rb
@@ -200,7 +200,6 @@ module Mongo
 
     def create_chunk(n)
       chunk = BSON::OrderedHash.new
-      chunk['_id']      = BSON::ObjectId.new
       chunk['n']        = n
       chunk['files_id'] = @files_id
       chunk['data']     = ''


### PR DESCRIPTION
I've been noticing an issue with saving files to GridFS within JRuby.  It may also affect MRI, but I have not tested it.  Sometimes, when saving a file to GridFS, the API methods for GridFS do not raise an exception, however I get this in my mongod log:

Wed Sep  1 09:22:48 [conn44] insert xxx.fs.chunks exception 11000 E11000 duplicate key error index: xxx.fs.chunks.$_id_  dup key: { : ObjectId('4c7dff4728d9940183000046') } 74ms

I was wondering why this my occur, and from looking at the source, I noticed that each new chunk is assigned an ObjectID before saving, and not letting the mongod handle the ObjectID creation.  Removing this line of code from the driver seems to have fixed the problem.

Regards,
Adam
