### PR TITLE
Logger complaining about missing method using mongoid and rails 3.1.2

### DIFF
--- a/lib/mongo/util/logging.rb
+++ b/lib/mongo/util/logging.rb
@@ -31,7 +31,7 @@ module Mongo
     def instrument(name, payload = {}, &blk)
       start_time = Time.now
       res = yield
-      if @logger && (@logger.level == DEBUG_LEVEL)
+      if @logger && @logger.respond_to?("level") && (@logger.level == DEBUG_LEVEL)
         log_operation(name, payload, start_time)
       end
       res


### PR DESCRIPTION
```
...undefined method `level' for #<Mongoid::Logger:0x00000103ca7570> (NoMethodError)"
```

Fixed by adding check for method existence. 
