### PR TITLE
RUBY-583: fix for first admin user on MongoDB 2.2

### DIFF
--- a/lib/mongo/db.rb
+++ b/lib/mongo/db.rb
@@ -192,7 +192,12 @@ module Mongo
       user  = users.find_one({:user => username}) || {:user => username}
       user['pwd'] = Mongo::Support.hash_password(username, password)
       user['readOnly'] = true if read_only;
-      users.save(user)
+      begin
+        users.save(user)
+      rescue OperationFailure => ex
+        # adding first admin user fails GLE in MongoDB 2.2
+        raise ex unless ex.message =~ /login/
+      end
       user
     end
 


### PR DESCRIPTION
This was originally part of the changes included in RUBY-577 but I think it belongs with RUBY-583.

Adding the first admin user to enable authentication in MongoDB 2.2 causes the subsequent get last error command to fail. Our fix is identical to that of the python driver implementation here:

https://github.com/mongodb/mongo-python-driver/blob/master/pymongo/database.py#L645-653
