### PR TITLE
Mongo::Pool: Always try at least once to get a socket.

### DIFF
--- a/lib/mongo/util/pool.rb
+++ b/lib/mongo/util/pool.rb
@@ -270,12 +270,6 @@ module Mongo
       @client.connect if !@client.connected?
       start_time = Time.now
       loop do
-        if (Time.now - start_time) > @timeout
-          raise ConnectionTimeoutError, "could not obtain connection within " +
-            "#{@timeout} seconds. The max pool size is currently #{@size}; " +
-            "consider increasing the pool size or timeout."
-        end
-
         @connection_mutex.synchronize do
           check_prune
           socket = nil
@@ -311,6 +305,12 @@ module Mongo
             # Otherwise, wait
             @queue.wait(@connection_mutex)
           end
+        end
+
+        if (Time.now - start_time) > @timeout
+          raise ConnectionTimeoutError, "could not obtain connection within " +
+            "#{@timeout} seconds. The max pool size is currently #{@size}; " +
+            "consider increasing the pool size or timeout."
         end
       end
     end


### PR DESCRIPTION
On heavily-loaded machines with a small timeout, it is actually
possible for the timeout to expire before even a single pass through
the checkout loop. This results in throwing ConnectionTimeoutError's,
even though nothing directly mongo-related is actually timing out or
going wrong.

Always pass through the loop at least once before timing out, so that
we are guaranteed to find a socket if there is one immediately
available.

This is the same code as PR #149, which appears to have been merged into the 1.8.2 release branch, but (accidentally?) dropped elsewhere.
