### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Here is a sample primary key factory, taken from the tests:
 
     class TestPKFactory
       def create_pk(row)
-        row['_id'] ||= Mongo::ObjectID.new
+        row['_id'] ||= BSON::ObjectId.new
         row
       end
     end
@@ -212,7 +212,7 @@ ActiveRecord-like framework for non-Rails apps) and the AR Mongo adapter code
       def create_pk(row)
         return row if row[:_id]
         row.delete(:_id)      # in case it exists but the value is nil
-        row['_id'] ||= Mongo::ObjectID.new
+        row['_id'] ||= BSON::ObjectId.new
         row
       end
     end


### PR DESCRIPTION
The brief code examples in the README are using the old Mongo::ObjectID notation from pre-0.2 updated them to the BSON namespace and ObjectId format from RUBY-158 - to see the confusion caused, just check out: http://stackoverflow.com/questions/9386533/bsonobjectid-vs-mongoobjectid/
