### PR TITLE
RUBY-669 Support aggregation out pipeline operator

### DIFF
--- a/lib/mongo/functional/read_preference.rb
+++ b/lib/mongo/functional/read_preference.rb
@@ -72,6 +72,8 @@ module Mongo
         out = selector.select { |k, v| k.to_s.downcase == 'out' }.first.last
         # the server only looks at the first key in the out object
         return out.respond_to?(:keys) && out.keys.first.to_s.downcase == 'inline' ? true : false
+      elsif command == 'aggregate'
+        return selector['pipeline'].none? { |op| op.key?('$out') || op.key?(:$out) }
       end
       SECONDARY_OK_COMMANDS.member?(command)
     end


### PR DESCRIPTION
This pull request provides support for the new $out aggregation pipeline operator. It is new in version 2.6 of the server.

The $out pipeline operator allows you to specify the name of a collection to which the result of the aggregation will be written.

The result of the aggregation returned to the user will be the raw result document from the server if $out is used.

There is an additional check on the read preference used with the aggregation. The only replica set member that can be used with $out is the primary. This is because the result set is written to a collection. If a read preference other than primary is specified, the aggregation will be rerouted to the primary and a warning will be displayed saying:

```
Database command 'aggregate' rerouted to primary node
```
