### PR TITLE
Restore some commented-out test cases for replset edge cases.

### DIFF
--- a/test/replica_set/client_test.rb
+++ b/test/replica_set/client_test.rb
@@ -94,75 +94,90 @@ class ClientTest < Test::Unit::TestCase
     @client[MONGO_TEST_DB]['bar'].find_one
   end
 
-  #def test_connect_with_first_node_removed
-  #  @client = MongoReplicaSetClient.new @rs.repl_set_seeds
-  #  @client[MONGO_TEST_DB]['bar'].save({:a => 1}, {:w => 2})
-  #
-  #  old_primary = [@client.primary_pool.host, @client.primary_pool.port]
-  #  old_primary_conn = Mongo::MongoClient.new(*old_primary)
-  #  assert_raise Mongo::ConnectionFailure do
-  #    old_primary_conn['admin'].command(step_down_command)
-  #  end
-  #
-  #  # Wait for new primary
-  #  rescue_connection_failure do
-  #    sleep 1 until @rs.get_node_with_state(1)
-  #  end
-  #
-  #  new_primary = @rs.get_all_host_pairs_with_state(1).first
-  #  new_primary_conn = Mongo::MongoClient.new(*new_primary)
-  #
-  #  config = nil
-  #
-  #  # Remove old primary from replset
-  #  rescue_connection_failure do
-  #    config = @client['local']['system.replset'].find_one
-  #  end
-  #
-  #  old_member = config['members'].select {|m| m['host'] == old_primary.join(':')}.first
-  #  config['members'].reject! {|m| m['host'] == old_primary.join(':')}
-  #  config['version'] += 1
-  #
-  #  begin
-  #    new_primary_conn['admin'].command({'replSetReconfig' => config})
-  #  rescue Mongo::ConnectionFailure
-  #  end
-  #
-  #  # Wait for the dust to settle
-  #  rescue_connection_failure do
-  #    assert @client[MONGO_TEST_DB]['bar'].find_one
-  #  end
-  #
-  #  # Make sure a new connection skips the old primary
-  #  @new_conn = MongoReplicaSetClient.new @rs.repl_set_seeds
-  #  @new_conn.connect
-  #  new_nodes = [@new_conn.primary] + @new_conn.secondaries
-  #  assert !(new_nodes).include?(old_primary)
-  #
-  #  # Add the old primary back
-  #  config['members'] << old_member
-  #  config['version'] += 1
-  #
-  #  begin
-  #    new_primary_conn['admin'].command({'replSetReconfig' => config})
-  #  rescue Mongo::ConnectionFailure
-  #  end
-  #end
+  def test_connect_with_first_node_removed
+    @client = MongoReplicaSetClient.new @rs.repl_set_seeds
+    @client[MONGO_TEST_DB]['bar'].save({:a => 1}, {:w => 2})
 
-  #def test_connect_with_hung_first_node
-  #  hung_node = nil
-  #  begin
-  #    hung_node = IO.popen('nc -lk 127.0.0.1 29999 >/dev/null 2>&1')
-  #
-  #    @client = MongoReplicaSetClient.new(['localhost:29999'] + @rs.repl_set_seeds,
-  #                                  :connect_timeout => 2)
-  #    @client.connect
-  #    assert ['localhost:29999'] != @client.primary
-  #    assert !@client.secondaries.include?('localhost:29999')
-  #  ensure
-  #    Process.kill("KILL", hung_node.pid) if hung_node
-  #  end
-  #end
+    sleep(5)
+
+    old_primary = @rs.primary.host_port_a
+    old_primary_conn = Mongo::MongoClient.new(*old_primary)
+
+    assert_raise Mongo::ConnectionFailure do
+      # Don't use step_down_command -- we *want* to make sure that the
+      # other node gets elected
+      old_primary_conn['admin'].command(:replSetStepDown => 60)
+    end
+
+    assert(!old_primary_conn['admin'].command({:ismaster => 1})['ismaster'])
+
+    # Wait for new primary
+    rescue_connection_failure do
+      sleep 1 until @rs.primary_name
+    end
+
+    new_primary = @rs.primary.host_port_a
+    new_primary_conn = Mongo::MongoClient.new(*new_primary)
+
+    assert(old_primary != new_primary)
+
+    config = nil
+
+    # Remove old primary from replset
+    rescue_connection_failure do
+      config = @client['local']['system.replset'].find_one
+    end
+
+    old_member = config['members'].select {|m| m['host'] == old_primary.join(':')}.first
+    config['members'].reject! {|m| m['host'] == old_primary.join(':')}
+    config['version'] += 1
+
+    begin
+      new_primary_conn['admin'].command({'replSetReconfig' => config})
+    rescue Mongo::ConnectionFailure
+    end
+
+    # Wait for the dust to settle
+    rescue_connection_failure do
+      assert @client[MONGO_TEST_DB]['bar'].find_one
+    end
+
+    # Make sure a new connection skips the old primary
+    @new_conn = MongoReplicaSetClient.new @rs.repl_set_seeds
+    @new_conn.connect
+    new_nodes = Set.new([@new_conn.primary]) + @new_conn.secondaries
+    assert !(new_nodes).include?(old_primary)
+
+    # Add the old primary back
+    config['members'] << old_member
+    config['version'] += 1
+
+    begin
+      new_primary_conn['admin'].command({'replSetReconfig' => config})
+    rescue Mongo::ConnectionFailure
+    end
+  end
+
+  def test_connect_with_hung_first_node
+    hung_node = nil
+    begin
+      hung_node = Thread.new do
+        srv = TCPServer.new('127.0.0.1', 29999)
+        socks = []
+        loop { socks << srv.accept }
+      end
+
+      Timeout::timeout(30, Mongo::OperationTimeout) do
+        @connection = ReplSetConnection.new(['localhost:29999'] + @rs.repl_set_seeds,
+                                            :connect_timeout => 2)
+        @connection.connect
+      end
+      assert ['localhost:29999'] != @connection.primary
+      assert !@connection.secondaries.include?('localhost:29999')
+    ensure
+      Thread.kill(hung_node) if hung_node
+    end
+  end
 
   def test_connect_with_connection_string
     @client = MongoClient.from_uri("mongodb://#{@rs.replicas[0].host_port},#{@rs.replicas[1].host_port}?replicaset=#{@rs.repl_set_name}")

--- a/test/replica_set/connection_test.rb
+++ b/test/replica_set/connection_test.rb
@@ -108,5 +108,4 @@ class ConnectionTest < Test::Unit::TestCase
     assert @connection.connected?
     assert_equal 1, @connection.write_concern[:w]
   end
-
 end


### PR DESCRIPTION
These were commented-out in f91a41d054595f43374a13e63afac120458a43f7
along with some test reorganization. Reinstate them, and update them
for test-suite changes since then.
