### PR TITLE
mongodb url may contain host but no username/password

### DIFF
--- a/lib/mongo/util/uri_parser.rb
+++ b/lib/mongo/util/uri_parser.rb
@@ -130,9 +130,9 @@ module Mongo
 
         if uname && pwd && db
           auths << {'db_name' => db, 'username' => uname, 'password' => pwd}
-        elsif uname || pwd || db
-          raise MongoArgumentError, "MongoDB URI must include all three of username, password, " +
-            "and db if any one of these is specified."
+        elsif uname || pwd
+          raise MongoArgumentError, "MongoDB URI must include username, password, " +
+            "and db if username or password are specified."
         end
 
         @nodes << [host, port]


### PR DESCRIPTION
currently urls like

mongodb://host/db_name 

cause the uri parser to die, but these are valid urls.  The gem requires urls to look like this:

mongodb://username:password@host/db_name

changed the parser to only throw an error if db & username were present with no password or if db & password were present with no username.
