### PR TITLE
Raised the maximum limit for individual documents to 16Mb

### DIFF
--- a/lib/bson/bson_ruby.rb
+++ b/lib/bson/bson_ruby.rb
@@ -20,7 +20,7 @@ module BSON
   # A BSON seralizer/deserializer in pure Ruby.
   class BSON_RUBY
 
-    DEFAULT_MAX_BSON_SIZE = 4 * 1024 * 1024
+    DEFAULT_MAX_BSON_SIZE = 16 * 1024 * 1024
 
     @@max_bson_size = DEFAULT_MAX_BSON_SIZE
 


### PR DESCRIPTION
Because you promised :)

"MongoDB limits the data size of individual BSON objects/documents. At the time of this writing the limit is 16MB."- http://www.mongodb.org/display/DOCS/Documents
