### PR TITLE
Add a failing test case around cursors and secondary reads.

### DIFF
--- a/test/replica_set/query_test.rb
+++ b/test/replica_set/query_test.rb
@@ -44,6 +44,27 @@ class ReplicaSetQueryTest < Test::Unit::TestCase
     end
   end
 
+  # Create a large collection and do a secondary query that returns
+  # enough records to require sending a GETMORE. In between opening
+  # the cursor and sending the GETMORE, do a :primary query. Confirm
+  # that the cursor reading from the secondary continues to talk to
+  # the secondary, rather than trying to read the cursor from the
+  # primary, where it does not exist.
+  def test_secondary_getmore
+    200.times do |i|
+      @coll.save({:a => i}, :safe => {:w => 3})
+    end
+    as = []
+    # Set an explicit batch size, in case the default ever changes.
+    @coll.find({}, { :batch_size => 100, :read => :secondary }) do |c|
+      c.each do |result|
+        as << result['a']
+        @coll.find({:a => result['a']}, :read => :primary).map
+      end
+    end
+    assert_equal(as.sort, 0.upto(199).to_a)
+  end
+
   def benchmark_queries
     t1 = Time.now
     10000.times { @coll.find_one }


### PR DESCRIPTION
If we do a secondary read that is large enough to require sending a
GETMORE, and then do another query before the GETMORE, the secondary
connection gets unpinned, and the GETMORE gets sent to the wrong
server, resulting in CURSOR_NOT_FOUND, even though the cursor still
exists on the server that was initially queried.

(I don't know if there is a way to mark a test that is expected to fail for now; I expect this shouldn't be merged as-is, but a pull request seemed like the right way to submit this, since I'd like to see some sort of test merged once the bug is fixed)
