### PR TITLE
Check for little endian updated to work with ruby 1.8.6 

### DIFF
--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -47,7 +47,7 @@ else
     raise LoadError if ENV['TEST_MODE'] && !ENV['C_EXT']
 
     # Raise LoadError unless little endian
-    raise LoadError unless [1,0,0,0].pack("i").bytes.first == 1
+    raise LoadError unless "\x01\x00\x00\x00".unpack("i").first == 1
 
     require 'bson_ext/cbson'
     raise LoadError unless defined?(CBson::VERSION)


### PR DESCRIPTION
Hi,

I've updated the check for little endian in lib/bson.rb to work with Ruby 1.8.6. The previous version used String#bytes, which has only been backported to Ruby 1.8.7.

The original author of the check for little endian has checked that my suggestion works on his PPC, see https://github.com/mongodb/mongo-ruby-driver/commit/afac79c05f437e35406d7cb3b7f4e16d9ce9f829

Regards

Mark
