### PR TITLE
Server description inspections in their own objects

### DIFF
--- a/lib/mongo/server.rb
+++ b/lib/mongo/server.rb
@@ -27,11 +27,6 @@ module Mongo
     include Event::Publisher
     include Event::Subscriber
 
-    # Error message for Unconnected errors.
-    #
-    # @since 3.0.0
-    UNCONNECTED = 'Server is currently not connected.'.freeze
-
     # @return [ String ] The configured address for the server.
     attr_reader :address
     # @return [ Server::Description ] The description of the server.

--- a/lib/mongo/server/description/inspection.rb
+++ b/lib/mongo/server/description/inspection.rb
@@ -1,0 +1,16 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'mongo/server/description/inspection/server_added'
+require 'mongo/server/description/inspection/server_removed'

--- a/lib/mongo/server/description/inspection/server_added.rb
+++ b/lib/mongo/server/description/inspection/server_added.rb
@@ -1,0 +1,46 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  class Server
+    class Description
+      module Inspection
+
+        # Handles inspecting the result of an ismaster command for servers
+        # added to the cluster.
+        #
+        # @since 2.0.0
+        class ServerAdded
+
+          # Run the server added inspection.
+          #
+          # @example Run the inspection.
+          #   ServerAdded.run(description, {})
+          #
+          # @param [ Description ] description The server description.
+          # @param [ Hash ] config The result of the ismaster command.
+          #
+          # @since 2.0.0
+          def self.run(description, config)
+            (config[Description::HOSTS] || []).each do |host|
+              unless description.hosts.include?(host)
+                description.publish(Event::HOST_ADDED, host)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mongo/server/description/inspection/server_removed.rb
+++ b/lib/mongo/server/description/inspection/server_removed.rb
@@ -1,0 +1,46 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  class Server
+    class Description
+      module Inspection
+
+        # Handles inspecting the result of an ismaster command for servers
+        # that were removed from the cluster.
+        #
+        # @since 2.0.0
+        class ServerRemoved
+
+          # Run the server added inspection.
+          #
+          # @example Run the inspection.
+          #   ServerAdded.run(description, {})
+          #
+          # @param [ Description ] description The server description.
+          # @param [ Hash ] config The result of the ismaster command.
+          #
+          # @since 2.0.0
+          def self.run(description, config)
+            description.hosts.each do |host|
+              unless (config[Description::HOSTS] || []).include?(host)
+                description.publish(Event::HOST_REMOVED, host)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Since the result of the ismaster command is the basis for a lot of checks for handling the state of a cluster, it made since to extract these out into their own objects so the description itself doesn't get a huge amount of logic checking all these things. I call them `Inspection`s for now since I didn't like `Check` or `Test`. 

cc/ @estolfo @samantharitter 
