### PR TITLE
minor: further fix race condition in refresh test

### DIFF
--- a/test/tools/mongo_config.rb
+++ b/test/tools/mongo_config.rb
@@ -430,8 +430,12 @@ module Mongo
 
       def members_by_name(names)
         names.collect do |name|
-          servers.find{|server| server.host_port == name}
+          member_by_name(name)
         end.compact
+      end
+
+      def member_by_name(name)
+        servers.find{|server| server.host_port == name}
       end
 
       def primary


### PR DESCRIPTION
In the first test, test_connect_and_manual_refresh_with_secondary_down, I'm stopping only one secondary as opposed to all of them so that the primary doesn't step itself down and become a secondary. I assert that the number of secondaries has decreased by one after a refresh.

In the second test, test_automated_refresh_with_secondary_down, I stop the secondary that has been pinned for reads. Then I assert that the version and read pool change after an automatic refresh.
