### PR TITLE
Tiny documentation fix for the 'fields' parameter of collection.find

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -134,7 +134,7 @@ module Mongo
     #   to Ruby 1.8).
     #
     # @option opts [Array, Hash] :fields field names that should be returned in the result
-    #   set ("_id" will always be included). By limiting results to a certain subset of fields,
+    #   set ("_id" will be included unless explicity excluded). By limiting results to a certain subset of fields,
     #   you can cut down on network traffic and decoding time. If using a Hash, keys should be field
     #   names and values should be either 1 or 0, depending on whether you want to include or exclude
     #   the given field.


### PR DESCRIPTION
Hey,
Saw this blog post, http://robots.thoughtbot.com/post/2403360445/yuletide-logs-and-mongodb-capped-collections#disqus_thread, which indicated a little confusion with the "fields" param documentation.  Here's a tiny doc change to clarify the fields parameter.
