### PR TITLE
Require 'jruby' in bson_java.rb

### DIFF
--- a/lib/bson/bson_java.rb
+++ b/lib/bson/bson_java.rb
@@ -1,3 +1,5 @@
+require 'jruby'
+
 include Java
 module BSON
   class BSON_JAVA


### PR DESCRIPTION
This prevents bson from failing with the following error on JRuby 1.7.0:

    NoMethodError: undefined method `runtime' for JRuby:Module
                    serialize at .../gems/bson-1.7.0-java/lib/bson/bson_java.rb:9
