### PR TITLE
No need to specify a database in the URI with x509

### DIFF
--- a/test/shared/ssl_shared.rb
+++ b/test/shared/ssl_shared.rb
@@ -181,7 +181,7 @@ module SSLTests
     end
 
     assert MongoClient.from_uri(
-      "mongodb://#{MONGODB_X509_USERNAME}@#{@uri_info}/$external?ssl=true;authMechanism=#{mechanism}",
+      "mongodb://#{MONGODB_X509_USERNAME}@#{@uri_info}/?ssl=true;authMechanism=#{mechanism}",
           :ssl_cert => CLIENT_CERT,
           :ssl_key  => CLIENT_CERT)
     assert db.authenticate(MONGODB_X509_USERNAME, nil, nil, nil, mechanism)


### PR DESCRIPTION
Taking out $external from the uri as x509 authenticates against the $external virtual database anyway.
