### PR TITLE
Ruby 756 allow some mixed case uri options

### DIFF
--- a/lib/mongo/functional/uri_parser.rb
+++ b/lib/mongo/functional/uri_parser.rb
@@ -125,6 +125,12 @@ module Mongo
       :wtimeoutms           => lambda { |arg| arg.to_i }
     }
 
+    OPT_CASE_SENSITIVE = [ :authsource,
+                           :gssapiservicename,
+                           :replicaset,
+                           :w
+                         ]
+
     attr_reader :auths,
                 :authmechanism,
                 :authsource,
@@ -348,7 +354,8 @@ module Mongo
 
       opts = CGI.parse(string_opts).inject({}) do |memo, (key, value)|
         value = value.first
-        memo[key.downcase.to_sym] = value.strip.downcase
+        key_sym = key.downcase.to_sym
+        memo[key_sym] = OPT_CASE_SENSITIVE.include?(key_sym) ? value.strip : value.strip.downcase
         memo
       end
 

--- a/test/functional/uri_test.rb
+++ b/test/functional/uri_test.rb
@@ -327,4 +327,16 @@ class URITest < Test::Unit::TestCase
     assert_equal true, parser.auths.first[:extra][:canonicalize_host_name]
   end
 
+  def test_opts_case_sensitivity
+    # options gssapiservicename, authsource, replicaset, w should be case sensitive
+    uri = "mongodb://localhost?gssapiServiceName=MongoDB;" +
+            "authSource=FooBar;" +
+            "replicaSet=Foo;" +
+            "w=Majority"
+    parser = Mongo::URIParser.new(uri)
+    assert_equal 'MongoDB', parser.gssapiservicename
+    assert_equal 'FooBar',  parser.authsource
+    assert_equal 'Foo',     parser.replicaset
+    assert_equal :Majority, parser.w
+  end
 end


### PR DESCRIPTION
This fixes a bug where you can't specify the name of a replicaset with mixed cases in the uri.

Also allows you to provide a mixed case authsource and gssapiservicename.
