### PR TITLE
Getting rid of warnings thrown by ruby

### DIFF
--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -23,7 +23,7 @@ module Mongo
 
     attr_reader :collection, :selector, :fields,
       :order, :hint, :snapshot, :timeout,
-      :full_collection_name, :batch_size
+      :full_collection_name
 
     # Create a new cursor.
     #


### PR DESCRIPTION
Ruby 1.8.6 was throwing two warnings in cursor.rb:
1. batch_size accessor was overridden by a method with the same name
2. @query_run and @closed were accessed before they were initialized

The fix for both of them was trivial.
