### PR TITLE
Serialize ActiveSupport::Multibyte::Chars as String

### DIFF
--- a/ext/cbson/cbson.c
+++ b/ext/cbson/cbson.c
@@ -457,6 +457,16 @@ static int write_element(VALUE key, VALUE value, VALUE extra, int allow_id) {
                 rb_raise(InvalidDocument, "Cannot serialize the Numeric type %s as BSON; only Bignum, Fixnum, and Float are supported.", cls);
                 break;
             }
+            if (strcmp(cls, "ActiveSupport::Multibyte::Chars") == 0) {
+                int length;
+                VALUE str = StringValue(value);
+                write_name_and_type(buffer, key, 0x02);
+                length = RSTRING_LENINT(str) + 1;
+                SAFE_WRITE(buffer, (char*)&length, 4);
+                write_utf8(buffer, str, 0);
+                SAFE_WRITE(buffer, &zero, 1);
+                break;
+            }
             bson_buffer_free(buffer);
             rb_raise(InvalidDocument, "Cannot serialize an object of class %s into BSON.", cls);
             break;

--- a/lib/bson/bson_ruby.rb
+++ b/lib/bson/bson_ruby.rb
@@ -628,7 +628,9 @@ module BSON
         raise InvalidDocument, "#{o.class} is not currently supported; " +
         "use a UTC Time instance instead."
       else
-        if defined?(ActiveSupport::TimeWithZone) && o.is_a?(ActiveSupport::TimeWithZone)
+        if defined?(ActiveSupport::Multibyte::Chars) && o.is_a?(ActiveSupport::Multibyte::Chars)
+          STRING
+        elsif defined?(ActiveSupport::TimeWithZone) && o.is_a?(ActiveSupport::TimeWithZone)
           raise InvalidDocument, "ActiveSupport::TimeWithZone is not currently supported; " +
           "use a UTC Time instance instead."
         else


### PR DESCRIPTION
ActiveSupport::Multibyte::Chars is really a utility class for working with multibyte strings. It can be safely converted serialized as String. The thing is, Rails and especially ActionMailer are using this class all over.
