### PR TITLE
RUBY-641: BSON::OrderedHash should allow options extraction using Array#extract_options!

### DIFF
--- a/lib/bson/ordered_hash.rb
+++ b/lib/bson/ordered_hash.rb
@@ -33,6 +33,14 @@ module BSON
       end
     end
 
+    # Allows activesupport Array#extract_options! to extract options
+    # when they are instance of BSON::OrderedHash
+    #
+    # @return [true, false] true if options can be extracted
+    def extractable_options?
+      instance_of?(BSON::OrderedHash)
+    end
+
     # We only need the body of this class if the RUBY_VERSION is before 1.9
     if RUBY_VERSION < '1.9'
       attr_accessor :ordered_keys

--- a/test/bson/ordered_hash_test.rb
+++ b/test/bson/ordered_hash_test.rb
@@ -258,4 +258,16 @@ class OrderedHashTest < Test::Unit::TestCase
     assert_nil @oh['f']
     assert_equal ['c', 'a', 'z'], @oh.keys
   end
+
+  def test_extractable_options_for_ordered_hash
+    assert @oh.extractable_options?
+  end
+
+  # Extractable_options should not be enabled by default for
+  # classes inherited from BSON::OrderedHash
+  #
+  def test_extractable_options_for_ordered_hash_inherited_classes_is_false
+    oh_child_class = Class.new(BSON::OrderedHash)
+    assert_false oh_child_class.new.extractable_options?
+  end
 end


### PR DESCRIPTION
Jira ticket: https://jira.mongodb.org/browse/RUBY-641

There's a commonly used approach to extract options from method arguments using `Array#extract_options!`

Example:

``` ruby
require 'active_support'

def foo(*args)
  args.extract_options!
end

foo(1, 1, { :some => 'hash' })  # => { :some => 'hash' } 
```

However when using `bson` gem inside a project the example above returns {}. 

ActiveSupport requires `BSON::OrderedHash` to implement method `#extractable_options?` to support options extraction. See https://github.com/rails/rails/blob/master/activesupport/lib/active_support/core_ext/array/extract_options.rb#L7
