### PR TITLE
minor: fix race condition in refresh test

### DIFF
--- a/test/tools/mongo_config.rb
+++ b/test/tools/mongo_config.rb
@@ -442,12 +442,12 @@ module Mongo
         members_by_name(secondary_names)
       end
 
-      def kill_primary
-        primary.kill
+      def stop_primary
+        primary.stop
       end
 
-      def kill_secondary
-        secondaries[rand(secondaries.length)].kill
+      def stop_secondary
+        secondaries[rand(secondaries.length)].stop
       end
 
       def replicas


### PR DESCRIPTION
Before 5ca92265ac89762de8585278ada0d3902c82468f our set consisted of two data nodes and an arbiter.
- Primary
- Secondary
- Arbiter

Now we have three data nodes so killing all secondaries causes the majority of the set to be down.
- Primary
- Secondary (X)
- Secondary (X)

As we know, this means the existing primary will step itself down once it notices the majority of the set is not up. It is just by coincidence that some of the refresh tests pass before that can occur. Sometimes that is not the case and we see an error during testing.

This pull request is meant to fix that problem and make the tests more robust in the future by using num_secondaries instead of hardcoded numbers.

To elaborate, the main change is that we go from a read preference of `:secondary_preferred` to a read preference of `:secondary` in order to test that refresh is in fact refreshing the view of the set and switching its view of the read pool appropriately. When using read preference of secondary, the query will raise an error if they don't exist. Then, when the members are restarted, they should reappear and be queryable via automated refresh. That requires calling refresh before we checkout a reader.

Historically, :refresh_mode => :sync was not intended to detect additions the set but only down or removed nodes so this can also be considered an enhancement to existing behavior.
