### PR TITLE
Transformations

### DIFF
--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -23,7 +23,7 @@ module Mongo
 
     attr_reader :collection, :selector, :fields,
       :order, :hint, :snapshot, :timeout,
-      :full_collection_name
+      :full_collection_name, :transformer
 
     # Create a new cursor.
     #
@@ -52,6 +52,7 @@ module Mongo
       @tailable   = opts[:tailable] || false
       @closed       = false
       @query_run    = false
+      @transformer = opts[:transformer]
       batch_size(opts[:batch_size] || 0)
 
       @full_collection_name = "#{@collection.db.name}.#{@collection.name}"
@@ -86,7 +87,11 @@ module Mongo
         raise OperationFailure, err
       end
 
-      doc
+      if @transformer.nil?
+        doc
+      else
+        @transformer.call(doc) if doc
+      end
     end
     alias :next :next_document
 

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -592,6 +592,20 @@ class TestCollection < Test::Unit::TestCase
     assert_equal 1, x
   end
 
+  def test_find_with_transformer
+    klass       = Struct.new(:id, :a)
+    transformer = Proc.new { |doc| klass.new(doc['_id'], doc['a']) }
+    cursor      = @@test.find({}, :transformer => transformer)
+    assert_equal(transformer, cursor.transformer)
+  end
+  
+  def test_find_one_with_transformer
+    klass       = Struct.new(:id, :a)
+    transformer = Proc.new { |doc| klass.new(doc['_id'], doc['a']) }
+    id          = @@test.insert('a' => 1)
+    doc         = @@test.find_one(id, :transformer => transformer)
+    assert_instance_of(klass, doc)
+  end
 
   def test_ensure_index
     @@test.drop_indexes

--- a/test/cursor_test.rb
+++ b/test/cursor_test.rb
@@ -454,4 +454,30 @@ class CursorTest < Test::Unit::TestCase
     assert_equal 100, cursor.map {|doc| doc }.length
   end
 
+  def test_transformer
+    transformer = Proc.new { |doc| doc }
+    cursor = Cursor.new(@@coll, :transformer => transformer)
+    assert_equal(transformer, cursor.transformer)
   end
+
+  def test_instance_transformation_with_next
+    klass       = Struct.new(:id, :a)
+    transformer = Proc.new { |doc| klass.new(doc['_id'], doc['a']) }
+    cursor      = Cursor.new(@@coll, :transformer => transformer)
+    instance    = cursor.next
+
+    assert_instance_of(klass, instance)
+    assert_instance_of(BSON::ObjectId, instance.id)
+    assert_equal(1, instance.a)
+  end
+
+  def test_instance_transformation_with_each
+    klass       = Struct.new(:id, :a)
+    transformer = Proc.new { |doc| klass.new(doc['_id'], doc['a']) }
+    cursor      = Cursor.new(@@coll, :transformer => transformer)
+
+    cursor.each do |instance|
+      assert_instance_of(klass, instance)
+    end
+  end
+end


### PR DESCRIPTION
Explained pretty thoroughly in the commit.

Thought about adding it at collection level as well, but decided that really only find needs it. Could always be added later. Also did not add it to find_and_modify. Any thoughts on whether it should be there or not are appreciated. This should make life a lot easier for object mappers.
