### PR TITLE
minor: adding filters and extra reports for simplecov

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,22 @@
 unless RUBY_VERSION < '1.9'
   require 'coveralls'
-  Coveralls.wear!
+  require 'simplecov'
+
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+    SimpleCov::Formatter::HTMLFormatter,
+    Coveralls::SimpleCov::Formatter
+  ]
+
+  SimpleCov.start do
+    # report groups
+    add_group 'Wire Protocol', 'lib/mongo/protocol'
+    add_group 'Connection Pool', 'lib/mongo/pool'
+
+    # filters
+    add_filter 'tasks'
+    add_filter 'spec'
+    add_filter 'bin'
+  end
 end
 
 require 'mongo'


### PR DESCRIPTION
Looks like we weren't filtering simplecov correctly and our code coverage is actually just a bit lower than we thought (~98.9%). I'm also enabling groups and the HTML report so that you can easily review which lines of code are currently being covered by a test.
