### PR TITLE
Mongo::Pool: Always try at least once to get a socket.

### DIFF
--- a/lib/mongo/util/pool.rb
+++ b/lib/mongo/util/pool.rb
@@ -267,12 +267,6 @@ module Mongo
       @client.connect if !@client.connected?
       start_time = Time.now
       loop do
-        if (Time.now - start_time) > @timeout
-          raise ConnectionTimeoutError, "could not obtain connection within " +
-            "#{@timeout} seconds. The max pool size is currently #{@size}; " +
-            "consider increasing the pool size or timeout."
-        end
-
         @connection_mutex.synchronize do
           if socket_for_thread = thread_local[:sockets][self.object_id]
             if !@checked_out.include?(socket_for_thread)
@@ -306,6 +300,12 @@ module Mongo
             # Otherwise, wait
             @queue.wait(@connection_mutex)
           end
+        end
+
+        if (Time.now - start_time) > @timeout
+          raise ConnectionTimeoutError, "could not obtain connection within " +
+            "#{@timeout} seconds. The max pool size is currently #{@size}; " +
+            "consider increasing the pool size or timeout."
         end
       end
     end


### PR DESCRIPTION
This is a bit of a screw case, but we have occasionally seen spurious ConnectionTimeoutError's on single-threaded programs that I suspect are attributable to this. I suspect that the specific case is if you happen to trigger a GC in between entering the function and checking the timeout, and the machine is hosed enough (e.g. swapping heavily)

Obviously, ideally machines would never get this loaded, but I think it's preferable that we don't cause spurious timeouts if it does --  this patch gives us the guarantee that if there is an available socket, a single-threaded program will always successfully check one out, which feels like desirable semantics -- basically, it means that single-threaded programs always behave as though there were just a single socket, with no pooling.

---

On heavily-loaded machines with a small timeout, it is actually
possible for the timeout to expire before even a single pass through
the checkout loop. This results in throwing ConnectionTimeoutError's,
even though nothing directly mongo-related is actually timing out or
going wrong.

Always pass through the loop at least once before timing out, so that
we are guaranteed to find a socket if there is one immediately
available.
