### PR TITLE
RUBY-698 adding deserialization options to collection#find and bson

### DIFF
--- a/lib/bson.rb
+++ b/lib/bson.rb
@@ -19,8 +19,8 @@ module BSON
     BSON_CODER.serialize(obj, check_keys, move_id)
   end
 
-  def self.deserialize(buf=nil)
-    BSON_CODER.deserialize(buf)
+  def self.deserialize(buf=nil, opts={})
+    BSON_CODER.deserialize(buf, opts)
   end
 
   # Reads a single BSON document from an IO object.

--- a/lib/bson/bson_c.rb
+++ b/lib/bson/bson_c.rb
@@ -20,8 +20,8 @@ module BSON
       ByteBuffer.new(CBson.serialize(obj, check_keys, move_id, max_bson_size))
     end
 
-    def self.deserialize(buf=nil)
-      CBson.deserialize(ByteBuffer.new(buf).to_s)
+    def self.deserialize(buf=nil, opts={})
+      CBson.deserialize(ByteBuffer.new(buf).to_s, opts)
     end
 
     def self.max_bson_size

--- a/lib/bson/bson_java.rb
+++ b/lib/bson/bson_java.rb
@@ -28,7 +28,7 @@ module BSON
       ByteBuffer.new(enc.encode(obj))
     end
 
-    def self.deserialize(buf)
+    def self.deserialize(buf, opts={})
       dec = Java::OrgJbson::RubyBSONDecoder.new
       callback = Java::OrgJbson::RubyBSONCallback.new(JRuby.runtime)
       dec.decode(buf.to_s.to_java_bytes, callback)

--- a/lib/bson/bson_ruby.rb
+++ b/lib/bson/bson_ruby.rb
@@ -108,8 +108,8 @@ module BSON
       new(max_bson_size).serialize(obj, check_keys, move_id)
     end
 
-    def self.deserialize(buf=nil)
-      new.deserialize(buf)
+    def self.deserialize(buf=nil, opts={})
+      new.deserialize(buf, opts)
     end
 
     def serialize(obj, check_keys=false, move_id=false)
@@ -199,7 +199,7 @@ module BSON
       end
     end
 
-    def deserialize(buf=nil)
+    def deserialize(buf=nil, opts={})
       # If buf is nil, use @buf, assumed to contain already-serialized BSON.
       # This is only true during testing.
       if buf.is_a? String
@@ -236,7 +236,7 @@ module BSON
           doc[key] = deserialize_array_data(@buf)
         when REGEX
           key = deserialize_cstr(@buf)
-          doc[key] = deserialize_regex_data(@buf)
+          doc[key] = deserialize_regex_data(@buf, opts)
         when OBJECT
           key = deserialize_cstr(@buf)
           doc[key] = deserialize_object_data(@buf)
@@ -334,7 +334,8 @@ module BSON
       a
     end
 
-    def deserialize_regex_data(buf)
+    def deserialize_regex_data(buf, opts={})
+      # TODO: check opts to see if Regexp should be compiled
       str = deserialize_cstr(buf)
       options_str = deserialize_cstr(buf)
       opts = 0

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -225,6 +225,8 @@ module Mongo
     # @option opts [Block] :transformer (nil) a block for transforming returned documents.
     #   This is normally used by object mappers to convert each returned document to an instance of a class.
     # @option opts [String] :comment (nil) a comment to include in profiling logs
+    # @option opts [Boolean] :compile_regex (true) whether BSON regex objects should be compiled into Ruby regexes.
+    #   If false, a BSON::Regexp object will be returned instead.
     #
     # @raise [ArgumentError]
     #   if timeout is set to false and find is not invoked in a block
@@ -251,6 +253,7 @@ module Mongo
       read               = opts.delete(:read) || @read
       tag_sets           = opts.delete(:tag_sets) || @tag_sets
       acceptable_latency = opts.delete(:acceptable_latency) || @acceptable_latency
+      compile_regex      = opts.key?(:compile_regex) ? opts.delete(:compile_regex) : true
 
       if timeout == false && !block_given?
         raise ArgumentError, "Collection#find must be invoked with a block when timeout is disabled."
@@ -281,7 +284,8 @@ module Mongo
         :read               => read,
         :tag_sets           => tag_sets,
         :comment            => comment,
-        :acceptable_latency => acceptable_latency
+        :acceptable_latency => acceptable_latency,
+        :compile_regex      => compile_regex
       })
 
       if block_given?

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -26,7 +26,8 @@ module Mongo
       :order, :hint, :snapshot, :timeout,
       :full_collection_name, :transformer,
       :options, :cursor_id, :show_disk_loc,
-      :comment, :read, :tag_sets, :acceptable_latency
+      :comment, :compile_regex, :read, :tag_sets,
+      :acceptable_latency
 
     # Create a new cursor.
     #
@@ -57,6 +58,7 @@ module Mongo
       @return_key    = opts.delete(:return_key)
       @show_disk_loc = opts.delete(:show_disk_loc)
       @comment       = opts.delete(:comment)
+      @compile_regex = opts.key?(:compile_regex) ? opts.delete(:compile_regex) : true
 
       # Wire-protocol settings
       @fields   = convert_fields_for_query(opts.delete(:fields))
@@ -536,7 +538,7 @@ module Mongo
           socket = @socket || checkout_socket_from_connection
           results, @n_received, @cursor_id = @connection.receive_message(
             Mongo::Constants::OP_QUERY, message, nil, socket, @command,
-            nil, exhaust?)
+            nil, exhaust?, compile_regex?)
         rescue ConnectionFailure => ex
           socket.close if socket
           @pool = nil
@@ -695,6 +697,10 @@ module Mongo
       if @command_cursor
         raise InvalidOperation, "Cannot call #{caller.first} on command cursors"
       end
+    end
+
+    def compile_regex?
+      @compile_regex
     end
   end
 end


### PR DESCRIPTION
This is some preliminary work in bson to allow for arbitrary options to be passed down at deserialization. The main motivation for these changes is to allow a user to specify that regexps should not be compiled upon deserialization.  I've made the API flexible enough so that if further deserialization options are added in the future, we can easily support them without too many changes.

Given my limited experience in C, I wanted to get a code review on this before adding the Regexp Wrapper class and further functionality.

I'd like reviewers to double check:
1. C syntax and correctness
2. Driver API integrity (no API breaking changes should be introduced)

Thanks!
