### PR TITLE
Remove deprecated JRuby Gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,8 +23,6 @@ group :testing do
 end
 
 platforms :jruby do
-  gem 'bouncy-castle-java'
-  gem 'jruby-openssl'
   gem 'jruby-launcher'
   gem 'jruby-jars'
 end


### PR DESCRIPTION
No longer needed and cause logs of error/debug output in console when running tests.
Left jruby-launcher as it is not deprecated and needed for windows dev.
