### PR TITLE
Fixes map_reduce call

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -565,7 +565,7 @@ module Mongo
     def map_reduce(map, reduce, opts={})
       map    = BSON::Code.new(map) unless map.is_a?(BSON::Code)
       reduce = BSON::Code.new(reduce) unless reduce.is_a?(BSON::Code)
-      raw    = opts[:raw]
+      raw    = opts.delete(:raw)
 
       hash = BSON::OrderedHash.new
       hash['mapreduce'] = self.name


### PR DESCRIPTION
Passing :raw option to the server results in 

Database command 'mapreduce' failed: {"ok"=>0.0, "errmsg"=>"unknown m/r field for sharding: raw"} (Mongo::OperationFailure)
/usr/local/lib/ruby/gems/1.9.1/gems/mongo-1.3.1/lib/mongo/db.rb:506:in `command'
/usr/local/lib/ruby/gems/1.9.1/gems/mongo-1.3.1/lib/mongo/collection.rb:576:in`map_reduce'

That broke our application
