### PR TITLE
RUBY-661 adding server_op_timeout option to find_one

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -356,7 +356,9 @@ module Mongo
              else
                raise TypeError, "spec_or_object_id must be an instance of ObjectId or Hash, or nil"
              end
-      find(spec, opts.merge(:limit => -1)).next_document
+      timeout = opts.delete(:server_op_timeout)
+      cursor = find(spec, opts.merge(:limit => -1))
+      timeout ? cursor.server_op_timeout(timeout).next_document : cursor.next_document
     end
 
     # Save a document to this collection.

--- a/test/functional/collection_test.rb
+++ b/test/functional/collection_test.rb
@@ -723,6 +723,16 @@ class TestCollection < Test::Unit::TestCase
     end
   end
 
+  def test_find_one_with_server_op_timeout
+    pend("This will fail until SERVER-10382 is completely resolved")
+    2.times { @@test.insert({}) }
+    timeout = 100
+    assert_raise ExecutionTimeout do
+      @@test.find_one({ '$where' => 'sleep(#{timeout}); return true' },
+                      { :server_op_timeout => timeout })
+    end
+  end
+
   def test_insert_adds_id
     doc = {"hello" => "world"}
     @@test.insert(doc)


### PR DESCRIPTION
A few small changes and a test to make :server_op_timeout a valid option with #find_one.

Note: it's not an option with #find and will not be, according to the spec.
