### PR TITLE
minor: fixing tests, stdlib logger require was missing

### DIFF
--- a/lib/mongo/logger.rb
+++ b/lib/mongo/logger.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'logger'
+
 module Mongo
 
   # Provides ability to log messages.


### PR DESCRIPTION
The standard library logger require was missing. cc/ @durran 

Resolves this failure:
https://jenkins.10gen.com/view/Ruby/job/mongo-ruby-driver/os_arch=linux64,ruby_language_version=2.0.0/lastBuild/console
