### PR TITLE
Raise error on insert into system collection.

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -20,20 +20,20 @@ module Mongo
     #
     # @param [String, Symbol] name the name of the collection.
     # @param [DB] db a MongoDB database instance.
-    # 
+    #
     # @option opts [String, Integer, Symbol] :w (1) Set default number of nodes to which a write
     #   should be acknowledged
     # @option opts [Boolean] :j (false) Set journal acknowledgement
     # @option opts [Integer] :wtimeout (nil) Set replica set acknowledgement timeout
     # @option opts [Boolean] :fsync (false) Set fsync acknowledgement.
-    #   
+    #
     #   Notes about write concern:
-    #     These write concern options will be used for insert, update, and remove methods called on this  
-    #     Collection instance. If no value is provided, the default values set on this instance's DB will be used. 
+    #     These write concern options will be used for insert, update, and remove methods called on this
+    #     Collection instance. If no value is provided, the default values set on this instance's DB will be used.
     #     These option values can be overridden for any invocation of insert, update, or remove.
     #
     # @option opts [:create_pk] :pk (BSON::ObjectId) A primary key factory to use
-    #   other than the default BSON::ObjectId. 
+    #   other than the default BSON::ObjectId.
     # @option opts [:primary, :secondary] :read The default read preference for queries
     #   initiates from this connection object. If +:secondary+ is chosen, reads will be sent
     #   to one of the closest available secondary nodes. If a secondary node cannot be located, the
@@ -315,10 +315,10 @@ module Mongo
     # @return [ObjectId] the _id of the saved document.
     #
     # @option opts [Hash] :w, :j, :wtimeout, :fsync Set the write concern for this operation.
-    #   :w > 0 will run a +getlasterror+ command on the database to report any assertion. 
+    #   :w > 0 will run a +getlasterror+ command on the database to report any assertion.
     #   :j will confirm a write has been committed to the journal,
     #   :wtimeout specifies how long to wait for write confirmation,
-    #   :fsync will confirm that a write has been fsynced. 
+    #   :fsync will confirm that a write has been fsynced.
     #   Options provided here will override any write concern options set on this collection,
     #   its database object, or the current connection. See the options
     #   for DB#get_last_error.
@@ -351,26 +351,29 @@ module Mongo
     # @option opts [Boolean] :j (false) Set journal acknowledgement
     # @option opts [Integer] :wtimeout (nil) Set replica set acknowledgement timeout
     # @option opts [Boolean] :fsync (false) Set fsync acknowledgement.
-    #   
+    #
     #   Notes on write concern:
     #     Options provided here will override any write concern options set on this collection,
-    #     its database object, or the current connection. See the options for +DB#get_last_error+. 
+    #     its database object, or the current connection. See the options for +DB#get_last_error+.
     #
     # @option opts [Boolean] :continue_on_error (+false+) If true, then
     #   continue a bulk insert even if one of the documents inserted
     #   triggers a database assertion (as in a duplicate insert, for instance).
     #   If not acknowledging writes, the list of ids returned will
     #   include the object ids of all documents attempted on insert, even
-    #   if some are rejected on error. When acknowledging writes, any error will raise an 
+    #   if some are rejected on error. When acknowledging writes, any error will raise an
     #   OperationFailure exception.
     #   MongoDB v2.0+.
     # @option opts [Boolean] :collect_on_error (+false+) if true, then
     #   collects invalid documents as an array. Note that this option changes the result format.
     #
-    # @raise [Mongo::OperationFailure] will be raised iff :w > 0 and the operation fails. 
+    # @raise [Mongo::OperationFailure] will be raised iff :w > 0 and the operation fails.
     #
     # @core insert insert-instance_method
     def insert(doc_or_docs, opts={})
+      if name.start_with?("system.") && name !~ /(\Asystem\.users)|(\Asystem\.indexes)/
+        raise Mongo::InvalidNSName, "cannot insert into system collections."
+      end
       doc_or_docs = [doc_or_docs] unless doc_or_docs.is_a?(Array)
       doc_or_docs.collect! { |doc| @pk_factory.create_pk(doc) }
       write_concern = get_write_concern(opts, self)
@@ -392,7 +395,7 @@ module Mongo
     #
     #   Notes on write concern:
     #     Options provided here will override any write concern options set on this collection,
-    #     its database object, or the current connection. See the options for +DB#get_last_error+.  
+    #     its database object, or the current connection. See the options for +DB#get_last_error+.
     #
     # @example remove all documents from the 'users' collection:
     #   users.remove
@@ -446,7 +449,7 @@ module Mongo
     #
     #   Notes on write concern:
     #     Options provided here will override any write concern options set on this collection,
-    #     its database object, or the current connection. See the options for DB#get_last_error. 
+    #     its database object, or the current connection. See the options for DB#get_last_error.
     #
     # @return [Hash, true] Returns a Hash containing the last error object if acknowledging writes.
     #   Otherwise, returns true.
@@ -631,7 +634,7 @@ module Mongo
     #
     # @param [Array] pipeline Should be a single array of pipeline operator hashes.
     #
-    #   '$project' Reshapes a document stream by including fields, excluding fields, inserting computed fields, 
+    #   '$project' Reshapes a document stream by including fields, excluding fields, inserting computed fields,
     #   renaming fields,or creating/populating fields that hold sub-documents.
     #
     #   '$match' Query-like interface for filtering documents out of the aggregation pipeline.

--- a/test/functional/collection_test.rb
+++ b/test/functional/collection_test.rb
@@ -1075,6 +1075,19 @@ end
     coll.ensure_index([['a', 1]])
   end
 
+  def test_insert_raises_exception_on_system_collection
+    collection = @@db["system.foo"]
+    assert_raise Mongo::InvalidNSName do
+      collection.insert({ :a => 1 })
+    end
+  end
+
+  def test_save_raises_exception_on_system_collection
+    collection = @@db["system.foo"]
+    assert_raise Mongo::InvalidNSName do
+      collection.save({ :a => 1 })
+    end
+  end
 
   if @@version > '2.0.0'
     def test_show_disk_loc


### PR DESCRIPTION
Only if the collection is not system.users or system.indexes.

Only performing the check on insert as this covers #insert and #save for new documents. Didn't put in initialize since there could be other system collections that might be queried, like system.namespaces.

Commit also cleaned up some trailing whitespace in the `Collection` class.

[ RUBY-492 ]
