### PR TITLE
RUBY-663 RUBY-664 batch insertion fixes with continue_on_error

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -1109,8 +1109,7 @@ module Mongo
     def insert_batch(message, documents, write_concern, continue_on_error, errors, collection_name=@name)
       begin
         send_insert_message(message, documents, collection_name, write_concern)
-      rescue ConnectionFailure, OperationFailure, OperationTimeout, SystemStackError,
-        NoMemoryError, SystemCallError => ex
+      rescue OperationFailure => ex
         raise ex unless continue_on_error
         errors << ex
       end
@@ -1170,7 +1169,7 @@ module Mongo
         insert_batch(message, docs_to_insert, write_concern, continue_on_error, errors, collection_name)
         # insert_batch collects errors if w > 0 and continue_on_error is true,
         # so raise the error here, as this is the last or only msg sent
-        raise errors.first unless errors.empty?
+        raise errors.last unless errors.empty?
       end
 
       collect_on_error ? [inserted_ids, error_docs] : inserted_ids

--- a/test/functional/collection_test.rb
+++ b/test/functional/collection_test.rb
@@ -292,6 +292,18 @@ class TestCollection < Test::Unit::TestCase
     return conn.db(MONGO_TEST_DB)["test"]
   end
 
+  def test_non_operation_failure_halts_insertion_with_continue_on_error
+    coll = limited_collection
+    coll.stubs(:send_insert_message).raises(OperationTimeout).times(1)
+    docs = []
+    10.times do
+      docs << {'foo' => 'a' * 950}
+    end
+    assert_raise OperationTimeout do
+      coll.insert(docs, :continue_on_error => true)
+    end
+  end
+
   def test_chunking_batch_insert
      docs = []
      10.times do


### PR DESCRIPTION
Two fixes in batch inserts:
- Only suppress OperationFailures (server errors) with continue_on_error.  Raise other types right away so insertion halts.
- Raise the most recent OperationFailure with continue_on_error.
