### PR TITLE
RUBY-529 raise exception for multiple attempts to auth on the same db

### DIFF
--- a/lib/mongo/util/uri_parser.rb
+++ b/lib/mongo/util/uri_parser.rb
@@ -285,7 +285,7 @@ module Mongo
       end
 
       if uname && pwd && db
-        auths << {'db_name' => db, 'username' => uname, 'password' => pwd}
+        auths << {:db_name => db, :username => uname, :password => pwd}
       elsif uname || pwd
         raise MongoArgumentError, "MongoDB URI must include username, password, "
           "and db if username and password are specified."

--- a/test/functional/connection_test.rb
+++ b/test/functional/connection_test.rb
@@ -336,8 +336,8 @@ class TestConnection < Test::Unit::TestCase
   context "Saved authentications" do
     setup do
       @client = standard_connection
-      @auth = {'db_name' => 'test', 'username' => 'bob', 'password' => 'secret'}
-      @client.add_auth(@auth['db_name'], @auth['username'], @auth['password'])
+      @auth = {:db_name => 'test', :username => 'bob', :password => 'secret'}
+      @client.add_auth(@auth[:db_name], @auth[:username], @auth[:password])
     end
 
     teardown do
@@ -348,11 +348,11 @@ class TestConnection < Test::Unit::TestCase
       assert_equal @auth, @client.auths[0]
     end
 
-    should "replace the auth if given a new auth for the same db" do
-      auth = {'db_name' => 'test', 'username' => 'mickey', 'password' => 'm0u53'}
-      @client.add_auth(auth['db_name'], auth['username'], auth['password'])
-      assert_equal 1, @client.auths.length
-      assert_equal auth, @client.auths[0]
+    should "not allow multiple authentications for the same db" do
+      auth = {:db_name => 'test', :username => 'mickey', :password => 'm0u53'}
+      assert_raise Mongo::MongoArgumentError do
+        @client.add_auth(auth[:db_name], auth[:username], auth[:password])
+      end
     end
 
     should "remove auths by database" do

--- a/test/functional/uri_test.rb
+++ b/test/functional/uri_test.rb
@@ -26,17 +26,17 @@ class URITest < Test::Unit::TestCase
 
   def test_complex_passwords
     parser = Mongo::URIParser.new('mongodb://bob:secret.word@a.example.com:27018/test')
-    assert_equal "bob", parser.auths[0]["username"]
-    assert_equal "secret.word", parser.auths[0]["password"]
+    assert_equal "bob", parser.auths[0][:username]
+    assert_equal "secret.word", parser.auths[0][:password]
 
     parser = Mongo::URIParser.new('mongodb://bob:s-_3#%R.t@a.example.com:27018/test')
-    assert_equal "bob", parser.auths[0]["username"]
-    assert_equal "s-_3#%R.t", parser.auths[0]["password"]
+    assert_equal "bob", parser.auths[0][:username]
+    assert_equal "s-_3#%R.t", parser.auths[0][:password]
   end
 
   def test_complex_usernames
     parser = Mongo::URIParser.new('mongodb://b:ob:secret.word@a.example.com:27018/test')
-    assert_equal "b:ob", parser.auths[0]["username"]
+    assert_equal "b:ob", parser.auths[0][:username]
   end
 
   def test_passwords_contain_no_commas
@@ -51,12 +51,12 @@ class URITest < Test::Unit::TestCase
     assert_equal ['a.example.com', 27018], parser.nodes[0]
     assert_equal ['b.example.com', 27017], parser.nodes[1]
     assert_equal 2, parser.auths.length
-    assert_equal "bob", parser.auths[0]["username"]
-    assert_equal "secret", parser.auths[0]["password"]
-    assert_equal "test", parser.auths[0]["db_name"]
-    assert_equal "bob", parser.auths[1]["username"]
-    assert_equal "secret", parser.auths[1]["password"]
-    assert_equal "test", parser.auths[1]["db_name"]
+    assert_equal "bob", parser.auths[0][:username]
+    assert_equal "secret", parser.auths[0][:password]
+    assert_equal "test", parser.auths[0][:db_name]
+    assert_equal "bob", parser.auths[1][:username]
+    assert_equal "secret", parser.auths[1][:password]
+    assert_equal "test", parser.auths[1][:db_name]
   end
 
   def test_opts_with_semincolon_separator

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -128,7 +128,7 @@ class ClientTest < Test::Unit::TestCase
       should "parse a uri with a hyphen & underscore in the username or password" do
         @client = MongoClient.from_uri("mongodb://hyphen-user_name:p-s_s@localhost:27017/db", :connect => false)
         assert_equal ['localhost', 27017], @client.host_port
-        auth_hash = { 'db_name' => 'db', 'username' => 'hyphen-user_name', "password" => 'p-s_s' }
+        auth_hash = { :db_name => 'db', :username => 'hyphen-user_name', :password => 'p-s_s' }
         assert_equal auth_hash, @client.auths[0]
       end
 
@@ -211,7 +211,7 @@ class ClientTest < Test::Unit::TestCase
         ENV['MONGODB_URI'] = "mongodb://hyphen-user_name:p-s_s@localhost:27017/db?connect=false"
         @client = MongoClient.new
         assert_equal ['localhost', 27017], @client.host_port
-        auth_hash = { 'db_name' => 'db', 'username' => 'hyphen-user_name', "password" => 'p-s_s' }
+        auth_hash = { :db_name => 'db', :username => 'hyphen-user_name', :password => 'p-s_s' }
         assert_equal auth_hash, @client.auths[0]
       end
 

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -122,7 +122,7 @@ class ConnectionTest < Test::Unit::TestCase
       should "parse a uri with a hyphen & underscore in the username or password" do
         @connection = Mongo::Connection.from_uri("mongodb://hyphen-user_name:p-s_s@localhost:27017/db", :connect => false)
         assert_equal ['localhost', 27017], @connection.host_port
-        auth_hash = { 'db_name' => 'db', 'username' => 'hyphen-user_name', "password" => 'p-s_s' }
+        auth_hash = { :db_name => 'db', :username => 'hyphen-user_name', :password => 'p-s_s' }
         assert_equal auth_hash, @connection.auths[0]
       end
 
@@ -205,7 +205,7 @@ class ConnectionTest < Test::Unit::TestCase
         ENV['MONGODB_URI'] = "mongodb://hyphen-user_name:p-s_s@localhost:27017/db?connect=false"
         @connection = Mongo::Connection.new
         assert_equal ['localhost', 27017], @connection.host_port
-        auth_hash = { 'db_name' => 'db', 'username' => 'hyphen-user_name', "password" => 'p-s_s' }
+        auth_hash = { :db_name => 'db', :username => 'hyphen-user_name', :password => 'p-s_s' }
         assert_equal auth_hash, @connection.auths[0]
       end
 


### PR DESCRIPTION
Server side, MongoDB will log out the first user when a second authentication 
is issued for the same database. In the past we've handled this by just
quietly updating the authentication credentials we have stored for that db.

The driver spec for auth now requires that we raise an explicit exception so 
that users don't unknowingly log out previous authentications applied to the 
database.
