### PR TITLE
With auth helper to require auth flag to run test

### DIFF
--- a/test/helpers/test_unit.rb
+++ b/test/helpers/test_unit.rb
@@ -233,6 +233,11 @@ class Test::Unit::TestCase
     end
   end
 
+  def with_auth(client, &block)
+    cmd_line_args = client['admin'].command({ :getCmdLineOpts => 1 })['parsed']
+    yield if cmd_line_args.include?('auth')
+  end
+
   def with_default_journaling(client, &block)
     cmd_line_args = client['admin'].command({ :getCmdLineOpts => 1 })['parsed']
     unless client.server_version < "2.0" || cmd_line_args.include?('nojournal')


### PR DESCRIPTION
Adding in a helper that checks the command line args and requires that auth be one of them in order to run the test.
