### PR TITLE
minor: fix Gemfile to specify activesupport up to 4.x if using < 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,11 @@ source 'https://rubygems.org'
 gem 'json'
 gem 'rake', :require => ['rake/testtask']
 gem 'rake-compiler', :require => ['rake/extensiontask', 'rake/javaextensiontask']
-gem 'activesupport'
+if RUBY_VERSION < '1.9.3'
+  gem 'activesupport', '~>3.0'
+else
+  gem 'activesupport'
+end
 
 group :deploy do
   gem 'git'


### PR DESCRIPTION
activesupport version 4.0.0, released on June 25th 2013, requires Ruby version >= 1.9.3
I've updated the Gemfile to install up to v 4.x for ruby versions < 1.9.3 and the latest stable for anything >= 1.9.3
