### PR TITLE
1.x stable

### DIFF
--- a/lib/mongo/mongo_client.rb
+++ b/lib/mongo/mongo_client.rb
@@ -35,7 +35,7 @@ module Mongo
     SSL_OPTS             = [:ssl, :ssl_key, :ssl_cert, :ssl_verify, :ssl_ca_cert]
     POOL_OPTS            = [:pool_size, :pool_timeout]
     READ_PREFERENCE_OPTS = [:read, :tag_sets, :secondary_acceptable_latency_ms]
-    WRITE_CONCERN_OPTS   = [:w, :j, :fsync, :wtimeout]
+    WRITE_CONCERN_OPTS   = [:w, :j, :fsync, :wtimeout, :no_grid_ensure_index]
     CLIENT_ONLY_OPTS     = [:slave_ok]
 
     mongo_thread_local_accessor :connections
@@ -143,6 +143,7 @@ module Mongo
       @primary      = nil
       @primary_pool = nil
       @mongos       = false
+      p "**************INITIALIZE******************"
 
       # Not set for direct connection
       @tag_sets = []

--- a/lib/mongo/networking.rb
+++ b/lib/mongo/networking.rb
@@ -242,7 +242,7 @@ module Mongo
       gle = BSON::OrderedHash.new
       gle[:getlasterror] = 1
       if write_concern.is_a?(Hash)
-        write_concern.assert_valid_keys(:w, :wtimeout, :fsync, :j)
+        write_concern.assert_valid_keys(:w, :wtimeout, :fsync, :j, :no_grid_ensure_index)
         gle.merge!(write_concern)
         gle.delete(:w) if gle[:w] == 1
       end

--- a/lib/mongo/util/write_concern.rb
+++ b/lib/mongo/util/write_concern.rb
@@ -48,7 +48,8 @@ module Mongo
         :w        => 1,
         :j        => false,
         :fsync    => false,
-        :wtimeout => nil
+        :wtimeout => nil,
+        :no_grid_ensure_index => false
       }
       write_concern.merge!(parent.write_concern) if parent
       write_concern.merge!(opts.reject {|k,v| !write_concern.keys.include?(k)})


### PR DESCRIPTION
add an option no_grid_ensure_index.

```
without this option, gridfs recreates indexes on every file read, and twice on puts

this is due to the fact that the [] method on Mongo::DB instantiates a new collection every time a new
Mongo::Grid is created. This causes the cache used by ensure_index to be empty every time, in turn
causing indexes to be rewritten
```

This patch is only really useful if for some (likely unjustifiable) reason you're creating Mongo::Grid lots of times, but if you are, it's nice to have the option not to spend time ensuring index.
