### PR TITLE
Arbitrary command opts need to be merged into the selector

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -719,10 +719,10 @@ module Mongo
           :pool => @connection.pinned_pool
         }
 
-        Cursor.new(self, seed)
-      else
-        result['result']
+        return Cursor.new(self, seed)
       end
+
+      result['result'] || result
     end
 
     # Perform a map-reduce operation on the current collection.


### PR DESCRIPTION
Update to db#command because arbitrary opts for a command need to be merged into the selector.

I updated the code to merge the opts with the selector in db#command. In order for this to work though, you need to remove options such as :read, :comment, :raw, and :socket from opts because they'll cause an error if passed as part of the query on $cmd.
