### PR TITLE
minor: cleanup of rake task, improvements to guard file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 .yardoc
 coverage
 data
-docs
+doc
 Gemfile.lock
 .ruby-gemset
 .ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ bundler_args: --without release development
 
 env: CI="travis"
 
-script: bundle exec rake test_with_coveralls
+script: bundle exec rake spec:ci
 
 notifications:
   email: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,8 @@ gem 'bson', '2.0.0.rc1'
 
 group :release do
   gem 'git'
+  gem 'kramdown'
   gem 'yard'
-  gem 'redcarpet', :platforms => :mri
 end
 
 group :testing do
@@ -15,20 +15,23 @@ group :testing do
 
   platforms :ruby_19, :ruby_20, :jruby do
     gem 'coveralls', :require => false
-    gem 'rubocop' unless RUBY_VERSION < '1.9'
+    gem 'rubocop' if RUBY_VERSION > '1.9'
   end
 end
 
 group :development do
-  gem 'pry-rescue'
-  gem 'pry-nav'
-  gem 'guard-rspec'
-
-  gem 'rb-inotify', :require => false # Linux
-  gem 'rb-fsevent', :require => false # OS X
   gem 'rb-fchange', :require => false # Windows
+  gem 'rb-fsevent', :require => false # OS X
+  gem 'rb-inotify', :require => false # Linux
   gem 'terminal-notifier-guard'
 
+  gem 'guard-bundler'
+  gem 'guard-rspec', :platforms => :mri
+  gem 'guard-jruby-rspec', :platforms => :jruby
   gem 'guard-rubocop', :platforms => [:ruby_19, :ruby_20, :jruby]
+  gem 'guard-yard', :platforms => [:mri_19, :mri_20]
+
   gem 'ruby-prof', :platforms => :mri
+  gem 'pry-rescue'
+  gem 'pry-nav'
 end

--- a/Guardfile
+++ b/Guardfile
@@ -1,12 +1,28 @@
-guard 'rspec', :all_after_pass => false do
+# supresses issues with pry hooks on jruby
+interactor :simple if RUBY_PLATFORM =~ /java/
+
+guard 'bundler' do
+  watch('Gemfile')
+  watch(/^.+\.gemspec/)
+end
+
+guard 'rspec', :all_after_pass => false, :cli => '-t ~style' do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$}) { |match| 'spec/#{match[1]}_spec.rb' }
   watch('spec/spec_helper.rb')  { 'spec' }
 end
 
 unless RUBY_VERSION < '1.9'
-  guard :rubocop do
-    watch(%r{.+\.rb$})
+  guard :rubocop, :cli => '-f s' do
+    watch(%r{(.+)\.rb$})
+    watch(%r{Rakefile$})
+    watch(%r{^lib/(.+)\.rake$})
     watch(%r{(?:.+/)?\.rubocop\.yml$}) { |m| File.dirname(m[0]) }
+  end
+
+  unless RUBY_PLATFORM =~ /java/
+    guard 'yard', :port => 8808 do
+      watch(%r{lib/.+\.rb})
+    end
   end
 end

--- a/spec/quality_spec.rb
+++ b/spec/quality_spec.rb
@@ -3,16 +3,18 @@ require 'spec_helper'
 describe 'Code Quality', :quality do
 
   unless RUBY_VERSION < '1.9'
-    it 'has no style-guide violations' do
+    it 'has no style-guide violations', :style do
       require 'rubocop'
       result = silence { Rubocop::CLI.new.run }
-      puts '[FAIL] Style issues found! To view a report, ' +
-           'please run "rubocop" from the project root.' unless result == 0
+      puts '[STYLE] style violations found. ' +
+           'Please run \'rubocop\' for a full report.' if result == 1
       expect(result).to eq(0)
     end
 
-    it 'has required minimum test coverage' do
-      expect(SimpleCov.result.covered_percent).to be >= COVERAGE_MIN
+    unless RUBY_PLATFORM =~ /java/
+      it 'has required minimum test coverage' do
+        expect(SimpleCov.result.covered_percent).to be >= COVERAGE_MIN
+      end
     end
   end
 

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -3,10 +3,12 @@ require 'rspec/core/rake_task'
 RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
 
-if RUBY_VERSION > '1.9'
-  require 'coveralls/rake/task'
-  Coveralls::RakeTask.new
-  task :test_with_coveralls => [:spec, 'coveralls:push']
-else
-  task :test_with_coveralls => [:spec]
+namespace :spec do
+  if RUBY_VERSION > '1.9' && RUBY_PLATFORM =~ /java/
+    require 'coveralls/rake/task'
+    Coveralls::RakeTask.new
+    task :ci => [:spec, 'coveralls:push']
+  else
+    task :ci => [:spec]
+  end
 end


### PR DESCRIPTION
- Cleaned up rake tasks, created 'spec' and 'spec:ci' which automatically
  determines whether or not to push to coveralls or not.
- Disabled coverage checks for JRuby. This could potentially be enabled again
  if we care enough to figure out why simplecov's reporting differs on the JVM,
  but for now lets just supress this test in that environment.
- Improved/added to the Guardfile. I disabled the style checker in the rspec
  guard so that it can run indpendently (we were previously running this twice
  when files changed) and I added a guard for yard so that we can easily review
  docs while we're working. I've also set guard to use the simple interactor for
  JRuby to suppress an error with pry hooks.
- Updated the .gitignore file for yard (s/docs/doc).
- Remove Red Carpet from the gem file and replaced it with Kramdown which
  works under all platforms.

Usage: bundle exec guard
