### PR TITLE
refactor: making client context shared and updating scope specs

### DIFF
--- a/spec/mongo/scope_spec.rb
+++ b/spec/mongo/scope_spec.rb
@@ -2,20 +2,13 @@ require 'spec_helper'
 
 describe Mongo::Scope do
 
-  let(:db) { double('db') }
-  let(:collection) { double('collection') }
+  include_context 'shared client'
 
   let(:selector) { {} }
   let(:opts) { {} }
 
-  let(:ascending) { 1 }
-  let(:descending) { -1 }
-
   let(:scope) do
-    db.stub(:name) { TEST_DB }
-    collection.stub(:name) { TEST_COLL }
-    collection.stub(:db) { db }
-    collection.stub(:full_namespace) { "#{TEST_DB}.#{TEST_COLL}" }
+    stub!
     described_class.new(collection, selector, opts)
   end
 
@@ -297,11 +290,10 @@ describe Mongo::Scope do
 
       context 'when no read pref is set on initializaiton' do
         let(:opts) { {} }
-        let(:collection_read) { :primary_preferred }
+        let(:read) { :primary_preferred }
 
         it 'returns the collection read preference' do
-          collection.stub(:read) { collection_read }
-          expect(scope.read).to eq(collection_read)
+          expect(scope.read).to eq(read)
         end
 
       end
@@ -411,7 +403,6 @@ describe Mongo::Scope do
     let(:client) { double('client') }
 
     it 'calls count on collection' do
-      collection.stub(:client) { client }
       collection.stub(:count) { 10 }
       expect(scope.count).to eq(10)
     end
@@ -422,7 +413,6 @@ describe Mongo::Scope do
     let(:client) { double('client') }
 
     it 'calls explain on collection' do
-      collection.stub(:client) { client }
       collection.stub(:explain) { { 'n' => 10, 'nscanned' => 11 } }
       expect(scope.explain).to eq({ 'n' => 10, 'nscanned' => 11 })
     end
@@ -434,7 +424,6 @@ describe Mongo::Scope do
     let(:distinct_stats) { { 'values' => [1], 'stats' => { 'n' => 3 } } }
 
     it 'calls distinct on collection' do
-      collection.stub(:client) { client }
       collection.stub(:distinct) { distinct_stats }
       expect(scope.distinct('name')).to eq(distinct_stats)
     end
@@ -550,7 +539,6 @@ describe Mongo::Scope do
       let(:client) { double('client') }
 
       it 'terminates the chaining' do
-        collection.stub(:client) { client }
         collection.stub(:count) { 10 }
         expect(scope.limit(5).skip(10).count).to eq(10)
       end

--- a/spec/support/shared/client.rb
+++ b/spec/support/shared/client.rb
@@ -1,0 +1,27 @@
+shared_context 'shared client' do
+
+  let(:client) { double('client') }
+  let(:db) { Mongo::Database.new(client, TEST_DB) }
+  let(:collection) { db[TEST_COLL] }
+  let(:connection) { double('connection') }
+  let(:node) { double('node') }
+  let(:read) { :primary }
+  let(:ascending) { 1 }
+  let(:descending) { -1 }
+
+  def stub!
+    connection.stub(:send_message) { true }
+
+    node.stub(:with_connection).and_yield(connection)
+
+    collection.stub(:full_namespace) { "#{db.name}.#{collection.name}" }
+    collection.stub(:read) { read }
+
+    client.stub(:mongos?) { false }
+    client.stub(:with_node).and_yield(connection)
+    client.stub(:secondary_preferred?) { false }
+    client.stub(:secondary?) { false }
+    client.stub(:primary?) { true }
+  end
+
+end


### PR DESCRIPTION
I've put the mocks and stubs for client & its related objects into a separate shared client context file.
It will make specs much cleaner and easier to maintain as the interfaces of some of these classes change.  It's essentially a way to isolate some current unknowns.

I've refactored scope specs to use this shared context.
