### PR TITLE
fix log debug level detect

### DIFF
--- a/lib/mongo/util/logging.rb
+++ b/lib/mongo/util/logging.rb
@@ -1,14 +1,10 @@
 module Mongo
   module Logging
 
-    DEBUG_LEVEL = defined?(Logger) ? Logger::DEBUG : 0
-
     def write_logging_startup_message
-      if @logger && (@logger.level == DEBUG_LEVEL)
-        log(:debug, "Logging level is currently :debug which could negatively impact " +
+      log(:debug, "Logging level is currently :debug which could negatively impact " +
           "client-side performance. You should set your logging level no lower than " +
           ":info in production.")
-      end
     end
 
     # Log a message with the given level.
@@ -16,42 +12,41 @@ module Mongo
       return unless @logger
       case level
         when :fatal then
-          @logger.fatal "MONGODB [FATAL] #{msg}"
+          @logger.fatal { "MONGODB [FATAL] #{msg}" }
         when :error then
-          @logger.error "MONGODB [ERROR] #{msg}"
+          @logger.error { "MONGODB [ERROR] #{msg}" }
         when :warn then
-          @logger.warn "MONGODB [WARNING] #{msg}"
+          @logger.warn { "MONGODB [WARNING] #{msg}" }
         when :info then
-          @logger.info "MONGODB [INFO] #{msg}"
+          @logger.info { "MONGODB [INFO] #{msg}" }
         when :debug then
-          @logger.debug "MONGODB [DEBUG] #{msg}"
+          @logger.debug { "MONGODB [DEBUG] #{msg}" }
         else
-          @logger.debug "MONGODB [DEBUG] #{msg}"
+          @logger.debug { "MONGODB [DEBUG] #{msg}" }
       end
     end
 
     # Execute the block and log the operation described by name and payload.
-    def instrument(name, payload = {}, &blk)
+    def instrument(name, payload = {})
       start_time = Time.now
       res = yield
-      if @logger && (@logger.level == DEBUG_LEVEL)
-        log_operation(name, payload, start_time)
-      end
+      log_operation(name, payload, start_time)
       res
     end
 
     protected
 
     def log_operation(name, payload, start_time)
-      msg = "MONGODB "
-      msg << "(#{((Time.now - start_time) * 1000).to_i}ms) "
-      msg << "#{payload[:database]}['#{payload[:collection]}'].#{name}("
-      msg << payload.values_at(:selector, :document, :documents, :fields ).compact.map(&:inspect).join(', ') + ")"
-      msg << ".skip(#{payload[:skip]})"   if payload[:skip]
-      msg << ".limit(#{payload[:limit]})" if payload[:limit]
-      msg << ".sort(#{payload[:order]})"  if payload[:order]
-
-      @logger.debug(msg)
+      @logger && @logger.debug do
+        msg = "MONGODB "
+        msg << "(#{((Time.now - start_time) * 1000).to_i}ms) "
+        msg << "#{payload[:database]}['#{payload[:collection]}'].#{name}("
+        msg << payload.values_at(:selector, :document, :documents, :fields ).compact.map(&:inspect).join(', ') + ")"
+        msg << ".skip(#{payload[:skip]})"   if payload[:skip]
+        msg << ".limit(#{payload[:limit]})" if payload[:limit]
+        msg << ".sort(#{payload[:order]})"  if payload[:order]
+        msg
+      end
     end
 
   end


### PR DESCRIPTION
- reason
  there hardcodes DEBUG_LEVEL in logging.rb:
    DEBUG_LEVEL = defined?(Logger) ? Logger::DEBUG : 0
  this could cause some incompatibility between different logger tools
  
  for Logger, DEBUG/0 < INFO/1 < WARN/2 < ERROR/3 < FATAL/4,
  for Log4r,  ALL/0 < DETAIL/1 < DEBUG/2 < INFO/3 < WARN/4 < ERROR/5 < FATAL/6.
  
  anyway, it is not in good pattern.
- suggestion
  logger.debug { ... }
  if current level is greater than DEBUG, the block will not be
  evaluated. it is also efficient.
  
  following is also supported by most loggers.
  logger.info { ... }
  logger.warn { ... }
  logger.error { ... }
  ...
