### PR TITLE
RUBY-697 Support nolock option in DB#eval

### DIFF
--- a/lib/mongo/db.rb
+++ b/lib/mongo/db.rb
@@ -452,6 +452,7 @@ module Mongo
 
       cmd = BSON::OrderedHash.new
       cmd[:$eval] = code
+      cmd.merge!(args.pop) if args.last.respond_to?(:keys) && args.last.key?(:nolock)
       cmd[:args] = args
       doc = command(cmd)
       doc['retval']

--- a/test/functional/db_test.rb
+++ b/test/functional/db_test.rb
@@ -252,6 +252,14 @@ class DBTest < Test::Unit::TestCase
     assert_equal 'hello', @@db['system'].find_one['_id']
   end
 
+  def test_eval_nolock
+    function = "db.system.save({_id:'hello', value: function(string) { print(string); } })"
+    @@db.expects(:command).with do |selector, opts|
+        selector[:nolock] == true
+    end.returns({ 'ok' => 1, 'retval' => 1 })
+    @@db.eval(function, 'hello', :nolock => true)
+  end
+
   if @@version >= "1.3.5"
     def test_db_stats
       stats = @@db.stats


### PR DESCRIPTION
This change to DB#eval allows a user to specify :nolock => true to prevent the command from taking a global write lock.

See the documentation here for details:
http://docs.mongodb.org/manual/reference/command/eval/

The splat operator was used in the method signature to allow arbitrary args but if :nolock => true is the last argument, it can just be popped off the args list.

Example usage:

```
db.eval(function, 'hello', :nolock => true)
```
