### PR TITLE
RUBY-702 Note fsync as deprecated in docs. Include server docs reference...

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -52,7 +52,8 @@ module Mongo
     #   should be acknowledged
     # @option opts [Boolean] :j (false) Set journal acknowledgement
     # @option opts [Integer] :wtimeout (nil) Set replica set acknowledgement timeout
-    # @option opts [Boolean] :fsync (false) Set fsync acknowledgement.
+    # @option opts [Boolean] :fsync (false) Deprecated; do not use. Forces an fsync of all server
+    #   data and returns acknowledgment only after completion. Use the ``j`` option instead.
     #
     #   Notes about write concern:
     #     These write concern options will be used for insert, update, and remove methods called on this
@@ -397,7 +398,8 @@ module Mongo
     #   :w > 0 will run a +getlasterror+ command on the database to report any assertion.
     #   :j will confirm a write has been committed to the journal,
     #   :wtimeout specifies how long to wait for write confirmation,
-    #   :fsync will confirm that a write has been fsynced.
+    #   :fsync Deprecated; do not use. Forces an fsync of all server data and returns acknowledgment
+    #     only after completion. Use the ``j`` option instead.
     #   Options provided here will override any write concern options set on this collection,
     #   its database object, or the current connection. See the options
     #   for DB#get_last_error.
@@ -429,7 +431,8 @@ module Mongo
     #   should be acknowledged
     # @option opts [Boolean] :j (false) Set journal acknowledgement
     # @option opts [Integer] :wtimeout (nil) Set replica set acknowledgement timeout
-    # @option opts [Boolean] :fsync (false) Set fsync acknowledgement.
+    # @option opts [Boolean] :fsync (false) Deprecated; do not use. Forces an fsync of all server
+    #   data and returns acknowledgment only after completion. Use the ``j`` option instead.
     #
     #   Notes on write concern:
     #     Options provided here will override any write concern options set on this collection,
@@ -465,7 +468,8 @@ module Mongo
     #   should be acknowledged
     # @option opts [Boolean] :j (false) Set journal acknowledgement
     # @option opts [Integer] :wtimeout (nil) Set replica set acknowledgement timeout
-    # @option opts [Boolean] :fsync (false) Set fsync acknowledgement.
+    # @option opts [Boolean] :fsync (false) Deprecated; do not use. Forces an fsync of all server
+    #   data and returns acknowledgment only after completion. Use the ``j`` option instead.
     #
     #   Notes on write concern:
     #     Options provided here will override any write concern options set on this collection,
@@ -504,7 +508,8 @@ module Mongo
     #   should be acknowledged
     # @option opts [Boolean] :j (false) Set journal acknowledgement
     # @option opts [Integer] :wtimeout (nil) Set replica set acknowledgement timeout
-    # @option opts [Boolean] :fsync (false) Set fsync acknowledgement.
+    # @option opts [Boolean] :fsync (false) Deprecated; do not use. Forces an fsync of all server
+    #   data and returns acknowledgment only after completion. Use the ``j`` option instead.
     #
     #   Notes on write concern:
     #     Options provided here will override any write concern options set on this collection,

--- a/lib/mongo/db.rb
+++ b/lib/mongo/db.rb
@@ -91,7 +91,8 @@ module Mongo
     #   should be acknowledged
     # @option opts [Boolean] :j (false) Set journal acknowledgement
     # @option opts [Integer] :wtimeout (nil) Set replica set acknowledgement timeout
-    # @option opts [Boolean] :fsync (false) Set fsync acknowledgement.
+    # @option opts [Boolean] :fsync (false) Deprecated; do not use. Forces an fsync of all server
+    #   data and returns acknowledgment only after completion. Use the ``j`` option instead.
     #
     #   Notes on write concern:
     #     These write concern options are propagated to Collection objects instantiated off of this DB. If no

--- a/lib/mongo/mongo_client.rb
+++ b/lib/mongo/mongo_client.rb
@@ -88,7 +88,8 @@ module Mongo
     #    should be acknowledged
     #  @option opts [Boolean] :j (false) Set journal acknowledgement
     #  @option opts [Integer] :wtimeout (nil) Set replica set acknowledgement timeout
-    #  @option opts [Boolean] :fsync (false) Set fsync acknowledgement.
+    #  @option opts [Boolean] :fsync (false) Deprecated; do not use. Forces an fsync of all server
+    #   data and returns acknowledgment only after completion. Use the ``j`` option instead.
     #
     #  Notes about Write-Concern Options:
     #   Write concern options are propagated to objects instantiated from this MongoClient.
@@ -243,8 +244,9 @@ module Mongo
       [@host, @port]
     end
 
-    # Fsync, then lock the mongod process against writes. Use this to get
-    # the datafiles in a state safe for snapshotting, backing up, etc.
+    # Fsync: Deprecated; do not use. Forces an fsync of all server
+    # data and returns acknowledgment only after completion.
+    # Use the ``j`` option instead.
     #
     # @return [BSON::OrderedHash] the command response
     def lock!

--- a/lib/mongo/mongo_replica_set_client.rb
+++ b/lib/mongo/mongo_replica_set_client.rb
@@ -50,7 +50,8 @@ module Mongo
     #     should be acknowledged
     #   @option opts [Boolean] :j (false) Set journal acknowledgement
     #   @option opts [Integer] :wtimeout (nil) Set acknowledgement timeout
-    #   @option opts [Boolean] :fsync (false) Set fsync acknowledgement.
+    #   @option opts [Boolean] :fsync (false) Deprecated; do not use. Forces an fsync of all server
+    #     data and returns acknowledgment only after completion. Use the ``j`` option instead.
     #
     #     Notes about write concern options:
     #       Write concern options are propagated to objects instantiated from this MongoReplicaSetClient.


### PR DESCRIPTION
Updated all references to fsync to note that it's deprecated and j should be used instead.

We need to add a reference to server docs when 2.6 is released.
