### PR TITLE
Testing around replica set modes.

### DIFF
--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -125,18 +125,6 @@ module Mongo
       options[REPLICA_SET_NAME]
     end
 
-    # Force a scan of all servers in the cluster.
-    #
-    # @example Scan the cluster.
-    #   cluster.scan!
-    #
-    # @return [ true ] Always true if no error.
-    #
-    # @since 2.0.0
-    def scan!
-      @servers.each{ |server| server.check! } and true
-    end
-
     # Get a list of server candidates from the cluster that can have operations
     # executed on them.
     #
@@ -147,7 +135,7 @@ module Mongo
     #
     # @since 2.0.0
     def servers
-      mode.select(@servers, replica_set_name)
+      mode.servers(@servers, replica_set_name)
     end
   end
 end

--- a/lib/mongo/cluster/mode.rb
+++ b/lib/mongo/cluster/mode.rb
@@ -38,13 +38,17 @@ module Mongo
       # @example Get the cluster mode.
       #   Mode.get(mode: :replica_set)
       #
+      # @note If a mode is not specified, we will return a replica set mode if
+      #   a set_name option is provided, otherwise a standalone.
+      #
       # @param [ Hash ] options The cluster options.
       #
       # @return [ ReplicaSet, Sharded, Standalone ] The mode.
       #
       # @since 2.0.0
       def self.get(options)
-        OPTIONS.fetch(options[:mode]) { ReplicaSet }
+        return OPTIONS.fetch(options[:mode]) if options.has_key?(:mode)
+        options.has_key?(:set_name) ? ReplicaSet : Standalone
       end
     end
   end

--- a/lib/mongo/cluster/mode/replica_set.rb
+++ b/lib/mongo/cluster/mode/replica_set.rb
@@ -24,7 +24,7 @@ module Mongo
         # Select appropriate servers for this mode.
         #
         # @example Select the servers.
-        #   ReplicaSet.select(servers, 'test')
+        #   ReplicaSet.servers(servers, 'test')
         #
         # @param [ Array<Server> ] servers The known servers.
         # @param [ String ] replica_set_name The name of the replica set.
@@ -32,9 +32,10 @@ module Mongo
         # @return [ Array<Server> ] The servers in the replica set.
         #
         # @since 2.0.0
-        def self.select(servers, replica_set_name = nil)
+        def self.servers(servers, replica_set_name = nil)
           servers.select do |server|
-            server.primary? || server.secondary?
+            (replica_set_name.nil? || server.replica_set_name == replica_set_name) &&
+              server.primary? || server.secondary?
           end
         end
       end

--- a/lib/mongo/cluster/mode/sharded.rb
+++ b/lib/mongo/cluster/mode/sharded.rb
@@ -24,14 +24,14 @@ module Mongo
         # Select appropriate servers for this mode.
         #
         # @example Select the servers.
-        #   Sharded.select(servers, 'test')
+        #   Sharded.servers(servers, 'test')
         #
         # @param [ Array<Server> ] servers The known servers.
         #
         # @return [ Array<Server> ] The mongos servers.
         #
         # @since 2.0.0
-        def self.select(servers, name = nil)
+        def self.servers(servers, name = nil)
           servers.select{ |server| server.mongos? }
         end
       end

--- a/lib/mongo/cluster/mode/standalone.rb
+++ b/lib/mongo/cluster/mode/standalone.rb
@@ -24,15 +24,15 @@ module Mongo
         # Select appropriate servers for this mode.
         #
         # @example Select the servers.
-        #   Standalone.select(servers, 'test')
+        #   Standalone.servers(servers, 'test')
         #
         # @param [ Array<Server> ] servers The known servers.
         #
         # @return [ Array<Server> ] The standalone servers.
         #
         # @since 2.0.0
-        def self.select(servers, name = nil)
-          servers.select{ |server| server.standalone? }
+        def self.servers(servers, name = nil)
+          [ servers.detect{ |server| server.standalone? } ]
         end
       end
     end

--- a/lib/mongo/server.rb
+++ b/lib/mongo/server.rb
@@ -57,18 +57,6 @@ module Mongo
       address == other.address
     end
 
-    # Tells the monitor to immediately check the server status.
-    #
-    # @example Check the server status.
-    #   server.check!
-    #
-    # @return [ Server::Description ] The updated server description.
-    #
-    # @since 2.0.0
-    def check!
-      @monitor.check!
-    end
-
     # Get a new context for this server in which to send messages.
     #
     # @example Get the server context.

--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -330,7 +330,7 @@ module Mongo
       #
       # @since 2.0.0
       def standalone?
-        replica_set_name.nil? && !mongos? && !ghost?
+        replica_set_name.nil? && !mongos? && !ghost? && !unknown?
       end
 
       # Is the server description currently unknown?

--- a/spec/mongo/cluster/mode/replica_set_spec.rb
+++ b/spec/mongo/cluster/mode/replica_set_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe Mongo::Cluster::Mode::ReplicaSet do
+
+  describe '.servers' do
+
+    let(:mongos) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:standalone) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:replica_set) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:replica_set_two) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:mongos_description) do
+      Mongo::Server::Description.new(mongos, { 'msg' => 'isdbgrid' })
+    end
+
+    let(:standalone_description) do
+      Mongo::Server::Description.new(standalone, { 'ismaster' => true })
+    end
+
+    let(:replica_set_description) do
+      Mongo::Server::Description.new(replica_set, { 'ismaster' => true, 'setName' => 'testing' })
+    end
+
+    let(:replica_set_two_description) do
+      Mongo::Server::Description.new(replica_set, { 'ismaster' => true, 'setName' => 'test' })
+    end
+
+    before do
+      mongos.instance_variable_set(:@description, mongos_description)
+      standalone.instance_variable_set(:@description, standalone_description)
+      replica_set.instance_variable_set(:@description, replica_set_description)
+      replica_set_two.instance_variable_set(:@description, replica_set_two_description)
+    end
+
+    context 'when no replica set name is provided' do
+
+      let(:servers) do
+        described_class.servers([ mongos, standalone, replica_set, replica_set_two ])
+      end
+
+      it 'returns only replica set members' do
+        expect(servers).to eq([ replica_set, replica_set_two ])
+      end
+    end
+
+    context 'when a replica set name is provided' do
+
+      let(:servers) do
+        described_class.servers([ mongos, standalone, replica_set, replica_set_two ], 'testing')
+      end
+
+      it 'returns only replica set members is the provided set' do
+        expect(servers).to eq([ replica_set ])
+      end
+    end
+  end
+end

--- a/spec/mongo/cluster/mode/sharded_spec.rb
+++ b/spec/mongo/cluster/mode/sharded_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe Mongo::Cluster::Mode::Sharded do
+
+  describe '.servers' do
+
+    let(:mongos) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:standalone) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:replica_set) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:mongos_description) do
+      Mongo::Server::Description.new(mongos, { 'msg' => 'isdbgrid' })
+    end
+
+    let(:standalone_description) do
+      Mongo::Server::Description.new(standalone, { 'ismaster' => true })
+    end
+
+    let(:replica_set_description) do
+      Mongo::Server::Description.new(replica_set, { 'ismaster' => true, 'setName' => 'testing' })
+    end
+
+    before do
+      mongos.instance_variable_set(:@description, mongos_description)
+      standalone.instance_variable_set(:@description, standalone_description)
+      replica_set.instance_variable_set(:@description, replica_set_description)
+    end
+
+    let(:servers) do
+      described_class.servers([ mongos, standalone, replica_set ])
+    end
+
+    it 'returns only mongos servers' do
+      expect(servers).to eq([ mongos ])
+    end
+  end
+end

--- a/spec/mongo/cluster/mode/standalone_spec.rb
+++ b/spec/mongo/cluster/mode/standalone_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Mongo::Cluster::Mode::Standalone do
+
+  describe '.servers' do
+
+    let(:mongos) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:standalone) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:standalone_two) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:replica_set) do
+      Mongo::Server.new('127.0.0.1:27017')
+    end
+
+    let(:mongos_description) do
+      Mongo::Server::Description.new(mongos, { 'msg' => 'isdbgrid' })
+    end
+
+    let(:standalone_description) do
+      Mongo::Server::Description.new(standalone, { 'ismaster' => true })
+    end
+
+    let(:replica_set_description) do
+      Mongo::Server::Description.new(replica_set, { 'ismaster' => true, 'setName' => 'testing' })
+    end
+
+    before do
+      mongos.instance_variable_set(:@description, mongos_description)
+      standalone.instance_variable_set(:@description, standalone_description)
+      standalone_two.instance_variable_set(:@description, standalone_description)
+      replica_set.instance_variable_set(:@description, replica_set_description)
+    end
+
+    let(:servers) do
+      described_class.servers([ mongos, standalone, standalone_two, replica_set ])
+    end
+
+    it 'returns only the first standalone server' do
+      expect(servers).to eq([ standalone ])
+    end
+  end
+end

--- a/spec/mongo/cluster/mode_spec.rb
+++ b/spec/mongo/cluster/mode_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe Mongo::Cluster::Mode do
+
+  describe '.get' do
+
+    context 'when provided a replica set option' do
+
+      let(:mode) do
+        described_class.get(mode: :replica_set)
+      end
+
+      it 'returns a replica set mode' do
+        expect(mode).to eq(Mongo::Cluster::Mode::ReplicaSet)
+      end
+    end
+
+    context 'when provided a standalone option' do
+
+      let(:mode) do
+        described_class.get(mode: :standalone)
+      end
+
+      it 'returns a standalone mode' do
+        expect(mode).to eq(Mongo::Cluster::Mode::Standalone)
+      end
+    end
+
+    context 'when provided a sharded option' do
+
+      let(:mode) do
+        described_class.get(mode: :sharded)
+      end
+
+      it 'returns a sharded mode' do
+        expect(mode).to eq(Mongo::Cluster::Mode::Sharded)
+      end
+    end
+
+    context 'when provided no option' do
+
+      context 'when a set name is in the options' do
+
+        let(:mode) do
+          described_class.get(set_name: 'testing')
+        end
+
+        it 'returns a replica set mode' do
+          expect(mode).to eq(Mongo::Cluster::Mode::ReplicaSet)
+        end
+      end
+
+      context 'when no set name is in the options' do
+
+        let(:mode) do
+          described_class.get({})
+        end
+
+        it 'returns a standalone mode' do
+          expect(mode).to eq(Mongo::Cluster::Mode::Standalone)
+        end
+      end
+    end
+  end
+end

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -56,7 +56,7 @@ describe Mongo::Cluster do
     end
 
     let(:cluster) do
-      described_class.new(client, addresses)
+      described_class.new(client, addresses, set_name: 'testing')
     end
 
     context 'when a server with the address does not exist' do
@@ -111,7 +111,7 @@ describe Mongo::Cluster do
       context 'when servers are discovered' do
 
         let(:cluster) do
-          described_class.new(client, addresses)
+          described_class.new(client, addresses, set_name: 'testing')
         end
 
         before do
@@ -132,7 +132,7 @@ describe Mongo::Cluster do
     end
 
     let(:cluster) do
-      described_class.new(client, addresses)
+      described_class.new(client, addresses, set_name: 'testing')
     end
 
     context 'when the address exists' do
@@ -208,7 +208,7 @@ describe Mongo::Cluster do
     end
 
     let(:cluster) do
-      described_class.new(client, addresses)
+      described_class.new(client, addresses, set_name: 'testing')
     end
 
     let(:servers_internal) do

--- a/spec/support/cluster_simulator.rb
+++ b/spec/support/cluster_simulator.rb
@@ -568,3 +568,45 @@ class ClusterSimulator
     end
   end
 end
+
+module Mongo
+  class Cluster
+
+    # Force a scan of all servers in the cluster.
+    #
+    # @api test
+    #
+    # @example Scan the cluster.
+    #   cluster.scan!
+    #
+    # @note This is for testing purposes only.
+    #
+    # @return [ true ] Always true if no error.
+    #
+    # @since 2.0.0
+    def scan!
+      @servers.each{ |server| server.check! } and true
+    end
+  end
+end
+
+module Mongo
+  class Server
+
+    # Tells the monitor to immediately check the server status.
+    #
+    # @api test
+    #
+    # @example Check the server status.
+    #   server.check!
+    #
+    # @note Used for testing purposes.
+    #
+    # @return [ Server::Description ] The updated server description.
+    #
+    # @since 2.0.0
+    def check!
+      @monitor.check!
+    end
+  end
+end


### PR DESCRIPTION
This is for cluster monitoring, also moves scanning a cluster and checking a server synchronously to test only environment for us - these methods are not available outside of our test suite.
