### PR TITLE
minor: removing useless ternary operator in read pref module

### DIFF
--- a/lib/mongo/functional/read_preference.rb
+++ b/lib/mongo/functional/read_preference.rb
@@ -71,7 +71,7 @@ module Mongo
       if command == 'mapreduce'
         out = selector.select { |k, v| k.to_s.downcase == 'out' }.first.last
         # the server only looks at the first key in the out object
-        return out.respond_to?(:keys) && out.keys.first.to_s.downcase == 'inline' ? true : false
+        return out.respond_to?(:keys) && out.keys.first.to_s.downcase == 'inline'
       elsif command == 'aggregate'
         return selector['pipeline'].none? { |op| op.key?('$out') || op.key?(:$out) }
       end


### PR DESCRIPTION
Someone pointed out in my rubyconf slides that this ternary operator is useless.
