### PR TITLE
minor: fixing prefixes in new test dbs so that they get cleaned up

### DIFF
--- a/test/functional/bulk_write_collection_view_test.rb
+++ b/test/functional/bulk_write_collection_view_test.rb
@@ -57,7 +57,7 @@ class BulkWriteCollectionViewTest < Test::Unit::TestCase
   @@test = @@db.collection("test")
   @@version = @@client.server_version
 
-  DATABASE_NAME = 'bulk_write_collection_view_test'
+  DATABASE_NAME = 'ruby_test_bulk_write_collection_view'
   COLLECTION_NAME = 'test'
   DUPLICATE_KEY_ERROR_CODE_SET = [11000, 11001, 12582, 16460].to_set
 

--- a/test/functional/collection_writer_test.rb
+++ b/test/functional/collection_writer_test.rb
@@ -25,7 +25,7 @@ end
 
 class CollectionWriterTest < Test::Unit::TestCase
 
-  DATABASE_NAME = 'collection_writer_test'
+  DATABASE_NAME = 'ruby_test_collection_writer'
   COLLECTION_NAME = 'test'
 
   def default_setup


### PR DESCRIPTION
Prefixing a few DBs created in some new tests with `ruby_test` so that `rake test:cleanup` doesn't miss them.
