### PR TITLE
Adding wrapper for tests that change uri ENV variable

### DIFF
--- a/test/functional/client_test.rb
+++ b/test/functional/client_test.rb
@@ -63,66 +63,48 @@ class ClientTest < Test::Unit::TestCase
   end
 
   def test_env_mongodb_uri
-    begin
-      old_mongodb_uri = ENV['MONGODB_URI']
-      ENV['MONGODB_URI'] = "mongodb://#{host_port}"
+    with_preserved_env_uri do
       con = MongoClient.new
       assert_equal mongo_host, con.primary_pool.host
       assert_equal mongo_port, con.primary_pool.port
-    ensure
-      ENV['MONGODB_URI'] = old_mongodb_uri
     end
   end
 
   def test_from_uri_implicit_mongodb_uri
-    begin
-      old_mongodb_uri = ENV['MONGODB_URI']
-      ENV['MONGODB_URI'] = "mongodb://#{host_port}"
+    uri = "mongodb://#{host_port}"
+    with_preserved_env_uri(uri) do
       con = MongoClient.from_uri
       assert_equal mongo_host, con.primary_pool.host
       assert_equal mongo_port, con.primary_pool.port
-    ensure
-      ENV['MONGODB_URI'] = old_mongodb_uri
     end
   end
 
   def test_db_from_uri_exists_no_options
-    begin
-      db_name = "_database"
-
-      old_mongodb_uri = ENV['MONGODB_URI']
-      ENV['MONGODB_URI'] = "mongodb://#{host_port}/#{db_name}"
+    db_name = "_database"
+    uri = "mongodb://#{host_port}/#{db_name}"
+    with_preserved_env_uri(uri) do
       con = MongoClient.from_uri
       db = con.db
       assert_equal db.name, db_name
-    ensure
-      ENV['MONGODB_URI'] = old_mongodb_uri
     end
   end
 
   def test_db_from_uri_exists_options
-    begin
-      db_name = "_database"
-
-      old_mongodb_uri = ENV['MONGODB_URI']
-      ENV['MONGODB_URI'] = "mongodb://#{host_port}/#{db_name}?"
+    db_name = "_database"
+    uri = "mongodb://#{host_port}/#{db_name}?"
+    with_preserved_env_uri(uri) do
       con = MongoClient.from_uri
       db = con.db
       assert_equal db.name, db_name
-    ensure
-      ENV['MONGODB_URI'] = old_mongodb_uri
     end
   end
 
   def test_db_from_uri_exists_no_db_name
-    begin
-      old_mongodb_uri = ENV['MONGODB_URI']
-      ENV['MONGODB_URI'] = "mongodb://#{host_port}/"
+    uri = "mongodb://#{host_port}/"
+    with_preserved_env_uri(uri) do
       con = MongoClient.from_uri
       db = con.db
       assert_equal db.name, MongoClient::DEFAULT_DB_NAME
-    ensure
-      ENV['MONGODB_URI'] = old_mongodb_uri
     end
   end
 

--- a/test/helpers/test_unit.rb
+++ b/test/helpers/test_unit.rb
@@ -213,6 +213,16 @@ class Test::Unit::TestCase
     end
   end
 
+  def with_preserved_env_uri(new_uri=nil, &block)
+    old_mongodb_uri = ENV['MONGODB_URI']
+    begin
+      ENV['MONGODB_URI'] = new_uri
+      yield
+    ensure
+      ENV['MONGODB_URI'] = old_mongodb_uri
+    end
+  end
+
   def with_write_operations(client, &block)
     wire_version = Mongo::MongoClient::RELEASE_2_4_AND_BEFORE
     if client.primary_wire_version_feature?(wire_version)

--- a/test/replica_set/client_test.rb
+++ b/test/replica_set/client_test.rb
@@ -217,29 +217,33 @@ class ReplicaSetClientTest < Test::Unit::TestCase
   end
 
   def test_connect_with_connection_string_in_env_var
-    ENV['MONGODB_URI'] = "mongodb://#{@rs.replicas[0].host_port},#{@rs.replicas[1].host_port}?replicaset=#{@rs.repl_set_name}"
-    @client = MongoReplicaSetClient.new
-    assert !@client.nil?
-    assert_equal 2, @client.seeds.length
-    assert_equal @rs.replicas[0].host, @client.seeds[0][0]
-    assert_equal @rs.replicas[1].host, @client.seeds[1][0]
-    assert_equal @rs.replicas[0].port, @client.seeds[0][1]
-    assert_equal @rs.replicas[1].port, @client.seeds[1][1]
-    assert_equal @rs.repl_set_name, @client.replica_set_name
-    assert @client.connected?
+    uri = "mongodb://#{@rs.replicas[0].host_port},#{@rs.replicas[1].host_port}?replicaset=#{@rs.repl_set_name}"
+    with_preserved_env_uri(uri) do
+      @client = MongoReplicaSetClient.new
+      assert !@client.nil?
+      assert_equal 2, @client.seeds.length
+      assert_equal @rs.replicas[0].host, @client.seeds[0][0]
+      assert_equal @rs.replicas[1].host, @client.seeds[1][0]
+      assert_equal @rs.replicas[0].port, @client.seeds[0][1]
+      assert_equal @rs.replicas[1].port, @client.seeds[1][1]
+      assert_equal @rs.repl_set_name, @client.replica_set_name
+      assert @client.connected?
+    end
   end
 
   def test_connect_with_connection_string_in_implicit_mongodb_uri
-    ENV['MONGODB_URI'] = "mongodb://#{@rs.replicas[0].host_port},#{@rs.replicas[1].host_port}?replicaset=#{@rs.repl_set_name}"
-    @client = MongoClient.from_uri
-    assert !@client.nil?
-    assert_equal 2, @client.seeds.length
-    assert_equal @rs.replicas[0].host, @client.seeds[0][0]
-    assert_equal @rs.replicas[1].host, @client.seeds[1][0]
-    assert_equal @rs.replicas[0].port, @client.seeds[0][1]
-    assert_equal @rs.replicas[1].port, @client.seeds[1][1]
-    assert_equal @rs.repl_set_name, @client.replica_set_name
-    assert @client.connected?
+    uri = "mongodb://#{@rs.replicas[0].host_port},#{@rs.replicas[1].host_port}?replicaset=#{@rs.repl_set_name}"
+    with_preserved_env_uri(uri) do
+      @client = MongoClient.from_uri
+      assert !@client.nil?
+      assert_equal 2, @client.seeds.length
+      assert_equal @rs.replicas[0].host, @client.seeds[0][0]
+      assert_equal @rs.replicas[1].host, @client.seeds[1][0]
+      assert_equal @rs.replicas[0].port, @client.seeds[0][1]
+      assert_equal @rs.replicas[1].port, @client.seeds[1][1]
+      assert_equal @rs.repl_set_name, @client.replica_set_name
+      assert @client.connected?
+    end
   end
 
   def test_connect_with_new_seed_format
@@ -264,25 +268,29 @@ class ReplicaSetClientTest < Test::Unit::TestCase
   end
 
   def test_connect_with_full_connection_string_in_env_var
-    ENV['MONGODB_URI'] = "mongodb://#{@rs.replicas[0].host_port},#{@rs.replicas[1].host_port}?replicaset=#{@rs.repl_set_name};w=2;fsync=true;slaveok=true"
-    @client = MongoReplicaSetClient.new
-    assert !@client.nil?
-    assert @client.connected?
-    assert_equal 2, @client.write_concern[:w]
-    assert @client.write_concern[:fsync]
-    assert @client.read_pool
+    uri = "mongodb://#{@rs.replicas[0].host_port},#{@rs.replicas[1].host_port}?replicaset=#{@rs.repl_set_name};w=2;fsync=true;slaveok=true"
+    with_preserved_env_uri(uri) do
+      @client = MongoReplicaSetClient.new
+      assert !@client.nil?
+      assert @client.connected?
+      assert_equal 2, @client.write_concern[:w]
+      assert @client.write_concern[:fsync]
+      assert @client.read_pool
+    end
   end
 
   def test_connect_options_override_env_var
-    ENV['MONGODB_URI'] = "mongodb://#{@rs.replicas[0].host_port},#{@rs.replicas[1].host_port}?replicaset=#{@rs.repl_set_name};w=2;fsync=true;slaveok=true"
-    @client = MongoReplicaSetClient.new({:w => 0})
-    assert !@client.nil?
-    assert @client.connected?
-    assert_equal 0, @client.write_concern[:w]
+    uri = "mongodb://#{@rs.replicas[0].host_port},#{@rs.replicas[1].host_port}?replicaset=#{@rs.repl_set_name};w=2;fsync=true;slaveok=true"
+    with_preserved_env_uri(uri) do
+      @client = MongoReplicaSetClient.new({:w => 0})
+      assert !@client.nil?
+      assert @client.connected?
+      assert_equal 0, @client.write_concern[:w]
+    end
   end
 
   def test_find_and_modify_with_secondary_read_preference
-    @client = MongoReplicaSetClient.new
+    @client = MongoReplicaSetClient.new @rs.repl_set_seeds
     collection = @client[TEST_DB].collection('test', :read => :secondary)
     collection << { :a => 1, :processed => false}
 

--- a/test/replica_set/connection_test.rb
+++ b/test/replica_set/connection_test.rb
@@ -59,33 +59,37 @@ class ReplicaSetConnectionTest < Test::Unit::TestCase
   end
 
   def test_connect_with_connection_string_in_env_var
-    ENV['MONGODB_URI'] = "mongodb://#{@rs.repl_set_seeds_uri}?replicaset=#{@rs.repl_set_name}"
-    @connection = ReplSetConnection.new
-    assert !@connection.nil?
-    assert_equal 3, @connection.seeds.length
-    assert_equal @rs.replicas[0].host, @connection.seeds[0][0]
-    assert_equal @rs.replicas[1].host, @connection.seeds[1][0]
-    assert_equal @rs.replicas[2].host, @connection.seeds[2][0]
-    assert_equal @rs.replicas[0].port, @connection.seeds[0][1]
-    assert_equal @rs.replicas[1].port, @connection.seeds[1][1]
-    assert_equal @rs.replicas[2].port, @connection.seeds[2][1]
-    assert_equal @rs.repl_set_name, @connection.replica_set_name
-    assert @connection.connected?
+    uri = "mongodb://#{@rs.repl_set_seeds_uri}?replicaset=#{@rs.repl_set_name}"
+    with_preserved_env_uri(uri) do
+      @connection = ReplSetConnection.new
+      assert !@connection.nil?
+      assert_equal 3, @connection.seeds.length
+      assert_equal @rs.replicas[0].host, @connection.seeds[0][0]
+      assert_equal @rs.replicas[1].host, @connection.seeds[1][0]
+      assert_equal @rs.replicas[2].host, @connection.seeds[2][0]
+      assert_equal @rs.replicas[0].port, @connection.seeds[0][1]
+      assert_equal @rs.replicas[1].port, @connection.seeds[1][1]
+      assert_equal @rs.replicas[2].port, @connection.seeds[2][1]
+      assert_equal @rs.repl_set_name, @connection.replica_set_name
+      assert @connection.connected?
+    end
   end
 
   def test_connect_with_connection_string_in_implicit_mongodb_uri
-    ENV['MONGODB_URI'] = "mongodb://#{@rs.repl_set_seeds_uri}?replicaset=#{@rs.repl_set_name}"
-    @connection = Connection.from_uri
-    assert !@connection.nil?
-    assert_equal 3, @connection.seeds.length
-    assert_equal @rs.replicas[0].host, @connection.seeds[0][0]
-    assert_equal @rs.replicas[1].host, @connection.seeds[1][0]
-    assert_equal @rs.replicas[2].host, @connection.seeds[2][0]
-    assert_equal @rs.replicas[0].port, @connection.seeds[0][1]
-    assert_equal @rs.replicas[1].port, @connection.seeds[1][1]
-    assert_equal @rs.replicas[2].port, @connection.seeds[2][1]
-    assert_equal @rs.repl_set_name, @connection.replica_set_name
-    assert @connection.connected?
+    uri = "mongodb://#{@rs.repl_set_seeds_uri}?replicaset=#{@rs.repl_set_name}"
+    with_preserved_env_uri(uri) do
+      @connection = Connection.from_uri
+      assert !@connection.nil?
+      assert_equal 3, @connection.seeds.length
+      assert_equal @rs.replicas[0].host, @connection.seeds[0][0]
+      assert_equal @rs.replicas[1].host, @connection.seeds[1][0]
+      assert_equal @rs.replicas[2].host, @connection.seeds[2][0]
+      assert_equal @rs.replicas[0].port, @connection.seeds[0][1]
+      assert_equal @rs.replicas[1].port, @connection.seeds[1][1]
+      assert_equal @rs.replicas[2].port, @connection.seeds[2][1]
+      assert_equal @rs.repl_set_name, @connection.replica_set_name
+      assert @connection.connected?
+    end
   end
 
   def test_connect_with_new_seed_format
@@ -110,21 +114,25 @@ class ReplicaSetConnectionTest < Test::Unit::TestCase
   end
 
   def test_connect_with_full_connection_string_in_env_var
-    ENV['MONGODB_URI'] = "mongodb://#{@rs.repl_set_seeds_uri}?replicaset=#{@rs.repl_set_name};safe=true;w=2;fsync=true;slaveok=true"
-    @connection = ReplSetConnection.new
-    assert !@connection.nil?
-    assert @connection.connected?
-    assert_equal 2, @connection.write_concern[:w]
-    assert @connection.write_concern[:fsync]
-    assert @connection.read_pool
+    uri = "mongodb://#{@rs.repl_set_seeds_uri}?replicaset=#{@rs.repl_set_name};safe=true;w=2;fsync=true;slaveok=true"
+    with_preserved_env_uri(uri) do
+      @connection = ReplSetConnection.new
+      assert !@connection.nil?
+      assert @connection.connected?
+      assert_equal 2, @connection.write_concern[:w]
+      assert @connection.write_concern[:fsync]
+      assert @connection.read_pool
+    end
   end
 
   def test_connect_options_override_env_var
-    ENV['MONGODB_URI'] = "mongodb://#{@rs.repl_set_seeds_uri}?replicaset=#{@rs.repl_set_name};safe=true;w=2;fsync=true;slaveok=true"
-    @connection = ReplSetConnection.new({:safe => {:w => 1}})
-    assert !@connection.nil?
-    assert @connection.connected?
-    assert_equal 1, @connection.write_concern[:w]
+    uri = "mongodb://#{@rs.repl_set_seeds_uri}?replicaset=#{@rs.repl_set_name};safe=true;w=2;fsync=true;slaveok=true"
+    with_preserved_env_uri(uri) do
+      @connection = ReplSetConnection.new({:safe => {:w => 1}})
+      assert !@connection.nil?
+      assert @connection.connected?
+      assert_equal 1, @connection.write_concern[:w]
+    end
   end
 
 end


### PR DESCRIPTION
While working on RUBY-700 (ipv6 support), I realized that we don't properly unset and reset the ENV['MONGODB_URI'] in tests. I've added a wrapper that makes sure we reset the variable after altering it in the test, even when there is an exception.
