### PR TITLE
Use the connect_timeout when checking out a new socket.

### DIFF
--- a/lib/mongo/util/pool.rb
+++ b/lib/mongo/util/pool.rb
@@ -161,7 +161,7 @@ module Mongo
     # therefore, it runs within a mutex.
     def checkout_new_socket
       begin
-        socket = @client.socket_class.new(@host, @port, @client.op_timeout)
+        socket = @client.socket_class.new(@host, @port, @client.op_timeout, @client.connect_timeout)
         socket.pool = self
       rescue => ex
         socket.close if socket


### PR DESCRIPTION
The utility of the connect_timeout is that it's much easier to set an
upper bound on the time a connect(2) should take than on an arbitary
mongo operation, so we can detect and react to failures or downed
machines more quickly. Thus, it makes sense to set it whenever we're
connecting to a server, even if it's not an initial connection.

Notably, without this change, mongo-ruby-driver with default settings
can hang forever after a reconfig where a server is removed from a
replset, if the old server starts blackholing traffic. With this
change, it will notice in 30s and reconnect to the remaining seed
nodes.
