### PR TITLE
minor: defaulting extra_opts to an empty hash in URIParser#connection

### DIFF
--- a/lib/mongo/functional/uri_parser.rb
+++ b/lib/mongo/functional/uri_parser.rb
@@ -163,7 +163,7 @@ module Mongo
     # @note Don't confuse this with attribute getter method #connect.
     #
     # @return [MongoClient,MongoReplicaSetClient]
-    def connection(extra_opts, legacy = false, sharded = false)
+    def connection(extra_opts={}, legacy = false, sharded = false)
       opts = connection_options.merge!(extra_opts)
       if(legacy)
         if replicaset?


### PR DESCRIPTION
Super minor.

I noticed this while working on an issue in MongoMapper last week. I was
creating a client instance from a connection string and was annoying to me
that I had pass an empty hash to this method.

Before:

Mongo::URIParser.new(uri).connection({})

After:

Mongo::URIParser.new(uri).connection
