### PR TITLE
Passing :filename to GridFS stored duplicate filename attributes

### DIFF
--- a/lib/mongo/gridfs/grid.rb
+++ b/lib/mongo/gridfs/grid.rb
@@ -68,7 +68,7 @@ module Mongo
     # @return [BSON::ObjectId] the file's id.
     def put(data, opts={})
       opts     = opts.dup
-      filename = opts[:filename]
+      filename = opts.delete(:filename)
       opts.merge!(default_grid_io_opts)
       file = GridIO.new(@files, @chunks, filename, 'w', opts)
       file.write(data)


### PR DESCRIPTION
Fixes the following conversation:

http://groups.google.com/group/mongodb-user/browse_thread/thread/a8615344be8226c9/7ef22f3e16dc726a?lnk=raot&pli=1
