### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-MongoDB Ruby Driver [![Build Status][travis-img]][travis-url] [![Code Climate][codeclimate-img]][codeclimate-url] [![Coverage Status][coveralls-img]][coveralls-url] [![Gem Version][rubygems-img]][rubygems-url]
+MongoDB Ruby Driver
 -----
+
+[![Build Status][travis-img]][travis-url] [![Code Climate][codeclimate-img]][codeclimate-url] [![Coverage Status][coveralls-img]][coveralls-url] [![Gem Version][rubygems-img]][rubygems-url] [![Inline docs][inchpages-img]][inchpages-url]
+
 The officially supported Ruby driver for [MongoDB](http://www.mongodb.org).
 
 > **Note: You are viewing the 2.x version of the MongoDB Ruby driver which is currently unreleased and under heavy development. To view the current stable version of driver, please use the [1.x-stable](https://github.com/mongodb/mongo-ruby-driver/tree/1.x-stable) branch.**
@@ -136,3 +139,5 @@ License
 [codeclimate-url]: https://codeclimate.com/github/mongodb/mongo-ruby-driver?branch=master
 [coveralls-img]: https://coveralls.io/repos/mongodb/mongo-ruby-driver/badge.png?branch=master
 [coveralls-url]: https://coveralls.io/r/mongodb/mongo-ruby-driver?branch=master
+[inchpages-img]: http://inch-pages.github.io/github/mongodb/mongo-ruby-driver.png
+[inchpages-url]: http://inch-pages.github.io/github/mongodb/mongo-ruby-driver


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/mongodb/mongo-ruby-driver.png)](http://inch-pages.github.io/github/mongodb/mongo-ruby-driver)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. Your status page is http://inch-pages.github.io/github/mongodb/mongo-ruby-driver/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
