### PR TITLE
GridIO#get_chunk should have an upper bound guard

### DIFF
--- a/lib/mongo/gridfs/grid_io.rb
+++ b/lib/mongo/gridfs/grid_io.rb
@@ -311,7 +311,7 @@ module Mongo
     end
 
     def get_chunk(n)
-      chunk = @chunks.find({'files_id' => @files_id, 'n' => n}).next_document
+      chunk = @chunks.find({'files_id' => @files_id, 'n' => n}).next_document if n <= last_chunk_number
       @chunk_position = 0
       chunk
     end


### PR DESCRIPTION
GridIO#get_chunk will attempt to fetch a chunk that is outside the bounds of the file. Where I noticed the problem was actually GridIO#read_all. If the size of the file you are reading is less than the chunk size, #read_all will try to get chunk 1 (the 2nd chunk) regardless. In my usecase, all files are less than the chunk size, which results in a 100% increase in the number of queries necessary.

Even though #read_all is my culprit, I couldn't see a way to change it without making it ugly. The addition to #get_chunk is very small and shouldn't cause problems elsewhere as #get_chunk appears to just return nil for non-existant chunks anyway.

Thanks,
-Derek
