### PR TITLE
Add description change events.

### DIFF
--- a/lib/mongo/event.rb
+++ b/lib/mongo/event.rb
@@ -14,18 +14,31 @@
 
 require 'mongo/event/publisher'
 require 'mongo/event/subscriber'
+require 'mongo/event/host_added'
+require 'mongo/event/host_removed'
 
 module Mongo
 
   module Event
 
-    ARBITER_ADDED     = "arbiter_added".freeze
-    ARBITER_REMOVED   = "arbiter_removed".freeze
+    # When a server description has a new host added.
+    #
+    # @since 3.0.0
+    HOST_ADDED = "host_added".freeze
 
-    SECONDARY_ADDED   = "server_added".freeze
-    SECONDARY_REMOVED = "server_removed".freeze
+    # When a server description has a host removed.
+    #
+    # @since 3.0.0
+    HOST_REMOVED = "host_removed".freeze
 
-    SERVER_PROMOTED   = "server_promoted".freeze
-    SERVER_DEMOTED    = "server_demoted".freeze
+    # When a server is to be added to a cluster.
+    #
+    # @since 3.0.0
+    SERVER_ADDED = "server_added".freeze
+
+    # When a server is to be removed from a cluster.
+    #
+    # @since 3.0.0
+    SERVER_REMOVED = "server_removed".freeze
   end
 end

--- a/lib/mongo/event/host_added.rb
+++ b/lib/mongo/event/host_added.rb
@@ -1,0 +1,44 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  module Event
+
+    # This handles host added events for server descriptions.
+    #
+    # @since 3.0.0
+    class HostAdded
+
+      # @return [ Mongo::Server ] server The event publisher.
+      attr_reader :server
+
+      # Initialize the new host added event handler.
+      #
+      # @example Create the new handler.
+      #   HostAdded.new(server)
+      #
+      # @param [ Mongo::Server ] server The server to publish from.
+      #
+      # @since 3.0.0
+      def initialize(server)
+        @server = server
+      end
+
+      def handle(address)
+        # @todo: Log the description change here.
+        server.publish(Event::SERVER_ADDED, address)
+      end
+    end
+  end
+end

--- a/lib/mongo/event/host_removed.rb
+++ b/lib/mongo/event/host_removed.rb
@@ -1,0 +1,44 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  module Event
+
+    # This handles host removed events for server descriptions.
+    #
+    # @since 3.0.0
+    class HostRemoved
+
+      # @return [ Mongo::Server ] server The event publisher.
+      attr_reader :server
+
+      # Initialize the new host removed event handler.
+      #
+      # @example Create the new handler.
+      #   HostRemoved.new(server)
+      #
+      # @param [ Mongo::Server ] server The server to publish from.
+      #
+      # @since 3.0.0
+      def initialize(server)
+        @server = server
+      end
+
+      def handle(address)
+        # @todo: Log the description change here.
+        server.publish(Event::SERVER_REMOVED, address)
+      end
+    end
+  end
+end

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -194,15 +194,12 @@ describe Mongo::Client do
   describe '#inspect' do
 
     let(:client) do
-      described_class.new(
-        ['1.0.0.1:2', '1.0.0.1:1'],
-        :read => :primary
-      )
+      described_class.new(['127.0.0.1:27017'], :read => :primary)
     end
 
     it 'returns the cluster information' do
       expect(client.inspect).to eq(
-        "<Mongo::Client:0x#{client.object_id} cluster=1.0.0.1:2, 1.0.0.1:1>"
+        "<Mongo::Client:0x#{client.object_id} cluster=127.0.0.1:27017>"
       )
     end
   end

--- a/spec/mongo/event/host_added_spec.rb
+++ b/spec/mongo/event/host_added_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Mongo::Event::HostAdded do
+
+  describe '#handle' do
+
+    let(:server) do
+      double('server')
+    end
+
+    let(:handler) do
+      described_class.new(server)
+    end
+
+    it 'publishes the event from the server' do
+      expect(server).to receive(:publish).with(Mongo::Event::SERVER_ADDED, 'test')
+      handler.handle('test')
+    end
+  end
+end

--- a/spec/mongo/event/host_removed_spec.rb
+++ b/spec/mongo/event/host_removed_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe Mongo::Event::HostRemoved do
+
+  describe '#handle' do
+
+    let(:server) do
+      double('server')
+    end
+
+    let(:handler) do
+      described_class.new(server)
+    end
+
+    it 'publishes the event from the server' do
+      expect(server).to receive(:publish).with(Mongo::Event::SERVER_REMOVED, 'test')
+      handler.handle('test')
+    end
+  end
+end


### PR DESCRIPTION
Further along the server implementation card, this commit introduces the
ability of a server description to update itself with the result of an
ismaster command. The result of any changes will fire corresponding
events to the server, starting with a host being added or removed in a
replica set.

This is part of RUBY-677, but does not complete it.
