### PR TITLE
Make it easier to use bson out of git with bundler

### DIFF
--- a/bson.gemspec
+++ b/bson.gemspec
@@ -1,5 +1,5 @@
 $:.unshift(File.join(File.dirname(__FILE__), 'lib'))
-require 'bson'
+require 'bson/version'
 
 Gem::Specification.new do |s|
   s.name = 'bson'

--- a/bson.java.gemspec
+++ b/bson.java.gemspec
@@ -1,5 +1,5 @@
 $:.unshift(File.join(File.dirname(__FILE__), 'lib'))
-require 'bson'
+require 'bson/version'
 
 Gem::Specification.new do |s|
   s.name = 'bson'

--- a/bson_ext.gemspec
+++ b/bson_ext.gemspec
@@ -1,18 +1,18 @@
 $:.unshift(File.join(File.dirname(__FILE__), 'lib'))
-require 'bson'
+require 'bson/version'
 
-VERSION_HEADER = File.open(File.join(File.dirname(__FILE__), 'ext', 'cbson', 'version.h'), "r")
-VERSION        = VERSION_HEADER.read.scan(/VERSION "(\d[^"]+)"/)[0][0]
+BSON_VERSION_HEADER = File.open(File.join(File.dirname(__FILE__), 'ext', 'cbson', 'version.h'), "r")
+BSON_VERSION        = BSON_VERSION_HEADER.read.scan(/VERSION "(\d[^"]+)"/)[0][0]
 Gem::Specification.new do |s|
   s.name = 'bson_ext'
 
-  s.version  = VERSION
+  s.version  = BSON_VERSION
   s.platform = Gem::Platform::RUBY
   s.summary  = 'C extensions for Ruby BSON.'
   s.description = 'C extensions to accelerate the Ruby BSON serialization. For more information about BSON, see http://bsonspec.org.  For information about MongoDB, see http://www.mongodb.org.'
   s.rubyforge_project = 'nowarning'
 
-  s.require_paths = ['ext']
+  s.require_paths = ['ext/bson_ext']
   s.files = ['Rakefile', 'bson_ext.gemspec']
   s.files += Dir['ext/**/*.rb'] + Dir['ext/**/*.c'] + Dir['ext/**/*.h']
   s.test_files = []


### PR DESCRIPTION
Requiring the entirety of the bson libraries in the gemspec can cause
them to establish state before all of the relevant pieces are in
place. In particular, loading bson can cause the bson gem to conclude
that bson_ext isn't available, when in fact its gemspec just hasn't
been parsed yet.
