### PR TITLE
ActiveSupport 2 compatibility issue

### DIFF
--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -86,7 +86,12 @@ else
 end
 
 require 'active_support'
-require 'active_support/hash_with_indifferent_access'
+begin
+  require 'active_support/hash_with_indifferent_access'
+rescue LoadError
+  # For ActiveSupport 2
+  require 'active_support/core_ext/hash/indifferent_access'
+end
 
 require 'bson/types/binary'
 require 'bson/types/code'


### PR DESCRIPTION
We're still on Rails 2 / ActiveSupport 2. The require path for hash with indifferent access changed between ActiveSupport 2 and 3.
