### PR TITLE
If sending data on a socket fails, close the socket.

### DIFF
--- a/lib/mongo/networking.rb
+++ b/lib/mongo/networking.rb
@@ -282,6 +282,7 @@ module Mongo
       end
       total_bytes_sent
       rescue => ex
+        socket.close
         raise ConnectionFailure, "Operation failed with the following exception: #{ex}:#{ex.message}"
       end
     end


### PR DESCRIPTION
This mirrors the behavior on receive, and can prevent a situation
where we keep trying to use the same socket to send data after a
connection is dropped.
