### PR TITLE
RUBY-669 out aggregation pipeline operator

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -685,8 +685,10 @@ module Mongo
     #
     #   '$sort' Sorts all input documents and returns them to the pipeline in sorted order.
     #
+    #   '$out' The name of a collection to which the result set will be saved.
+    #
     # @option opts [:primary, :secondary] :read Read preference indicating which server to perform this query
-    #  on. See Collection#find for more details.
+    #  on. Must be :primary if $out is used. See Collection#find for more details.
     # @option opts [String]  :comment (nil) a comment to include in profiling logs
     # @option opts [Hash] :cursor cursor options for aggregation
     #
@@ -719,6 +721,8 @@ module Mongo
         }
 
         Cursor.new(self, seed)
+      elsif hash['pipeline'].any? { |op| op['$out'] || op[:$out] }
+        result
       else
         result['result']
       end

--- a/lib/mongo/utils/support.rb
+++ b/lib/mongo/utils/support.rb
@@ -80,6 +80,8 @@ module Mongo
         # mongo looks at the first key in the out object, and doesn't
         # look at the value
         out.is_a?(Hash) && out.keys.first.to_s.downcase == 'inline' ? true : false
+      elsif command == 'aggregate'
+        selector['pipeline'].any? { |op| op['$out'] || op[:$out] } ? false : true
       else
         SECONDARY_OK_COMMANDS.member?(command)
       end

--- a/test/functional/collection_test.rb
+++ b/test/functional/collection_test.rb
@@ -889,6 +889,44 @@ class TestCollection < Test::Unit::TestCase
     end
   end
 
+  if @@version >= "2.5.2"
+    def test_out_aggregate
+      setup_aggregate_data
+      pipeline = [{:$out => 'test_out'}]
+      docs = @@test.find.to_a
+      result = @@test.aggregate(pipeline)
+      assert_equal docs, @@db.collection('test_out').find.to_a
+    end
+
+    def test_out_aggregate_nonprimary_raises_expection
+      pipeline = [{:$out => 'test_out'}]
+      assert_raise MongoArgumentError do
+        @@test.aggregate(pipeline, :read => :secondary)
+      end
+    end
+
+    def test_out_aggregate_nonprimary_raises_expection_with_string
+      pipeline = [{'$out' => 'test_out'}]
+      assert_raise MongoArgumentError do
+        @@test.aggregate(pipeline, :read => :secondary)
+      end
+    end
+
+    def test_out_aggregate_returns_raw_response
+      pipeline = [{:$out => 'test_out'}]
+      response = @@test.aggregate(pipeline)
+      assert response.key?('result')
+      assert response.key?('ok')
+    end
+
+    def test_out_aggregate_raw_response_with_string
+      pipeline = [{'$out' => 'test_out'}]
+      response = @@test.aggregate(pipeline)
+      assert response.key?('result')
+      assert response.key?('ok')
+    end
+  end
+
   if @@version > "1.1.1"
     def test_map_reduce
       @@test << { "user_id" => 1 }


### PR DESCRIPTION
This pull request provides support for the new $out aggregation pipeline operator.  It is new in version 2.6 of the server.

The $out pipeline option allows you to specify the name of a collection to which the result of the aggregation should be written.

The result of the aggregation returned to the user will be the raw result document from the server if $out is used.

There is an additional check on the read preference used with the aggregation. The only replica set member that can be used with $out is the primary. This is because the result set is written to a collection. If a read preference other than primary is specified, a MongoArgumentError is raised.
