### PR TITLE
minor: locking mime-types verison for ruby 1.8 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gem 'json'
 gem 'rake', :require => ['rake/testtask']
 gem 'rake-compiler', :require => ['rake/extensiontask', 'rake/javaextensiontask']
+gem 'mime-types', '~> 1.25'
 if RUBY_VERSION < '1.9.3'
   gem 'activesupport', '~>3.0'
 else


### PR DESCRIPTION
I did this recently on our 2.0 branch as well, but the mime-types gem (a dependency of our dependicies) was a little aggressive in deprecating support for Ruby 1.8 and their latest version won't bundle correctly on older verisons of Ruby.

Since we still have to support Ruby 1.8, I'm locking the mime-type gem at the latest minor that's compatible with our needs.This will resolve the following Travis failure:

https://travis-ci.org/mongodb/mongo-ruby-driver/jobs/15294601
