### PR TITLE
Common usage of GridIO#gets runs into an infinite loop when reaching the end of a file

### DIFF
--- a/lib/mongo/gridfs/grid_io.rb
+++ b/lib/mongo/gridfs/grid_io.rb
@@ -235,7 +235,7 @@ module Mongo
             end
           end
         end
-        result
+        result.length > 0 ? result : nil
       else
         result = ''
         len = 0
@@ -244,7 +244,7 @@ module Mongo
           len += 1
           break if char == separator || (length ? len >= length : false)
         end
-        result
+        result.length > 0 ? result : nil
       end
     end
 

--- a/test/grid_io_test.rb
+++ b/test/grid_io_test.rb
@@ -69,6 +69,24 @@ class GridIOTest < Test::Unit::TestCase
         assert_equal 10, string.length
       end
 
+      should "read to the end of the file one line at a time" do
+        file = GridIO.new(@files, @chunks, nil, "r", :query => {:_id => @file.files_id})
+        bytes = 0
+        while string = file.gets
+          bytes += string.length
+        end
+        assert_equal 1_000_000, bytes
+      end
+
+      should "read to the end of the file one multi-character separator at a time" do
+        file = GridIO.new(@files, @chunks, nil, "r", :query => {:_id => @file.files_id})
+        bytes = 0
+        while string = file.gets("45")
+          bytes += string.length
+        end
+        assert_equal 1_000_000, bytes
+      end
+
       should "read to a given separator" do
         file = GridIO.new(@files, @chunks, nil, "r", :query => {:_id => @file.files_id})
         string = file.gets("5")


### PR DESCRIPTION
Fixed GridIO#gets to handle the end of a file

Neither a multi-character nor single-character separator search returned nil after hitting the EOF.
