### PR TITLE
Big Endian Support

### DIFF
--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -45,6 +45,8 @@ else
   begin
     # Need this for running test with and without c ext in Ruby 1.9.
     raise LoadError if ENV['TEST_MODE'] && !ENV['C_EXT']
+    #raise LoadError unless little endian
+    raise LoadError unless [1,0,0,0].pack("i").bytes.first==1
     require 'bson_ext/cbson'
     raise LoadError unless defined?(CBson::VERSION)
     if CBson::VERSION < MINIMUM_BSON_EXT_VERSION


### PR DESCRIPTION
This change checks that the machine is little endian before the C module is loaded. If the bson_ext gem is installed on a PPC (Big Endian) platfrom, currently, it will merely raise an error when you attempt to use the extension.
