### PR TITLE
Ruby 759 default batch size

### DIFF
--- a/lib/mongo/mongo_replica_set_client.rb
+++ b/lib/mongo/mongo_replica_set_client.rb
@@ -471,7 +471,8 @@ module Mongo
     end
 
     def max_write_batch_size
-      local_manager && local_manager.primary_pool && local_manager.primary_pool.node.max_write_batch_size
+      local_manager && local_manager.primary_pool && local_manager.primary_pool.node.max_write_batch_size ||
+        DEFAULT_MAX_WRITE_BATCH_SIZE
     end
 
     private

--- a/test/replica_set/max_values_test.rb
+++ b/test/replica_set/max_values_test.rb
@@ -141,5 +141,11 @@ class MaxValuesTest < Test::Unit::TestCase
     @client.local_manager.primary_pool.node.stubs(:max_write_batch_size).returns(999)
     assert_equal 999, @client.max_write_batch_size
   end
+
+  def test_max_write_batch_size_no_manager
+    # Simulate no local manager being set yet - RUBY-759
+    @client.stubs(:local_manager).returns(nil)
+    assert_equal Mongo::MongoClient::DEFAULT_MAX_WRITE_BATCH_SIZE, @client.max_write_batch_size
+  end
 end
 


### PR DESCRIPTION
This pull request adds in a default value for max write batch size in the case that the local manager hasn't been set yet. There is a test included as well.
