### PR TITLE
minor: removing compiled c-extensions with test cleanup

### DIFF
--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -127,7 +127,7 @@ namespace :test do
       # moving on anyway
     end
 
-    %w(data tmp coverage mongodb_server).each do |dir|
+    %w(data tmp coverage lib/bson_ext).each do |dir|
       if File.directory?(dir)
         puts "[CLEAN-UP] Removing '#{dir}'..."
         FileUtils.rm_rf(dir)


### PR DESCRIPTION
Feel free to shoot this down if you guys thing its a bad idea, but I'd like to add `lib/bson_ext` to the list of directories we cleanup after each test run when `test:cleanup` is triggered. Right now, those compiled extensions hang around and it causes issues when you're testing across multiple rubies.

For example, I often like to do this:

``` bash
rvm jruby,1.8.7,1.9.3,2.0.0 do bundle exec rake test:commit
```

However, if I'm testing with extensions enabled and switching between versions (especially for 1.8 to 2.0) this currently fails if those compiled c extensions stick around.
