### PR TITLE
Initialize MongoShardedClient with MONGODB_URI.

### DIFF
--- a/lib/mongo/util/uri_parser.rb
+++ b/lib/mongo/util/uri_parser.rb
@@ -140,8 +140,8 @@ module Mongo
     # @note Don't confuse this with attribute getter method #connect.
     #
     # @return [MongoClient,MongoReplicaSetClient]
-    def connection(extra_opts, legacy=false)
-      opts = connection_options.merge! extra_opts
+    def connection(extra_opts, legacy = false, sharded = false)
+      opts = connection_options.merge!(extra_opts)
       if(legacy)
         if replicaset?
           ReplSetConnection.new(node_strings, opts)
@@ -149,7 +149,9 @@ module Mongo
           Connection.new(host, port, opts)
         end
       else
-        if replicaset?
+        if sharded
+          MongoShardedClient.new(node_strings, opts)
+        elsif replicaset?
           MongoReplicaSetClient.new(node_strings, opts)
         else
           MongoClient.new(host, port, opts)

--- a/test/functional/uri_test.rb
+++ b/test/functional/uri_test.rb
@@ -174,4 +174,27 @@ class URITest < Test::Unit::TestCase
     parser = Mongo::URIParser.new("mongodb://localhost:27018?readPreference=nearest")
     assert_nil parser.connection_options[:read]
   end
+
+  def test_connection_when_sharded_with_no_options
+    parser = Mongo::URIParser.new("mongodb://localhost:27017,localhost:27018")
+    client = parser.connection({}, false, true)
+    assert_equal [[ "localhost", 27017 ], [ "localhost", 27018 ]], client.seeds
+    assert_true client.mongos?
+  end
+
+  def test_connection_when_sharded_with_options
+    parser = Mongo::URIParser.new("mongodb://localhost:27017,localhost:27018")
+    client = parser.connection({ :refresh_interval => 10 }, false, true)
+    assert_equal [[ "localhost", 27017 ], [ "localhost", 27018 ]], client.seeds
+    assert_equal 10, client.refresh_interval
+    assert_true client.mongos?
+  end
+
+  def test_connection_when_sharded_with_uri_options
+    parser = Mongo::URIParser.new("mongodb://localhost:27017,localhost:27018?readPreference=nearest")
+    client = parser.connection({}, false, true)
+    assert_equal [[ "localhost", 27017 ], [ "localhost", 27018 ]], client.seeds
+    assert_equal :nearest, client.read
+    assert_true client.mongos?
+  end
 end

--- a/test/unit/mongo_sharded_client_test.rb
+++ b/test/unit/mongo_sharded_client_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class MongoShardedClientTest < Test::Unit::TestCase
+  include Mongo
+
+  def setup
+    ENV["MONGODB_URI"] = nil
+  end
+
+  def test_initialize_with_single_mongos_uri
+    ENV["MONGODB_URI"] = "mongodb://localhost:27017"
+    client = MongoShardedClient.new
+    assert_equal [[ "localhost", 27017 ]], client.seeds
+  end
+
+  def test_initialize_with_multiple_mongos_uris
+    ENV["MONGODB_URI"] = "mongodb://localhost:27017,localhost:27018"
+    client = MongoShardedClient.new
+    assert_equal [[ "localhost", 27017 ], [ "localhost", 27018 ]], client.seeds
+  end
+
+  def test_from_uri_with_string
+    client = MongoShardedClient.from_uri("mongodb://localhost:27017,localhost:27018")
+    assert_equal [[ "localhost", 27017 ], [ "localhost", 27018 ]], client.seeds
+  end
+
+  def test_from_uri_with_env_variable
+    ENV["MONGODB_URI"] = "mongodb://localhost:27017,localhost:27018"
+    client = MongoShardedClient.from_uri
+    assert_equal [[ "localhost", 27017 ], [ "localhost", 27018 ]], client.seeds
+  end
+end


### PR DESCRIPTION
This fixes the errors that were occurring when instantiating a
MongoShardedClient when a MONGODB_URI environment variable is present.
This also fixes MongoShardedClient.from_uri to properly get a
MongoShardedClient connection from the URIParser.

[ RUBY-541 ]
