### PR TITLE
Switching parameter name in Collection#group from key to opts to fix YARD doc

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -598,10 +598,10 @@ module Mongo
         if opts.is_a? Array
           key_type = "key"
           key_value = {}
-          key.each { |k| key_value[k] = 1 }
+          opts.each { |k| key_value[k] = 1 }
         else
           key_type  = "$keyf"
-          key_value = key.is_a?(BSON::Code) ? key : BSON::Code.new(key)
+          key_value = opts.is_a?(BSON::Code) ? opts : BSON::Code.new(opts)
         end
 
         group_command["group"][key_type] = key_value


### PR DESCRIPTION
If you are upgrading the version of the mongo-ruby-driver in your project and you are using Collection#group, you are greeted with a deprecation warning. The warning refers you to the [documentation](http://api.mongodb.org/ruby/1.2.0/Mongo/Collection.html#group-instance_method), but that isn't all that helpful. It tells you that there is now an opts hash, but you don't know what to put in it.

If you look at the source, you can see that there is documentation for what should go in the opts hash, but YARD doesn't pick up on it because the Collection#group method doesn't have a parameter called opts. I've changed the key parameter to opts so that the ydoc now properly generates.
