### PR TITLE
RUBY-639 raise OperationTimeout on ssl socket connect timeout

### DIFF
--- a/lib/mongo/util/ssl_socket.rb
+++ b/lib/mongo/util/ssl_socket.rb
@@ -67,7 +67,7 @@ module Mongo
 
     def connect
       if @connect_timeout
-        Timeout::timeout(@connect_timeout, ConnectionTimeoutError) do
+        Timeout::timeout(@connect_timeout, OperationTimeout) do
           @socket.connect
         end
       else


### PR DESCRIPTION
An SSLSocket should raise an OperationTimeout if it times out while the socket is connecting.

Regarding testing: testing with connect_timeout on client as 0.00001 works in most cases but it's not guaranteed to timeout before the socket has a chance to connect.  There aren't many ways to test connect_timeout reliably, as we've recognized in the past:
https://github.com/mongodb/mongo-ruby-driver/blob/1.x-stable/test/replica_set/client_test.rb#L43

I welcome any suggestions on how we can test this reliably, otherwise, I suggest we test locally with this test but then disable it:
https://github.com/estolfo/mongo-ruby-driver/commit/84e64588928688a7f9b28ca717853bf4d935b414#L1R43
