### PR TITLE
A fix for the mongo.gemspec dependency statement to prevent errors on older versions of Rubygems

### DIFF
--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -30,5 +30,5 @@ Gem::Specification.new do |s|
   s.email = 'mongodb-dev@googlegroups.com'
   s.homepage = 'http://www.mongodb.org'
 
-  s.add_dependency('bson', Mongo::VERSION)
+  s.add_dependency('bson', "~> #{Mongo::VERSION}")
 end


### PR DESCRIPTION
As discussed on [this commit which introduced this problem](https://github.com/mongodb/mongo-ruby-driver/commit/9e2f562892cf339275d2e7f835268c64723daf33), if your `gemspec` file dependencies don't have a `~>` or `>=` or something to that effect, it can cause older versions of `rubygems` to throw errors.  Newer versions of rubygems have a workaround for this error, but I'm not certain which version it was patched in.

Read [this blog post on Rubygems.org by Tenderlove](http://blog.rubygems.org/2011/08/31/shaving-the-yaml-yak.html) for an in-depth explanation.  As the gemfile sits currently, I cannot use the gem on [Heroku](http://www.heroku.com) due to the fact that their ruby environment is running `rubygems 1.3.7`.
