### PR TITLE
Fixing to HashWithIndifferentAccess exception

### DIFF
--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -87,6 +87,9 @@ else
   end
 end
 
+require 'active_support'
+require 'active_support/hash_with_indifferent_access'
+
 require 'bson/types/binary'
 require 'bson/types/code'
 require 'bson/types/dbref'


### PR DESCRIPTION
Fixing to following exception: 

```
.../gems/bson-1.7.0/lib/bson/ordered_hash.rb:25: 
uninitialized constant BSON::HashWithIndifferentAccess (NameError)
```
