### PR TITLE
Pass the `find` payload to instrumentation even if no logger

### DIFF
--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -463,9 +463,8 @@ module Mongo
 
     def send_initial_query
       message = construct_query_message
-      payload = instrument_payload if @logger
       sock    = @socket || checkout_socket_from_connection
-      instrument(:find, payload) do
+      instrument(:find, instrument_payload) do
         begin
         results, @n_received, @cursor_id = @connection.receive_message(
           Mongo::Constants::OP_QUERY, message, nil, sock, @command,


### PR DESCRIPTION
for the benefit of anyone hooking into the `instrument` method. It also means it matches the behaviour of insert, update, remove methods. Generating the payload is very cheap, so don't think there are any worries there.
