### PR TITLE
Provide Server Context

### DIFF
--- a/lib/mongo/server/context.rb
+++ b/lib/mongo/server/context.rb
@@ -1,0 +1,55 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  class Server
+
+    # Represents a context in which messages are sent to the server on a
+    # connection.
+    #
+    # @since 2.0.0
+    class Context
+
+      # @return [ Mongo::Server ] server The server the context is for.
+      attr_reader :server
+
+      # Instantiate a server context.
+      #
+      # @example Instantiate a server context.
+      #   Mongo::Server::Context.new(server)
+      #
+      # @param [ Mongo::Server ] server The server the context is for.
+      #
+      # @since 2.0.0
+      def initialize(server)
+        @server = server
+      end
+
+      # Execute a block of code with a connection, that is checked out of the
+      # pool and then checked back in.
+      #
+      # @example Send a message with the connection.
+      #   context.with_connection do |connection|
+      #     connection.dispatch([ command ])
+      #   end
+      #
+      # @return [ Object ] The result of the block execution.
+      #
+      # @since 2.0.0
+      def with_connection(&block)
+        server.pool.with_connection(&block)
+      end
+    end
+  end
+end

--- a/lib/mongo/server/monitor.rb
+++ b/lib/mongo/server/monitor.rb
@@ -34,7 +34,7 @@ module Mongo
       # The constant for the ismaster command.
       #
       # @since 2.0.0
-      ISMASTER = Protocol::Query.new(Database::ADMIN, Database::COMMAND, STATUS, :limit => -1).freeze
+      ISMASTER = Protocol::Query.new(Database::ADMIN, Database::COMMAND, STATUS, :limit => -1)
 
       # @return [ Mutex ] The refresh operation mutex.
       attr_reader :mutex

--- a/spec/mongo/server_spec.rb
+++ b/spec/mongo/server_spec.rb
@@ -45,69 +45,6 @@ describe Mongo::Server do
     end
   end
 
-  describe '#dispatch' do
-
-    let!(:server) do
-      described_class.new('127.0.0.1:27017')
-    end
-
-    let(:documents) do
-      [{ 'name' => 'testing' }]
-    end
-
-    let(:insert) do
-      Mongo::Protocol::Insert.new(TEST_DB, TEST_COLL, documents)
-    end
-
-    let(:query) do
-      Mongo::Protocol::Query.new(TEST_DB, TEST_COLL, {})
-    end
-
-    let(:delete) do
-      Mongo::Protocol::Delete.new(TEST_DB, TEST_COLL, {})
-    end
-
-    context 'when providing a single message' do
-
-      let(:reply) do
-        server.dispatch([ insert, query ])
-      end
-
-      # @todo: Can remove this once we have more implemented with global hooks.
-      after do
-        server.dispatch([ delete ])
-      end
-
-      it 'it dispatchs the message to the socket' do
-        expect(reply.documents.first['name']).to eq('testing')
-      end
-    end
-
-    context 'when providing multiple messages' do
-
-      let(:selector) do
-        { :getlasterror => 1 }
-      end
-
-      let(:command) do
-        Mongo::Protocol::Query.new(TEST_DB, '$cmd', selector, :limit => -1)
-      end
-
-      let(:reply) do
-        server.dispatch([ insert, command ])
-      end
-
-      # @todo: Can remove this once we have more implemented with global hooks.
-      after do
-        server.dispatch([ delete ])
-      end
-
-      it 'it dispatchs the message to the socket' do
-        expect(reply.documents.first['ok']).to eq(1.0)
-      end
-    end
-  end
-
   describe '#initialize' do
 
     let(:address) do


### PR DESCRIPTION
This removes the thread local connection pinning in the connection pool, and also gets rid of the dispatch mutex on Server since server is no longer sending messages. One must now ask the server for a `context` and then with the context get a connection. Example:

``` ruby
server.context.with_connection do |connection|
  connection.dispatch([ insert, insert ])
end
```

The `with_connection` block handles the checkout/checkin from the connection pool.

cc/ @estolfo @samantharitter 
