### PR TITLE
Ruby 779 encoding

### DIFF
--- a/lib/bson/bson_ruby.rb
+++ b/lib/bson/bson_ruby.rb
@@ -52,16 +52,15 @@ module BSON
     end
 
     if RUBY_VERSION >= '1.9'
-      UTF8_ENCODING   = Encoding.find('utf-8')
-      BINARY_ENCODING = Encoding.find('binary')
 
       def self.to_utf8_binary(str)
         begin
-          str.unpack("U*")
-        rescue
-          raise InvalidStringEncoding, "String not valid utf-8: #{str.inspect}"
+          data = str.dup.force_encoding('utf-8')
+          data.encode!('binary', 'utf-8')
+        rescue EncodingError
+          raise InvalidStringEncoding, "String not valid utf-8: #{str.inspect}" unless data.valid_encoding?
+          data.force_encoding('binary')
         end
-        str.dup.force_encoding(BINARY_ENCODING)
       end
     else
       def self.to_utf8_binary(str)

--- a/test/bson/bson_test.rb
+++ b/test/bson/bson_test.rb
@@ -233,6 +233,12 @@ class BSONTest < Test::Unit::TestCase
         assert_raise BSON::InvalidStringEncoding do
           BSON::BSON_CODER.serialize({'str' => str})
         end
+
+        str2 = "\xED\xAE\xBA\xED\xB6\x86"
+        assert !str2.valid_encoding?
+        assert_raise BSON::InvalidStringEncoding do
+          BSON::BSON_CODER.serialize({'str' => str2})
+        end
       end
 
       def test_non_utf8_key


### PR DESCRIPTION
Some utf-8 strings didn't throw an exception when #unpack("U*") was called but the encoding still wasn't valid. This PR checks to make sure the encoding is valid and throws and exception if not.
