### PR TITLE
Make ENV['MONGODB_URI'] the default first arg for `Mongo::Connection.from_uri`

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,11 +175,13 @@ of v1.3.0, the Ruby driver detects forking and reconnects automatically.
 
 ## Environment variable `MONGODB_URI`
 
-`Mongo::Connection.new` and `Mongo::ReplSetConnection.new` will use <code>ENV["MONGODB_URI"]</code> if no other args are provided.
+`Mongo::Connection.from_uri`, `Mongo::Connection.new` and `Mongo::ReplSetConnection.new` will use <code>ENV["MONGODB_URI"]</code> if no other args are provided.
 
 The URI must fit this specification:
 
     mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
+
+If the type of connection (direct or replica set) should be determined entirely from <code>ENV["MONGODB_URI"]</code>, you may want to use `Mongo::Connection.from_uri` because it will return either `Mongo::Connection` or a `Mongo::ReplSetConnection` depending on how many hosts are specified. Trying to use `Mongo::Connection.new` with multiple hosts in <code>ENV["MONGODB_URI"]</code> will raise an exception.
 
 ## String Encoding
 

--- a/lib/mongo/connection.rb
+++ b/lib/mongo/connection.rb
@@ -162,7 +162,9 @@ module Mongo
       ReplSetConnection.new(*(nodes+[opts]))
     end
 
-    # Initialize a connection to MongoDB using the MongoDB URI spec:
+    # Initialize a connection to MongoDB using the MongoDB URI spec.
+    #
+    # Since Connection.new cannot be used with any <code>ENV["MONGODB_URI"]</code> that has multiple hosts (implying a replicaset), you may use this when the type of your connection varies by environment and should be determined solely from <code>ENV["MONGODB_URI"]</code>.
     #
     # @param uri [String]
     #   A string of the format mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/database]
@@ -170,7 +172,7 @@ module Mongo
     # @param opts Any of the options available for Connection.new
     #
     # @return [Mongo::Connection, Mongo::ReplSetConnection]
-    def self.from_uri(uri, extra_opts={})
+    def self.from_uri(uri = ENV['MONGODB_URI'], extra_opts={})
       parser = URIParser.new uri, extra_opts
       parser.connection
     end

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -70,6 +70,18 @@ class TestConnection < Test::Unit::TestCase
     end
   end
 
+  def test_from_uri_implicit_mongodb_uri
+    begin
+      old_mongodb_uri = ENV['MONGODB_URI']
+      ENV['MONGODB_URI'] = "mongodb://#{host_port}"
+      con = Connection.from_uri
+      assert_equal mongo_host, con.primary_pool.host
+      assert_equal mongo_port, con.primary_pool.port
+    ensure
+      ENV['MONGODB_URI'] = old_mongodb_uri
+    end
+  end
+
   def test_server_version
     assert_match(/\d\.\d+(\.\d+)?/, @conn.server_version.to_s)
   end

--- a/test/replica_sets/connect_test.rb
+++ b/test/replica_sets/connect_test.rb
@@ -119,6 +119,20 @@ class ConnectTest < Test::Unit::TestCase
       ENV['MONGODB_URI'] = old_mongodb_uri
     end
   end
+
+  def test_connect_with_connection_string_in_implicit_mongodb_uri
+    begin
+      old_mongodb_uri = ENV['MONGODB_URI']
+      ENV['MONGODB_URI'] = "mongodb://#{@rs.host}:#{@rs.ports[0]},#{@rs.host}:#{@rs.ports[1]}?replicaset=#{@rs.name}"
+      silently do
+        @conn = Connection.from_uri
+      end
+      assert @conn.is_a?(ReplSetConnection)
+      assert @conn.connected?
+    ensure
+      ENV['MONGODB_URI'] = old_mongodb_uri
+    end
+  end
   
   def test_connect_with_new_seed_format
     @conn = ReplSetConnection.new build_seeds(3)


### PR DESCRIPTION
Seems like this makes sense.
