### PR TITLE
fix bug in OrderedHash that prevents YAML.load

### DIFF
--- a/lib/bson/ordered_hash.rb
+++ b/lib/bson/ordered_hash.rb
@@ -57,8 +57,13 @@ module BSON
       end
 
       def initialize(*a, &b)
-        super
         @ordered_keys = []
+        super
+      end
+
+      def yaml_initialize(tag, val)
+        @ordered_keys = []        
+        super
       end
 
       def keys


### PR DESCRIPTION
If there is a BSON::OrderedHash that gets unserialized from YAML, an exception is thrown. This bit me with delayed_mongoid_job where objects are YAML serialized.

What happens is that OrderedHash.yaml_initialize gets called, but since it is not implemented, the Hash.yaml_initialize is called which doesn't set the @ordered_keys instance variable up. This blows up pretty much all the other operations.
