### PR TITLE
Ruby 661 updated server timeout error code and renaming of option in cursor

### DIFF
--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -276,16 +276,16 @@ module Mongo
     # the default cursor idle timeout (unless the "no cursor idle timeout"
     # flag has been set).
     #
-    # @note This can only be used with MongoDB 2.5+
+    # @note This will only have an effect in MongoDB 2.5+
     #
-    # @param max_time_ms [Fixnum] max execution time (in milliseconds)
+    # @param server_op_timeout [Fixnum] max execution time (in milliseconds)
     #
-    # @return [Fixnum, Cursor] either the current max_time_ms or cursor
-    def max_time(max_time_ms=nil)
-      return @max_time_ms unless max_time_ms
+    # @return [Fixnum, Cursor] either the current server_op_timeout or cursor
+    def server_op_timeout(server_op_timeout=nil)
+      return @server_op_timeout unless server_op_timeout
       check_modifiable
 
-      @max_time_ms = max_time_ms
+      @server_op_timeout = server_op_timeout
       self
     end
 
@@ -652,7 +652,7 @@ module Mongo
       spec['$returnKey']   = true if @return_key
       spec['$showDiskLoc'] = true if @show_disk_loc
       spec['$comment']  = @comment if @comment
-      spec['$maxTimeMS'] = @max_time_ms if @max_time_ms
+      spec['$maxTimeMS'] = @server_op_timeout if @server_op_timeout
       if needs_read_pref?
         read_pref = Mongo::ReadPreference::mongos(@read, @tag_sets)
         spec['$readPreference'] = read_pref if read_pref
@@ -666,7 +666,7 @@ module Mongo
 
     def query_contains_special_fields?
       @order || @explain || @hint || @snapshot || @show_disk_loc ||
-        @max_scan || @return_key || @comment || @max_time_ms || needs_read_pref?
+        @max_scan || @return_key || @comment || @server_op_timeout || needs_read_pref?
     end
 
     def close_cursor_if_query_complete

--- a/test/functional/cursor_test.rb
+++ b/test/functional/cursor_test.rb
@@ -91,35 +91,32 @@ class CursorTest < Test::Unit::TestCase
     end
   end
 
-  if @@version >= "2.5.2"
-    def test_cursor_timeout
-      cursor = @@coll.find
-      cursor.stubs(:send_initial_query).returns(true)
+  def test_server_op_timeout
+    cursor = @@coll.find
+    cursor.stubs(:send_initial_query).returns(true)
 
-      cursor.instance_variable_set(:@cache, [{
-        '$err' => 'operation exceeded time limit',
-        'code' => 16986
-      }])
+    cursor.instance_variable_set(:@cache, [{
+      '$err' => 'operation exceeded time limit',
+      'code' => 50
+    }])
 
-      assert_raise ExecutionTimeout do
-        cursor.to_a
-      end
+    assert_raise ExecutionTimeout do
+      cursor.to_a
+    end
+  end
+
+  def test_server_op_timeout_js
+    pend("This will fail until SERVER-10382 is completely resolved")
+    2.times { @@coll.insert({}) }
+
+    cursor = @@coll.find({'$where' => 'sleep(100); return true'})
+    cursor.server_op_timeout(100);
+
+    assert_raise ExecutionTimeout do
+      cursor.to_a
     end
 
-    def test_cursor_timeout_js
-      if @@version >= "2.5"
-        2.times { @@coll.insert({}) }
-
-        cursor = @@coll.find({'$where' => 'sleep(100); return true'})
-        cursor.max_time(100);
-
-        assert_raise ExecutionTimeout do
-          cursor.to_a
-        end
-
-        @@coll.remove
-      end
-    end
+    @@coll.remove
   end
 
   def test_exhaust_after_limit_error


### PR DESCRIPTION
Two commits:

1) Update error code for a server op timeout to 50

2) Rename maxTimeMs option to server op timeout in cursor. 
   Removed version check in tests because you can just send the option to versions < 2.5.2 and it'll be ignored.
   Marked js test as pending until the server bug is fixed (timeouts on js are returning an incorrect error)
