### PR TITLE
Fix createIndexes command format, RUBY-713.

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -1126,7 +1126,7 @@ module Mongo
       selector.merge!(opts)
 
       begin
-        cmd = BSON::OrderedHash[:createIndexes, @name].merge!(selector)
+        cmd = BSON::OrderedHash[:createIndexes, @name, :indexes, [selector]]
         @db.command(cmd)
       rescue Mongo::OperationFailure => ex
         if ex.error_code == Mongo::ErrorCode::COMMAND_NOT_FOUND || ex.error_code.nil?


### PR DESCRIPTION
The new createIndexes command requires the "indexes" field to be an array of index specs.
