### PR TITLE
Always get primary pool with a sharded client. (RUBY-542)

### DIFF
--- a/lib/mongo/util/read_preference.rb
+++ b/lib/mongo/util/read_preference.rb
@@ -34,6 +34,8 @@ module Mongo
     end
 
     def select_pool(mode, tags, latency)
+      return primary_pool if @client.mongos?
+
       if mode == :primary && !tags.empty?
         raise MongoArgumentError, "Read preferecy :primary cannot be combined with tags"
       end


### PR DESCRIPTION
In the case of a sharded client, all of our nodes that are provided
should be mongos nodes, and thus all should be primary. The read
preference thusly is not handled by the driver, but by the mongos server
and all read operations should pass through the primary mongos.

The case where we have multiple mongos is not handled here, as the
driver does not currently support having multiple primary nodes
configured. I've put a TODO in `ReadPreference` to indicate this, the question
is whether or not this is something that should be done or not.

[ RUBY-542 ]
