### PR TITLE
Don't merge named nil opts into command selector

### DIFF
--- a/lib/mongo/db.rb
+++ b/lib/mongo/db.rb
@@ -555,10 +555,10 @@ module Mongo
       check_response = opts.delete(:check_response) { true }
 
       # build up the command hash
-      command = opts[:socket] ? { :socket => opts.delete(:socket) } : {}
-      command.merge!({ :comment => opts.delete(:comment) }) if opts[:comment]
+      command = opts.key?(:socket) ? { :socket => opts.delete(:socket) } : {}
+      command.merge!({ :comment => opts.delete(:comment) }) if opts.key?(:comment)
       command[:limit] = -1
-      command[:read] = Mongo::ReadPreference::cmd_read_pref(opts.delete(:read), selector) if opts[:read]
+      command[:read] = Mongo::ReadPreference::cmd_read_pref(opts.delete(:read), selector) if opts.key?(:read)
       # arbitrary opts are merged into the selector
       command[:selector] = selector.merge!(opts)
 

--- a/test/unit/db_test.rb
+++ b/test/unit/db_test.rb
@@ -55,6 +55,14 @@ class DBTest < Test::Unit::TestCase
         end
       end
 
+      should "not include named nil opts in selector" do
+        @cursor = mock(:next_document => {"ok" => 1})
+        Cursor.expects(:new).with(@collection, :limit => -1,
+          :selector => {:ping => 1}, :socket => nil).returns(@cursor)
+        command = {:ping => 1}
+        @db.command(command, :socket => nil)
+      end
+
       should "create the proper cursor" do
         @cursor = mock(:next_document => {"ok" => 1})
         Cursor.expects(:new).with(@collection,


### PR DESCRIPTION
This pull request solves a bunch of failures in Jenkins on 1.8.7
https://jenkins.10gen.com/job/mongo-ruby-driver-1.x-stable/16/mongodb_server=stable-release,os_arch=linux64,ruby_language_version=1.8.7-p374,test_type=with-ext/console

The problem is that if :socket => nil is passed as a command option into db#command, the nil socket was being merged into the command selector. This was because in the logic

```
opts[:socket] ? { :socket => opts.delete(:socket) } : {}
```

opts[:socket] evaluates to nil/false so the :socket => nil pair wouldn't get pruned out of opts.

I've updated the code to prune out the named opts depending on whether the opts has that key.  This should avoid ending up with a selector that was causing the Jenkins failures like below:

```
{ :ping => 1, :socket => nil }
```
