### PR TITLE
Optimization

### DIFF
--- a/lib/bson/types/object_id.rb
+++ b/lib/bson/types/object_id.rb
@@ -131,11 +131,7 @@ module BSON
     #
     # @return [String]
     def to_s
-      str = ' ' * 24
-      12.times do |i|
-        str[i * 2, 2] = '%02x' % @data[i]
-      end
-      str
+      @data.map {|e| v=e.to_s(16); v.size == 1 ? "0#{v}" : v }.join
     end
 
     def inspect

--- a/test/bson/object_id_test.rb
+++ b/test/bson/object_id_test.rb
@@ -51,6 +51,12 @@ class ObjectIdTest < Test::Unit::TestCase
     assert_equal 24, $1.length
   end
 
+  def test_to_s2
+    @o = ObjectId.new([76, 244, 52, 174, 44, 84, 121, 76, 88, 0, 0, 3])
+    s = '4cf434ae2c54794c58000003'
+    assert_equal @o.to_s, s
+  end
+
   def test_method
     assert_equal ObjectId.from_string(@o.to_s), BSON::ObjectId(@o.to_s)
   end


### PR DESCRIPTION
please check this optimization on ObjectId#to_s

```
$ rvm 1.9.2 exec ruby bm2.rb 
              user     system      total        real
ObjectId#to_s  2.670000   0.000000   2.670000 (  2.680380)
new ObjectId#to_s  1.960000   0.000000   1.960000 (  1.959184)
new ObjectId#to_s manual formatting + Array#join  0.820000   0.000000   0.820000 (  0.822145)
new ObjectId#to_s manual formatting + Array#to_s  1.590000   0.000000   1.590000 (  1.585476)

$ cat bm2.rb 

require 'benchmark'
require 'bson'

Benchmark.bm(8) do |r|
  r.report("ObjectId#to_s") do
    100000.times do
      o = BSON::ObjectId.new
      o.to_s
    end
  end

  r.report("new ObjectId#to_s") do
    100000.times do
      o = BSON::ObjectId.new
      o.data.map {|e| '%02x' % e }.join
    end
  end

  r.report("new ObjectId#to_s manual formatting + Array#join") do
    100000.times do
      o = BSON::ObjectId.new
      o.data.map {|e| v=e.to_s(16); v.size == 1 ? "0#{v}" : v }.join
    end
  end

  r.report("new ObjectId#to_s manual formatting + Array#to_s") do
    100000.times do
      o = BSON::ObjectId.new
      o.data.map {|e| v=e.to_s(16); v.size == 1 ? "0#{v}" : v }.to_s
    end
  end
end
```
