### PR TITLE
minor: retrying step down for replica set tests

### DIFF
--- a/test/helpers/test_unit.rb
+++ b/test/helpers/test_unit.rb
@@ -131,10 +131,17 @@ class Test::Unit::TestCase
     $1
   end
 
-  def step_down_command
-    step_down_command = BSON::OrderedHash.new
-    step_down_command[:replSetStepDown] = 30
-    step_down_command
+  def perform_step_down(member)
+    start   = Time.now
+    timeout = 20 # seconds
+    begin
+      step_down_command = BSON::OrderedHash.new
+      step_down_command[:replSetStepDown] = 30
+      member['admin'].command(step_down_command)
+    rescue Mongo::OperationFailure => e
+      retry unless (Time.now - start) > timeout
+      raise e
+    end
   end
 
   def new_mock_socket(host='localhost', port=27017)

--- a/test/replica_set/client_test.rb
+++ b/test/replica_set/client_test.rb
@@ -82,7 +82,7 @@ class ReplicaSetClientTest < Test::Unit::TestCase
 
     primary = Mongo::MongoClient.new(*@client.primary)
     assert_raise Mongo::ConnectionFailure do
-      primary['admin'].command(step_down_command)
+      perform_step_down(primary)
     end
     assert @client.connected?
 
@@ -114,7 +114,7 @@ class ReplicaSetClientTest < Test::Unit::TestCase
 
     primary = Mongo::MongoClient.new(*@client.primary)
     assert_raise Mongo::ConnectionFailure do
-      primary['admin'].command(step_down_command)
+      perform_step_down(primary)
     end
 
     rescue_connection_failure do
@@ -141,7 +141,7 @@ class ReplicaSetClientTest < Test::Unit::TestCase
   #   old_primary_conn = Mongo::MongoClient.new(*old_primary)
 
   #   assert_raise Mongo::ConnectionFailure do
-  #     old_primary_conn['admin'].command(step_down_command)
+  #     perform_step_down(old_primary_conn)
   #   end
 
   #   # Wait for new primary

--- a/test/replica_set/complex_connect_test.rb
+++ b/test/replica_set/complex_connect_test.rb
@@ -55,9 +55,8 @@ class ComplexConnectTest < Test::Unit::TestCase
     end
     @rs.start
 
-
     assert_raise ConnectionFailure do
-      primary['admin'].command(step_down_command)
+      perform_step_down(primary)
     end
 
     # isMaster is currently broken in 2.1+ when called on removed nodes


### PR DESCRIPTION
This change will make our test retry the step down command for up to 20 seconds before failing completely. Locally, this probably won't make single bit of different to anyone, but I'm hoping this fixes the flapping tests in Jenkins that are failing due to lagging secondaries.
