### PR TITLE
Get rid of "implicit conversion 64-bit 32-bit" warnings

### DIFF
--- a/ext/cbson/cbson.c
+++ b/ext/cbson/cbson.c
@@ -30,9 +30,15 @@
 #ifndef RSTRING_LEN
 #  define RSTRING_LEN(v) RSTRING(v)->len
 #endif
+#ifndef RSTRING_LENINT
+#  define RSTRING_LENINT(v) rb_long2int(RSTRING_LEN(v))
+#endif
 
 #ifndef RARRAY_LEN
 #  define RARRAY_LEN(v) RARRAY(v)->len
+#endif
+#ifndef RARRAY_LENINT
+#  define RARRAY_LENINT(v) rb_long2int(RARRAY_LEN(v))
 #endif
 
 #if HAVE_RUBY_ST_H


### PR DESCRIPTION
Hello,

This resolves "warning: implicit conversion shortens 64-bit value into a 32-bit value"
The problem is String/Array length is a long (so 64 bits on some platforms instead of 32) and the extension use int
There are 2 solutions:
- use long everywhere (but waste of memory, and hard to do)
- cast into ints (but potential lost of data)

I did the second, because all these cases are about String/Array lengths,
and it is very unlikely to have a String/Array of more than 2 billions elements (that would mean at least 2GB in memory).

The last cast might need to be reviewed (htonl((int)time(NULL))) because htonl want a 32-bit int, but time(NULL) will overflow with the year 2038 problem.

Note: RSTRING_LENINT and RARRAY_LENINT are relatively new, so I define them if necessary.

P.S.:
The commit 9da68bb3db09136e75f6147dde61aca4769d183a: RUBY-189 use result of ismaster's maxBsonObjectSize
is wrong because it defines a method accessible from Ruby which is void.
You should return "INT2FIX(max_bson_size);".
The tests are still failing, so I suppose the other side of the equality is wrong too.
