### PR TITLE
RUBY-618 remove dependency on 3rd-party utf8 encoding helpers

### DIFF
--- a/ext/cbson/cbson.c
+++ b/ext/cbson/cbson.c
@@ -98,13 +98,14 @@ static int max_bson_size;
 #define STR_NEW(p,n) rb_str_new((p), (n))
 #endif
 
-static void write_utf8(bson_buffer_t buffer, VALUE string, char check_null) {
-    result_t status = check_string((unsigned char*)RSTRING_PTR(string), RSTRING_LEN(string),
-                                   1, check_null);
+static void write_utf8(bson_buffer_t buffer, VALUE string, int allow_null) {
+    result_t status = validate_utf8_encoding(
+        (const char*)RSTRING_PTR(string), RSTRING_LEN(string), allow_null);
+
     if (status == HAS_NULL) {
         bson_buffer_free(buffer);
         rb_raise(InvalidDocument, "Key names / regex patterns must not contain the NULL byte");
-    } else if (status == NOT_UTF_8) {
+    } else if (status == INVALID_UTF8) {
         bson_buffer_free(buffer);
         rb_raise(InvalidStringEncoding, "String not valid UTF-8");
     }
@@ -186,7 +187,7 @@ static VALUE pack_extra(bson_buffer_t buffer, VALUE check_keys) {
 
 static void write_name_and_type(bson_buffer_t buffer, VALUE name, char type) {
     SAFE_WRITE(buffer, &type, 1);
-    write_utf8(buffer, name, 1);
+    write_utf8(buffer, name, 0);
     SAFE_WRITE(buffer, &zero, 1);
 }
 
@@ -315,7 +316,7 @@ static int write_element(VALUE key, VALUE value, VALUE extra, int allow_id) {
             write_name_and_type(buffer, key, 0x02);
             length = RSTRING_LENINT(value) + 1;
             SAFE_WRITE(buffer, (char*)&length, 4);
-            write_utf8(buffer, value, 0);
+            write_utf8(buffer, value, 1);
             SAFE_WRITE(buffer, &zero, 1);
             break;
         }
@@ -447,7 +448,7 @@ static int write_element(VALUE key, VALUE value, VALUE extra, int allow_id) {
                 write_name_and_type(buffer, key, 0x02);
                 length = RSTRING_LENINT(str) + 1;
                 SAFE_WRITE(buffer, (char*)&length, 4);
-                write_utf8(buffer, str, 0);
+                write_utf8(buffer, str, 1);
                 SAFE_WRITE(buffer, &zero, 1);
                 break;
             }
@@ -488,7 +489,7 @@ static int write_element(VALUE key, VALUE value, VALUE extra, int allow_id) {
 
             write_name_and_type(buffer, key, 0x0B);
 
-            write_utf8(buffer, pattern, 1);
+            write_utf8(buffer, pattern, 0);
             SAFE_WRITE(buffer, &zero, 1);
 
             if (flags & IGNORECASE) {

--- a/ext/cbson/encoding_helpers.c
+++ b/ext/cbson/encoding_helpers.c
@@ -1,102 +1,98 @@
+/*
+ * Copyright 2013 10gen Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <string.h>
 #include "encoding_helpers.h"
 
-/*
- * Portions Copyright 2001 Unicode, Inc.
- *
- * Disclaimer
- *
- * This source code is provided as is by Unicode, Inc. No claims are
- * made as to fitness for any particular purpose. No warranties of any
- * kind are expressed or implied. The recipient agrees to determine
- * applicability of information provided. If this file has been
- * purchased on magnetic or optical media from Unicode, Inc., the
- * sole remedy for any claim will be exchange of defective media
- * within 90 days of receipt.
- *
- * Limitations on Rights to Redistribute This Code
- *
- * Unicode, Inc. hereby grants the right to freely use the information
- * supplied in this file in the creation of products supporting the
- * Unicode Standard, and to make copies of this file in any form
- * for internal or external distribution as long as this notice
- * remains attached.
- */
 
-/*
- * Index into the table below with the first byte of a UTF-8 sequence to
- * get the number of trailing bytes that are supposed to follow it.
- */
-static const char trailingBytesForUTF8[256] = {
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, 0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-    2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, 3,3,3,3,3,3,3,3,4,4,4,4,5,5,5,5
-};
+static void
+get_utf8_sequence (const char       *utf8,
+                   unsigned char    *seq_length,
+                   unsigned char    *first_mask)
+{
+   unsigned char c = *(const unsigned char *)utf8;
+   unsigned char m;
+   unsigned char n;
 
-/* --------------------------------------------------------------------- */
+   /*
+    * See the following[1] for a description of what the given multi-byte
+    * sequences will be based on the bits set of the first byte. We also need
+    * to mask the first byte based on that.  All subsequent bytes are masked
+    * against 0x3F.
+    *
+    * [1] http://www.joelonsoftware.com/articles/Unicode.html
+    */
 
-/*
- * Utility routine to tell whether a sequence of bytes is legal UTF-8.
- * This must be called with the length pre-determined by the first byte.
- * The length can be set by:
- *  length = trailingBytesForUTF8[*source]+1;
- * and the sequence is illegal right away if there aren't that many bytes
- * available.
- * If presented with a length > 4, this returns 0.  The Unicode
- * definition of UTF-8 goes up to 4-byte sequences.
- */
-static unsigned char isLegalUTF8(const unsigned char* source, int length) {
-    unsigned char a;
-    const unsigned char* srcptr = source + length;
-    switch (length) {
-    default: return 0;
-        /* Everything else falls through when "true"... */
-    case 4: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
-    case 3: if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
-    case 2: if ((a = (*--srcptr)) > 0xBF) return 0;
-        switch (*source) {
-            /* no fall-through in this inner switch */
-            case 0xE0: if (a < 0xA0) return 0; break;
-            case 0xF0: if (a < 0x90) return 0; break;
-            case 0xF4: if (a > 0x8F) return 0; break;
-            default:  if (a < 0x80) return 0;
-        }
-        case 1: if (*source >= 0x80 && *source < 0xC2) return 0;
-        if (*source > 0xF4) return 0;
-    }
-    return 1;
+   if ((c & 0x80) == 0) {
+      n = 1;
+      m = 0x7F;
+   } else if ((c & 0xE0) == 0xC0) {
+      n = 2;
+      m = 0x1F;
+   } else if ((c & 0xF0) == 0xE0) {
+      n = 3;
+      m = 0x0F;
+   } else if ((c & 0xF8) == 0xF0) {
+      n = 4;
+      m = 0x07;
+   } else if ((c & 0xFC) == 0xF8) {
+      n = 5;
+      m = 0x03;
+   } else if ((c & 0xFE) == 0xFC) {
+      n = 6;
+      m = 0x01;
+   } else {
+      n = 0;
+      m = 0;
+   }
+
+   *seq_length = n;
+   *first_mask = m;
 }
 
-result_t check_string(const unsigned char* string, const long length,
-                      const char check_utf8, const char check_null) {
-    int position = 0;
-    /* By default we go character by character. Will be different for checking
-     * UTF-8 */
-    int sequence_length = 1;
 
-    if (!check_utf8 && !check_null) {
-        return VALID;
-    }
+result_t
+validate_utf8_encoding (const char  *utf8,
+                        size_t      utf8_len,
+                        int         allow_null)
+{
+   unsigned char first_mask;
+   unsigned char seq_length;
+   unsigned i;
+   unsigned j;
 
-    while (position < length) {
-        if (check_null && *(string + position) == 0) {
-            return HAS_NULL;
-        }
-        if (check_utf8) {
-            sequence_length = trailingBytesForUTF8[*(string + position)] + 1;
-            if ((position + sequence_length) > length) {
-                return NOT_UTF_8;
+   for (i = 0; i < utf8_len; i += seq_length) {
+      get_utf8_sequence(&utf8[i], &seq_length, &first_mask);
+      if (!seq_length) {
+         return INVALID_UTF8;
+      }
+      for (j = i + 1; j < (i + seq_length); j++) {
+         if ((utf8[j] & 0xC0) != 0x80) {
+            return INVALID_UTF8;
+         }
+      }
+      if (!allow_null) {
+         for (j = 0; j < seq_length; j++) {
+            if (((i + j) > utf8_len) || !utf8[i + j]) {
+               return HAS_NULL;
             }
-            if (!isLegalUTF8(string + position, sequence_length)) {
-                return NOT_UTF_8;
-            }
-        }
-        position += sequence_length;
-    }
+         }
+      }
+   }
 
-    return VALID;
+   return VALID_UTF8;
 }

--- a/ext/cbson/encoding_helpers.h
+++ b/ext/cbson/encoding_helpers.h
@@ -1,13 +1,50 @@
+/*
+ * Copyright 2013 10gen Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
 #ifndef ENCODING_HELPERS_H
 #define ENCODING_HELPERS_H
 
+#include <unistd.h>
+
 typedef enum {
-    VALID,
-    NOT_UTF_8,
+    VALID_UTF8,
+    INVALID_UTF8,
     HAS_NULL
 } result_t;
 
-result_t check_string(const unsigned char* string, const long length,
-                      const char check_utf8, const char check_null);
+/**
+ * validate_utf8_encoding:
+ * @utf8: A UTF-8 encoded string.
+ * @utf8_len: The length of @utf8 in bytes.
+ * @allow_null: 1 If '\0' is allowed within @utf8, excluding trailing \0.
+ *
+ * Validates that @utf8 is a valid UTF-8 string.
+ *
+ * If @allow_null is 1, then '\0' is allowed within @utf8_len bytes of @utf8.
+ * Generally, this is bad practice since the main point of UTF-8 strings is
+ * that they can be used with strlen() and friends. However, some languages
+ * such as Python can send UTF-8 encoded strings with NUL's in them.
+ *
+ * Returns: enum indicating validity of @utf8.
+ */
+result_t
+validate_utf8_encoding (const char  *utf8,
+                        size_t      utf8_len,
+                        int         allow_null);
 
-#endif
+
+#endif /* ENCODING_HELPERS_H */


### PR DESCRIPTION
There was some concern of license compatibility with the 3rd-party encoding helpers we currently have in the bson c-extension. This commit removes the 3rd-party code and replaces it with an alternate implementation that came from the new mongo-c-driver.

This commit is a pre-requisite to RUBY-615 which is an effort to correct/improve our Apache 2.0 license compliance.
