### PR TITLE
Add all server description fields

### DIFF
--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -52,6 +52,21 @@ module Mongo
       # @since 2.0.0
       MAX_MESSAGE_BYTES = 'maxMessageSizeBytes'.freeze
 
+      # Constant for the max wire version.
+      #
+      # @since 2.0.0
+      MAX_WIRE_VERSION = 'maxWireVersion'.freeze
+
+      # Constant for min wire version.
+      #
+      # @since 2.0.0
+      MIN_WIRE_VERSION = 'minWireVersion'.freeze
+
+      # Constant for reading max write batch size.
+      #
+      # @since 2.0.0
+      MAX_WRITE_BATCH_SIZE = 'maxWriteBatchSize'.freeze
+
       # Constant for reading passive info from config.
       #
       # @since 2.0.0
@@ -160,6 +175,42 @@ module Mongo
         config[MAX_MESSAGE_BYTES]
       end
 
+      # Get the maximum batch size for writes.
+      #
+      # @example Get the max batch size.
+      #   config.max_write_batch_size
+      #
+      # @return [ Integer ] The max batch size.
+      #
+      # @since 2.0.0
+      def max_write_batch_size
+        config[MAX_WRITE_BATCH_SIZE]
+      end
+
+      # Get the maximum wire version.
+      #
+      # @example Get the max wire version.
+      #   config.max_wire_version
+      #
+      # @return [ Integer ] The max wire version supported.
+      #
+      # @since 2.0.0
+      def max_wire_version
+        config[MAX_WIRE_VERSION]
+      end
+
+      # Get the minimum wire version.
+      #
+      # @example Get the min wire version.
+      #   config.min_wire_version
+      #
+      # @return [ Integer ] The min wire version supported.
+      #
+      # @since 2.0.0
+      def min_wire_version
+        config[MIN_WIRE_VERSION]
+      end
+
       # Will return true if the server is passive.
       #
       # @example Is the server passive?
@@ -200,12 +251,12 @@ module Mongo
       # none.
       #
       # @example Get the replica set name.
-      #   description.set_name
+      #   description.replica_set_name
       #
       # @return [ String, nil ] The name of the replica set.
       #
       # @since 2.0.0
-      def set_name
+      def replica_set_name
         config[SET_NAME]
       end
 

--- a/spec/mongo/server/description_spec.rb
+++ b/spec/mongo/server/description_spec.rb
@@ -18,6 +18,9 @@ describe Mongo::Server::Description do
       'me' => '127.0.0.1:27019',
       'maxBsonObjectSize' => 16777216,
       'maxMessageSizeBytes' => 48000000,
+      'maxWriteBatchSize' => 1000,
+      'maxWireVersion' => 2,
+      'minWireVersion' => 0,
       'ok' => 1
     }
   end
@@ -130,6 +133,39 @@ describe Mongo::Server::Description do
     end
   end
 
+  describe '#max_write_batch_size' do
+
+    let(:description) do
+      described_class.new(replica)
+    end
+
+    it 'returns the value' do
+      expect(description.max_write_batch_size).to eq(1000)
+    end
+  end
+
+  describe '#max_wire_version' do
+
+    let(:description) do
+      described_class.new(replica)
+    end
+
+    it 'returns the value' do
+      expect(description.max_wire_version).to eq(2)
+    end
+  end
+
+  describe '#min_wire_version' do
+
+    let(:description) do
+      described_class.new(replica)
+    end
+
+    it 'returns the value' do
+      expect(description.min_wire_version).to eq(0)
+    end
+  end
+
   describe '#passive?' do
 
     context 'when the server is passive' do
@@ -205,7 +241,7 @@ describe Mongo::Server::Description do
     end
   end
 
-  describe '#set_name' do
+  describe '#replica_set_name' do
 
     context 'when the server is in a replica set' do
 
@@ -214,7 +250,7 @@ describe Mongo::Server::Description do
       end
 
       it 'returns the replica set name' do
-        expect(description.set_name).to eq('mongodb_set')
+        expect(description.replica_set_name).to eq('mongodb_set')
       end
     end
 
@@ -225,7 +261,7 @@ describe Mongo::Server::Description do
       end
 
       it 'returns nil' do
-        expect(description.set_name).to be_nil
+        expect(description.replica_set_name).to be_nil
       end
     end
   end


### PR DESCRIPTION
This adds all the remaining fields described in the cluster monitoring spec for server descriptions.

This also renames `set_name` to `replica_set_name` as `set_anything` in Ruby is always considered a setter, and this is more idiomatic.
