### PR TITLE
RUBY-645 add equality + hash methods to wire protocol messages

### DIFF
--- a/lib/mongo/protocol/message.rb
+++ b/lib/mongo/protocol/message.rb
@@ -79,6 +79,28 @@ module Mongo
         message
       end
 
+      # Tests for equality between two wire protocol messages
+      # by comparing class and field values.
+      #
+      # @param other [Mongo::Protocol::Message] The wire protocol message.
+      # @return [true, false] The equality of the messages.
+      def ==(other)
+        return false if self.class != other.class
+        fields.all? do |field|
+          name = field[:name]
+          instance_variable_get(name) ==
+            other.instance_variable_get(name)
+        end
+      end
+      alias_method :eql?, :==
+
+      # Creates a hash from the values of the fields of a message.
+      #
+      # @return [ Fixnum ] The hash code for the message.
+      def hash
+        fields.map { |field| instance_variable_get(field[:name]) }.hash
+      end
+
       private
 
       @@request_id = 0

--- a/spec/mongo/protocol/delete_spec.rb
+++ b/spec/mongo/protocol/delete_spec.rb
@@ -35,6 +35,80 @@ describe Mongo::Protocol::Delete do
     end
   end
 
+  describe '#==' do
+
+    context 'when the other is a delete' do
+
+      context 'when the fields are equal' do
+        let(:other) do
+          described_class.new(db, coll, selector, opts)
+        end
+
+        it 'returns true' do
+          expect(message).to eq(other)
+        end
+      end
+
+      context 'when the database is not equal' do
+        let(:other) do
+          described_class.new('tyler', coll, selector, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the collection is not equal' do
+        let(:other) do
+          described_class.new(db, 'tyler', selector, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the selector is not equal' do
+        let(:other) do
+          described_class.new(db, coll, { :a => 1 }, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the options are not equal' do
+        let(:other) do
+          described_class.new(db, coll, selector, :flags => [:single_remove])
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+    end
+
+    context 'when the other is not a delete' do
+      let(:other) do
+        expect(message).not_to eq('test')
+      end
+    end
+  end
+
+  describe '#hash' do
+    let(:values) do
+      message.send(:fields).map do |field|
+        message.instance_variable_get(field[:name])
+      end
+    end
+
+    it 'returns a hash of the field values' do
+      expect(message.hash).to eq(values.hash)
+    end
+  end
+
   describe '#serialize' do
     let(:bytes) { message.serialize }
 

--- a/spec/mongo/protocol/get_more_spec.rb
+++ b/spec/mongo/protocol/get_more_spec.rb
@@ -28,6 +28,80 @@ describe Mongo::Protocol::GetMore do
     end
   end
 
+  describe '#==' do
+
+    context 'when the other is a getmore' do
+
+      context 'when the fields are equal' do
+        let(:other) do
+          described_class.new(db, coll, limit, cursor_id)
+        end
+
+        it 'returns true' do
+          expect(message).to eq(other)
+        end
+      end
+
+      context 'when the database is not equal' do
+        let(:other) do
+          described_class.new('tyler', coll, limit, cursor_id)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the collection is not equal' do
+        let(:other) do
+          described_class.new(db, 'tyler', limit, cursor_id)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the limit is not equal' do
+        let(:other) do
+          described_class.new(db, coll, 123, cursor_id)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the cursor id is not equal' do
+        let(:other) do
+          described_class.new(db, coll, limit, 7777)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+    end
+
+    context 'when the other is not a getmore' do
+      let(:other) do
+        expect(message).not_to eq('test')
+      end
+    end
+  end
+
+  describe '#hash' do
+    let(:values) do
+      message.send(:fields).map do |field|
+        message.instance_variable_get(field[:name])
+      end
+    end
+
+    it 'returns a hash of the field values' do
+      expect(message.hash).to eq(values.hash)
+    end
+  end
+
   describe '#serialize' do
     let(:bytes) { message.serialize }
 

--- a/spec/mongo/protocol/insert_spec.rb
+++ b/spec/mongo/protocol/insert_spec.rb
@@ -37,6 +37,80 @@ describe Mongo::Protocol::Insert do
     end
   end
 
+  describe '#==' do
+
+    context 'when the other is an insert' do
+
+      context 'when the fields are equal' do
+        let(:other) do
+          described_class.new(db, coll, docs, opts)
+        end
+
+        it 'returns true' do
+          expect(message).to eq(other)
+        end
+      end
+
+      context 'when the database is not equal' do
+        let(:other) do
+          described_class.new('tyler', coll, docs, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the collection is not equal' do
+        let(:other) do
+          described_class.new(db, 'tyler', docs, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the documents are not equal' do
+        let(:other) do
+          described_class.new(db, coll, docs[1..1], opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the opts are not equal' do
+        let(:other) do
+          described_class.new(db, coll, docs, :flags => [:continue_on_error])
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+    end
+
+    context 'when the other is not an insert' do
+      let(:other) do
+        expect(message).not_to eq('test')
+      end
+    end
+  end
+
+  describe '#hash' do
+    let(:values) do
+      message.send(:fields).map do |field|
+        message.instance_variable_get(field[:name])
+      end
+    end
+
+    it 'returns a hash of the field values' do
+      expect(message.hash).to eq(values.hash)
+    end
+  end
+
   describe '#serialize' do
     let(:bytes) { message.serialize }
 

--- a/spec/mongo/protocol/kill_cursors_spec.rb
+++ b/spec/mongo/protocol/kill_cursors_spec.rb
@@ -20,6 +20,50 @@ describe Mongo::Protocol::KillCursors do
     end
   end
 
+  describe '#==' do
+
+    context 'when the other is a killcursors' do
+
+      context 'when the cursor ids are equal' do
+        let(:other) do
+          described_class.new(cursor_ids)
+        end
+
+        it 'returns true' do
+          expect(message).to eq(other)
+        end
+      end
+
+      context 'when the cursor ids are not equal' do
+        let(:other) do
+          described_class.new([123, 456])
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+    end
+
+    context 'when the other is not a killcursors' do
+      let(:other) do
+        expect(message).not_to eq('test')
+      end
+    end
+  end
+
+  describe '#hash' do
+    let(:values) do
+      message.send(:fields).map do |field|
+        message.instance_variable_get(field[:name])
+      end
+    end
+
+    it 'returns a hash of the field values' do
+      expect(message.hash).to eq(values.hash)
+    end
+  end
+
   describe '#serialize' do
     let(:bytes) { message.serialize }
 

--- a/spec/mongo/protocol/query_spec.rb
+++ b/spec/mongo/protocol/query_spec.rb
@@ -59,6 +59,80 @@ describe Mongo::Protocol::Query do
     end
   end
 
+  describe '#==' do
+
+    context 'when the other is a query' do
+
+      context 'when the fields are equal' do
+        let(:other) do
+          described_class.new(db, coll, selector, opts)
+        end
+
+        it 'returns true' do
+          expect(message).to eq(other)
+        end
+      end
+
+      context 'when the database is not equal' do
+        let(:other) do
+          described_class.new('tyler', coll, selector, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the collection is not equal' do
+        let(:other) do
+          described_class.new(db, 'tyler', selector, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the selector is not equal' do
+        let(:other) do
+          described_class.new(db, coll, { :a => 1 }, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the options are not equal' do
+        let(:other) do
+          described_class.new(db, coll, selector, { :skip => 2 })
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+    end
+
+    context 'when the other is not a query' do
+      let(:other) do
+        expect(message).not_to eq('test')
+      end
+    end
+  end
+
+  describe '#hash' do
+    let(:values) do
+      message.send(:fields).map do |field|
+        message.instance_variable_get(field[:name])
+      end
+    end
+
+    it 'returns a hash of the field values' do
+      expect(message.hash).to eq(values.hash)
+    end
+  end
+
   describe '#serialize' do
     let(:bytes) { message.serialize }
 

--- a/spec/mongo/protocol/reply_spec.rb
+++ b/spec/mongo/protocol/reply_spec.rb
@@ -28,6 +28,62 @@ describe Mongo::Protocol::Reply do
   let(:io)    { StringIO.new(header + data) }
   let(:reply) { described_class.deserialize(io) }
 
+  describe '#==' do
+
+    context 'when the other is a reply' do
+
+      context 'when the fields are equal' do
+        let(:other) do
+          other = described_class.allocate
+          other.instance_variable_set(:@flags, [])
+          other.instance_variable_set(:@number_returned, n_returned)
+          other.instance_variable_set(:@cursor_id, cursor_id)
+          other.instance_variable_set(:@documents, documents)
+          other.instance_variable_set(:@starting_from, start)
+          other
+        end
+
+        it 'returns true' do
+          expect(reply).to eq(other)
+        end
+      end
+
+      context 'when fields are not equal' do
+        let(:other) do
+          other = described_class.allocate
+          other.instance_variable_set(:@flags, [:await_capable])
+          other.instance_variable_set(:@number_returned, n_returned)
+          other.instance_variable_set(:@cursor_id, cursor_id)
+          other.instance_variable_set(:@documents, documents)
+          other.instance_variable_set(:@starting_from, start)
+          other
+        end
+
+        it 'returns false' do
+          expect(reply).not_to eq(other)
+        end
+      end
+    end
+
+    context 'when the other is not a reply' do
+      let(:other) do
+        expect(message).not_to eq('test')
+      end
+    end
+  end
+
+  describe '#hash' do
+    let(:values) do
+      reply.send(:fields).map do |field|
+        reply.instance_variable_get(field[:name])
+      end
+    end
+
+    it 'returns a hash of the field values' do
+      expect(reply.hash).to eq(values.hash)
+    end
+  end
+
   describe '#deserialize' do
 
     describe 'response flags' do

--- a/spec/mongo/protocol/update_spec.rb
+++ b/spec/mongo/protocol/update_spec.rb
@@ -28,6 +28,91 @@ describe Mongo::Protocol::Update do
     end
   end
 
+  describe '#==' do
+
+    context 'when the other is an update' do
+
+      context 'when the fields are equal' do
+        let(:other) do
+          described_class.new(db, coll, selector, update_doc, opts)
+        end
+
+        it 'returns true' do
+          expect(message).to eq(other)
+        end
+      end
+
+      context 'when the database is not equal' do
+        let(:other) do
+          described_class.new('tyler', coll, selector, update_doc, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the collection is not equal' do
+        let(:other) do
+          described_class.new(db, 'tyler', selector, update_doc, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the selector is not equal' do
+        let(:other) do
+          described_class.new(db, coll, { :a => 1 }, update_doc, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the update document is not equal' do
+        let(:other) do
+          described_class.new(db, coll, selector, { :a => 1 }, opts)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+
+      context 'when the options are not equal' do
+        let(:other) do
+          described_class.new(db, coll, selector, update_doc,
+                              :flags => :upsert)
+        end
+
+        it 'returns false' do
+          expect(message).not_to eq(other)
+        end
+      end
+    end
+
+    context 'when the other is not a query' do
+      let(:other) do
+        expect(message).not_to eq('test')
+      end
+    end
+  end
+
+  describe '#hash' do
+    let(:values) do
+      message.send(:fields).map do |field|
+        message.instance_variable_get(field[:name])
+      end
+    end
+
+    it 'returns a hash of the field values' do
+      expect(message.hash).to eq(values.hash)
+    end
+  end
+
   describe '#serialize' do
     let(:bytes) { message.serialize }
 


### PR DESCRIPTION
Pretty self-explanatory. Please review to make sure putting the logic for these into message is :ok:.
