### PR TITLE
RUBY-701 fixing missing pid attribute on unix socket type

### DIFF
--- a/lib/mongo/connection/socket/ssl_socket.rb
+++ b/lib/mongo/connection/socket/ssl_socket.rb
@@ -23,9 +23,9 @@ module Mongo
     include SocketUtil
 
     def initialize(host, port, op_timeout=nil, connect_timeout=nil, opts={})
-      @pid             = Process.pid
       @op_timeout      = op_timeout
       @connect_timeout = connect_timeout
+      @pid             = Process.pid
       @auths           = Set.new
 
       @tcp_socket = ::TCPSocket.new(host, port)

--- a/lib/mongo/connection/socket/unix_socket.rb
+++ b/lib/mongo/connection/socket/unix_socket.rb
@@ -25,6 +25,7 @@ module Mongo
     def initialize(socket_path, port=:socket, op_timeout=nil, connect_timeout=nil, opts={})
       @op_timeout      = op_timeout
       @connect_timeout = connect_timeout
+      @pid             = Process.pid
       @auths           = Set.new
 
       @address         = socket_path


### PR DESCRIPTION
One of these things is not like the others. This missing pid attribute on
Mongo::UnixSocket was causing Pool#checkout to always issue a new new socket
instance when using unix domain sockets.
