### PR TITLE
RUBY-686 some additional authentication prep and cleanup

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,1 @@
-lib/**/*.rb lib/mongo/**/*.rb lib/bson/**/*.rb -e ./tasks/yard/yard_ext.rb -p tasks/yard/templates
+lib/**/*.rb lib/mongo/**/*.rb lib/bson/**/*.rb

--- a/lib/bson/types/dbref.rb
+++ b/lib/bson/types/dbref.rb
@@ -23,8 +23,6 @@ module BSON
     #
     # @param [String] a collection name
     # @param [ObjectId] an object id
-    #
-    # @core dbrefs constructor_details
     def initialize(namespace, object_id)
       @namespace = namespace
       @object_id = object_id

--- a/lib/bson/types/object_id.rb
+++ b/lib/bson/types/object_id.rb
@@ -22,8 +22,6 @@ module BSON
   end
 
   # Generates MongoDB object ids.
-  #
-  # @core objectids
   class ObjectId
     attr_accessor :data
 

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -68,8 +68,6 @@ module Mongo
     #   if collection name is not a string or symbol
     #
     # @return [Collection]
-    #
-    # @core collections constructor_details
     def initialize(name, db, opts={})
       if db.is_a?(String) && name.is_a?(Mongo::DB)
         warn "Warning: the order of parameters to initialize a collection have changed. " +
@@ -227,8 +225,6 @@ module Mongo
     #
     # @raise [RuntimeError]
     #   if given unknown options
-    #
-    # @core find find-instance_method
     def find(selector={}, opts={})
       opts               = opts.dup
       fields             = opts.delete(:fields)
@@ -424,8 +420,6 @@ module Mongo
     #   collects invalid documents as an array. Note that this option changes the result format.
     #
     # @raise [Mongo::OperationFailure] will be raised iff :w > 0 and the operation fails.
-    #
-    # @core insert insert-instance_method
     def insert(doc_or_docs, opts={})
       doc_or_docs = [doc_or_docs] unless doc_or_docs.is_a?(Array)
       doc_or_docs.collect! { |doc| @pk_factory.create_pk(doc) }
@@ -461,8 +455,6 @@ module Mongo
     #   Otherwise, returns true.
     #
     # @raise [Mongo::OperationFailure] will be raised iff :w > 0 and the operation fails.
-    #
-    # @core remove remove-instance_method
     def remove(selector={}, opts={})
       send_write_operation(:delete, selector, nil, nil, opts)
     end
@@ -495,8 +487,6 @@ module Mongo
     #   Otherwise, returns true.
     #
     # @raise [Mongo::OperationFailure] will be raised iff :w > 0 and the operation fails.
-    #
-    # @core update update-instance_method
     def update(selector, document, opts={})
       send_write_operation(:update, selector, document, !document.keys.first.to_s.start_with?("$"), opts)
     end
@@ -550,8 +540,6 @@ module Mongo
     #   @restaurants.create_index([['location', Mongo::GEO2D]], :min => 500, :max => 500)
     #
     # @return [String] the name of the index created.
-    #
-    # @core indexes create_index-instance_method
     def create_index(spec, opts={})
       opts[:dropDups]   = opts[:drop_dups] if opts[:drop_dups]
       opts[:bucketSize] = opts[:bucket_size] if opts[:bucket_size]
@@ -599,8 +587,6 @@ module Mongo
     # Drop a specified index.
     #
     # @param [String] name
-    #
-    # @core indexes
     def drop_index(name)
       if name.is_a?(Array)
         return drop_index(index_name(name))
@@ -610,8 +596,6 @@ module Mongo
     end
 
     # Drop all indexes.
-    #
-    # @core indexes
     def drop_indexes
       @cache = {}
 
@@ -648,8 +632,6 @@ module Mongo
     #  response object from the server including 'ok' and 'lastErrorObject'.
     #
     # @return [Hash] the matched document.
-    #
-    # @core findandmodify find_and_modify-instance_method
     def find_and_modify(opts={})
       full_response = opts.delete(:full_response)
 
@@ -757,8 +739,6 @@ module Mongo
     # @raise ArgumentError if you specify { :out => { :inline => true }} but don't specify :raw => true.
     #
     # @see http://www.mongodb.org/display/DOCS/MapReduce Offical MongoDB map/reduce documentation.
-    #
-    # @core mapreduce map_reduce-instance_method
     def map_reduce(map, reduce, opts={})
       opts = opts.dup
       map    = BSON::Code.new(map) unless map.is_a?(BSON::Code)
@@ -982,8 +962,6 @@ module Mongo
     # Get information on the indexes for this collection.
     #
     # @return [Hash] a hash where the keys are index names.
-    #
-    # @core indexes
     def index_information
       @db.index_information(@name)
     end

--- a/lib/mongo/connection/node.rb
+++ b/lib/mongo/connection/node.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'thread'
+
 module Mongo
   class Node
 

--- a/lib/mongo/connection/pool.rb
+++ b/lib/mongo/connection/pool.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'thread'
+
 module Mongo
   class Pool
     PING_ATTEMPTS  = 6

--- a/lib/mongo/connection/pool_manager.rb
+++ b/lib/mongo/connection/pool_manager.rb
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 require 'set'
+require 'thread'
 
 module Mongo
   class PoolManager

--- a/lib/mongo/connection/sharding_pool_manager.rb
+++ b/lib/mongo/connection/sharding_pool_manager.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'thread'
+
 module Mongo
   class ShardingPoolManager < PoolManager
     def inspect

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -34,8 +34,6 @@ module Mongo
     # similar methods. Application developers shouldn't have to create cursors manually.
     #
     # @return [Cursor]
-    #
-    # @core cursors constructor_details
     def initialize(collection, opts={})
       opts = opts.dup
       @cursor_id  = opts.delete(:cursor_id)
@@ -236,8 +234,6 @@ module Mongo
     # @return [Integer] the current number_to_return if no parameter is given.
     #
     # @raise [InvalidOperation] if this cursor has already been used.
-    #
-    # @core limit limit-instance_method
     def limit(number_to_return=nil)
       return @limit unless number_to_return
       check_modifiable
@@ -359,8 +355,6 @@ module Mongo
     # Get the explain plan for this cursor.
     #
     # @return [Hash] a document containing the explain plan for this cursor.
-    #
-    # @core explain explain-instance_method
     def explain
       check_command_cursor
       c = Cursor.new(@collection,

--- a/lib/mongo/functional.rb
+++ b/lib/mongo/functional.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'mongo/functional/authentication'
 require 'mongo/functional/logging'
 require 'mongo/functional/read_preference'
 require 'mongo/functional/write_concern'

--- a/lib/mongo/functional/authentication.rb
+++ b/lib/mongo/functional/authentication.rb
@@ -1,0 +1,116 @@
+# Copyright (C) 2013 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'digest/md5'
+
+module Mongo
+  module Authentication
+
+    extend self
+
+    # Generate an MD5 for authentication.
+    #
+    # @param [String] username
+    # @param [String] password
+    # @param [String] nonce
+    #
+    # @return [String] a key for db authentication.
+    def auth_key(username, password, nonce)
+      Digest::MD5.hexdigest("#{nonce}#{username}#{hash_password(username, password)}")
+    end
+
+    # Return a hashed password for auth.
+    #
+    # @param [String] username
+    # @param [String] plaintext
+    #
+    # @return [String]
+    def hash_password(username, plaintext)
+      Digest::MD5.hexdigest("#{username}:mongo:#{plaintext}")
+    end
+
+    # Apply each of the saved database authentications.
+    #
+    # @return [Boolean] returns true if authentications exist and succeeds,
+    #   false if none exists.
+    #
+    # @raise [AuthenticationError] raises an exception if any one
+    #   authentication fails.
+    def apply_saved_authentication(opts={})
+      return false if @auths.empty?
+      @auths.each do |auth|
+        self[auth[:db_name]].issue_authentication(auth[:username], auth[:password], false,
+          :source => auth[:source], :socket => opts[:socket])
+      end
+      true
+    end
+
+    # Save an authentication to this connection. When connecting,
+    # the connection will attempt to re-authenticate on every db
+    # specified in the list of auths. This method is called automatically
+    # by DB#authenticate.
+    #
+    # Note: this method will not actually issue an authentication command.
+    #   To do that, either run MongoClient#apply_saved_authentication
+    #   or DB#authenticate.
+    #
+    # @param [String] db_name
+    # @param [String] username
+    # @param [String] password
+    #
+    # @return [Hash] a hash representing the authentication just added.
+    def add_auth(db_name, username, password, source)
+      if @auths.any? {|a| a[:db_name] == db_name}
+        raise MongoArgumentError,
+          "Cannot apply multiple authentications to database '#{db_name}'"
+      end
+
+      auth = {
+        :db_name  => db_name,
+        :username => username,
+        :password => password,
+        :source => source
+      }
+      @auths << auth
+      auth
+    end
+
+    # Remove a saved authentication for this connection.
+    #
+    # @param [String] db_name
+    #
+    # @return [Boolean]
+    def remove_auth(db_name)
+      return unless @auths
+      @auths.reject! { |a| a[:db_name] == db_name } ? true : false
+    end
+
+    # Remove all authentication information stored in this connection.
+    #
+    # @return [true] this operation return true because it always succeeds.
+    def clear_auths
+      @auths = []
+      true
+    end
+
+    def authenticate_pools
+      @primary_pool.authenticate_existing
+    end
+
+    def logout_pools(db)
+      @primary_pool.logout_existing(db)
+    end
+
+  end
+end

--- a/lib/mongo/functional/uri_parser.rb
+++ b/lib/mongo/functional/uri_parser.rb
@@ -134,9 +134,8 @@ module Mongo
     # @note Passwords can contain any character except for ','
     #
     # @param [String] uri The MongoDB URI string.
-    # @param [Hash,nil] extra_opts Extra options. Will override anything already specified in the URI.
-    #
-    # @core connections
+    # @param [Hash,nil] extra_opts Extra options. Will override anything
+    #   already specified in the URI.
     def initialize(uri)
       if uri.start_with?('mongodb://')
         uri = uri[10..-1]

--- a/lib/mongo/gridfs/grid.rb
+++ b/lib/mongo/gridfs/grid.rb
@@ -23,8 +23,6 @@ module Mongo
     # Initialize a new Grid instance, consisting of a MongoDB database
     # and a filesystem prefix if not using the default.
     #
-    # @core gridfs
-    #
     # @see GridFileSystem
     def initialize(db, fs_name=DEFAULT_FS_NAME)
       raise MongoArgumentError, "db must be a Mongo::DB." unless db.is_a?(Mongo::DB)

--- a/lib/mongo/mongo_client.rb
+++ b/lib/mongo/mongo_client.rb
@@ -21,6 +21,7 @@ module Mongo
     include Mongo::Logging
     include Mongo::Networking
     include Mongo::WriteConcern
+    include Mongo::Authentication
 
     Mutex              = ::Mutex
     ConditionVariable  = ::ConditionVariable
@@ -130,8 +131,6 @@ module Mongo
     #   driver fails to connect to a replica set with that name.
     #
     # @raise [MongoArgumentError] If called with no arguments and <code>ENV["MONGODB_URI"]</code> implies a replica set.
-    #
-    # @core self.connections
     def initialize(*args)
       opts = args.last.is_a?(Hash) ? args.pop : {}
       @host, @port = parse_init(args[0], args[1], opts)
@@ -262,81 +261,6 @@ module Mongo
       self['admin']['$cmd.sys.unlock'].find_one
     end
 
-    # Apply each of the saved database authentications.
-    #
-    # @return [Boolean] returns true if authentications exist and succeeds, false
-    #   if none exists.
-    #
-    # @raise [AuthenticationError] raises an exception if any one
-    #   authentication fails.
-    def apply_saved_authentication(opts={})
-      return false if @auths.empty?
-      @auths.each do |auth|
-        self[auth[:db_name]].issue_authentication(auth[:username], auth[:password], false,
-          :source => auth[:source], :socket => opts[:socket])
-      end
-      true
-    end
-
-    # Save an authentication to this connection.
-    #
-    # When connecting, the connection will attempt to re-authenticate on
-    # every database specified in the list of auths. This method is called
-    # automatically by DB#authenticate.
-    #
-    # Note: this method will not actually issue an authentication command.
-    # To do that, either run MongoClient#apply_saved_authentication or
-    # DB#authenticate.
-    #
-    # @param db_name [String] the database name.
-    # @param username [String] the username.
-    # @param password [String] the users password.
-    # @param source [String] (nil) optional database name if authenticating
-    # against a different database than specified with db_name.
-    #
-    # @return [Hash] a hash representing the authentication just added.
-    def add_auth(db_name, username, password, source=nil)
-      if @auths.any? {|a| a[:db_name] == db_name}
-        raise MongoArgumentError,
-            "Cannot apply multiple authentications to database '#{db_name}'"
-      end
-
-      auth = {
-        :db_name  => db_name,
-        :username => username,
-        :password => password,
-        :source   => source
-      }
-      @auths << auth
-      auth
-    end
-
-    # Remove a saved authentication for this connection.
-    #
-    # @param [String] db_name
-    #
-    # @return [Boolean]
-    def remove_auth(db_name)
-      return unless @auths
-      @auths.reject! { |a| a[:db_name] == db_name } ? true : false
-    end
-
-    # Remove all authentication information stored in this connection.
-    #
-    # @return [true] this operation return true because it always succeeds.
-    def clear_auths
-      @auths = []
-      true
-    end
-
-    def authenticate_pools
-      @primary_pool.authenticate_existing
-    end
-
-    def logout_pools(db)
-      @primary_pool.logout_existing(db)
-    end
-
     # Return a hash with all database names
     # and their respective sizes on disk.
     #
@@ -362,9 +286,7 @@ module Mongo
     # @param [String] db_name a valid database name.
     # @param [Hash] opts options to be passed to the DB constructor.
     #
-    # @return [Mongo::DB]
-    #
-    # @core databases db-instance_method
+    # @return [DB]
     def db(db_name = @default_db, opts = {})
       DB.new(db_name, self, opts)
     end
@@ -373,9 +295,7 @@ module Mongo
     #
     # @param [String] db_name a valid database name.
     #
-    # @return [Mongo::DB]
-    #
-    # @core databases []-instance_method
+    # @return [DB]
     def [](db_name)
       DB.new(db_name, self)
     end
@@ -403,11 +323,13 @@ module Mongo
     # Copy the database +from+ to +to+ on localhost. The +from+ database is
     # assumed to be on localhost, but an alternate host can be specified.
     #
-    # @param [String] from name of the database to copy from.
-    # @param [String] to name of the database to copy to.
-    # @param [String] from_host host of the 'from' database.
-    # @param [String] username username for authentication against from_db (>=1.3.x).
-    # @param [String] password password for authentication against from_db (>=1.3.x).
+    # @param from [String] name of the database to copy from.
+    # @param to [String] name of the database to copy to.
+    # @param from_host [String] host of the 'from' database.
+    # @param username [String] username (applies to 'from' db)
+    # @param password [String] password (applies to 'from' db)
+    #
+    # @note This command only supports the MONGODB-CR authentication mechanism.
     def copy_database(from, to, from_host=DEFAULT_HOST, username=nil, password=nil)
       oh = BSON::OrderedHash.new
       oh[:copydb]   = 1
@@ -424,7 +346,7 @@ module Mongo
         result = self["admin"].command(nonce_cmd)
         oh[:nonce] = result["nonce"]
         oh[:username] = username
-        oh[:key] = Mongo::Support.auth_key(username, password, oh[:nonce])
+        oh[:key] = Mongo::Authentication.auth_key(username, password, oh[:nonce])
       end
       self["admin"].command(oh)
     end

--- a/lib/mongo/utils/support.rb
+++ b/lib/mongo/utils/support.rb
@@ -12,34 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'digest/md5'
-
 module Mongo
   module Support
 
     include Mongo::Conversions
     extend self
-
-    # Generate an MD5 for authentication.
-    #
-    # @param [String] username
-    # @param [String] password
-    # @param [String] nonce
-    #
-    # @return [String] a key for db authentication.
-    def auth_key(username, password, nonce)
-      Digest::MD5.hexdigest("#{nonce}#{username}#{hash_password(username, password)}")
-    end
-
-    # Return a hashed password for auth.
-    #
-    # @param [String] username
-    # @param [String] plaintext
-    #
-    # @return [String]
-    def hash_password(username, plaintext)
-      Digest::MD5.hexdigest("#{username}:mongo:#{plaintext}")
-    end
 
     def validate_db_name(db_name)
       unless [String, Symbol].include?(db_name.class)

--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -61,7 +61,10 @@ namespace :test do
   desc "Runs commit test suites"
   task :commit do
     COMMIT_TESTS = %w(ext ruby replica_set sharded_cluster)
-    COMMIT_TESTS.each{|task| puts "test:#{task}"; Rake::Task["test:#{task}"].execute}
+    COMMIT_TESTS.each do |task|
+      puts "[RUNNING] test:#{task}"
+      Rake::Task["test:#{task}"].execute
+    end
     Rake::Task['test:cleanup'].execute
   end
 

--- a/tasks/yard/templates/default/tags/html/core.erb
+++ b/tasks/yard/templates/default/tags/html/core.erb
@@ -1,8 +1,0 @@
-<% if object.has_tag?(:core) %>
-  <p class="tag_title"><strong>Core Docs:</strong></p>
-  <ul class="see">
-    <% for tag in object.tags(:core) %>
-      <li><a href='<%= "http://dochub.mongodb.org/core/#{tag.name}" %>' name='<%= tag.text %>'><%= tag.name.capitalize %></a></li>
-    <% end %>
-  </ul>
-<% end %>

--- a/tasks/yard/templates/default/tags/setup.rb
+++ b/tasks/yard/templates/default/tags/setup.rb
@@ -1,4 +1,0 @@
-def init
-  super
-  sections.push :core
-end

--- a/tasks/yard/yard_ext.rb
+++ b/tasks/yard/yard_ext.rb
@@ -1,1 +1,0 @@
-YARD::Tags::Library.define_tag "Core", :core, :with_name

--- a/test/functional/client_test.rb
+++ b/test/functional/client_test.rb
@@ -15,7 +15,7 @@
 require 'test_helper'
 require 'logger'
 
-class TestConnection < Test::Unit::TestCase
+class ClientTest < Test::Unit::TestCase
 
   include Mongo
   include BSON


### PR DESCRIPTION
- standardizing some terminology in client/db (connection -> client)
- removed yardoc extension and update yardopts
- removed `@core` tag references (mongodb.org docs don't support this anymore)
- added some references to thread back so that if the order of things in the
  loadpath change references to Mutex/ConditionVariable will still work.
- moved authentication related functionality to a new auth module.
