### PR TITLE
RUBY-639 socket connect timeouts throw ConnectionTimeoutError

### DIFF
--- a/lib/mongo/util/node.rb
+++ b/lib/mongo/util/node.rb
@@ -65,7 +65,8 @@ module Mongo
                                              @client.op_timeout,
                                              @client.connect_timeout,
                                              @client.socket_opts)
-        rescue OperationTimeout, ConnectionFailure, OperationFailure, SocketError, SystemCallError, IOError => ex
+        rescue ConnectionTimeoutError, OperationTimeout, ConnectionFailure, OperationFailure,
+               SocketError, SystemCallError, IOError => ex
           @client.log(:debug, "Failed connection to #{host_string} with #{ex.class}, #{ex.message}.")
           close
         end

--- a/lib/mongo/util/ssl_socket.rb
+++ b/lib/mongo/util/ssl_socket.rb
@@ -67,7 +67,7 @@ module Mongo
 
     def connect
       if @connect_timeout
-        Timeout::timeout(@connect_timeout, OperationTimeout) do
+        Timeout::timeout(@connect_timeout, ConnectionTimeoutError) do
           @socket.connect
         end
       else

--- a/lib/mongo/util/tcp_socket.rb
+++ b/lib/mongo/util/tcp_socket.rb
@@ -42,7 +42,7 @@ module Mongo
 
     def connect
       if @connect_timeout
-        Timeout::timeout(@connect_timeout, OperationTimeout) do
+        Timeout::timeout(@connect_timeout, ConnectionTimeoutError) do
           @socket.connect(@socket_address)
         end
       else


### PR DESCRIPTION
When a connect_timeout value times out a socket when connecting, throw a ConnectionTimeoutError.  Handle the error in node's connect method.
