### PR TITLE
Prohibit find() with no selector in Bulk API

### DIFF
--- a/lib/mongo/bulk_write_collection_view.rb
+++ b/lib/mongo/bulk_write_collection_view.rb
@@ -18,7 +18,7 @@ module Mongo
   class BulkWriteCollectionView
     include Mongo::WriteConcern
 
-    DEFAULT_OP_ARGS = {:q => {}}
+    DEFAULT_OP_ARGS = {:q => nil}
     MULTIPLE_ERRORS_MSG = "batch item errors occurred"
 
     attr_reader :collection, :options, :ops, :op_args
@@ -313,6 +313,7 @@ module Mongo
     end
 
     def op_push(op)
+      raise MongoArgumentError, "non-nil query must be set via find" if op.first != :insert && !op.last[:q]
       @ops << op
       self
     end


### PR DESCRIPTION
RUBY-722

While we already prohibited find() with no selector as the user would get a Ruby ArgumentError for misuse,the spirit of this ticket also indicates that find with non-nil arg must be specified for non-insert bulk ops. This pull request has tests to check this. Also added a test for #find with trailing hash args usage and clarified some other tests relating to update arg usage.
