### PR TITLE
b2json,j2bson: don't assume fixed ruby location

### DIFF
--- a/bin/b2json
+++ b/bin/b2json
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 # encoding: UTF-8
 
 # --

--- a/bin/j2bson
+++ b/bin/j2bson
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 # encoding: UTF-8
 
 # --


### PR DESCRIPTION
like bin/mongo_console, b2json and j2bson shouldn't assume fixed ruby interpreter's location.
