### PR TITLE
Added database_name attr_reader to uri_parser

### DIFF
--- a/lib/mongo/util/uri_parser.rb
+++ b/lib/mongo/util/uri_parser.rb
@@ -76,7 +76,7 @@ module Mongo
                   :wtimeoutms       => lambda {|arg| arg.to_i }
                  }
 
-    attr_reader :nodes, :auths, :connect, :replicaset, :slaveok, :safe, :w, :wtimeout, :fsync, :journal, :connecttimeoutms, :sockettimeoutms, :wtimeoutms
+    attr_reader :nodes, :auths, :connect, :replicaset, :slaveok, :safe, :w, :wtimeout, :fsync, :journal, :connecttimeoutms, :sockettimeoutms, :wtimeoutms, :database_name
 
     # Parse a MongoDB URI. This method is used by Connection.from_uri.
     # Returns an array of nodes and an array of db authorizations, if applicable.
@@ -164,6 +164,8 @@ module Mongo
       pwd      = matches[3]
       hosturis = matches[4].split(',')
       db       = matches[8]
+
+      @database_name = db
 
       hosturis.each do |hosturi|
         # If port is present, use it, otherwise use default port

--- a/test/uri_test.rb
+++ b/test/uri_test.rb
@@ -17,6 +17,11 @@ class URITest < Test::Unit::TestCase
     assert_equal 27018, parser.nodes[0][1]
   end
 
+  def test_basic_uri_with_database
+    parser = Mongo::URIParser.new('mongodb://localhost/test_db')
+    assert_equal 'test_db', parser.database_name
+  end
+
   def test_multiple_uris
     parser = Mongo::URIParser.new('mongodb://a.example.com:27018,b.example.com')
     assert_equal 2, parser.nodes.length


### PR DESCRIPTION
The auths array doesn't contemplate unauthenticated URIs like mongodb://localhost/test_db.
I don't know if this is the right way to go about this but this would eliminate the need to parse the URI again.
