### PR TITLE
Cleaning up references to system.users and unnecessary auth test

### DIFF
--- a/test/functional/client_test.rb
+++ b/test/functional/client_test.rb
@@ -183,21 +183,6 @@ class ClientTest < Test::Unit::TestCase
     @client.drop_database('new')
   end
 
-  def test_copy_database_with_auth
-    @client.db('old').collection('copy-test').insert('a' => 1)
-    @client.db('old').add_user('bob', 'secret')
-
-    assert_raise Mongo::OperationFailure do
-      @client.copy_database('old', 'new', host_port, 'bob', 'badpassword')
-    end
-
-    result = @client.copy_database('old', 'new', host_port, 'bob', 'secret')
-    assert Mongo::Support.ok?(result)
-
-    @client.drop_database('old')
-    @client.drop_database('new')
-  end
-
   def test_database_names
     @client.drop_database(MONGO_TEST_DB)
     @client.db(MONGO_TEST_DB).collection('info-test').insert('a' => 1)

--- a/test/functional/db_test.rb
+++ b/test/functional/db_test.rb
@@ -30,7 +30,6 @@ class DBTest < Test::Unit::TestCase
 
   @@client  = standard_connection
   @@db    = @@client.db(MONGO_TEST_DB)
-  @@users = @@db.collection('system.users')
   @@version = @@client.server_version
 
   def test_close
@@ -43,7 +42,6 @@ class DBTest < Test::Unit::TestCase
       assert_match(/NilClass/, ex.to_s)
     ensure
       @@db = standard_connection.db(MONGO_TEST_DB)
-      @@users = @@db.collection('system.users')
     end
   end
 

--- a/test/shared/authentication.rb
+++ b/test/shared/authentication.rb
@@ -32,12 +32,14 @@ module AuthenticationTests
 
   def test_add_user
     @db.add_user('bob','user')
-    assert @db['system.users'].find_one({:user => 'bob'})
+    assert @db.authenticate('bob', 'user')
   end
 
    def test_remove_user
     @db.remove_user('bob')
-    assert_nil @db['system.users'].find_one({:user => 'bob'})
+    assert_raise Mongo::AuthenticationError do
+      @db.authenticate('bob', 'user')
+    end
   end
 
   def test_remove_non_existent_user


### PR DESCRIPTION
I removed a few references to system.users and a test that checks you can't copy a db if authenticated.  Testing authentication is good enough, we don't have to check this particular operation.
