### PR TITLE
RUBY-584 fixing unit tests that require a mongodb connection

### DIFF
--- a/lib/mongo/mongo_sharded_client.rb
+++ b/lib/mongo/mongo_sharded_client.rb
@@ -140,7 +140,8 @@ module Mongo
     # @param opts [ Hash ] Any of the options available for MongoShardedClient.new
     #
     # @return [ Mongo::MongoShardedClient ] The sharded client.
-    def self.from_uri(uri = ENV['MONGODB_URI'], options = {})
+    def self.from_uri(uri, options = {})
+      uri ||= ENV['MONGODB_URI']
       URIParser.new(uri).connection(options, false, true)
     end
   end

--- a/test/unit/mongo_sharded_client_test.rb
+++ b/test/unit/mongo_sharded_client_test.rb
@@ -9,24 +9,24 @@ class MongoShardedClientTest < Test::Unit::TestCase
 
   def test_initialize_with_single_mongos_uri
     ENV["MONGODB_URI"] = "mongodb://localhost:27017"
-    client = MongoShardedClient.new
+    client = MongoShardedClient.new(:connect => false)
     assert_equal [[ "localhost", 27017 ]], client.seeds
   end
 
   def test_initialize_with_multiple_mongos_uris
     ENV["MONGODB_URI"] = "mongodb://localhost:27017,localhost:27018"
-    client = MongoShardedClient.new
+    client = MongoShardedClient.new(:connect => false)
     assert_equal [[ "localhost", 27017 ], [ "localhost", 27018 ]], client.seeds
   end
 
   def test_from_uri_with_string
-    client = MongoShardedClient.from_uri("mongodb://localhost:27017,localhost:27018")
+    client = MongoShardedClient.from_uri("mongodb://localhost:27017,localhost:27018", :connect => false)
     assert_equal [[ "localhost", 27017 ], [ "localhost", 27018 ]], client.seeds
   end
 
   def test_from_uri_with_env_variable
     ENV["MONGODB_URI"] = "mongodb://localhost:27017,localhost:27018"
-    client = MongoShardedClient.from_uri
+    client = MongoShardedClient.from_uri(nil, :connect => false)
     assert_equal [[ "localhost", 27017 ], [ "localhost", 27018 ]], client.seeds
   end
 end


### PR DESCRIPTION
These unit tests were forcing a connection and requiring a MongoDB server be present in order for them to run successfully. This shouldn't be the case for unit tests in general and was proving to be a problem for package maintainers attempting to run our test suite.
