### PR TITLE
Use ENV['MONGODB_URI'] if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,14 @@ Certain Ruby application servers work by forking, and it has long been necessary
 re-establish the child process's connection to the database after fork. But with the release
 of v1.3.0, the Ruby driver detects forking and reconnects automatically.
 
+## Environment variable `MONGODB_URI`
+
+`Mongo::Connection.new` and `Mongo::ReplSetConnection.new` will use <code>ENV["MONGODB_URI"]</code> if no other args are provided.
+
+The URI must fit this specification:
+
+    mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+
 ## String Encoding
 
 The BSON ("Binary JSON") format used to communicate with Mongo requires that

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -58,6 +58,18 @@ class TestConnection < Test::Unit::TestCase
     assert_equal mongo_port, con.primary_pool.port
   end
 
+  def test_env_mongodb_uri
+    begin
+      old_mongodb_uri = ENV['MONGODB_URI']
+      ENV['MONGODB_URI'] = "mongodb://#{host_port}"
+      con = Connection.new
+      assert_equal mongo_host, con.primary_pool.host
+      assert_equal mongo_port, con.primary_pool.port
+    ensure
+      ENV['MONGODB_URI'] = old_mongodb_uri
+    end
+  end
+
   def test_server_version
     assert_match(/\d\.\d+(\.\d+)?/, @conn.server_version.to_s)
   end

--- a/test/replica_sets/connect_test.rb
+++ b/test/replica_sets/connect_test.rb
@@ -105,6 +105,20 @@ class ConnectTest < Test::Unit::TestCase
     assert @conn.is_a?(ReplSetConnection)
     assert @conn.connected?
   end
+
+  def test_connect_with_connection_string_in_env_var
+    begin
+      old_mongodb_uri = ENV['MONGODB_URI']
+      ENV['MONGODB_URI'] = "mongodb://#{@rs.host}:#{@rs.ports[0]},#{@rs.host}:#{@rs.ports[1]}?replicaset=#{@rs.name}"
+      silently do
+        @conn = ReplSetConnection.new
+      end
+      assert @conn.is_a?(ReplSetConnection)
+      assert @conn.connected?
+    ensure
+      ENV['MONGODB_URI'] = old_mongodb_uri
+    end
+  end
   
   def test_connect_with_new_seed_format
     @conn = ReplSetConnection.new build_seeds(3)
@@ -127,5 +141,22 @@ class ConnectTest < Test::Unit::TestCase
     assert_equal 2, @conn.safe[:w]
     assert @conn.safe[:fsync]
     assert @conn.read_pool
+  end
+
+  def test_connect_with_full_connection_string_in_env_var
+    begin
+      old_mongodb_uri = ENV['MONGODB_URI']
+      ENV['MONGODB_URI'] = "mongodb://#{@rs.host}:#{@rs.ports[0]},#{@rs.host}:#{@rs.ports[1]}?replicaset=#{@rs.name};safe=true;w=2;fsync=true;slaveok=true"
+      silently do
+        @conn = ReplSetConnection.new
+      end
+      assert @conn.is_a?(ReplSetConnection)
+      assert @conn.connected?
+      assert_equal 2, @conn.safe[:w]
+      assert @conn.safe[:fsync]
+      assert @conn.read_pool
+    ensure
+      ENV['MONGODB_URI'] = old_mongodb_uri
+    end
   end
 end


### PR DESCRIPTION
hi,

There's a growing trend to use `_URL`-style environment variables in database drivers:
- [Rails looks for `ENV['DATABASE_URL']`](https://github.com/rails/rails/commit/4605b5639db4fa15f8b6627245c74b899241f38a)
- [The official Redis client uses `ENV['REDIS_URL']`](https://github.com/redis/redis-rb/commit/06b2a58b2ea33112728eae901ed242e7615ebcd7)
- [Dalli uses `ENV['MEMCACHE_SERVERS']`](https://github.com/mperham/dalli/commit/628b2b13d70678ee610ef34014e4caa5389f98a2) - and I will shortly be making a pull request to support `ENV['MEMCACHE_URL']`

Note that I followed the convention already established in the MongoDB code of calling it a "URI" and not a "URL", so that is one difference from the general trend.

Fundamentally, this change will make MongoDB a lot easier to deploy on services like Heroku that encourage environment variables.

Thanks!
Seamus

PS. `rake test:ruby` and `rake test:c` all pass - plus I added more tests.
