### PR TITLE
RUBY-607: Fix nearest read pref option

### DIFF
--- a/lib/mongo/mongo_replica_set_client.rb
+++ b/lib/mongo/mongo_replica_set_client.rb
@@ -422,6 +422,10 @@ module Mongo
       local_manager ? local_manager.secondary_pools : []
     end
 
+    def pools
+      local_manager ? local_manager.pools : []
+    end
+
     def tag_map
       local_manager ? local_manager.tag_map : {}
     end

--- a/lib/mongo/util/read_preference.rb
+++ b/lib/mongo/util/read_preference.rb
@@ -77,7 +77,7 @@ module Mongo
         when :secondary_preferred
           select_secondary_pool(secondary_pools, read_pref) || primary_pool
         when :nearest
-          select_secondary_pool(pools, read_pref)
+          select_near_pool(pools, read_pref)
       end
     end
 

--- a/test/unit/read_pref_test.rb
+++ b/test/unit/read_pref_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class ReadPrefTest < Test::Unit::TestCase
+  include ReadPreference
+
+  def setup
+    mock_pool = mock()
+    mock_pool.stubs(:ping_time).returns(Pool::MAX_PING_TIME)
+
+    stubs(:primary_pool).returns(mock_pool)
+    stubs(:secondary_pools).returns([mock_pool])
+    stubs(:pools).returns([mock_pool])
+  end
+
+  def test_select_pool
+    ReadPreference::READ_PREFERENCES.map do |rp|
+      assert select_pool({:mode => rp, :tags => [], :latency => 15})
+    end
+  end
+
+end


### PR DESCRIPTION
Specifying a :nearest read preference was failing in the read preference module. This pull request fixes the issue so that :nearest can be used as a read preference.

A unit test is part of this PR as well to verify that select_pool works for each read mode in the read preference module.
