### PR TITLE
Duplicate 'filename' attribute w/ GridFS

### DIFF
--- a/lib/mongo/gridfs/grid.rb
+++ b/lib/mongo/gridfs/grid.rb
@@ -65,7 +65,7 @@ module Mongo
     #
     # @return [Mongo::ObjectId] the file's id.
     def put(data, opts={})
-      filename = opts[:filename]
+      filename = opts.delete :filename
       opts.merge!(default_grid_io_opts)
       file = GridIO.new(@files, @chunks, filename, 'w', opts=opts)
       file.write(data)


### PR DESCRIPTION
When using Grid.put(..) with an opts map containing :filename, the "filename" attribute was duplicated in the fs.files document.

Changed:
filename = opts[:filename]

to 

filemame = opts.delete :filename

so that it was no longer in the opts map when writing using GridIO.

Steve Ardis
scardis@gmail.com
