### PR TITLE
Call super in BSON::OrderedHash

### DIFF
--- a/lib/bson/ordered_hash.rb
+++ b/lib/bson/ordered_hash.rb
@@ -30,7 +30,7 @@ module BSON
         when BSON::OrderedHash
            keys == other.keys && values == other.values
         else
-          !other.nil? && keys.size == other.keys.size && keys.all? {|x| self[x] == other[x] }
+          super
         end
       rescue
         false


### PR DESCRIPTION
Hi, 

I had a case where an OrderedHash was being compared to a Mustache::Context object, which made my view take several minutes to render. This patch fixed the problem without breaking any tests (tested on 1.8.7 and 1.9.2), but should be reviewed for correctness.

I also fixed a warning about missing parentheses in the same class.
