### PR TITLE
get_md5 method should return @server_md5.

### DIFF
--- a/lib/mongo/gridfs/grid_io.rb
+++ b/lib/mongo/gridfs/grid_io.rb
@@ -454,7 +454,9 @@ module Mongo
       @server_md5 = @files.db.command(md5_command)['md5']
       if @safe
         @client_md5 = @local_md5.hexdigest
-        if @local_md5 != @server_md5
+        if @local_md5 == @server_md5
+          @server_md5
+        else
           raise GridMD5Failure, "File on server failed MD5 check"
         end
       else


### PR DESCRIPTION
get_md5 method should return @server_md5 when putting file with GridFS on safe mode unless client_md5 doesn't match server_md5.
