### PR TITLE
minor: removing vestigial call to deprecated Client#authenticate_pools

### DIFF
--- a/lib/mongo/db.rb
+++ b/lib/mongo/db.rb
@@ -164,7 +164,6 @@ module Mongo
         socket.checkin if socket
       end
 
-      @client.authenticate_pools
       true
     end
 


### PR DESCRIPTION
This was left in here and should have been removed when this method was deprecated. It's currently causing double authentications.
