### PR TITLE
Fluent API base classes

### DIFF
--- a/lib/mongo/collection_view.rb
+++ b/lib/mongo/collection_view.rb
@@ -12,6 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'mongo/fluent/queryable'
+require 'mongo/fluent/writable'
+require 'mongo/fluent/modifyable'
+require 'mongo/fluent/validatable'
+
 module Mongo
 
   # Representation of a query and options producing a result set of documents.
@@ -31,8 +36,12 @@ module Mongo
   # @api semipublic
   class CollectionView
     include Enumerable
+    include Queryable
+    include Modifyable
+    include Writable
+    include Validatable
 
-    # @return [ Collection ] The +Collection+ to query.
+    # @return [ Collection ] The +Collection+ to perform an operation on.
     attr_reader :collection
     # @return [ Hash ] The query selector.
     attr_reader :selector
@@ -75,8 +84,8 @@ module Mongo
     #   results.
     def initialize(collection, selector = {}, opts = {})
       @collection = collection
-      @selector = selector.dup
-      @opts = opts.dup
+      @selector   = selector.dup
+      @opts       = opts.dup
     end
 
     # Get a human-readable string representation of +CollectionView+.
@@ -91,27 +100,9 @@ module Mongo
     #
     # @return [ Integer ] The number of documents in the result set.
     def count
+      #Mongo::Operation::Command.new({ :selector => { :count => @collection.name,
+      #                                               :query => @selector } })
       @collection.count(CollectionView.new(@collection, @selector, @opts))
-    end
-
-    # Get the explain plan for the query.
-    #
-    # @return [ Hash ] A single document with the explain plan.
-    def explain
-      explain_limit = limit || 0
-      opts = @opts.merge(:limit => -explain_limit.abs, :explain => true)
-      @collection.explain(CollectionView.new(@collection, @selector, opts))
-    end
-
-    # Get the distinct values for a specified field across a single
-    # collection.
-    # Note that if a @selector is defined, it will be used in the anaylsis.
-    #
-    # @param key [ Symbol, String ] The field to collect distinct values from.
-    #
-    # @return [ Hash ] A doc with an array of the distinct values and query plan.
-    def distinct(key)
-      @collection.distinct(self, key)
     end
 
     # Associate a comment with the query.
@@ -278,6 +269,27 @@ module Mongo
       mutate(:sort, sort)
     end
 
+    # Set the upsert flag to true for all following operations.
+    #
+    # @param upsert [ true ] (false) Whether to set the upsert flag.
+    #
+    # @return [ true, false, CollectionView ] Either the upsert setting or a
+    # new +CollectionView+.
+    def upsert(upsert = nil)
+      return !!@opts[:upsert] if upsert.nil?
+      set_option(:upsert, upsert)
+    end
+
+    # Modify this +CollectionView+ to specify that the upsert flag should be truedefine the attributes by which the result set
+    # will be sorted.
+    #
+    # @param sort [ Hash ] The attributes and directions to sort by.
+    #
+    # @return [ CollectionView ] self.
+    def upsert!(upsert = nil)
+      mutate(:upsert, upsert)
+    end
+
     # Set options for the query.
     #
     # @param q_opts [ Hash ] Query options.
@@ -351,6 +363,8 @@ module Mongo
       end if block_given?
       enum
     end
+    alias_method :fetch, :each
+    # @todo: specs for fetch
 
     private
 
@@ -411,6 +425,5 @@ module Mongo
       @opts.merge!(field => value) unless value.nil?
       self
     end
-
   end
 end

--- a/lib/mongo/fluent/modifyable.rb
+++ b/lib/mongo/fluent/modifyable.rb
@@ -1,0 +1,146 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+
+  # These methods uses the FindAndModify command.
+  # Each method returns a document, either the original or the modified one.
+  module Modifyable
+
+    # Removes a document matching the query spec.
+    # The removed document will then be returned.
+    #
+    # @return [ Hash ] The document that was removed.
+    #
+    # @raise [ Exception ] If skip has been specified earlier in the chain.
+    #
+    # @since 3.0.0
+    def fetch_one_then_remove
+      validate_modify!
+
+      spec = { :findAndModify => collection.name,
+               :query         => selector,
+               :sort          => sort,
+               :remove        => true,
+               :new           => false
+              }
+
+      Mongo::Operation::Command.new(spec)
+    end
+
+    # Replace the document matching the query spec with the provided replacement.
+    # The original document will then be returned.
+    #
+    # @return [ Hash ] The document that has been replaced.
+    #
+    # @raise [ Exception ] If skip has been specified earlier in the chain.
+    # @raise [ Exception ] If the document has keys beginning with '$'.
+    #
+    # @since 3.0.0
+    def fetch_one_then_replace(replacement)
+      validate_modify!
+      validate_replacement!(replacement)
+
+      spec = { :findAndModify => collection.name,
+               :query         => selector,
+               :sort          => sort,
+               :update        => replacement,
+               :new           => false
+             }
+
+      Mongo::Operation::Command.new(spec)
+    end
+
+    # Update the document matching the query spec by applying the specified update.
+    # The original document will then be returned.
+    #
+    # @return [ Hash ] The original document that has been updated.
+    #
+    # @raise [ Exception ] If skip has been specified earlier in the chain.
+    # @raise [ Exception ] If the first key in the document doesn't begin with '$'.
+    #
+    # @since 3.0.0
+    def fetch_one_then_update(update)
+      validate_modify!
+      validate_update!(update)
+
+      spec = { :findAndModify => collection.name,
+               :query         => selector,
+               :sort          => sort,
+               :update        => update,
+               :new           => false
+      }
+
+      Mongo::Operation::Command.new(spec)
+    end
+
+    # Replaces the document matching the query spec with the provided replacement.
+    # The replaced document is then returned.
+    #
+    # @return [ Hash ] The replaced document.
+    #
+    # @raise [ Exception ] If skip has been specified earlier in the chain.
+    # @raise [ Exception ] If the document has keys beginning with '$'.
+    #
+    # @since 3.0.0
+    def replace_one_then_fetch(replacement)
+      validate_modify!
+      validate_replacement!(replacement)
+
+      spec = { :findAndModify => collection.name,
+               :query         => selector,
+               :sort          => sort,
+               :update        => replacement,
+               :new           => true
+      }
+
+      Mongo::Operation::Command.new(spec)
+    end
+
+    # Updates the document matching the query spec with the provided update.
+    # The updated document is then returned.
+    #
+    # @return [ Hash ] The updated document.
+    #
+    # @raise [ Exception ] If skip has been specified earlier in the chain.
+    # @raise [ Exception ] If the first key in the document doesn't begin with '$'.
+    #
+    # @since 3.0.0
+    def update_one_then_fetch(update)
+      validate_modify!
+      validate_update!(update)
+
+      spec = { :findAndModify => collection.name,
+               :query         => selector,
+               :sort          => sort,
+               :update        => update,
+               :new           => true
+      }
+
+      Mongo::Operation::Command.new(spec)
+    end
+
+    private
+
+    # Verifies that skip has not been specified as it's invalid with these methods.
+    #
+    # @raise [ Exception ] If skip has been specified earlier in the chain.
+    #
+    # @since 3.0.0
+    def validate_modify!
+      # @todo: update with real error
+      raise Exception, 'Skip cannot be combined with this method' if skip
+    end
+  end
+end

--- a/lib/mongo/fluent/queryable.rb
+++ b/lib/mongo/fluent/queryable.rb
@@ -1,0 +1,51 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+
+  module Queryable
+
+    # Get the distinct values for a specified field across a single
+    # collection.
+    # Note that if a @selector is defined, it will be used in the analysis.
+    # If a limit has been specified, an error is raised.
+    #
+    # @param key [ Symbol, String ] The field to collect distinct values from.
+    #
+    # @return [ Hash ] A doc with an array of the distinct values and query plan.
+    def distinct(key)
+      raise Exception, 'Skip cannot be combined with this method' if skip
+      raise Exception, 'Limit other than 1 has been specified' if limit && limit > 1
+      @collection.distinct(self, key)
+    end
+
+    # Get the explain plan for the query.
+    #
+    # @return [ Hash ] A single document with the explain plan.
+    def explain
+      explain_limit = limit || 0
+      opts = @opts.merge(:limit => -explain_limit.abs, :explain => true)
+      @collection.explain(CollectionView.new(@collection, @selector, opts))
+    end
+
+    # Fetches a single document matching the query spec.
+    #
+    # @return [ Hash ] The first document matching the query spec.
+    #
+    # @since 3.0.0
+    def fetch_one
+      limit(1).to_a.first
+    end
+  end
+end

--- a/lib/mongo/fluent/validatable.rb
+++ b/lib/mongo/fluent/validatable.rb
@@ -1,0 +1,43 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+
+  # Methods for validating update and replacement documents.
+  module Validatable
+
+    # Ensure that the document represents a replacement.
+    #
+    # @todo: document specific error
+    # @raise [ Exception ] If the document has keys beginning with '$'.
+    #
+    # @since 3.0.0
+    def validate_replacement!(doc)
+      # @todo: update with real error
+      raise Exception, "document must not contain any operators" unless doc.keys.all?{|key| key !~ /^\$/}
+    end
+
+    # Ensure that the document represents an update.
+    #
+    # @todo: document specific error
+    # @raise [ Exception ] If the first key in the document doesn't begin with '$'.
+    #
+    # @since 3.0.0
+    def validate_update!(doc)
+      # @todo: update with real error
+      raise Exception, "document must start with an operator" unless !doc.empty? &&
+          doc.keys.first.to_s =~ /^\$/
+    end
+  end
+end

--- a/lib/mongo/fluent/writable.rb
+++ b/lib/mongo/fluent/writable.rb
@@ -1,0 +1,153 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+
+  # These methods are writes.
+  module Writable
+
+    # Removes all the documents matching the query spec.
+    # If a limit other than 1 has been specified, an error is raised.
+    #
+    # @return [ RemoveResult ] Document specifying success or failure of
+    #   the operation.
+    #
+    # @since 3.0.0
+    def remove
+      validate_write!
+      validate_no_limit!
+
+      spec = { :deletes       => [{ :q     => selector,
+                                    :limit => limit }],
+               :db_name       => collection.database.name,
+               :coll_name     => collection.name,
+               :write_concern => write_concern,
+              }
+      Operation::Write::Delete.new(spec).execute(collection.client)
+    end
+
+    # Removes a single document matching the query spec.
+    # If a limit has been specified, it is ignored.
+    #
+    # @return [ RemoveResult ] Document specifying success or failure of
+    #   the operation.
+    #
+    # @since 3.0.0
+    def remove_one
+      validate_write!
+
+      spec = { :deletes       => [{ :q     => selector,
+                                    :limit => 1 }],
+               :db_name       => collection.database.name,
+               :coll_name     => collection.name,
+               :write_concern => write_concern,
+      }
+      Operation::Write::Delete.new(spec).execute(collection.client)
+    end
+
+    # Replaces a single document matching the query spec with the
+    # provided replacement.
+    # If a limit has been specified, it is ignored.
+    #
+    # @return [ ReplaceResult ] Document specifying success or failure of
+    #   the operation.
+    #
+    # @since 3.0.0
+    def replace_one(replacement)
+      validate_write!
+      validate_replacement!(replacement)
+
+      spec = { :updates       => [{ :q      => selector,
+                                    :u      => replacement,
+                                    :multi  => false,
+                                    :upsert => upsert }],
+               :db_name       => collection.database.name,
+               :coll_name     => collection.name,
+               :write_concern => write_concern,
+             }
+      Mongo::Operation::Write::Update.new(spec)
+    end
+
+    # Updates all the documents matching the query spec by applying
+    # the specified update.
+    # If a limit other than 1 has been specified, an error is raised.
+    #
+    # @return [ UpdateResult ] Document specifying success or failure of
+    #   the operation.
+    #
+    # @since 3.0.0
+    def update(update)
+      validate_no_limit!
+      validate_write!
+      validate_update!(update)
+
+      spec = { :updates       => [{ :q      => selector,
+                                    :u      => update,
+                                    :multi  => true,
+                                    :upsert => upsert }],
+               :db_name       => collection.database.name,
+               :coll_name     => collection.name,
+               :write_concern => write_concern,
+      }
+      Mongo::Operation::Write::Update.new(spec)
+    end
+
+    # Updates a single document matching the query spec by applying the
+    # specified update.
+    # If a limit has been specified, it is ignored.
+    #
+    # @return [ UpdateResult ] Document specifying success or failure of
+    #   the operation.
+    #
+    # @since 3.0.0
+    def update_one(update)
+      validate_write!
+      validate_update!(update)
+
+      spec = { :updates       => [{ :q      => selector,
+                                    :u      => update,
+                                    :multi  => false,
+                                    :upsert => upsert }],
+               :db_name       => collection.database.name,
+               :coll_name     => collection.name,
+               :write_concern => write_concern,
+      }
+      Mongo::Operation::Write::Update.new(spec)
+    end
+
+    private
+
+    # Verifies that skip and sort have not been specified as they're invalid with
+    #   these methods.
+    #
+    # @raise [ Exception ] If skip or sort have been specified earlier in the chain.
+    #
+    # @since 3.0.0
+    def validate_write!
+      # @todo: update with real error
+      raise Exception, 'Sort cannot be combined with this method' if sort
+      raise Exception, 'Skip cannot be combined with this method' if skip
+    end
+
+    # Verifies that limit has not been specified as it's invalid with these methods.
+    #
+    # @raise [ Exception ] If limit has been specified earlier in the chain.
+    #
+    # @since 3.0.0
+    def validate_no_limit!
+      # @todo: update with real error
+      raise Exception, 'Limit other than 1 has been specified' if limit && limit > 1
+    end
+  end
+end

--- a/spec/mongo/fluent/writable_spec.rb
+++ b/spec/mongo/fluent/writable_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+
+describe Mongo::CollectionView do
+  include_context 'shared client'
+
+  let(:view) { described_class.new(collection, {:name => 'Emily'})}
+
+  describe '#remove' do
+
+    context 'when sort has been specified' do
+
+      it 'raises an exception' do
+        expect{ view.sort({ :a => 1}).remove }.to raise_error
+      end
+    end
+
+    context 'when skip has been specified' do
+
+      it 'raises an exception' do
+        expect{ view.skip(2).remove }.to raise_error
+      end
+    end
+
+    context 'when limit other than 1 has been specified' do
+
+      it 'raises an exception' do
+        #expect(view.limit(2).remove)
+      end
+    end
+  end
+end

--- a/spec/mongo/view_spec.rb
+++ b/spec/mongo/view_spec.rb
@@ -31,6 +31,10 @@ describe Mongo::CollectionView do
     it 'dups the options' do
       expect(view.opts).not_to be(opts)
     end
+
+    it 'defaults upsert setting to false' do
+      expect(view.upsert).to be(false)
+    end
   end
 
   describe '#inspect' do
@@ -363,6 +367,44 @@ describe Mongo::CollectionView do
       it 'sets the sort option on the same CollectionView' do
         view.sort!(new_sort)
         expect(view.sort).to eq(new_sort)
+      end
+    end
+  end
+
+  describe '#upsert' do
+
+    context 'when upsert is set' do
+      let(:opts) { { :upsert => false } }
+      let(:new_upsert) { true }
+
+      it 'sets the upsert option' do
+        new_view = view.upsert(new_upsert)
+        expect(new_view.upsert).to eq(new_upsert)
+      end
+
+      it 'returns a new CollectionView' do
+        expect(view.upsert(new_upsert)).not_to be(view)
+      end
+    end
+
+    context 'when a upsert value is not specified' do
+      let(:opts) { { :upsert => true } }
+
+      it 'returns the upsert setting' do
+        expect(view.upsert).to eq(opts[:upsert])
+      end
+    end
+  end
+
+  describe '#upsert!' do
+
+    context 'when an upsert setting is specified' do
+      let(:opts) { { :upsert => false } }
+      let(:new_upsert) { true }
+
+      it 'sets the upsert option on the same CollectionView' do
+        view.upsert!(new_upsert)
+        expect(view.upsert).to eq(new_upsert)
       end
     end
   end


### PR DESCRIPTION
I've taken a stab at implementing the fluent API.

There is one base class, CollectionView, that has all the methods to change and set options. CollectionView includes the Enumerable module and implements #each so that results can be iterated over.

There are four modules included in the CollectionView class and that implement different subcategories of the fluent API.

Modifyable:
- all methods using FindAndModify
- all return a single document
- all raise an error if skip is specified

Writable
- all methods using update or remove operations
- all raise an error if skip or sort is specified

Validatable
- methods for checking documents for being updates or replacements

Queryable
- methods involving doing a query
