### PR TITLE
Only let the right mapreduce queries go to secondaries

### DIFF
--- a/lib/mongo/util/support.rb
+++ b/lib/mongo/util/support.rb
@@ -69,10 +69,10 @@ module Mongo
       command = selector.keys.first.to_s.downcase
 
       if command == 'mapreduce'
-        map_reduce = selector[command]
-        if map_reduce && map_reduce.is_a?(Hash) && map_reduce.has_key?('out')
-          map_reduce['out'] == 'inline' ? false : true
-        end
+        out = selector.select { |k, v| k.to_s.downcase == 'out' }.first.last
+        # mongo looks at the first key in the out object, and doesn't
+        # look at the value
+        out.is_a?(Hash) && out.keys.first.to_s.downcase == 'inline' ? true : false
       else
         SECONDARY_OK_COMMANDS.member?(command)
       end

--- a/test/unit/util_test.rb
+++ b/test/unit/util_test.rb
@@ -1,0 +1,55 @@
+require File.expand_path("../../test_helper", __FILE__)
+
+class UtilTest < Test::Unit::TestCase
+  context "Support" do
+    context ".secondary_ok?" do
+      should "return false for mapreduces with a string for out" do
+        assert_equal false, Mongo::Support.secondary_ok?(BSON::OrderedHash[
+            'mapreduce', 'test-collection',
+            'out', 'new-test-collection'
+          ])
+      end
+
+      should "return false for mapreduces replacing a collection" do
+        assert_equal false, Mongo::Support.secondary_ok?(BSON::OrderedHash[
+            'mapreduce', 'test-collection',
+            'out', BSON::OrderedHash['replace', 'new-test-collection']
+          ])
+      end
+
+      should "return false for mapreduces replacing the inline collection" do
+        assert_equal false, Mongo::Support.secondary_ok?(BSON::OrderedHash[
+            'mapreduce', 'test-collection',
+            'out', 'inline'
+          ])
+      end
+
+      should "return true for inline output mapreduces when inline is a symbol" do
+        assert_equal true, Mongo::Support.secondary_ok?(BSON::OrderedHash[
+            'mapreduce', 'test-collection',
+            'out', BSON::OrderedHash[:inline, 'true']
+          ])
+      end
+
+      should "return true for inline output mapreduces when inline is a string" do
+        assert_equal true, Mongo::Support.secondary_ok?(BSON::OrderedHash[
+            'mapreduce', 'test-collection',
+            'out', BSON::OrderedHash['inline', 'true']
+          ])
+      end
+
+      should 'return true for count' do
+        assert_equal true, Mongo::Support.secondary_ok?(BSON::OrderedHash[
+            'count', 'test-collection',
+            'query', BSON::OrderedHash['a', 'b']
+          ])
+      end
+
+      should 'return false for serverStatus' do
+        assert_equal false, Mongo::Support.secondary_ok?(BSON::OrderedHash[
+            'serverStatus', 1
+          ])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Specifically, they should have an out parameter, the value of that out
parameter should be a hash, and the first key of that hash should be
the string or symbol inline.

Right now, secondary_ok? will return true for mapreduces if :out is not the string 'inline'.
