### PR TITLE
RUBY-635 adding 'full_response' option to find_and_modify

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -616,25 +616,36 @@ module Mongo
 
     # Atomically update and return a document using MongoDB's findAndModify command. (MongoDB > 1.3.0)
     #
-    # @option opts [Hash] :query ({}) a query selector document for matching the desired document.
-    # @option opts [Hash] :update (nil) the update operation to perform on the matched document.
-    # @option opts [Array, String, OrderedHash] :sort ({}) specify a sort option for the query using any
-    #   of the sort options available for Cursor#sort. Sort order is important if the query will be matching
-    #   multiple documents since only the first matching document will be updated and returned.
-    # @option opts [Boolean] :remove (false) If true, removes the the returned document from the collection.
-    # @option opts [Boolean] :new (false) If true, returns the updated document; otherwise, returns the document
-    #   prior to update.
+    # @option opts [Hash] :query ({}) a query selector document for matching
+    #  the desired document.
+    # @option opts [Hash] :update (nil) the update operation to perform on the
+    #  matched document.
+    # @option opts [Array, String, OrderedHash] :sort ({}) specify a sort
+    #  option for the query using any
+    #  of the sort options available for Cursor#sort. Sort order is important
+    #  if the query will be matching multiple documents since only the first
+    #  matching document will be updated and returned.
+    # @option opts [Boolean] :remove (false) If true, removes the the returned
+    #  document from the collection.
+    # @option opts [Boolean] :new (false) If true, returns the updated
+    #  document; otherwise, returns the document prior to update.
+    # @option opts [Boolean] :full_response (false) If true, returns the entire
+    #  response object from the server including 'ok' and 'lastErrorObject'.
     #
     # @return [Hash] the matched document.
     #
     # @core findandmodify find_and_modify-instance_method
     def find_and_modify(opts={})
+      full_response = opts.delete(:full_response)
+
       cmd = BSON::OrderedHash.new
       cmd[:findandmodify] = @name
       cmd.merge!(opts)
-      cmd[:sort] = Mongo::Support.format_order_clause(opts[:sort]) if opts[:sort]
 
-      @db.command(cmd)['value']
+      cmd[:sort] =
+        Mongo::Support.format_order_clause(opts[:sort]) if opts[:sort]
+
+      full_response ? @db.command(cmd) : @db.command(cmd)['value']
     end
 
     # Perform an aggregation using the aggregation framework on the current collection.

--- a/test/functional/collection_test.rb
+++ b/test/functional/collection_test.rb
@@ -955,7 +955,9 @@ class TestCollection < Test::Unit::TestCase
       @@test << { :a => 2, :processed => false }
       @@test << { :a => 3, :processed => false }
 
-      @@test.find_and_modify(:query => {}, :sort => [['a', -1]], :update => {"$set" => {:processed => true}})
+      @@test.find_and_modify(:query => {},
+                             :sort => [['a', -1]],
+                             :update => {"$set" => {:processed => true}})
 
       assert @@test.find_one({:a => 3})['processed']
     end
@@ -968,6 +970,21 @@ class TestCollection < Test::Unit::TestCase
       assert_raise Mongo::OperationFailure do
         @@test.find_and_modify(:blimey => {})
       end
+    end
+
+    def test_find_and_modify_with_full_response
+      @@test << { :a => 1, :processed => false }
+      @@test << { :a => 2, :processed => false }
+      @@test << { :a => 3, :processed => false }
+
+      doc = @@test.find_and_modify(:query => {},
+                                   :sort => [['a', -1]],
+                                   :update => {"$set" => {:processed => true}},
+                                   :full_response => true,
+                                   :new => true)
+
+      assert doc['value']['processed']
+      assert ['ok', 'value', 'lastErrorObject'].all? { |key| doc.key?(key) }
     end
   end
 


### PR DESCRIPTION
This is a pretty trival addon to find and modify. This improvement request came in a long time ago and I guess I just lost track of the ticket, trying to squash it now.

This change adds a :full_response option to the Collection#find_and_modify helper in the same way that the python driver works. This allows users easy access to things like lastErrorObject in the raw response from the server.
