### PR TITLE
Add Connection#db_from_uri to round out MONGODB_URI support

### DIFF
--- a/lib/mongo/connection.rb
+++ b/lib/mongo/connection.rb
@@ -34,6 +34,7 @@ module Mongo
 
     DEFAULT_HOST = 'localhost'
     DEFAULT_PORT = 27017
+    DEFAULT_DB_NAME = 'test'
     GENERIC_OPTS = [:ssl, :auths, :pool_size, :pool_timeout, :timeout, :op_timeout, :connect_timeout, :safe, :logger, :connect]
     CONNECTION_OPTS = [:slave_ok]
 
@@ -312,7 +313,13 @@ module Mongo
     # @return [Mongo::DB]
     #
     # @core databases db-instance_method
-    def db(db_name, opts={})
+    def db(db_name=nil, opts={})
+      if !db_name && uri = ENV['MONGODB_URI']
+        db_name = uri[%r{/([^/\?]+)(\?|$)}, 1]
+      end
+
+      db_name ||= DEFAULT_DB_NAME
+
       DB.new(db_name, self, opts)
     end
 
@@ -325,22 +332,6 @@ module Mongo
     # @core databases []-instance_method
     def [](db_name)
       DB.new(db_name, self)
-    end
-
-    # Return the database specified in ENV['MONGODB_URI']
-    #
-    # @param [String] uri the uri to use
-    # @param [Hash] opts options to be passed to the DB constructor.
-    #
-    # @return [Mongo::DB]
-    #
-    # @core databases db_from_uri-instance_method
-    def db_from_uri(uri=ENV['MONGODB_URI'], opts={})
-      if db_name = uri[%r{/([^/\?]+)(\?|$)}, 1]
-        DB.new(db_name, self, opts)
-      else
-        raise ArgumentError.new("No database name found in #{uri}")
-      end
     end
 
     # Drop a database.

--- a/test/connection_test.rb
+++ b/test/connection_test.rb
@@ -89,7 +89,7 @@ class TestConnection < Test::Unit::TestCase
       old_mongodb_uri = ENV['MONGODB_URI']
       ENV['MONGODB_URI'] = "mongodb://#{host_port}/#{db_name}"
       con = Connection.from_uri
-      db = con.db_from_uri
+      db = con.db
       assert_equal db.name, db_name
     ensure
       ENV['MONGODB_URI'] = old_mongodb_uri
@@ -103,7 +103,7 @@ class TestConnection < Test::Unit::TestCase
       old_mongodb_uri = ENV['MONGODB_URI']
       ENV['MONGODB_URI'] = "mongodb://#{host_port}/#{db_name}?"
       con = Connection.from_uri
-      db = con.db_from_uri
+      db = con.db
       assert_equal db.name, db_name
     ensure
       ENV['MONGODB_URI'] = old_mongodb_uri
@@ -115,8 +115,8 @@ class TestConnection < Test::Unit::TestCase
       old_mongodb_uri = ENV['MONGODB_URI']
       ENV['MONGODB_URI'] = "mongodb://#{host_port}/"
       con = Connection.from_uri
-
-      assert_raise ArgumentError do con.db_from_uri end
+      db = con.db
+      assert_equal db.name, Mongo::Connection::DEFAULT_DB_NAME
     ensure
       ENV['MONGODB_URI'] = old_mongodb_uri
     end


### PR DESCRIPTION
The new `ENV['MONGODB_URI']` support does everything but allow you to automatically connect to the database name provided in the URI. This pull adds `Mongo::Connection#db_from_uri` which returns a `Mongo::DB` named after the database name given in `ENV['MONGODB_URI']`:

``` ruby
ENV['MONGODB_URI'] = 'mongodb://my.database.host/database'

conn = Mongo::Connection.new
db = conn.db_from_uri
db.name #=> "database"
```
