### PR TITLE
mongos expects read preferences to be strings, not symbols.

### DIFF
--- a/lib/mongo/util/read_preference.rb
+++ b/lib/mongo/util/read_preference.rb
@@ -9,11 +9,11 @@ module Mongo
     ]
 
     MONGOS_MODES = {
-      :primary              => :primary,
-      :primary_preferred    => :primaryPreferred,
-      :secondary            => :secondary,
-      :secondary_preferred  => :secondaryPreferred,
-      :nearest              => :nearest
+      :primary              => 'primary',
+      :primary_preferred    => 'primaryPreferred',
+      :secondary            => 'secondary',
+      :secondary_preferred  => 'secondaryPreferred',
+      :nearest              => 'nearest'
     }
 
     def self.mongos(mode, tag_sets)

--- a/test/sharded_cluster/basic_test.rb
+++ b/test/sharded_cluster/basic_test.rb
@@ -36,7 +36,7 @@ class BasicTest < Test::Unit::TestCase
     @client = MongoClient.new(host, port, {:read => :secondary, :tag_sets => tags})
     assert @client.connected?
     cursor = Cursor.new(@client[MONGO_TEST_DB]['whatever'], {})
-    assert_equal cursor.construct_query_spec['$readPreference'], {:mode => :secondary, :tags => tags}
+    assert_equal cursor.construct_query_spec['$readPreference'], {:mode => 'secondary', :tags => tags}
   end
 
   def test_find_one_with_read_secondary
@@ -68,7 +68,7 @@ class BasicTest < Test::Unit::TestCase
     @client = MongoShardedClient.new(@seeds, {:read => :secondary, :tag_sets => tags})
     assert @client.connected?
     cursor = Cursor.new(@client[MONGO_TEST_DB]['whatever'], {})
-    assert_equal cursor.construct_query_spec['$readPreference'], {:mode => :secondary, :tags => tags}
+    assert_equal cursor.construct_query_spec['$readPreference'], {:mode => 'secondary', :tags => tags}
   end
 
   def test_hard_refresh

--- a/test/unit/cursor_test.rb
+++ b/test/unit/cursor_test.rb
@@ -124,7 +124,7 @@ class CursorTest < Test::Unit::TestCase
 
         spec = cursor.construct_query_spec
         assert spec.has_key?('$readPreference')
-        assert_equal :secondary, spec['$readPreference'][:mode]
+        assert_equal 'secondary', spec['$readPreference'][:mode]
         assert !spec['$readPreference'].has_key?(:tags)
 
         # secondary preferred with tags
@@ -132,7 +132,7 @@ class CursorTest < Test::Unit::TestCase
 
         spec = cursor.construct_query_spec
         assert spec.has_key?('$readPreference')
-        assert_equal :secondaryPreferred, spec['$readPreference'][:mode]
+        assert_equal 'secondaryPreferred', spec['$readPreference'][:mode]
         assert_equal @tag_sets, spec['$readPreference'][:tags]
 
         # primary preferred
@@ -140,7 +140,7 @@ class CursorTest < Test::Unit::TestCase
 
         spec = cursor.construct_query_spec
         assert spec.has_key?('$readPreference')
-        assert_equal :primaryPreferred, spec['$readPreference'][:mode]
+        assert_equal 'primaryPreferred', spec['$readPreference'][:mode]
         assert !spec['$readPreference'].has_key?(:tags)
 
         # primary preferred with tags
@@ -148,7 +148,7 @@ class CursorTest < Test::Unit::TestCase
 
         spec = cursor.construct_query_spec
         assert spec.has_key?('$readPreference')
-        assert_equal :primaryPreferred, spec['$readPreference'][:mode]
+        assert_equal 'primaryPreferred', spec['$readPreference'][:mode]
         assert_equal @tag_sets, spec['$readPreference'][:tags]
 
         # nearest
@@ -156,7 +156,7 @@ class CursorTest < Test::Unit::TestCase
 
         spec = cursor.construct_query_spec
         assert spec.has_key?('$readPreference')
-        assert_equal :nearest, spec['$readPreference'][:mode]
+        assert_equal 'nearest', spec['$readPreference'][:mode]
         assert !spec['$readPreference'].has_key?(:tags)
 
         # nearest with tags
@@ -164,7 +164,7 @@ class CursorTest < Test::Unit::TestCase
 
         spec = cursor.construct_query_spec
         assert spec.has_key?('$readPreference')
-        assert_equal :nearest, spec['$readPreference'][:mode]
+        assert_equal 'nearest', spec['$readPreference'][:mode]
         assert_equal @tag_sets, spec['$readPreference'][:tags]
       end
 


### PR DESCRIPTION
This should actually fix RUBY-542. Without this, using read
preferences with a mongos cluster that's backed by replica sets will
error with

```
wrong type for field (mode) 14 != 2
```

This is raised by _extraReadPref in dbclient_rs.cpp, when it does:

```
const string mode = prefDoc["mode"].String();
```

BSON type 14 (0xE) is the (deprecated) Symbol type, and type 2 is
String, so this indicates that mongos is getting a symbol when it
expects a string.

The sharding tests passed either way because they don't actually
construct replica sets for the shards, and _extractReadPref is only
used by DBClientReplicaSet. Thus, the $readPreference field passed to
mongos is completely ignored by the test mongoS, and not even parsed.

Passes `test:sharded_cluster` on 1.8, 1.9, 2.0, and jruby.
