### PR TITLE
Don't bork input args

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -168,6 +168,7 @@ module Mongo
     #
     # @core find find-instance_method
     def find(selector={}, opts={})
+      opts = opts.dup # don't bork input args
       fields = opts.delete(:fields)
       fields = ["_id"] if fields && fields.empty?
       skip   = opts.delete(:skip) || skip || 0

--- a/lib/mongo/gridfs/grid_file_system.rb
+++ b/lib/mongo/gridfs/grid_file_system.rb
@@ -93,6 +93,7 @@ module Mongo
     #
     #  @return [Mongo::GridIO]
     def open(filename, mode, opts={})
+      opts = opts.dup # don't bork input args
       opts.merge!(default_grid_io_opts(filename))
       del  = opts.delete(:delete_old) && mode == 'w'
       file = GridIO.new(@files, @chunks, filename, mode, opts)

--- a/lib/mongo/gridfs/grid_io.rb
+++ b/lib/mongo/gridfs/grid_io.rb
@@ -51,6 +51,7 @@ module Mongo
     # @option opts [Boolean] :safe (false) When safe mode is enabled, the chunks sent to the server
     #   will be validated using an md5 hash. If validation fails, an exception will be raised.
     def initialize(files, chunks, filename, mode, opts={})
+      opts = opts.dup # don't bork input args
       @files        = files
       @chunks       = chunks
       @filename     = filename


### PR DESCRIPTION
hey,

I noticed that calling find twice with the same options hash did different things:

```
selector = { :hello => 'world' }
opts = { :limit => 10 }
a = collection.find(selector, opts) # => successfully limited to 10 docs
b = collection.find(selector, opts) # => unlimited... what?
```

It's because Collection (and also GridFS, turns out) bork input args like opts by modifying them directly. While you could say it's the user's job to watch out for this, I think it's pretty surprising and other mongo-ruby-driver objects don't do it.

Thanks for your excellent work!
Best,
Seamus
