### PR TITLE
RUBY-650 catch adding multiple options

### DIFF
--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -386,7 +386,7 @@ module Mongo
     def add_option(opt)
       check_modifiable
 
-      if (opt == OP_QUERY_EXHAUST) && (@limit != 0)
+      if exhaust?(opt) && (@limit != 0)
         raise MongoArgumentError, "Exhaust option is incompatible with limit."
       end
 
@@ -633,8 +633,8 @@ module Mongo
     # Check whether the exhaust option is set
     #
     # @return [true, false] The state of the exhaust flag.
-    def exhaust?
-      !(@options & OP_QUERY_EXHAUST).zero?
+    def exhaust?(opts = options)
+      !(opts & OP_QUERY_EXHAUST).zero?
     end
 
     def check_modifiable

--- a/test/functional/cursor_test.rb
+++ b/test/functional/cursor_test.rb
@@ -96,6 +96,10 @@ class CursorTest < Test::Unit::TestCase
     assert_raise MongoArgumentError do
       c.add_option(OP_QUERY_EXHAUST)
     end
+
+    assert_raise MongoArgumentError do
+      c.add_option(OP_QUERY_EXHAUST + OP_QUERY_SLAVE_OK)
+    end
   end
 
   def test_limit_after_exhaust_error


### PR DESCRIPTION
Bernie pointed out that users could pass multiple options to `Cursor#add_option` so I am making some changes to account for that. I made the code a bit cleaner by re-using `#exhaust?` (making it more flexible) and added a test for this.
