### PR TITLE
minor: style fix, removing redudant reference to self

### DIFF
--- a/lib/mongo/scope.rb
+++ b/lib/mongo/scope.rb
@@ -80,9 +80,8 @@ module Mongo
     # @return [String] A string representation of a +Scope+ instance.
     #
     def inspect
-      "<Mongo::Scope:0x#{self.object_id} " +
-        "namespace='#{@collection.full_namespace} " +
-        "@selector=#{@selector.inspect} @opts=#{@opts.inspect}>"
+      "<Mongo::Scope:0x#{object_id} namespace='#{@collection.full_namespace}" +
+      " @selector=#{@selector.inspect} @opts=#{@opts.inspect}>"
     end
 
     # Get the size of the result set for the query.


### PR DESCRIPTION
The style checker is currently failing due to an unnecessary reference to `self`
in Scope#inspect. This commit resolves that.

``` bash
mongo-ruby-driver|master ⇒ bundle update
mongo-ruby-driver|master ⇒ rubocop --version
0.10.0
mongo-ruby-driver|master ⇒ rubocop 
Inspecting 30 files
............C.................

Offences:

lib/mongo/scope.rb:83:26: C: Redundant `self` detected.
     "<Mongo::Scope:0x#{self.object_id} " +
                        ^^^^
```
