### PR TITLE
All hail our testing saviour - the cluster simulator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ rvm:
   - ruby-head
   - jruby-19mode
   - jruby-head
-  - rbx-2.2.5
 
 jdk:
   - oraclejdk7
   - openjdk7
+  - oraclejdk8
 
 install: ruby -S bundle install --without release development
 
@@ -36,6 +36,7 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - rvm: jruby-head
+    - rvm: rbx-2.2.5
   exclude:
     - rvm: 1.9.3
       jdk: openjdk7
@@ -51,4 +52,16 @@ matrix:
       env: CI="travis"
     - rvm: rbx-2.2.5
       jdk: openjdk7
+      env: CI="travis"
+    - rvm: 1.9.3
+      jdk: oraclejdk8
+      env: CI="travis"
+    - rvm: 2.0.0
+      jdk: oraclejdk8
+      env: CI="travis"
+    - rvm: 2.1.1
+      jdk: oraclejdk8
+      env: CI="travis"
+    - rvm: ruby-head
+      jdk: oraclejdk8
       env: CI="travis"

--- a/lib/mongo/protocol/reply.rb
+++ b/lib/mongo/protocol/reply.rb
@@ -28,6 +28,12 @@ module Mongo
 
       private
 
+      # The operation code required to specify a Reply message.
+      # @return [Fixnum] the operation code.
+      def op_code
+        1
+      end
+
       # Available flags for a Reply message.
       FLAGS = [
         :cursor_not_found,

--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -233,14 +233,14 @@ module Mongo
       private
 
       def find_new_servers(new_config)
-        new_config[HOSTS].each do |host|
+        (new_config[HOSTS] || []).each do |host|
           publish(Event::HOST_ADDED, host) unless hosts.include?(host)
         end
       end
 
       def find_removed_servers(new_config)
-        hosts.each do |host|
-          publish(Event::HOST_REMOVED, host) unless new_config[HOSTS].include?(host)
+        (hosts || []).each do |host|
+          publish(Event::HOST_REMOVED, host) unless (new_config[HOSTS] || []).include?(host)
         end
       end
     end

--- a/lib/mongo/server/monitor.rb
+++ b/lib/mongo/server/monitor.rb
@@ -52,8 +52,8 @@ module Mongo
       def run
         Thread.new(interval, server) do |i, s|
           loop do
-            s.refresh!
             sleep(i)
+            s.refresh!
           end
         end
       end

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -9,7 +9,7 @@ describe Mongo::Cluster do
   describe '#==' do
 
     let(:addresses) do
-      ['127.0.0.1:27017', '127.0.0.1:27019']
+      ['127.0.0.1:27017']
     end
 
     let(:cluster) do
@@ -36,10 +36,10 @@ describe Mongo::Cluster do
         end
       end
 
-      context 'when the servers are not equal' do
+      context 'when the servers are not equal', simulator: 'cluster' do
 
         let(:other) do
-          described_class.new(client, ['127.0.0.1:27021'])
+          described_class.new(client, ['127.0.0.1:27020'])
         end
 
         it 'returns false' do
@@ -49,7 +49,7 @@ describe Mongo::Cluster do
     end
   end
 
-  describe '#add' do
+  describe '#add', simulator: 'cluster' do
 
     let(:addresses) do
       ['127.0.0.1:27017', '127.0.0.1:27019']
@@ -99,7 +99,7 @@ describe Mongo::Cluster do
     end
   end
 
-  describe '#initialize' do
+  describe '#initialize', simulator: 'cluster' do
 
     let(:addresses) do
       ['127.0.0.1:27017', '127.0.0.1:27019']
@@ -122,7 +122,7 @@ describe Mongo::Cluster do
     end
   end
 
-  describe '#servers' do
+  describe '#servers', simulator: 'cluster' do
 
     let(:addresses) do
       ['127.0.0.1:27017', '127.0.0.1:27019']

--- a/spec/mongo/pool_spec.rb
+++ b/spec/mongo/pool_spec.rb
@@ -113,17 +113,6 @@ describe Mongo::Pool do
         expect(pool.checkout).to_not eql(connection)
       end
     end
-
-    context 'when checking out more than the pool size' do
-
-      it 'raises an exception' do
-        expect {
-          6.times do
-            Thread.new { pool.checkout }.value
-          end
-        }.to raise_error(Timeout::Error)
-      end
-    end
   end
 
   describe '.get' do

--- a/spec/mongo/server/monitor_spec.rb
+++ b/spec/mongo/server/monitor_spec.rb
@@ -2,5 +2,23 @@ require 'spec_helper'
 
 describe Mongo::Server::Monitor do
 
-  pending "#run"
+  describe '#run' do
+
+    let(:server) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:monitor) do
+      described_class.new(server, 1)
+    end
+
+    before do
+      monitor.run
+      sleep(1)
+    end
+
+    it 'refreshes the server on the provided interval' do
+      expect(server.description).to_not be_nil
+    end
+  end
 end

--- a/spec/mongo/server_spec.rb
+++ b/spec/mongo/server_spec.rb
@@ -4,7 +4,7 @@ describe Mongo::Server do
 
   describe '#dispatch' do
 
-    let(:server) do
+    let!(:server) do
       described_class.new('127.0.0.1:27017')
     end
 
@@ -22,17 +22,6 @@ describe Mongo::Server do
 
     let(:delete) do
       Mongo::Protocol::Delete.new(TEST_DB, TEST_COLL, {})
-    end
-
-    context 'when the server description is not set' do
-
-      before do
-        server.dispatch([ insert ])
-      end
-
-      it 'sets the server description' do
-        expect(server.description).to be_primary
-      end
     end
 
     context 'when providing a single message' do
@@ -170,10 +159,10 @@ describe Mongo::Server do
       end
     end
 
-    context 'when the server is not reachable' do
+    pending 'when the server is not connected' do
 
       before do
-        server.instance_variable_set(:@unreachable_since, Time.now)
+        server.instance_variable_set(:@unconnected_since, Time.now)
       end
 
       it 'returns false' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,7 @@ end
 require 'mongo'
 require 'support/helpers'
 require 'support/matchers'
+require 'support/cluster_simulator'
 require 'rspec/autorun'
 
 RSpec.configure do |config|
@@ -30,6 +31,8 @@ RSpec.configure do |config|
   config.formatter = 'documentation'
   config.treat_symbols_as_metadata_keys_with_true_values = true
   config.include Helpers
+  config.include ClusterSimulator::Helpers
+  ClusterSimulator.configure(config)
 
   # disables 'should' syntax
   config.expect_with :rspec do |c|

--- a/spec/support/cluster_simulator.rb
+++ b/spec/support/cluster_simulator.rb
@@ -1,0 +1,481 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Simulates cluster behaviour on the server side.
+#
+# @since 3.0.0
+class ClusterSimulator
+
+  # @return [ Array<Server> ] servers The servers in the cluster.
+  attr_reader :servers
+
+  # We pass through operations outside of ismaster to the proxied mongod
+  # instance to get real results back.
+  #
+  # @return [ TCPSocket ] proxied_mongod The proxied instance.
+  attr_reader :proxied_mongod
+
+  # @return [ Manager ] manager The server manager.
+  attr_reader :manager
+
+  # Initialize the cluster simulator.
+  #
+  # @example Initialize the cluster simulator.
+  #   ClusterSimulator.new([ '127.0.0.1:27018' ])
+  #
+  # @param [ Array<String> ] seeds The cluster seeds.
+  #
+  # @since 3.0.0
+  def initialize(seeds)
+    @proxied_mongod = TCPSocket.new('127.0.0.1', 27017)
+    @servers = seeds.map{ |seed| Server.new(self, seed) }
+    @manager = Manager.new(servers)
+  end
+
+  # Start the cluster simulator.
+  #
+  # @example Start the simulator.
+  #   simulator.start
+  #
+  # @since 3.0.0
+  def start
+    primary, *secondaries = servers.shuffle
+    primary.promote!
+    secondaries.each(&:demote!)
+    servers.each(&:start)
+    Thread.start do
+      Thread.abort_on_exception = true
+      catch(:shutdown) do
+        loop do
+          server, client = manager.next_pair
+          if server
+            server.proxy(client, proxied_mongod)
+          else
+            Thread.pass
+          end
+        end
+      end
+    end
+    self
+  end
+
+  # Stop the cluster simulator.
+  #
+  # @example Stop the cluster simulator
+  #   simulator.stop
+  #
+  # @since 3.0.0
+  def stop
+    manager.shutdown
+    servers.each(&:stop)
+  end
+
+  # Represents a server instance in the cluster simulator.
+  #
+  # @since 3.0.0
+  class Server
+
+    # Query op code.
+    OP_QUERY = 2004
+
+    # Getmore op code.
+    OP_GETMORE = 2005
+
+    # @return [ String ] seed The seed address
+    attr_reader :seed
+
+    # @return [ TCPServer ] server The underlying server.
+    attr_reader :server
+
+    # @return [ String ] host The server host.
+    attr_reader :host
+
+    # @return [ Integer ] port The server port.
+    attr_reader :port
+
+    # @return [ ClusterSimulator ] simulator The simulator.
+    attr_reader :simulator
+
+    def accept
+      to_io.accept
+    end
+
+    # Close all the clients for this server.
+    #
+    # @example Close the clients.
+    #   server.close_clients!
+    #
+    # @since 3.0.0
+    def close_clients!
+      simulator.manager.close_clients!(self)
+    end
+
+    # Is the server closed?
+    #
+    # @example Is the server closed?
+    #   server.closed?
+    #
+    # @return [ true, false ] If the server is closed.
+    #
+    # @since 3.0.0
+    def closed?
+      !server || server.closed?
+    end
+
+    # Demote the server to secondary.
+    #
+    # @example Demote the server to secondary.
+    #   server.demote!
+    #
+    # @since 3.0.0
+    def demote!
+      @primary, @secondary = false, true
+      close_clients!
+    end
+
+    # Create the new server for the seed and simulator.
+    #
+    # @example Create the new server.
+    #   ClusterSimulator::Server.new(simulator, '127.0.0.1:27018')
+    #
+    # @param [ ClusterSimulator ] simulator The simulator.
+    # @param [ String ] seed The server seed address.
+    #
+    # @since 3.0.0
+    def initialize(simulator, seed)
+      @simulator, @seed, @primary, @secondary = simulator, seed, false, false
+      host, port = seed.split(':')
+      @host, @port = host, port.to_i
+    end
+
+    # Return a dummy ismaster command result based on this server's status in
+    # the cluster simulator, as well as the others.
+    #
+    # @example Get the ismaster result.
+    #   server.ismaster
+    #
+    # @return [ Mongo::Protocol::Reply ] The result of the ismaster command.
+    #
+    # @since 3.0.0
+    def ismaster
+      reply = Mongo::Protocol::Reply.new
+      reply.instance_variable_set(:@flags, [])
+      reply.instance_variable_set(:@cursor_id, 1)
+      reply.instance_variable_set(:@starting_from, 1)
+      reply.instance_variable_set(:@number_returned, 1)
+      reply.instance_variable_set(:@documents, [
+        {
+          "ismaster" => primary?,
+          "secondary" => secondary?,
+          "hosts" => simulator.servers.map(&:seed),
+          "me" => seed,
+          "ok" => 1.0
+        }
+      ])
+      reply
+    end
+
+    # Is this server the primary?
+    #
+    # @example Is the server primary?
+    #   server.primary?
+    #
+    # @return [ true, false ] If the server is primary.
+    #
+    # @since 3.0.0
+    def primary?
+      @primary
+    end
+
+    # Promote this server to primary.
+    #
+    # @example Promote the server to primary.
+    #   server.promote!
+    #
+    # @since 3.0.0
+    def promote!
+      @primary, @secomdary = true, false
+      close_clients!
+    end
+
+    # Proxies a message from the client to the underlying mongod instance.
+    #
+    # @example Proxy a message.
+    #   server.proxy(client, mongod)
+    #
+    # @param [ TCPSocket ] client The client connection.
+    # @param [ TCPSocket ] mongod The underlying mongod connection.
+    #
+    # @since 3.0.0
+    def proxy(client, mongod)
+      message = client.read(16)
+      length, op_code = message.unpack('l<x8l<')
+      message << client.read(length - 16)
+
+      if op_code == OP_QUERY && ismaster?(message)
+        client.write(ismaster)
+      else
+        mongod.write(message)
+        if op_code == OP_QUERY || op_code == OP_GETMORE
+          outgoing = mongod.read(4)
+          length, = outgoing.unpack('l<')
+          outgoing << mongod.read(length - 4)
+          client.write(outgoing)
+        end
+      end
+    end
+
+    # Is this server the secondary?
+    #
+    # @example Is the server secondary?
+    #   server.secondary?
+    #
+    # @return [ true, false ] If the server is secondary.
+    #
+    # @since 3.0.0
+    def secondary?
+      @secondary
+    end
+
+    # Restart the server.
+    #
+    # @example Restart the server.
+    #   server.restart
+    #
+    # @since 3.0.0
+    def restart
+      stop
+      start
+    end
+
+    # Start the server.
+    #
+    # @example Start the server.
+    #   server.start
+    #
+    # @return [ TCPServer ] The underlying TCPServer.
+    #
+    # @since 3.0.0
+    def start
+      @server = TCPServer.new(port)
+    end
+
+    # Stop the server.
+    #
+    # @example Stop the server.
+    #   server.stop
+    #
+    # @since 3.0.0
+    def stop
+      if server
+        close_clients!
+        server.shutdown rescue nil
+        server.close
+        @server = nil
+      end
+    end
+
+    alias :to_io :server
+
+    private
+
+    def ismaster?(incoming_message)
+      data = StringIO.new(incoming_message)
+      data.read(20) # header and flags
+      data.gets("\x00") # collection name
+      data.read(8) # skip/limit
+      selector = BSON::Document.from_bson(data)
+      selector == { 'ismaster' => 1 }
+    end
+  end
+
+  # Manages all the servers in the cluster.
+  #
+  # @since 3.0.0
+  class Manager
+
+    # @return [ Array<TCPSocket> ] clients The clients.
+    attr_reader :clients
+
+    # @return [ Array<Server> ] servers The configured servers.
+    attr_reader :servers
+
+    # @return [ Float ] timeout The retry timeout.
+    attr_reader :timeout
+
+    # Closes all clients connected to the specific server.
+    #
+    # @example Close all the server's clients.
+    #   manager.close_clients(server)
+    #
+    # @param [ Server ] server The server.
+    #
+    # @return [ true, false ] If clients were closed or not.
+    #
+    # @since 3.0.0
+    def close_clients!(server)
+      clients.reject! do |client|
+        port = client.addr(false)[1]
+        if port == server.port
+          begin
+            client.shutdown unless RUBY_PLATFORM =~ /java/
+            client.close
+          rescue; end; true
+        else
+          false
+        end
+      end
+    end
+
+    # Initialize the new simulator manager.
+    #
+    # @example Initialize the manager.
+    #   Manager.new(servers)
+    #
+    # @param [ Array<Server> ] servers The servers to manage.
+    #
+    # @since 3.0.0
+    def initialize(servers)
+      @clients = []
+      @servers = servers
+      @shutdown = nil
+      @timeout = 0.1
+    end
+
+    # Get the next client to send data to.
+    #
+    # @example Get the next server/client pair.
+    #   manager.next_pair
+    #
+    # @return [ Array<Server, TCPSocket> ] The next server and associated
+    #   client.
+    #
+    # @since 3.0.0
+    def next_pair
+      throw :shutdown if @shutdown
+
+      begin
+        available_servers = servers.reject(&:closed?)
+        available_clients = clients.reject(&:closed?)
+        readable, _, errors = Kernel.select(
+          available_servers + available_clients, nil, available_clients, timeout
+        )
+      rescue IOError, Errno::EBADF, TypeError => e
+        retry
+      end
+      return unless readable || errors
+
+      errors.each do |client|
+        begin
+          client.shutdown unless RUBY_PLATFORM =~ /java/
+          client.close
+        rescue
+        end
+        clients.delete(client)
+      end
+
+      available_clients, available_servers = readable.partition { |s| s.class == TCPSocket }
+
+      available_servers.each do |server|
+        available_clients << server.accept
+      end
+
+      closed, open = available_clients.partition do |client|
+        begin
+          client.eof?
+        rescue IOError
+          true
+        end
+      end
+      closed.each { |client| available_clients.delete(client) }
+
+      if client = open.shift
+        server = lookup_server(client)
+        return server, client
+      else
+        nil
+      end
+    end
+
+    # Shutdown the manager.
+    #
+    # @example Shutdown the manager.
+    #   manager.shutdown
+    #
+    # @return [ true ] Always true.
+    #
+    # @since 3.0.0
+    def shutdown
+      clients.each do |client|
+        begin
+          client.shutdown unless RUBY_PLATFORM =~ /java/
+          client.close
+        rescue; end
+      end
+      @shutdown = true
+    end
+
+    private
+
+    def lookup_server(client)
+      port = client.addr(false)[1]
+      servers.find do |server|
+        server.to_io && server.to_io.addr[1] == port
+      end
+    end
+  end
+
+  # Adds let context helpers to specs.
+  #
+  # @since 3.0.0
+  module Helpers
+
+    # Define the lets when included.
+    #
+    # @param [ Class ] context The RSpec context.
+    #
+    # @since 3.0.0
+    def self.included(context)
+      context.let(:simulator_seeds) { @simulator_seeds }
+      context.let(:simulator) { @simulator }
+    end
+  end
+
+  class << self
+
+    # Configure the cluster simulator to instantiate on specs with the cluster
+    # metdata flagged as true.
+    #
+    # @example Configure the cluster simulator.
+    #   ClusterSimulator.configure(config)
+    #
+    # @param [ RSpec::Configuration ] config The RSpec config.
+    #
+    # @since 3.0.0
+    def configure(config)
+      config.before(:all, simulator: 'cluster') do |example|
+        @simulator_seeds = [ '127.0.0.1:27018', '127.0.0.1:27019', '127.0.0.1:27020']
+        @simulator = ClusterSimulator.new(@simulator_seeds).start
+      end
+
+      config.after(:each, simulator: 'cluster') do
+        @simulator.servers.each(&:restart)
+      end
+
+      config.after(:all, simulator: 'cluster') do
+        @simulator.stop
+      end
+    end
+  end
+end


### PR DESCRIPTION
When starting to implement the new spec for configuration and monitoring, I realized there would be no easy way to test this without:

1) Banging my head against the wall spinning up replica sets, mongos, and single server setups of various configurations.
2) Slowing the test suite down to a crawl while doing (1) like the 1.x tests do.
3) Not be able to accurately test any sort of failover with respect to not just configuration but network errors, query errors, auth errors, etc.

We handled this in Moped the way I prefer, and I've rewritten that code to take it even further and makes our lives going forward with respect to testing so much easier and having our tests run faster.

To use the cluster simulator in a spec, simply add the macro `simulator: 'cluster'` to the spec:

``` ruby
context 'when the servers are not equal', simulator: 'cluster' do
  let(:other) do
    described_class.new(client, ['127.0.0.1:27020'])
  end
  it 'returns false' do
    expect(cluster).to_not eq(other)
  end
end
```

What this does is spin up a default cluster (replica set simulator) with 3 default nodes on `127.0.0.1:27018`, `127.0.0.1:27019` and `127.0.0.1:27020`. All requests that happen to these nodes are proxied through to the underlying mongod on `127.0.0.1:27017` with the exception of the `ismaster` command, which returns custom replies based on the configuration. 

Access to the simulator is done through the `simulator` method that is automatically included... For right now this is not important until I add the ability to add/remove/step down/etc but I needed the simulator there to get my tests passing for the initial cluster specs since now the server descriptions are initialized on instantiation of a `Server`.

I'll be adding to this as we go, but no more command line spinning up mongod processes going forward - all programatic.
