### PR TITLE
Resolves a jenkins failure when trying to kill a process that's not found.

### DIFF
--- a/test/replica_set/client_test.rb
+++ b/test/replica_set/client_test.rb
@@ -206,7 +206,11 @@ class ReplicaSetClientTest < Test::Unit::TestCase
       assert ['localhost:29999'] != @client.primary
       assert !@client.secondaries.include?('localhost:29999')
     ensure
-      Process.kill("KILL", hung_node.pid) if hung_node
+      begin
+        Process.kill("KILL", hung_node.pid) if hung_node
+      rescue
+        # the process ended, was killed already, or the system doesn't support nc
+      end
     end
   end
 


### PR DESCRIPTION
https://jenkins.10gen.com/view/Ruby/job/mongo-ruby-driver-1.x-stable/mongodb_server=22-release,os_arch=linux64,ruby_language_version=jruby,test_type=replica-set/295/console
