### PR TITLE
Look for BSON tests in the correct directory level

### DIFF
--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 TEST_SUITES = {
-  :bson => { :pattern => 'test/bson/**/*_test.rb' },
+  :bson => { :pattern => 'test/bson/*_test.rb' },
   :unit => { :pattern => 'test/unit/**/*_test.rb' },
   :functional => {
     :pattern => 'test/functional/**/*_test.rb',


### PR DESCRIPTION
A refactor a while ago changed the directory that the bson rake task was looking for tests in. Changing it back...
