### PR TITLE
minor: use true, false instead of Boolean in documentation

### DIFF
--- a/lib/mongo/protocol/message.rb
+++ b/lib/mongo/protocol/message.rb
@@ -154,7 +154,7 @@ module Mongo
       #
       # @param name [String] Name of the field
       # @param type [Module] Type specific serialization strategies
-      # @param multi [ Boolean, Symbol ] Specify as +true+ to
+      # @param multi [true, false, Symbol] Specify as +true+ to
       #   serialize the field's value as an array of type +:type+ or as a
       #   symbol describing the field having the number of items in the
       #   array (used upon deserialization)

--- a/lib/mongo/scope.rb
+++ b/lib/mongo/scope.rb
@@ -61,10 +61,10 @@ module Mongo
     #   specified number of docs. Use to prevent queries from running too long.
     # @option opts :read [Symbol] The read preference to use for the query.
     #   If none is provided, the collection's default read preference is used.
-    # @option opts :show_disk_loc [Boolean] Return disk location info as a
-    #   field in each doc.
+    # @option opts :show_disk_loc [true, false] Return disk location info as
+    #   a field in each doc.
     # @option opts :skip [Integer] The number of documents to skip.
-    # @option opts :snapshot [Boolean] Prevents returning a doc more than
+    # @option opts :snapshot [true, false] Prevents returning a doc more than
     #   once.
     # @option opts :sort [Hash] The key and direction pairs used to sort the
     #   results.
@@ -294,11 +294,12 @@ module Mongo
     #
     # @param q_opts [Hash] Query options.
     #
-    # @option q_opts :snapshot [Boolean] Prevents returning docs more than once.
+    # @option q_opts :snapshot [true, false] Prevents returning docs more
+    #   than once.
     # @option q_opts :max_scan [Integer] Constrain the query to only scan the
     #   specified number of docs.
-    # @option q_opts :show_disk_loc [Boolean] Return disk location info as a
-    #   field in each doc.
+    # @option q_opts :show_disk_loc [true, false] Return disk location info
+    #   as a field in each doc.
     #
     # @return [Hash, Scope] Either the query options or a new +Scope+.
     #
@@ -315,11 +316,12 @@ module Mongo
     #
     # @param q_opts [Hash] Query options.
     #
-    # @option q_opts :snapshot [Boolean] Prevents returning docs more than once.
+    # @option q_opts :snapshot [true, false] Prevents returning docs more
+    #   than once.
     # @option q_opts :max_scan [Integer] Constrain the query to only scan the
     #   specified number of docs.
-    # @option q_opts :show_disk_loc [Boolean] Return disk location info as a
-    #   field in each doc.
+    # @option q_opts :show_disk_loc [true, false] Return disk location info
+    #   as a field in each doc.
     #
     # @return [Scope] self
     #
@@ -333,7 +335,7 @@ module Mongo
 
     # Compare two +Scope+ objects.
     #
-    # @return [Boolean] Equal if collection, selector, and opts of two
+    # @return [true, false] Equal if collection, selector, and opts of two
     #   +Scopes+ match.
     #
     def ==(other)


### PR DESCRIPTION
We should use true, false as the Type possibilities in yard documentation.
