### PR TITLE
Skip tests using server version 2.0 relying on profiling info until SERVER-4754 is resolved

### DIFF
--- a/test/helpers/test_unit.rb
+++ b/test/helpers/test_unit.rb
@@ -306,6 +306,13 @@ class Test::Unit::TestCase
   def batch_commands?(wire_version)
     wire_version >= Mongo::MongoClient::BATCH_COMMANDS
   end
+
+  def subject_to_server_4754?(client)
+    # Until SERVER-4754 is resolved, profiling info is not collected
+    # when mongod is started with --auth in versions < 2.2
+    cmd_line_args = client['admin'].command({ :getCmdLineOpts => 1 })['parsed']
+    client.server_version < '2.2' && cmd_line_args.include?('auth')
+  end
 end
 
 # Before and after hooks for the entire test run

--- a/test/replica_set/cursor_test.rb
+++ b/test/replica_set/cursor_test.rb
@@ -132,6 +132,7 @@ class ReplicaSetCursorTest < Test::Unit::TestCase
   # batch from send_initial_query is 101 documents
   # check that you get n_docs back from the query, with the same port
   def cursor_get_more_test(read=:primary)
+    return if subject_to_server_4754?(@client)
     set_read_client_and_tag(read)
     10.times do
       # assert that the query went to the correct member
@@ -152,6 +153,7 @@ class ReplicaSetCursorTest < Test::Unit::TestCase
 
   # batch from get_more can be huge, so close after send_initial_query
   def kill_cursor_test(read=:primary)
+    return if subject_to_server_4754?(@client)
     set_read_client_and_tag(read)
     10.times do
       # assert that the query went to the correct member
@@ -171,6 +173,7 @@ class ReplicaSetCursorTest < Test::Unit::TestCase
   end
 
   def assert_cursors_on_members(read=:primary)
+    return if subject_to_server_4754?(@client)
     set_read_client_and_tag(read)
     # assert that the query went to the correct member
     route_query(read)


### PR DESCRIPTION
https://jira.mongodb.org/browse/SERVER-4754

https://jenkins.10gen.com/job/mongo-ruby-driver-emilys-fork
