### PR TITLE
Return the raw value if the option is an array

### DIFF
--- a/lib/mongo/util/conversions.rb
+++ b/lib/mongo/util/conversions.rb
@@ -77,6 +77,7 @@ module Mongo #:nodoc:
     #
     # If the value is invalid then an error will be raised.
     def sort_value(value)
+      return value if value.kind_of?(Array)
       val = value.to_s.downcase
       return 1 if ASCENDING_CONVERSION.include?(val)
       return -1 if DESCENDING_CONVERSION.include?(val)


### PR DESCRIPTION
Mongo accepts an array when using sort to allow you to sort by preference, for example

`Person.order_by(:first_name, ['Dan', 'Rob'])`

I know i will need to write tests etc however putting pull request up to get people's opinions, it's a feature i need and wondered why it wasn't allowed in the gem as it works fine.
