### PR TITLE
RUBY-736 Clone sets and lists of pools before returning in PoolManager

### DIFF
--- a/lib/mongo/connection/pool_manager.rb
+++ b/lib/mongo/connection/pool_manager.rb
@@ -17,14 +17,9 @@ module Mongo
     include ThreadLocalVariableManager
 
     attr_reader :client,
-                :arbiters,
                 :primary,
-                :secondaries,
                 :primary_pool,
-                :secondary_pools,
-                :hosts,
                 :seeds,
-                :pools,
                 :max_bson_size,
                 :max_message_size,
                 :max_wire_version,
@@ -143,6 +138,47 @@ module Mongo
 
     def read
       read_pool.host_port
+    end
+
+    def hosts
+      @connect_mutex.synchronize do
+        @hosts.nil? ? nil : @hosts.clone
+      end
+    end
+
+    def pools
+      @connect_mutex.synchronize do
+        @pools.nil? ? nil : @pools.clone
+      end
+    end
+
+    def secondaries
+      @connect_mutex.synchronize do
+        @secondaries.nil? ? nil : @secondaries.clone
+      end
+    end
+
+    def secondary_pools
+      @connect_mutex.synchronize do
+        @secondary_pools.nil? ? nil : @secondary_pools.clone
+      end
+    end
+
+    def arbiters
+      @connect_mutex.synchronize do
+        @arbiters.nil? ? nil : @arbiters.clone
+      end
+    end
+
+    def state_snapshot
+      @connect_mutex.synchronize do
+        { :pools           => @pools.nil?           ? nil : @pools.clone,
+          :secondaries     => @secondaries.nil?     ? nil : @secondaries.clone,
+          :secondary_pools => @secondary_pools.nil? ? nil : @secondary_pools.clone,
+          :hosts           => @hosts.nil?           ? nil : @hosts.clone,
+          :arbiters        => @arbiters.nil?        ? nil : @arbiters.clone
+        }
+      end
     end
 
     private

--- a/test/unit/pool_manager_test.rb
+++ b/test/unit/pool_manager_test.rb
@@ -106,6 +106,37 @@ class PoolManagerUnitTest < Test::Unit::TestCase
       assert_equal [['localhost', 27020]], manager.arbiters
     end
 
+    should "return clones of pool lists" do
+
+      @db.stubs(:command).returns(
+        # First call to get a socket.
+        @ismaster.merge({'ismaster' => true}),
+
+        # Subsequent calls to configure pools.
+        @ismaster.merge({'ismaster' => true}),
+        @ismaster.merge({'secondary' => true, 'maxBsonObjectSize' => 500}),
+        @ismaster.merge({'secondary' => true, 'maxMessageSizeBytes' => 700}),
+        @ismaster.merge({'arbiterOnly' => true})
+      )
+
+      seeds = [['localhost', 27017], ['localhost', 27018]]
+      manager = Mongo::PoolManager.new(@client, seeds)
+      @client.stubs(:local_manager).returns(manager)
+      manager.connect
+
+      assert_not_equal manager.instance_variable_get(:@arbiters).object_id, manager.arbiters.object_id
+      assert_not_equal manager.instance_variable_get(:@secondaries).object_id, manager.secondaries.object_id
+      assert_not_equal manager.instance_variable_get(:@secondary_pools).object_id, manager.secondary_pools.object_id
+      assert_not_equal manager.instance_variable_get(:@hosts).object_id, manager.hosts.object_id
+      assert_not_equal manager.instance_variable_get(:@pools).object_id, manager.pools.object_id
+
+      assert_not_equal manager.instance_variable_get(:@arbiters).object_id, manager.state_snapshot[:arbiters].object_id
+      assert_not_equal manager.instance_variable_get(:@secondaries).object_id, manager.state_snapshot[:secondaries].object_id
+      assert_not_equal manager.instance_variable_get(:@secondary_pools).object_id, manager.state_snapshot[:secondary_pools].object_id
+      assert_not_equal manager.instance_variable_get(:@hosts).object_id, manager.state_snapshot[:hosts].object_id
+      assert_not_equal manager.instance_variable_get(:@pools).object_id, manager.state_snapshot[:pools].object_id
+    end
+
   end
 
 end


### PR DESCRIPTION
This pull request addresses the need for thread-safe reads on certain pool manager attributes. These changes will avoid a situation in which someone is iterating through a list of pools associated with a pool manager while the pool manager is trying to connect and simultaneously mutating one of the lists.

Anyone looking to get a snapshot of the replica set state with consistency between lists should use the #state_snapshot method on a PoolManager instance. For individual access to the lists, the explicit methods can be used (such as #pools, #secondaries, #arbiters, etc)

Note that #clone in Ruby is a shallow copy, so only the actual list is cloned, not the list members themselves.

Tests are passing: https://jenkins.10gen.com/job/mongo-ruby-driver-emily/3246/
