### PR TITLE
RUBY-644 adding some base error classes

### DIFF
--- a/lib/mongo/errors.rb
+++ b/lib/mongo/errors.rb
@@ -1,0 +1,10 @@
+module Mongo
+  # Base error class for all Mongo related errors.
+  class MongoError < StandardError; end
+
+  # Base error class for all errors coming from the driver.
+  class DriverError < MongoError; end
+
+  # Base error class for all errors coming from the server.
+  class OperationError < MongoError; end
+end


### PR DESCRIPTION
Pretty self explanatory.

Will allow us to replace sections of open pull requests that currently extend StandardError with more specific classifications in order to relate them to MongoDB.
