### PR TITLE
minor: removing unnecessary username in sasl plain

### DIFF
--- a/lib/mongo/functional/authentication.rb
+++ b/lib/mongo/functional/authentication.rb
@@ -249,7 +249,6 @@ module Mongo
       cmd = BSON::OrderedHash.new
       cmd[:saslStart]     = 1
       cmd[:mechanism]     = auth[:mechanism]
-      cmd[:username]      = auth[:username]
       cmd[:payload]       = BSON::Binary.new(payload)
       cmd[:autoAuthorize] = 1
 


### PR DESCRIPTION
Correcting an accidental inclusion of a "username" field in the BSON document for the PLAIN auth command. This value is baked into the payload field and it isn't needed.
