### PR TITLE
Proper ObjectId json encoding for rails 3

### DIFF
--- a/lib/bson/types/object_id.rb
+++ b/lib/bson/types/object_id.rb
@@ -152,6 +152,14 @@ module BSON
     def to_json(*a)
       "{\"$oid\": \"#{to_s}\"}"
     end
+    
+    # Create the JSON hash structure convert to MongoDB extended format. Rails 2.3.3 
+    # introduced as_json to create the needed hash structure to encode objects into JSON.
+    # 
+    # @return [Hash] the hash representation as MongoDB extended JSON
+    def as_json(options ={})
+      {"$oid" => to_s}
+    end
 
     # Return the UTC time at which this ObjectId was generated. This may
     # be used in lieu of a created_at timestamp since this information

--- a/test/bson/object_id_test.rb
+++ b/test/bson/object_id_test.rb
@@ -127,4 +127,9 @@ class ObjectIdTest < Test::Unit::TestCase
     id = ObjectId.new
     assert_equal "{\"$oid\": \"#{id}\"}", id.to_json
   end
+  
+  def test_as_json
+    id = ObjectId.new
+    assert_equal({"$oid" => id.to_s}, id.as_json)
+  end
 end


### PR DESCRIPTION
Introduced in rails 2.3.3 and also in rails 3.0 encoding to json now first uses the method as_json to generate the proper hash structure and then to_json is called to convert that into proper json format. I've implemented as_json so in new rails projects mongo ids will properly be encoded into the extended format. Without this fix mongo documents ids were getting converted into {_id :{data : [12,5,77.19.....]} now they will get converted to
{_id :{"$oid" : "4ca24a513c850c7697000006"} } when using the rails render :json methods.
