### PR TITLE
Fix segmentation fault from calling from_string with a non-string

### DIFF
--- a/ext/cbson/cbson.c
+++ b/ext/cbson/cbson.c
@@ -954,7 +954,13 @@ static VALUE objectid_from_string(VALUE self, VALUE str)
     int i;
 
     if (!legal_objectid_str(str)) {
+      if (TYPE(str) == T_STRING) {
         rb_raise(InvalidObjectId, "illegal ObjectId format: %s", RSTRING_PTR(str));
+      } else {
+        VALUE inspect;
+        inspect = rb_funcall(str, rb_intern("to_s"), 0);
+        rb_raise(InvalidObjectId, "not a String: %s", inspect);
+      }
     }
 
     oid = rb_ary_new2(12);

--- a/test/bson/object_id_test.rb
+++ b/test/bson/object_id_test.rb
@@ -70,8 +70,14 @@ class ObjectIdTest < Test::Unit::TestCase
   end
 
   def test_illegal_from_string
-    assert_raise InvalidObjectId do 
+    assert_raise InvalidObjectId do
       ObjectId.from_string("")
+    end
+  end
+
+  def test_from_string_with_object_id
+    assert_raise InvalidObjectId do
+      ObjectId.from_string(@o)
     end
   end
 


### PR DESCRIPTION
- Calling BSON::ObjectId.from_string with a BSON::ObjectId segfaulted
- C function attempted to use BSON::ObjectId as a String
- Adds separate check/exception for non-String arguments
