### PR TITLE
Revert ObjectId#to_ary

### DIFF
--- a/lib/bson/types/object_id.rb
+++ b/lib/bson/types/object_id.rb
@@ -116,13 +116,6 @@ module BSON
       @data.dup
     end
 
-    # Returns the object id as a single element in an array for use with Kernel#Array
-    #
-    # @return [Array]
-    def to_ary
-      [ self ]
-    end
-
     # Given a string representation of an ObjectId, return a new ObjectId
     # with that value.
     #

--- a/test/bson/object_id_test.rb
+++ b/test/bson/object_id_test.rb
@@ -136,9 +136,13 @@ class ObjectIdTest < Test::Unit::TestCase
     assert_equal({"$oid" => id.to_s}, id.as_json)
   end
 
-  def test_to_ary
+  def test_object_id_array_flatten
     id = ObjectId.new
-    assert_equal [id], id.to_ary
-    assert_equal Array(id), id.to_ary
+    assert_equal [ id ], [[ id ]].flatten
+  end
+
+  def test_object_id_array_flatten_bang
+    id = ObjectId.new
+    assert_equal [ id ], [[ id ]].flatten!
   end
 end


### PR DESCRIPTION
The introduction of commit 078354a39a985d84e8597425535f7b6b3c3fdfcf breaks any application that would attempt to flatten an array of object ids, forcing it to appear hung and never exiting (and really hard to debug for those who don't have a good knowledge of Ruby's core API). Since we do this in Mongoid, and I'm sure many others do, release 1.6.3 is unusable.

The proper implementation of this would be to return `nil` from `BSON::ObjectId#to_ary` in order to allow proper flattening as well as allowing for `Kernel.Array` to work properly. However `BSON::ObjectId` does not follow Ruby conventions with respect to `BSON::ObjectId#to_a` either, which returns the internal data instead of the object id wrapped in an array.

I was about to re-implement `BSON::ObjectId#to_a` as well, however this has repercussions as there are current expectations around what `BSON::ObjectId#to_a` returns in the driver albeit incorrect. So this pull is simply to get the driver back to a reusable state with tests around `Array#flatten` and `Array#flatten!` to ensure this isn't broken again.

There needs to be an overhaul of this class with regards to core Ruby APIs and what they are expected to return, as simple changes like this have rippling affects. `BSON::ObjectId#to_a` needs to change to adhere to this, but it's going to break other things as well. IMO it's best to stay with the existing functionality to not be breaking apps in patch releases.
