### PR TITLE
Connection Health

### DIFF
--- a/lib/mongo/connection.rb
+++ b/lib/mongo/connection.rb
@@ -482,6 +482,22 @@ module Mongo
       @primary_pool && @primary_pool.host && @primary_pool.port
     end
 
+    # Determine if the connection is active. In a normal case the *server_info* operation
+    # will be performed without issues, but if the connection was dropped by the server or
+    # for some reason the sockets are unsynchronized, a ConnectionFailure will be raised and
+    # the return will be false.
+    #
+    # @return [Boolean]
+    def active?
+      return false unless connected?
+
+      server_info
+      true
+
+      rescue ConnectionFailure
+      false
+    end
+
     # Determine whether we're reading from a primary node. If false,
     # this connection connects to a secondary node and @slave_ok is true.
     #

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -200,6 +200,26 @@ class TestConnection < Test::Unit::TestCase
     assert_equal Mongo::DEFAULT_MAX_BSON_SIZE, BSON::BSON_CODER.max_bson_size
   end
 
+  def test_connection_activity
+    conn = standard_connection
+    assert conn.active?
+
+    conn.primary_pool.close
+    assert !conn.active?
+
+    # Simulate a dropped connection.
+    dropped_socket = Mocha::Mock.new
+    dropped_socket.stubs(:read).raises(Errno::ECONNRESET)
+    dropped_socket.stubs(:send).raises(Errno::ECONNRESET)
+    dropped_socket.stub_everything
+
+    conn.primary_pool.host = 'localhost'
+    conn.primary_pool.port = Mongo::Connection::DEFAULT_PORT
+    conn.primary_pool.instance_variable_set("@sockets", [dropped_socket])
+
+    assert !conn.active?
+  end
+
   context "Saved authentications" do
     setup do
       @conn = standard_connection


### PR DESCRIPTION
Hey guys,

First, Github is reporting 3 commits in this pull request but this is related to: 29eb568c

Added a new _active?_ method to the Connection class, to verify if the connection is healthy. I've seen there's no way right now to check that since the _connected?_ method only verifies if the primary connection pool is there.

I've found that if you have a long running task (a daemon, or an long time idle web server) and the Mongo server dropped the connection due to a timeout or anything else, the first request request after a long period inactivity will fail with "Connection reset by peer". With this mechanism you can verify if the connection is still active before sending a query and handle errors more gracefully.

This mechanism is similar to the one used in the MySQL adapter bundled with ActiveRecord, you can check it out here: https://github.com/rails/rails/blob/master/activerecord/lib/active_record/connection_adapters/mysql_adapter.rb#L281

I used the 'server_info' command to check the connection, but if you think there's an even lighter/faster command, feel free to change it. (In the MySQL adapter is just a 'select 1')

Cheers!
Mauro.
