### PR TITLE
Execute commands on a database.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 group :testing do
   gem 'json', :platforms => [ :ruby_18, :jruby ]
-  gem 'rspec'
+  gem 'rspec', '~> 2.14'
 
   platforms :ruby_19, :ruby_20, :jruby do
     gem 'coveralls', :require => false

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -44,8 +44,22 @@ module Mongo
       Collection.new(self, collection_name)
     end
 
-    # @todo: durran: need read preference and node for this.
+    # Execute a command on the database.
+    #
+    # @example Execute a command.
+    #   database.command(:ismaster => 1)
+    #
+    # @param [ Hash ] operation The command to execute.
+    #
+    # @return [ Hash ] The result of the command execution.
     def command(operation)
+      cmd = Protocol::Query.new(
+        name,
+        COMMAND,
+        operation,
+        :limit => -1, :read => client.read_preference
+      )
+      cluster.execute(cmd)
     end
 
     # Instantiate a new database object.
@@ -85,6 +99,22 @@ module Mongo
       def initialize
         super(MESSAGE)
       end
+    end
+
+    private
+
+    # Get the cluster from the client to execute operations on.
+    #
+    # @api private
+    #
+    # @example Get the cluster.
+    #   database.cluster
+    #
+    # @return [ Mongo::Cluster ] The cluster.
+    #
+    # @since 2.0.0
+    def cluster
+      client.cluster
     end
   end
 end

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -31,6 +31,31 @@ describe Mongo::Database do
     end
   end
 
+  describe '#command' do
+
+    let(:query) do
+      Mongo::Protocol::Query.new(
+        'test',
+        '$cmd',
+        { :ismaster => 1 },
+        { :limit => -1, :read => :secondary }
+      )
+    end
+
+    let(:cluster) { double('cluster') }
+    let(:database) { described_class.new(client, :test) }
+
+    before do
+      expect(client).to receive(:cluster).and_return(cluster)
+      expect(client).to receive(:read_preference).and_return(:secondary)
+      expect(cluster).to receive(:execute).with(query).and_return(:ok => 1)
+    end
+
+    it 'sends the query command to the cluster' do
+      expect(database.command(:ismaster => 1)).to eq(:ok => 1)
+    end
+  end
+
   describe '#initialize' do
 
     context 'when provided a valid name' do


### PR DESCRIPTION
This constructs a query message and sends it to the cluster to be
executed. Currently mocked until read preference and cluster are
complete.

Just a quick pull for this one area.
