### PR TITLE
Use a constant for command not found code 59

### DIFF
--- a/lib/mongo.rb
+++ b/lib/mongo.rb
@@ -58,10 +58,11 @@ module Mongo
   end
 
   module ErrorCode # MongoDB Core Server src/mongo/base/error_codes.err
-    BAD_VALUE = 2
-    UNKNOWN_ERROR = 8
-    INVALID_BSON = 22
-    WRITE_CONCERN_FAILED = 64
+    BAD_VALUE                = 2
+    UNKNOWN_ERROR            = 8
+    INVALID_BSON             = 22
+    COMMAND_NOT_FOUND        = 59
+    WRITE_CONCERN_FAILED     = 64
     MULTIPLE_ERRORS_OCCURRED = 65
   end
 end

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -1067,7 +1067,7 @@ module Mongo
         cmd = BSON::OrderedHash[:createIndexes, @name].merge!(selector)
         @db.command(cmd)
       rescue Mongo::OperationFailure => ex
-        if ex.error_code == 59 || ex.error_code.nil?
+        if ex.error_code == Mongo::ErrorCode::COMMAND_NOT_FOUND || ex.error_code.nil?
           selector[:ns] = "#{@db.name}.#{@name}"
           send_write(:insert, nil, selector, false, {:w => 1}, Mongo::DB::SYSTEM_INDEX_COLLECTION)
         else

--- a/lib/mongo/db.rb
+++ b/lib/mongo/db.rb
@@ -213,11 +213,11 @@ module Mongo
       begin
         user_info = command(:usersInfo => username)
       # MongoDB >= 2.5.3 requires the use of commands to manage users.
-      # "No such command" error didn't return an error code (59) before
+      # "Command not found" error didn't return an error code (59) before
       # MongoDB 2.4.7 so we assume that a nil error code means the usersInfo
       # command doesn't exist and we should fall back to the legacy add user code.
       rescue OperationFailure => ex
-        raise ex unless ex.error_code == 59 || ex.error_code.nil?
+        raise ex unless ex.error_code == Mongo::ErrorCode::COMMAND_NOT_FOUND || ex.error_code.nil?
         return legacy_add_user(username, password, read_only, opts)
       end
 
@@ -238,7 +238,7 @@ module Mongo
       begin
         command(:dropUser => username)
       rescue OperationFailure => ex
-        raise ex unless ex.error_code == 59 || ex.error_code.nil?
+        raise ex unless ex.error_code == Mongo::ErrorCode::COMMAND_NOT_FOUND || ex.error_code.nil?
         response = self[SYSTEM_USER_COLLECTION].remove({:user => username}, :w => 1)
         response.key?('n') && response['n'] > 0 ? response : false
       end


### PR DESCRIPTION
Instead of checking for the integer 59 in the code directly, use a constant for the "command not found" error.
