### PR TITLE
Fixing find_and_modify RS test to include a query

### DIFF
--- a/test/replica_set/client_test.rb
+++ b/test/replica_set/client_test.rb
@@ -329,12 +329,13 @@ class ReplicaSetClientTest < Test::Unit::TestCase
   def test_find_and_modify_with_secondary_read_preference
     @client = MongoReplicaSetClient.new @rs.repl_set_seeds
     collection = @client[TEST_DB].collection('test', :read => :secondary)
-    collection << { :a => 1, :processed => false}
+    id = BSON::ObjectId.new
+    collection << { :a => id, :processed => false }
 
     collection.find_and_modify(
-      :query => {},
-      :update => {"$set" => {:processed => true}}
+      :query => { 'a' => id },
+      :update => { "$set" => { :processed => true }}
     )
-    assert_equal collection.find_one({}, :fields => {:_id => 0}, :read => :primary), {'a' => 1, 'processed' => true}
+    assert_equal true, collection.find_one({ 'a' => id }, :read => :primary)['processed']
   end
 end


### PR DESCRIPTION
This resolves a failure on jenkins:
https://jenkins.10gen.com/job/mongo-ruby-driver-1.x-stable/245/mongodb_server=stable-release,os_arch=linux64,ruby_language_version=2.1.0,test_type=replica-set/console

This test is more precise if a unique value is used for 'a' and then used to query and update the document. Otherwise there is the possibility of docs being left in the collection from other tests. The find_and_modify command would update one of these docs and then the find_one could return a different doc than the one that was updated.

Cleanup after other tests needs to be investigated as well...
