### PR TITLE
Fix pool pinning semantics with :{primary,secondary}_preferred

### DIFF
--- a/lib/mongo/util/pool.rb
+++ b/lib/mongo/util/pool.rb
@@ -90,8 +90,8 @@ module Mongo
     end
 
     def matches_mode(mode)
-      if mode == :primary && @node.secondary? ||
-        mode == :secondary && @node.primary?
+      if [:primary, :primary_preferred].include?(mode) && @node.secondary? ||
+          [:secondary, :secondary_preferred].include?(mode) && @node.primary?
         false
       else
         true


### PR DESCRIPTION
When specifying :read => :secondary_preferred, I expect queries to
only go to a primary if no secondaries are available (and
vice-versa). Because the unpinning logic only unpins for :primary and
:secondary queries, it's possible that a query with :read =>
:secondary_preferred is routed immediately to a primary (without
checking for secondaries) because that primary was the pinned node.

Solve this by unpinning for :{primary,secondary}_preferred as well as
:{primary,secondary}. In the case that, e.g., no primary is available
when a :read => :primary query is made, this will be slightly less
efficient as it could have used the pinning, but that should be fairly
uncommon anyway.
