### PR TITLE
expand path when loading java ext to make it load from within a jar file

### DIFF
--- a/lib/bson/bson_java.rb
+++ b/lib/bson/bson_java.rb
@@ -16,7 +16,7 @@ require 'jruby'
 
 include Java
 
-jar_dir = File.join(File.dirname(__FILE__), '../../ext/jbson')
+jar_dir = File.expand_path(File.join(File.dirname(__FILE__), '../../ext/jbson'))
 require File.join(jar_dir, 'lib/java-bson.jar')
 require File.join(jar_dir, 'target/jbson.jar')
 

--- a/lib/mongo/functional/sasl_java.rb
+++ b/lib/mongo/functional/sasl_java.rb
@@ -16,7 +16,7 @@ require 'jruby'
 
 include Java
 
-jar_dir = File.join(File.dirname(__FILE__), '../../../ext/jsasl')
+jar_dir = File.expand_path(File.join(File.dirname(__FILE__), '../../../ext/jsasl'))
 require File.join(jar_dir, 'target/jsasl.jar')
 
 module Mongo


### PR DESCRIPTION
If you try to bundle a jruby app+gems in a jar file and run it without exploding it, the extension can not be loaded. The user facing exception is "NameError: cannot load Java class org.bson.types.ObjectId" but the underlying problem is the following:

LoadError: no such file to load -- file:/Users/andi/src/tik/mediaservice2/target/mediaservice-0.0.1-SNAPSHOT.jar!/ruby/jruby/1.9/gems/bson-1.9.2-java/lib/bson/../../ext/jbson/lib/java-bson
  require at org/jruby/RubyKernel.java:1085
   (root) at file:/Users/andi/src/tik/mediaservice2/target/mediaservice-0.0.1-SNAPSHOT.jar!/ruby/jruby/1.9/gems/bson-1.9.2-java/lib/bson/bson_java.rb:20
  require at org/jruby/RubyKernel.java:1085
   (root) at file:/Users/andi/src/tik/mediaservice2/target/mediaservice-0.0.1-SNAPSHOT.jar!/ruby/jruby/1.9/gems/bson-1.9.2-java/lib/bson.rb:1
[...]

Using expand_path to eliminate the ../.. in the path fixes the error
