### PR TITLE
MongoClient correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Here is a quick example of basic usage for the Ruby driver:
 require 'mongo'
 
 # connecting to the database
-client = Mongo::Client.new # defaults to localhost:27017
+client = Mongo::MongoClient.new # defaults to localhost:27017
 db     = client['example-db']
 coll   = db['example-collection']
 


### PR DESCRIPTION
it should be MongoClient (with `include Mongo`) or Mongo::MongoClient (without `include Mongo`) by default
