### PR TITLE
RUBY-662 prevent ObjectId initialization with bad data

### DIFF
--- a/lib/bson/types/object_id.rb
+++ b/lib/bson/types/object_id.rb
@@ -41,6 +41,9 @@ module BSON
     #   the remaining bytes will consist of the standard machine id, pid, and counter. If
     #   you need a zeroed timestamp, used ObjectId.from_time.
     def initialize(data=nil, time=nil)
+      if data && (!data.is_a?(Array) || data.size != 12)
+        raise InvalidObjectId, 'ObjectId requires 12 byte array'
+      end
       @data = data || generate(time)
     end
 

--- a/test/bson/object_id_test.rb
+++ b/test/bson/object_id_test.rb
@@ -26,10 +26,16 @@ class ObjectIdTest < Test::Unit::TestCase
   end
 
   def test_array_uniq_for_equilavent_ids
-    a = ObjectId.new('123')
-    b = ObjectId.new('123')
+    a = ObjectId.new('123456789101'.unpack('C*'))
+    b = ObjectId.new('123456789101'.unpack('C*'))
     assert_equal a, b
     assert_equal 1, [a, b].uniq.size
+  end
+
+  def test_initialization_with_bad_data
+    assert_raise InvalidObjectId do
+      ObjectId.new('\xff')
+    end
   end
 
   def test_create_pk_method


### PR DESCRIPTION
The problem described in the JIRA ticket is actually occurring because `ObjectID#to_s` in `cbson.c` expects an array of 12 bytes to be stored in `@data`. I did not want to change the interface for making ObjectIds from strings so this was the easiest way to do some basic checking of provided ObjectId data similar to what happens in the python driver here: https://github.com/mongodb/mongo-python-driver/blob/master/bson/objectid.py#L169
