### PR TITLE
Patch for installing bson_ext gem on ruby-2.0.0-p0

### DIFF
--- a/ext/cbson/extconf.rb
+++ b/ext/cbson/extconf.rb
@@ -8,7 +8,7 @@ have_header("ruby/encoding.h")
 
 dir_config('cbson')
 
-if RUBY_VERSION >= "2.0.0"
+if "#{RUBY_VERSION}-p#{RUBY_PATCHLEVEL}".eql? '2.0.0-p0'
   FileUtils.mkdir "../bson_ext/bson_ext"
   create_makefile('bson_ext/cbson')  
 else


### PR DESCRIPTION
Hi,
I had some issues installing the `bson_ext` gem on ruby-2.0.0-p0, as originally reported @ [RUBY-561](https://jira.mongodb.org/browse/RUBY-561).

The thing is that even when I tried to install it on rubygems-2.0.3 ( suggested as a workaround in the ticket ) it still didn't load properly.

```
➜  mongo-ruby-driver rvm:(ruby-2.0.0) git:(master) ✗ ruby -v
ruby 2.0.0p0 (2013-02-24 revision 39474) [x86_64-darwin11.4.2]
➜  mongo-ruby-driver rvm:(ruby-2.0.0) git:(master) ✗ gem --version
2.0.3
➜  mongo-ruby-driver rvm:(ruby-2.0.0) git:(master) ✗ gem install bson_ext
Building native extensions.  This could take a while...
Successfully installed bson_ext-1.8.3
Parsing documentation for bson_ext-1.8.3
unable to convert "\xCF" from ASCII-8BIT to UTF-8 for ext/bson_ext/bson_ext, skipping
Done installing documentation for bson_ext (0 sec).
1 gem installed
➜  mongo-ruby-driver rvm:(ruby-2.0.0) git:(master) ✗ ruby -e "require 'bson';require 'bson_ext/cbson'"
      ** Notice: The native BSON extension was not loaded. **

      For optimal performance, use of the BSON extension is recommended.

      To enable the extension make sure ENV['BSON_EXT_DISABLED'] is not set
      and run the following command:

        gem install bson_ext

      If you continue to receive this message after installing, make sure that
      the bson_ext gem is in your load path.
/Users/eran/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require': cannot load such file -- bson_ext/cbson (LoadError)
    from /Users/eran/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/site_ruby/2.0.0/rubygems/core_ext/kernel_require.rb:45:in `require'
    from -e:1:in `<main>'
```

After applying the patch

```
➜  mongo-ruby-driver rvm:(ruby-2.0.0) git:(master) ✗ gem build bson_ext.gemspec
WARNING:  licenses is empty
  Successfully built RubyGem
  Name: bson_ext
  Version: 1.8.3
  File: bson_ext-1.8.3.gem
➜  mongo-ruby-driver rvm:(ruby-2.0.0) git:(master) ✗ gem install bson_ext-1.8.3.gem 
Building native extensions.  This could take a while...
Successfully installed bson_ext-1.8.3
Parsing documentation for bson_ext-1.8.3
unable to convert "\xCF" from ASCII-8BIT to UTF-8 for ext/bson_ext/bson_ext, skipping
Done installing documentation for bson_ext (0 sec).
1 gem installed
➜  mongo-ruby-driver rvm:(ruby-2.0.0) git:(master) ✗ ruby -e "require 'bson';require 'bson_ext/cbson'"
➜  mongo-ruby-driver rvm:(ruby-2.0.0) git:(master) ✗ 
```

I thought that this patch could be useful or even just as a reference to another workaround to the issue
