### PR TITLE
minor: adding namespace to SSLError in ssl socket

### DIFF
--- a/lib/mongo/util/ssl_socket.rb
+++ b/lib/mongo/util/ssl_socket.rb
@@ -51,7 +51,7 @@ module Mongo
         @socket = OpenSSL::SSL::SSLSocket.new(@tcp_socket, @context)
         @socket.sync_close = true
         connect
-      rescue SSLError
+      rescue OpenSSL::SSL::SSLError
         raise ConnectionFailure, "SSL handshake failed. MongoDB may " +
                                  "not be configured with SSL support."
       end


### PR DESCRIPTION
The SSLError caught in ssl socket when connecting is missing its namespace.
