### PR TITLE
RUBY-576 documentation fix for ensure index

### DIFF
--- a/lib/mongo.rb
+++ b/lib/mongo.rb
@@ -6,14 +6,16 @@ module Mongo
   GEOHAYSTACK = 'geoHaystack'
   TEXT        = 'text'
   HASHED      = 'hashed'
-  INDEX_TYPES = [ ASCENDING,
-                  DESCENDING,
-                  GEO2D,
-                  GEO2DSPHERE,
-                  GEOHAYSTACK,
-                  TEXT,
-                  HASHED
-                ]
+
+  INDEX_TYPES = {
+    'ASCENDING'   => ASCENDING,
+    'DESCENDING'  => DESCENDING,
+    'GEO2D'       => GEO2D,
+    'GEO2DSPHERE' => GEO2DSPHERE,
+    'GEOHAYSTACK' => GEOHAYSTACK,
+    'TEXT'        => TEXT,
+    'HASHED'      => HASHED
+  }
 
   DEFAULT_MAX_BSON_SIZE = 4 * 1024 * 1024
   DEFAULT_MAX_MESSAGE_SIZE = DEFAULT_MAX_BSON_SIZE * 2


### PR DESCRIPTION
- Syntax correction for Collection#ensure_index examples.
- Added Ruby 1.8 and Ruby 1.9 examples for Collection#create_index.
- Added index type validation for hash syntax 
