### PR TITLE
RUBY-564 Support for (hashed, text, 2dsphere) index types

### DIFF
--- a/lib/mongo.rb
+++ b/lib/mongo.rb
@@ -2,7 +2,18 @@ module Mongo
   ASCENDING   =  1
   DESCENDING  = -1
   GEO2D       = '2d'
+  GEO2DSPHERE = '2dsphere'
   GEOHAYSTACK = 'geoHaystack'
+  TEXT        = 'text'
+  HASHED      = 'hashed'
+  INDEX_TYPES = [ ASCENDING,
+                  DESCENDING,
+                  GEO2D,
+                  GEO2DSPHERE,
+                  GEOHAYSTACK,
+                  TEXT,
+                  HASHED
+                ]
 
   DEFAULT_MAX_BSON_SIZE = 4 * 1024 * 1024
   DEFAULT_MAX_MESSAGE_SIZE = DEFAULT_MAX_BSON_SIZE * 2

--- a/lib/mongo/db.rb
+++ b/lib/mongo/db.rb
@@ -441,7 +441,7 @@ module Mongo
     #
     # @param [String] collection_name
     #
-    # @return [Hash] keys are index names and the values are lists of [key, direction] pairs
+    # @return [Hash] keys are index names and the values are lists of [key, type] pairs
     #   defining the index.
     def index_information(collection_name)
       sel  = {:ns => full_collection_name(collection_name)}

--- a/test/functional/collection_test.rb
+++ b/test/functional/collection_test.rb
@@ -1252,10 +1252,34 @@ end
       assert_nil @geo.index_information['baz']
     end
 
+    #should "create a text index" do
+    #  @geo.save({'title' => "some text"})
+    #  @geo.create_index([['title', Mongo::TEXT]])
+    #  assert @geo.index_information['title_text']
+    #end
+
+    should "create a hashed index" do
+      @geo.save({'a' => 1})
+      @geo.create_index([['a', Mongo::HASHED]])
+      assert @geo.index_information['a_hashed']
+    end
+
     should "create a geospatial index" do
       @geo.save({'loc' => [-100, 100]})
       @geo.create_index([['loc', Mongo::GEO2D]])
       assert @geo.index_information['loc_2d']
+    end
+
+    should "create a geoHaystack index" do
+      @geo.save({ "_id" => 100, "pos" => { "long" => 126.9, "lat" => 35.2 }, "type" => "restaurant"})
+      @geo.create_index([['pos', Mongo::GEOHAYSTACK], ['type', Mongo::ASCENDING]], :bucket_size => 1)
+      puts @geo.index_information['loc_geoHaystack_type_1']
+    end
+
+    should "create a geo 2dsphere index" do
+      @collection.insert({"coordinates" => [ 5 , 5 ], "type" => "Point"})
+      @geo.create_index([['coordinates', Mongo::GEO2DSPHERE]])
+      assert @geo.index_information['coordinates_2dsphere']
     end
 
     should "create a unique index" do

--- a/test/unit/collection_test.rb
+++ b/test/unit/collection_test.rb
@@ -106,7 +106,7 @@ class CollectionTest < Test::Unit::TestCase
       @coll.ensure_index [["x", Mongo::DESCENDING]]
     end
 
-    should "call generate_indexes for a new direction on the same field for ensure_index" do
+    should "call generate_indexes for a new type on the same field for ensure_index" do
       @client = MongoClient.new('localhost', 27017, :logger => @logger, :connect => false)
       @db   = @client['testing']
       @coll = @db.collection('books')


### PR DESCRIPTION
In Mongo module: Added in constants for hashed, text, and 2dsphere index types.  Added array constant for index types.

Added in conversion of bucket_size to bucketSize for use with geoHaystack indexes in the create_index and ensure_index methods on a collection.

Included hashed, text and 2dsphere in the list of valid index types when creating an index.

Wrote tests that ensure 2dsphere, text, geoHaystack, and hashed indexes can be created.  NOTE: the test on a text index is commented out because the server must be started with 'setParameter textSearchEnabled=1'

Updated documentation for all affected methods, specifically references to index types as "directions".
