### PR TITLE
RUBY-658 fixing issue with default db from connection uri

### DIFF
--- a/lib/mongo/util/uri_parser.rb
+++ b/lib/mongo/util/uri_parser.rb
@@ -108,7 +108,7 @@ module Mongo
       :w                => lambda { |arg| Mongo::Support.is_i?(arg) ? arg.to_i : arg.to_sym },
       :wtimeout         => lambda { |arg| arg.to_i },
       :wtimeoutms       => lambda { |arg| arg.to_i }
-     }
+    }
 
     attr_reader :auths,
                 :connect,
@@ -253,6 +253,7 @@ module Mongo
         opts[:name] = replicaset
       end
 
+      opts[:default_db] = @db
       opts[:connect] = connect?
 
       opts
@@ -277,7 +278,7 @@ module Mongo
       uname    = matches[2]
       pwd      = matches[3]
       hosturis = matches[4].split(',')
-      db       = matches[8]
+      @db      = matches[8]
 
       hosturis.each do |hosturi|
         # If port is present, use it, otherwise use default port
@@ -295,8 +296,8 @@ module Mongo
         raise MongoArgumentError, "No nodes specified. Please ensure that you've provided at least one node."
       end
 
-      if uname && pwd && db
-        auths << {:db_name => db, :username => uname, :password => pwd}
+      if uname && pwd && @db
+        auths << {:db_name => @db, :username => uname, :password => pwd}
       elsif uname || pwd
         raise MongoArgumentError, "MongoDB URI must include username, password, "
           "and db if username and password are specified."

--- a/test/functional/connection_test.rb
+++ b/test/functional/connection_test.rb
@@ -122,11 +122,23 @@ class TestConnection < Test::Unit::TestCase
       ENV['MONGODB_URI'] = "mongodb://#{host_port}/"
       con = MongoClient.from_uri
       db = con.db
-      assert_equal db.name, Mongo::MongoClient::DEFAULT_DB_NAME
+      assert_equal db.name, MongoClient::DEFAULT_DB_NAME
     ensure
       ENV['MONGODB_URI'] = old_mongodb_uri
     end
   end
+
+  def test_db_from_uri_from_string_param
+    db_name = "_database"
+    db = MongoClient.from_uri("mongodb://#{host_port}/#{db_name}").db
+    assert_equal db.name, db_name
+  end
+
+  def test_db_from_uri_from_string_param_no_db_name
+    db = MongoClient.from_uri("mongodb://#{host_port}").db
+    assert_equal db.name, MongoClient::DEFAULT_DB_NAME
+  end
+
 
   def test_server_version
     assert_match(/\d\.\d+(\.\d+)?/, @client.server_version.to_s)


### PR DESCRIPTION
We had some broken (or at least it felt broken) logic around default DB names in `MongoClient` when created from a connection string URI that comes from something other than `ENV['MONGODB_URI']` or from `MongoClient#from_uri` directly. This fixes the issue and uses the DB name from the URI before falling back to the 'test' DB default.

In short, this makes the following behave as you'd expect:

``` ruby
client = Mongo::MongoClient.from_uri('mongodb://localhost/some_database')
db = client.db
db.name #=> 'some_database'
```

Let's not carry the hard-coded references to `ENV['MONGODB_URI']` over to the 2.0 driver, they need to die here :(
