### PR TITLE
Ruby 775 recursive locking

### DIFF
--- a/test/replica_set/refresh_test.rb
+++ b/test/replica_set/refresh_test.rb
@@ -123,6 +123,24 @@ class ReplicaSetRefreshTest < Test::Unit::TestCase
     end
   end
 
+
+  def test_manager_recursive_locking
+    # See RUBY-775
+    # This tests that there isn't recursive locking when a pool manager reconnects
+    # to all replica set members. The bug in RUBY-775 occurred because the same lock
+    # acquired in order to connect the pool manager was used to read the pool manager's
+    # state.
+    client = MongoReplicaSetClient.new(@rs.repl_set_seeds)
+
+    cursor = client[TEST_DB]['rs-refresh-test'].find
+    client.stubs(:receive_message).raises(ConnectionFailure)
+    client.manager.stubs(:refresh_required?).returns(true)
+    client.manager.stubs(:check_connection_health).returns(true)
+    assert_raise ConnectionFailure do
+      cursor.next
+    end
+  end
+
 =begin
   def test_automated_refresh_with_removed_node
     client = MongoReplicaSetClient.new(@rs.repl_set_seeds,

--- a/test/unit/pool_manager_test.rb
+++ b/test/unit/pool_manager_test.rb
@@ -106,37 +106,6 @@ class PoolManagerUnitTest < Test::Unit::TestCase
       assert_equal [['localhost', 27020]], manager.arbiters
     end
 
-    should "return clones of pool lists" do
-
-      @db.stubs(:command).returns(
-        # First call to get a socket.
-        @ismaster.merge({'ismaster' => true}),
-
-        # Subsequent calls to configure pools.
-        @ismaster.merge({'ismaster' => true}),
-        @ismaster.merge({'secondary' => true, 'maxBsonObjectSize' => 500}),
-        @ismaster.merge({'secondary' => true, 'maxMessageSizeBytes' => 700}),
-        @ismaster.merge({'arbiterOnly' => true})
-      )
-
-      seeds = [['localhost', 27017], ['localhost', 27018]]
-      manager = Mongo::PoolManager.new(@client, seeds)
-      @client.stubs(:local_manager).returns(manager)
-      manager.connect
-
-      assert_not_equal manager.instance_variable_get(:@arbiters).object_id, manager.arbiters.object_id
-      assert_not_equal manager.instance_variable_get(:@secondaries).object_id, manager.secondaries.object_id
-      assert_not_equal manager.instance_variable_get(:@secondary_pools).object_id, manager.secondary_pools.object_id
-      assert_not_equal manager.instance_variable_get(:@hosts).object_id, manager.hosts.object_id
-      assert_not_equal manager.instance_variable_get(:@pools).object_id, manager.pools.object_id
-
-      assert_not_equal manager.instance_variable_get(:@arbiters).object_id, manager.state_snapshot[:arbiters].object_id
-      assert_not_equal manager.instance_variable_get(:@secondaries).object_id, manager.state_snapshot[:secondaries].object_id
-      assert_not_equal manager.instance_variable_get(:@secondary_pools).object_id, manager.state_snapshot[:secondary_pools].object_id
-      assert_not_equal manager.instance_variable_get(:@hosts).object_id, manager.state_snapshot[:hosts].object_id
-      assert_not_equal manager.instance_variable_get(:@pools).object_id, manager.state_snapshot[:pools].object_id
-    end
-
   end
 
 end


### PR DESCRIPTION
This pull request changes the pool manager to keep two sets of state: immutable and mutable. The mutable state is what is manipulated through the #connect code path.
The mutable state is then cloned to immutable attributes, which are attr_reader - able

The recursive locking bug was due to the pool manager taking a lock in order to connect and then eventually trying to take the same lock in order to allow some other object to read its state.
