### PR TITLE
Allow logging from Collection using Connection logger

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -86,6 +86,7 @@ module Mongo
 
       @db, @name  = db, name
       @connection = @db.connection
+      @logger     = @connection.logger
       @cache_time = @db.cache_time
       @cache = Hash.new(0)
       unless pk_factory

--- a/test/unit/collection_test.rb
+++ b/test/unit/collection_test.rb
@@ -124,5 +124,15 @@ class CollectionTest < Test::Unit::TestCase
 
       @coll.ensure_index [["x", Mongo::DESCENDING], ["y", Mongo::DESCENDING]]
     end
+
+    should "use the connection's logger" do
+      @conn = Connection.new('localhost', 27017, :logger => @logger, :connect => false)
+      @db   = @conn['testing']
+      @coll = @db.collection('books')
+      @logger.expects(:warn).with do |msg|
+        msg == "MONGODB [WARNING] test warning"
+      end
+      @coll.log(:warn, "test warning")
+    end
   end
 end


### PR DESCRIPTION
Collection logging instrumentation hasn't been working since the logging refactor. The fix uses the connection's logger in the collection.
