### PR TITLE
Don't modify method arguments

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -168,6 +168,8 @@ module Mongo
     #
     # @core find find-instance_method
     def find(selector={}, opts={})
+      opts = opts.dup
+      
       fields = opts.delete(:fields)
       fields = ["_id"] if fields && fields.empty?
       skip   = opts.delete(:skip) || skip || 0
@@ -433,6 +435,8 @@ module Mongo
     #
     # @core indexes create_index-instance_method
     def create_index(spec, opts={})
+      opts = opts.dup
+      
       opts[:dropDups] = opts.delete(:drop_dups) if opts[:drop_dups]
       field_spec = parse_index_spec(spec)
       name = opts.delete(:name) || generate_index_name(field_spec)
@@ -459,6 +463,8 @@ module Mongo
     #
     # @return [String] the name of the index.
     def ensure_index(spec, opts={})
+      opts = opts.dup
+      
       now = Time.now.utc.to_i
       field_spec = parse_index_spec(spec)
 
@@ -553,6 +559,8 @@ module Mongo
     #
     # @core mapreduce map_reduce-instance_method
     def map_reduce(map, reduce, opts={})
+      opts = opts.dup
+      
       map    = BSON::Code.new(map) unless map.is_a?(BSON::Code)
       reduce = BSON::Code.new(reduce) unless reduce.is_a?(BSON::Code)
       raw    = opts.delete(:raw)


### PR DESCRIPTION
Many of the methods of Collection modified the "opts" hash passed as last argument. This is bad form, and can cause unexpected bugs in client code. For example this code should work but doesn't:

options = {:sort => :prop}
res1 = coll.find({}, options)
res2 = coll.find({}, options)

res1 and res2 should be the same but they aren't, since "options" will be emptied by the first call to #find.
