### PR TITLE
RUBY-570 removing test files from gemspec (for now)

### DIFF
--- a/bson.gemspec
+++ b/bson.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
     s.platform = Gem::Platform::RUBY
   end
 
-  s.test_files        = Dir['test/bson/*.rb']
   s.executables       = ['b2json', 'j2bson']
   s.require_paths     = ['lib']
   s.has_rdoc          = 'yard'

--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files             += ['README.md', 'Rakefile', 'bin/mongo_console']
   s.files             += ['lib/mongo.rb'] + Dir['lib/mongo/**/*.rb']
 
-  s.test_files        = Dir['test/**/*.rb']
+  s.test_files        = Dir['test/**/*.rb'] - Dir['test/bson/*']
   s.executables       = ['mongo_console']
   s.require_paths     = ['lib']
   s.has_rdoc          = 'yard'


### PR DESCRIPTION
The structure of our combined test suite doesn't allow it to be separated out
easily so that it can be included with each gem in our repository
(specifically, the test_helper).

Since you can't actually run these test files we've been inlcuding in our
gemspec, I'm removing them for now. Long term after ruby-bson 2.0 is released
the bson gem should include a runnable test suite in the release verison.

This change does two things:
- Removes non-functional test files from bson.gemspec
- Removes bson test suite from mongo.gemspec
