### PR TITLE
The port is set to 0 (instead of DEFAULT_PORT) if the optional port is not specified in the replica set config record

### DIFF
--- a/lib/mongo/connection.rb
+++ b/lib/mongo/connection.rb
@@ -738,7 +738,7 @@ module Mongo
         end
 
         host, port = host.split(':')
-        [host, port.to_i]
+        [host, port ? port.to_i : DEFAULT_PORT]
       end
 
       # Replace the list of seed nodes with the canonical list.


### PR DESCRIPTION
Note the following config record containing hosts without the [optional](http://www.mongodb.org/display/DOCS/Replica+Set+Configuration) ":port" specified.  When a connection is made, the discovery code will set the port to 0 when the host string is split on  ":".

I also noticed that @arbiters is not being set for this config record, but I didn't attempt a fix for this.

```
>db.runCommand("isMaster")
{
"setName" : "stage1",
"ismaster" : true,
"secondary" : false,
"hosts" : [
    "mongo01.customink.com",
    "mongo02.customink.com"
],
"arbiters" : [
    "oa.customink.com"
],
"ok" : 1
} 
```
