### PR TITLE
Moving check for server version to test helper

### DIFF
--- a/test/functional/collection_test.rb
+++ b/test/functional/collection_test.rb
@@ -723,12 +723,10 @@ class TestCollection < Test::Unit::TestCase
     end
   end
 
-  if @@version >= "2.5.3"
-    def test_find_one_with_server_op_timeout
-      with_forced_timeout(@@client) do
-        assert_raise ExecutionTimeout do
-          @@test.find_one({}, { :server_op_timeout => 100 })
-        end
+  def test_find_one_with_server_op_timeout
+    with_forced_timeout(@@client) do
+      assert_raise ExecutionTimeout do
+        @@test.find_one({}, { :server_op_timeout => 100 })
       end
     end
   end

--- a/test/functional/cursor_test.rb
+++ b/test/functional/cursor_test.rb
@@ -105,13 +105,11 @@ class CursorTest < Test::Unit::TestCase
     end
   end
 
-  if @@version >= "2.5.3"
-    def test_server_op_timeout
-      with_forced_timeout(@@connection) do
-        assert_raise ExecutionTimeout do
-          cursor = @@coll.find.server_op_timeout(100)
-          cursor.to_a
-        end
+  def test_server_op_timeout
+    with_forced_timeout(@@connection) do
+      assert_raise ExecutionTimeout do
+        cursor = @@coll.find.server_op_timeout(100)
+        cursor.to_a
       end
     end
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -222,13 +222,15 @@ class Test::Unit::TestCase
 
   def with_forced_timeout(client)
     cmd_line_args = client['admin'].command({ :getCmdLineOpts => 1 })['argv']
-    if cmd_line_args.include?('enableTestCommands=1')
-      #Force any query or command with valid non-zero max time to fail (SERVER-10650)
-      client['admin'].command({ :configureFailPoint => 'maxTimeAlwaysTimeOut',
-                                :mode => 'alwaysOn' })
-      yield if block_given?
-      client['admin'].command({ :configureFailPoint => 'maxTimeAlwaysTimeOut',
-                                :mode => 'off' })
+    if cmd_line_args.include?('enableTestCommands=1') && client.server_version >= "2.5.3"
+      begin
+        #Force any query or command with valid non-zero max time to fail (SERVER-10650)
+        client['admin'].command({ :configureFailPoint => 'maxTimeAlwaysTimeOut',
+                                  :mode => 'alwaysOn' })
+        yield if block_given?
+        client['admin'].command({ :configureFailPoint => 'maxTimeAlwaysTimeOut',
+                                  :mode => 'off' })
+      end
     end
   end
 end


### PR DESCRIPTION
We are using a test helper method, with_forced_timeout, for tests using maxTimeMS.
I moved the version check to that helper so we don't have to remember to put them around the tests themselves.
