### PR TITLE
RUBY-608 fixing uri parser so that it handles authentication correctly

### DIFF
--- a/lib/mongo/util/uri_parser.rb
+++ b/lib/mongo/util/uri_parser.rb
@@ -239,7 +239,7 @@ module Mongo
       end
 
       if @slaveok && !@readpreference
-        if direct?
+        unless replicaset?
           opts[:slave_ok] = true
         else
           opts[:read] = :secondary_preferred
@@ -247,10 +247,7 @@ module Mongo
       end
 
       opts[:ssl] = @ssl
-
-      if direct?
-        opts[:auths] = auths
-      end
+      opts[:auths] = auths
 
       if replicaset.is_a?(String)
         opts[:name] = replicaset
@@ -304,9 +301,6 @@ module Mongo
         raise MongoArgumentError, "MongoDB URI must include username, password, "
           "and db if username and password are specified."
       end
-
-      # The auths are repeated for each host in a replica set
-      @auths *= hosturis.length
     end
 
     # This method uses the lambdas defined in OPT_VALID and OPT_CONV to validate

--- a/test/functional/authentication_test.rb
+++ b/test/functional/authentication_test.rb
@@ -27,6 +27,17 @@ class AuthenticationTest < Test::Unit::TestCase
 
   def test_authenticate_with_connection_uri
     @db.add_user('eunice', 'uritest')
-    assert MongoClient.from_uri("mongodb://eunice:uritest@#{host_port}/#{@db.name}")
+
+    client =
+      MongoClient.from_uri("mongodb://eunice:uritest@#{host_port}/#{@db.name}")
+
+    assert client
+    assert_equal client.auths.size, 1
+    assert client[MONGO_TEST_DB]['auth_test'].count
+
+    auth = client.auths.first
+    assert_equal @db.name, auth[:db_name]
+    assert_equal 'eunice', auth[:username]
+    assert_equal 'uritest', auth[:password]
   end
 end

--- a/test/functional/uri_test.rb
+++ b/test/functional/uri_test.rb
@@ -59,20 +59,6 @@ class URITest < Test::Unit::TestCase
     end
   end
 
-  def test_multiple_uris_with_auths
-    parser = Mongo::URIParser.new('mongodb://bob:secret@a.example.com:27018,b.example.com/test')
-    assert_equal 2, parser.nodes.length
-    assert_equal ['a.example.com', 27018], parser.nodes[0]
-    assert_equal ['b.example.com', 27017], parser.nodes[1]
-    assert_equal 2, parser.auths.length
-    assert_equal "bob", parser.auths[0][:username]
-    assert_equal "secret", parser.auths[0][:password]
-    assert_equal "test", parser.auths[0][:db_name]
-    assert_equal "bob", parser.auths[1][:username]
-    assert_equal "secret", parser.auths[1][:password]
-    assert_equal "test", parser.auths[1][:db_name]
-  end
-
   def test_opts_with_semincolon_separator
     parser = Mongo::URIParser.new('mongodb://localhost:27018?connect=direct;slaveok=true;safe=true')
     assert_equal 'direct', parser.connect

--- a/test/replica_set/authentication_test.rb
+++ b/test/replica_set/authentication_test.rb
@@ -28,7 +28,19 @@ class ReplicaSetAuthenticationTest < Test::Unit::TestCase
 
   def test_authenticate_with_connection_uri
     @db.add_user('eunice', 'uritest')
-    assert MongoReplicaSetClient.from_uri(
-      "mongodb://eunice:uritest@#{@rs.repl_set_seeds.join(',')}/#{@db.name}?replicaSet=#{@rs.repl_set_name}")
+
+    client =
+      MongoReplicaSetClient.from_uri(
+        "mongodb://eunice:uritest@#{@rs.repl_set_seeds.join(',')}/#{@db.name}" +
+        "?replicaSet=#{@rs.repl_set_name}")
+
+    assert client
+    assert_equal client.auths.size, 1
+    assert client[MONGO_TEST_DB]['auth_test'].count
+
+    auth = client.auths.first
+    assert_equal @db.name, auth[:db_name]
+    assert_equal 'eunice', auth[:username]
+    assert_equal 'uritest', auth[:password]
   end
 end


### PR DESCRIPTION
Looks like this has been broken for a while (I tested as far back as 1.7.1 and
this hasn't been working as advertised since at least then) and some of the
URI tests I added recently when we re-enabled the auth test suite weren't good
enough to catch this.

We were parsing the auth info out of the URI correctly, we just weren't
passing it to the client instance at all.

I've corrected this and as a result I also needed to address spec
violation/behavior discrepency in the URI parser that was discovered recently.

https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/util/uri_parser.rb#L294-L295

While correcting this behavior issue is technically a correction to documented
behavior and the mongodb uri spec, it may be best to include this change in
the next minor release.
