### PR TITLE
Determine server type

### DIFF
--- a/lib/mongo/server.rb
+++ b/lib/mongo/server.rb
@@ -17,6 +17,7 @@ require 'mongo/server/address'
 require 'mongo/server/context'
 require 'mongo/server/description'
 require 'mongo/server/monitor'
+require 'mongo/server/type'
 
 module Mongo
 

--- a/lib/mongo/server/type.rb
+++ b/lib/mongo/server/type.rb
@@ -1,0 +1,102 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  class Server
+
+    # Represents what kind of type a server is.
+    #
+    # @since 2.0.0
+    class Type
+
+      # Constant for arbiter types.
+      #
+      # @since 2.0.0
+      ARBITER = :arbiter.freeze
+
+      # Constant for ghost types.
+      #
+      # @since 2.0.0
+      GHOST = :ghost.freeze
+
+      # Constant for mongos types.
+      #
+      # @since 2.0.0
+      MONGOS = :mongos.freeze
+
+      # Constant for other types.
+      #
+      # @since 2.0.0
+      OTHER = :other.freeze
+
+      # Constant for primary types.
+      #
+      # @since 2.0.0
+      PRIMARY = :primary.freeze
+
+      # Constant for secondary types.
+      #
+      # @since 2.0.0
+      SECONDARY = :secondary.freeze
+
+      # Constant for standalone types.
+      #
+      # @since 2.0.0
+      STANDALONE = :standalone.freeze
+
+      # Constant for unknown types.
+      #
+      # @since 2.0.0
+      UNKNOWN = :unknown.freeze
+
+      # List of rules for determining the type of server it is. We have this
+      # logic here since we don't determine whether a server should be
+      # selectable by the cluster at the time a message is to be dispatched,
+      # but at the time the description is updated. This means we need to store
+      # a server type and determine if it changed. This is much cleaner then
+      # checking each predicate method on both objects every time - this way it
+      # only happens on the new description.
+      #
+      # @since 2.0.0
+      RULES = [
+        ->(description){ description.arbiter?   ? ARBITER   : false },
+        ->(description){ description.ghost?     ? GHOST     : false },
+        ->(description){ description.mongos?    ? MONGOS    : false },
+        ->(description){ description.primary?   ? PRIMARY   : false },
+        ->(description){ description.secondary? ? SECONDARY : false },
+        ->(description){ description.unknown?   ? UNKNOWN   : false }
+      ]
+
+      class << self
+
+        # Determine the server type given the description.
+        #
+        # @example Determine the server type.
+        #   Type.determine(description)
+        #
+        # @param [ Description ] description The server description.
+        #
+        # @return [ Symbol ] The server type.
+        #
+        # @since 2.0.0
+        def determine(description)
+          RULES.each do |rule|
+            type = rule.call(description)
+            return type if type
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/mongo/server/type_spec.rb
+++ b/spec/mongo/server/type_spec.rb
@@ -1,0 +1,97 @@
+require 'spec_helper'
+
+describe Mongo::Server::Type do
+
+  describe '.determine' do
+
+    let(:server_type) do
+      described_class.determine(description)
+    end
+
+    context 'when the description indicates an arbiter' do
+
+      let(:ismaster) do
+        { 'arbiterOnly' => true, 'setName' => 'test' }
+      end
+
+      let(:description) do
+        Mongo::Server::Description.new(ismaster)
+      end
+
+      it 'returns arbiter' do
+        expect(server_type).to eq(Mongo::Server::Type::ARBITER)
+      end
+    end
+
+    context 'when the description indicates a ghost' do
+
+      let(:ismaster) do
+        { 'isreplicaset' => true }
+      end
+
+      let(:description) do
+        Mongo::Server::Description.new(ismaster)
+      end
+
+      it 'returns ghost' do
+        expect(server_type).to eq(Mongo::Server::Type::GHOST)
+      end
+    end
+
+    context 'when the description indicates a mongos' do
+
+      let(:ismaster) do
+        { 'msg' => 'isdbgrid', 'ismaster' => true }
+      end
+
+      let(:description) do
+        Mongo::Server::Description.new(ismaster)
+      end
+
+      it 'returns mongos' do
+        expect(server_type).to eq(Mongo::Server::Type::MONGOS)
+      end
+    end
+
+    context 'when the description indicates a primary' do
+
+      let(:ismaster) do
+        { 'setName' => 'test', 'ismaster' => true }
+      end
+
+      let(:description) do
+        Mongo::Server::Description.new(ismaster)
+      end
+
+      it 'returns primary' do
+        expect(server_type).to eq(Mongo::Server::Type::PRIMARY)
+      end
+    end
+
+    context 'when the description indicates a secondary' do
+
+      let(:ismaster) do
+        { 'setName' => 'test', 'secondary' => true }
+      end
+
+      let(:description) do
+        Mongo::Server::Description.new(ismaster)
+      end
+
+      it 'returns secondary' do
+        expect(server_type).to eq(Mongo::Server::Type::SECONDARY)
+      end
+    end
+
+    context 'when the description indicates an unknown' do
+
+      let(:description) do
+        Mongo::Server::Description.new({})
+      end
+
+      it 'returns unknown' do
+        expect(server_type).to eq(Mongo::Server::Type::UNKNOWN)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the first step in cluster monitoring towards firing events based on the cluster type when a server type changes.

cc/ @estolfo @samantharitter 
