### PR TITLE
a bit more detailed logging time

### DIFF
--- a/lib/mongo/util/logging.rb
+++ b/lib/mongo/util/logging.rb
@@ -50,7 +50,7 @@ module Mongo
     def log_operation(name, payload, duration)
       @logger && @logger.debug do
         msg = "MONGODB "
-        msg << "(#{(duration * 1000).to_i}ms) "
+        msg << "(%.1fms) " % (duration * 1000)
         msg << "#{payload[:database]}['#{payload[:collection]}'].#{name}("
         msg << payload.values_at(:selector, :document, :documents, :fields ).compact.map(&:inspect).join(', ') + ")"
         msg << ".skip(#{payload[:skip]})"   if payload[:skip]

--- a/test/functional/connection_test.rb
+++ b/test/functional/connection_test.rb
@@ -198,7 +198,7 @@ class TestConnection < Test::Unit::TestCase
     logger = Logger.new(output)
     logger.level = Logger::DEBUG
     standard_connection(:logger => logger).db(MONGO_TEST_DB)
-    assert_match(/\(\d+ms\)/, output.string)
+    assert_match(/\(\d+.\d{1}ms\)/, output.string)
     assert output.string.include?("admin['$cmd'].find")
   end
 


### PR DESCRIPTION
log `MONGO (1.3ms) ...` instead of `MONGO (1ms) ...`
