### PR TITLE
test_check_command_response - fix for 2.0.9 Jenkins

### DIFF
--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -139,7 +139,7 @@ module Mongo
       doc = @cache.shift
 
       if doc && (err = doc['errmsg'] || doc['$err']) # assignment
-        code = doc['code']
+        code = doc['code'] || doc['assertionCode']
 
         # If the server has stopped being the master (e.g., it's one of a
         # pair but it has died or something like that) then we close that

--- a/test/functional/db_test.rb
+++ b/test/functional/db_test.rb
@@ -189,7 +189,7 @@ class DBTest < Test::Unit::TestCase
       @@db.command(command)
     rescue => ex
       raised = true
-      assert ex.message.include?("forced error"),
+      assert ex.message.include?("forced error") || ex.result.has_key?("assertion") && ex.result["assertion"].include?("forced error"),
         "error message does not contain 'forced error'"
       assert_equal 10038, ex.error_code
 


### PR DESCRIPTION
The code assignment is now identical even if it is duplicated/redundant, and the test fix seems better than more significant message reconstruction to mirror what DB#command does in Cursor#next.  The new driver should only do this in one place if possible, but for 1.x-stable, I think that this fix is appropriate/minimal.
