### PR TITLE
Fixed issue w/ :connect_timeout option

### DIFF
--- a/lib/mongo/connection.rb
+++ b/lib/mongo/connection.rb
@@ -604,6 +604,8 @@ module Mongo
     def check_is_master(node)
       begin
         host, port = *node
+        socket = nil
+        config = nil
 
         if @connect_timeout
           Mongo::TimeoutHandler.timeout(@connect_timeout, OperationTimeout) do


### PR DESCRIPTION
A scoping issue causes a `SystemStackError: stack level too deep` exception when the `:connect_timeout` option is given, as reported here:

https://groups.google.com/forum/#!topic/mongodb-user/tsLjZjufXEE

To replicate:

``` ruby
Mongo::Connection.new(nil, nil, :connect_timeout => 5)
```

This tiny commit fixes the issue.
