### PR TITLE
RUBY-595 Modeling the abstract Message type

### DIFF
--- a/lib/mongo/protocol.rb
+++ b/lib/mongo/protocol.rb
@@ -1,0 +1,4 @@
+# Wire Protocol Base
+require 'mongo/protocol/serializers'
+require 'mongo/protocol/bit_vector'
+require 'mongo/protocol/message'

--- a/lib/mongo/protocol/bit_vector.rb
+++ b/lib/mongo/protocol/bit_vector.rb
@@ -1,0 +1,41 @@
+module Mongo
+  module Protocol
+    # Class used to define a bitvector for a MongoDB wire protocol message.
+    #
+    # Defines serialization strategy based upon initialization.
+    class BitVector
+
+      # Initializes a BitVector with a layout.
+      #
+      # @param layout [Array<Symbol>] the array of fields in the bit vector.
+      def initialize(layout)
+        @masks = {}
+        layout.each_with_index do |field, index|
+          @masks[field] = 2 ** index
+        end
+      end
+
+      # Serializes vector by encoding each symbol according to it's mask.
+      #
+      # @param buffer [IO] the buffer to receive the serialized vector.
+      # @param value [Array<Symbol>] the array of flags to encode.
+      def serialize(buffer, value)
+        bits = 0
+        value.each { |flag| bits |= @masks[flag] }
+        buffer << [bits].pack(INT32_PACK)
+      end
+
+      # Deserializes vector by decoding the symbol according to its mask.
+      #
+      # @param [IO] the stream containing the vector to be deserialized.
+      def deserialize(io)
+        vector = io.read(4).unpack(INT32_PACK).first
+        flags = []
+        @masks.each do |flag, mask|
+          flags << flag if mask & vector != 0
+        end
+        flags
+      end
+    end
+  end
+end

--- a/lib/mongo/protocol/message.rb
+++ b/lib/mongo/protocol/message.rb
@@ -1,0 +1,185 @@
+module Mongo
+  module Protocol
+
+    # An abstract class providing functionality required by all messages in 
+    # the MongoDB wire protocol. It provides a minimal DSL for defining typed
+    # fields to enable serialization and deserialization over the wire.
+    #
+    # Messages produce a new request id upon serialization and can be
+    # serialized multiple times in order to repeat operations.
+    #
+    # @example
+    #
+    #   class WireProtocolMessage < Message
+    #
+    #     private
+    #
+    #     OP_CODE = 1234
+    #     FLAGS = [ :first_bit, :bit_two ]
+    #
+    #     # header
+    #     field :length, Int32
+    #     field :request_id, Int32
+    #     field :response_to, Int32
+    #     field :op_code, Int32
+    #
+    #     # payload
+    #     field :flags, BitVector.new(FLAGS)
+    #     field :namespace, CString
+    #     field :document, Document
+    #     field :documents, Document, :multi => true
+    #   end
+    #
+    # All messages classes *must* contain the message header as required by
+    # the MongoDB wire protocol as the first four fields, namely:
+    #
+    #   field :length, Int32
+    #   field :request_id, Int32
+    #   field :response_to, Int32
+    #   field :op_code, Int32
+    #
+    class Message
+      include Serializers
+
+      # Method to serialize the message into bytes that can be sent on
+      # the wire.
+      #
+      # @param buffer [String] buffer where the message should be inserted
+      # @return [String] buffer containing the serialized message
+      def serialize(buffer = ''.force_encoding('BINARY'))
+        start = buffer.bytesize
+        serialize_fields(buffer)
+        length = buffer.bytesize - start
+        buffer[start, 4] = Int32::serialize('', length)
+        buffer
+      end
+
+      alias :to_s :serialize
+
+      # Deserializes messages from an IO stream.
+      #
+      # @param [IO] Stream containing a message.
+      # @return [Message] Instance of a Message class.
+      def self.deserialize(io)
+        message = allocate
+        fields.each do |field|
+          if field[:multi]
+            deserialize_array(message, io, field)
+          else
+            deserialize_field(message, io, field)
+          end
+        end
+        message
+      end
+
+      protected
+
+      # Serializes message fields into a buffer.
+      #
+      # @param [String] the buffer
+      def serialize_fields(buffer)
+        fields.each do |field|
+          value = instance_variable_get(field[:name])
+          if field[:multi]
+            value.each do |item|
+              field[:type]::serialize(buffer, item)
+            end
+          else
+            field[:type]::serialize(buffer, value)
+          end
+        end
+      end
+
+      # Class variables for atomic request id
+      @@request_id = 0
+      @@id_lock = Mutex.new
+
+      # Generates a request id for a message.
+      #
+      # @return [Fixnum] a request id used for sending a message to the
+      #   server. The server will put this id in the response_to field of
+      #   a reply.
+      def request_id
+        request_id = nil
+        @@id_lock.synchronize do
+          request_id = @@request_id += 1
+        end
+        request_id
+      end
+
+      # A method for getting the message class OP_CODE
+      #
+      # @return [Integer] the opcode
+      def op_code
+        self.class::OP_CODE
+      end
+
+      # An method for getting the fields for a message class
+      #
+      # @return [Integer] the fields for the message class
+      def fields
+        self.class.fields
+      end
+
+      # An method for getting the fields for a message class
+      #
+      # @return [Integer] the fields for the message class
+      def self.fields
+        @fields ||= []
+      end
+
+      # A method for declaring a message field.
+      #
+      # @param name [String] Name of the field.
+      # @param type [Module] Type specific serialization strategies.
+      # @param options [Hash] The additional field options.
+      #
+      # @option options :multi [ Boolean, Symbol ] Specify as +true+ to
+      #   serialize the field's value as an array of type +:type+ or as a
+      #   symbol describing the field having the number of items in the
+      #   array (used upon deserialization).
+      #
+      #     Note: In fields where multi is a symbol representing the field
+      #     containing number items in the repetition, the field containing
+      #     that information *must* be deserialized prior to deserializing
+      #     fields that use the number.
+      def self.field(name, type, options = {})
+        fields << {
+          :name => "@#{name}".intern,
+          :type => type,
+          :multi => options[:multi]
+        }
+
+        attr_accessor name
+      end
+
+      # Deserializes an array of fields in a message.
+      #
+      # The number of items in the array must be described by a previously
+      # deserialized field specified in the class by the field dsl under
+      # the key +:multi+.
+      #
+      # @param message [Message] Message to contain the deserialized array.
+      # @param io [IO] Stream containing the array to deserialize.
+      # @param field [Hash] Hash representing a field.
+      def self.deserialize_array(message, io, field)
+        elements = []
+        count = message.instance_variable_get(field[:multi])
+        count.times { elements << field[:type]::deserialize(io) }
+        message.instance_variable_set(field[:name], elements)
+      end
+
+      # Deserializes a single field in a message.
+      #
+      # @param message [Message] Message to contain the deserialized field.
+      # @param io [IO] Stream containing the field to deserialize.
+      # @param field [Hash] Hash representing a field.
+      def self.deserialize_field(message, io, field)
+        message.instance_variable_set(
+          field[:name],
+          field[:type]::deserialize(io)
+        )
+      end
+    end
+  end
+end

--- a/lib/mongo/protocol/serializers.rb
+++ b/lib/mongo/protocol/serializers.rb
@@ -1,0 +1,63 @@
+module Mongo
+  module Protocol
+
+    # Container for various serialization strategies.
+    #
+    # Each strategy must have a serialization method named +serailize+
+    # and a deserialization method named +deserialize+.
+    #
+    # Serialize methods must take buffer and value arguements and
+    # serialize the value into the buffer.
+    #
+    # Deserialize methods must take an IO stream argument and
+    # deserialize the value from the stream of bytes.
+    module Serializers
+      private
+
+      NULL = 0.chr.freeze
+      INT32_PACK = 'l<'.freeze
+      INT64_PACK = 'q<'.freeze
+
+      module CString
+        def self.serialize(buffer, value)
+          buffer << value
+          buffer << NULL
+        end
+
+        def self.deserialize(io)
+          io.gets(NULL)
+        end
+      end
+
+      module Int32
+        def self.serialize(buffer, value)
+          buffer << [value].pack(INT32_PACK)
+        end
+
+        def self.deserialize(io)
+          io.read(4).unpack(INT32_PACK).first
+        end
+      end
+
+      module Int64
+        def self.serialize(buffer, value)
+          buffer << [value].pack(INT64_PACK)
+        end
+
+        def self.deserialize(io)
+          io.read(8).unpack(INT64_PACK).first
+        end
+      end
+
+      module Document
+        def self.serialize(buffer, value)
+          value.to_bson(buffer)
+        end
+
+        def self.deserialize(io)
+          Hash.from_bson(io)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the initial commit for implementation of the modeled MongoDB wire protocol.
### The Idea

Provides an abstract base class named `Message` that all messages will subclass.

I chose to use a class instead of a module because for modeling `Message` because I believe the relationship between `Message` and messages is best defined as a "is-a" relationship instead of a "behaves-like" relationship and has the benefit of clearly delineating methods which are public (`#serialize` and `#deserialize`) from those which are protected and called only by the subclasses of Message (`#field`).
### The DSL

The basic functionality included in the Message class allows for messages to be defined through the use of field declarations. Fields are denoted, in order, by name and type (implying a particular serialization strategy) through a simple DSL:

``` ruby
field :length, Int32
field :namespace, CString
field :document, Document
```
### Serialization and Deserialization

The serialization strategies contained in the Serializers module each have their own submodule in order to quickly and directly invoke the correct strategy for a field.
### Request IDs

New request ids are generated atomically, admittedly not in the most performant way, each time the public serialize method is invoked in order to easily send multiple requests of the same type (subsequent GetMore messages for example).

Other strategies, such as simply setting the request id to a fixed number or randomly generating a 32bit integer (such as the python driver), in my opinion, are unacceptable given the possibility of future asynchronous capability. We can improve upon the performance of the implementation using a hash of thread id and a counter masked into the 32 bit field however at this point I wanted to do the clearest thing and leave optimizations to a later revision.
### Performance Notes

Moped does not generate request ids and requires that the user of the API provide one upon message instantiation. Barring this discrepancy and it's penalty on performance, this implementation exceeds the performance of Moped's.

At the cost of future flexibility, it is possible to define special header serializers and deserializers that deal with the 16-byte struct as a whole unit which greatly increases performance and DRYs up the message definitions. I have chosen not to do this in the interest of maintaining maximum flexibility. However, if in talking to the server team we can infer that the header format will remain constant this is an optimization we can make.
