### PR TITLE
typo in docs/WRITE_CONCERN.md

### DIFF
--- a/docs/WRITE_CONCERN.md
+++ b/docs/WRITE_CONCERN.md
@@ -10,7 +10,7 @@ Write concern is set using the `:safe` option. There are several possible option
     @collection.save({:doc => 'foo'}, :safe => {:w => 2, :wtimeout => 200, :j => true})
 
 The first, `true`, simply indicates that we should request a response from the server to ensure that to errors have occurred. The second, `{:w => 2}`, forces the server to wait until at least two servers have recorded the write. The third does the same but will time out if the replication can't be completed in 200 milliseconds.
-Setting a value for `wtimeout` is encouraed.
+Setting a value for `wtimeout` is encouraged.
 
 Finally, the fourth example forces the journal to sync to disk if journaling is enabled.
 


### PR DESCRIPTION
I found a small typo while browsing the docs on api.mongodb.org
