### PR TITLE
RUBY-686 using set for auths to fix issues with logout

### DIFF
--- a/lib/mongo.rb
+++ b/lib/mongo.rb
@@ -60,6 +60,9 @@ end
 
 require 'bson'
 
+require 'set'
+require 'thread'
+
 require 'mongo/utils'
 require 'mongo/exception'
 require 'mongo/functional'

--- a/lib/mongo/connection/node.rb
+++ b/lib/mongo/connection/node.rb
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'thread'
-
 module Mongo
   class Node
 

--- a/lib/mongo/connection/pool.rb
+++ b/lib/mongo/connection/pool.rb
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'thread'
-
 module Mongo
   class Pool
     PING_ATTEMPTS  = 6

--- a/lib/mongo/connection/pool_manager.rb
+++ b/lib/mongo/connection/pool_manager.rb
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'set'
-require 'thread'
-
 module Mongo
   class PoolManager
     include ThreadLocalVariableManager

--- a/lib/mongo/connection/sharding_pool_manager.rb
+++ b/lib/mongo/connection/sharding_pool_manager.rb
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'thread'
-
 module Mongo
   class ShardingPoolManager < PoolManager
     def inspect

--- a/lib/mongo/functional/uri_parser.rb
+++ b/lib/mongo/functional/uri_parser.rb
@@ -267,7 +267,7 @@ module Mongo
 
     def parse_hosts(uri_without_proto)
       @nodes = []
-      @auths = []
+      @auths = Set.new
 
       matches = MONGODB_URI_MATCHER.match(uri_without_proto)
 

--- a/test/functional/client_test.rb
+++ b/test/functional/client_test.rb
@@ -402,7 +402,7 @@ class ClientTest < Test::Unit::TestCase
     end
 
     should "save the authentication" do
-      assert_equal @auth, @client.auths[0]
+      assert_equal @auth, @client.auths.first
     end
 
     should "not allow multiple authentications for the same db" do

--- a/test/functional/pool_test.rb
+++ b/test/functional/pool_test.rb
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 require 'test_helper'
-require 'thread'
 
 class PoolTest < Test::Unit::TestCase
   include Mongo

--- a/test/functional/uri_test.rb
+++ b/test/functional/uri_test.rb
@@ -40,17 +40,17 @@ class URITest < Test::Unit::TestCase
 
   def test_complex_passwords
     parser = Mongo::URIParser.new('mongodb://bob:secret.word@a.example.com:27018/test')
-    assert_equal "bob", parser.auths[0][:username]
-    assert_equal "secret.word", parser.auths[0][:password]
+    assert_equal "bob", parser.auths.first[:username]
+    assert_equal "secret.word", parser.auths.first[:password]
 
     parser = Mongo::URIParser.new('mongodb://bob:s-_3#%R.t@a.example.com:27018/test')
-    assert_equal "bob", parser.auths[0][:username]
-    assert_equal "s-_3#%R.t", parser.auths[0][:password]
+    assert_equal "bob", parser.auths.first[:username]
+    assert_equal "s-_3#%R.t", parser.auths.first[:password]
   end
 
   def test_complex_usernames
     parser = Mongo::URIParser.new('mongodb://b:ob:secret.word@a.example.com:27018/test')
-    assert_equal "b:ob", parser.auths[0][:username]
+    assert_equal "b:ob", parser.auths.first[:username]
   end
 
   def test_username_with_encoded_symbol

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -143,7 +143,7 @@ class ClientTest < Test::Unit::TestCase
         @client = MongoClient.from_uri("mongodb://hyphen-user_name:p-s_s@localhost:27017/db", :connect => false)
         assert_equal ['localhost', 27017], @client.host_port
         auth_hash = { :db_name => 'db', :username => 'hyphen-user_name', :password => 'p-s_s' }
-        assert_equal auth_hash, @client.auths[0]
+        assert_equal auth_hash, @client.auths.first
       end
 
       should "attempt to connect" do
@@ -226,7 +226,7 @@ class ClientTest < Test::Unit::TestCase
         @client = MongoClient.new
         assert_equal ['localhost', 27017], @client.host_port
         auth_hash = { :db_name => 'db', :username => 'hyphen-user_name', :password => 'p-s_s' }
-        assert_equal auth_hash, @client.auths[0]
+        assert_equal auth_hash, @client.auths.first
       end
 
       should "attempt to connect" do

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -137,7 +137,7 @@ class ConnectionTest < Test::Unit::TestCase
         @connection = Mongo::Connection.from_uri("mongodb://hyphen-user_name:p-s_s@localhost:27017/db", :connect => false)
         assert_equal ['localhost', 27017], @connection.host_port
         auth_hash = { :db_name => 'db', :username => 'hyphen-user_name', :password => 'p-s_s' }
-        assert_equal auth_hash, @connection.auths[0]
+        assert_equal auth_hash, @connection.auths.first
       end
 
       should "attempt to connect" do
@@ -220,7 +220,7 @@ class ConnectionTest < Test::Unit::TestCase
         @connection = Mongo::Connection.new
         assert_equal ['localhost', 27017], @connection.host_port
         auth_hash = { :db_name => 'db', :username => 'hyphen-user_name', :password => 'p-s_s' }
-        assert_equal auth_hash, @connection.auths[0]
+        assert_equal auth_hash, @connection.auths.first
       end
 
       should "attempt to connect" do


### PR DESCRIPTION
- Switching MongoClient#auths to be a Set rather than an Array (still
  Enumerable) so that we can fix an issue with logout and be a little more
  intelligent when applying auths to a given socket.
- Consolidated requires for 'set' and 'thread'
