### PR TITLE
RUBY-690 Test that aggregate supports explain option

### DIFF
--- a/test/functional/collection_test.rb
+++ b/test/functional/collection_test.rb
@@ -62,12 +62,24 @@ class TestCollection < Test::Unit::TestCase
     end
   end
 
-  if @@version >= '2.5.2'
-    def test_aggregation_arbitrary_opts
+  if @@version >= '2.5.3'
+    def test_aggregation_allow_disk_usage
       @@db.expects(:command).with do |selector, opts|
         opts[:allowDiskUsage] == true
       end.returns({ 'ok' => 1 })
       @@test.aggregate([], :allowDiskUsage => true)
+    end
+
+    def test_aggregation_supports_explain
+      @@db.expects(:command).with do |selector, opts|
+        opts[:explain] == true
+      end.returns({ 'ok' => 1 })
+      @@test.aggregate([], :explain => true)
+    end
+
+    def test_aggregation_explain_returns_raw_result
+      response = @@test.aggregate([], :explain => true)
+      assert response['stages']
     end
   end
 


### PR DESCRIPTION
I've added two tests to the functional/collection_test.rb that checks explain:

The first one tests to make sure that explain is passed along as a command option for the aggregation.

The second one verifies that the raw result document will be returned when explain is specified.
