### PR TITLE
Fix for auth-related Jenkins failures

### DIFF
--- a/tasks/testing.rake
+++ b/tasks/testing.rake
@@ -117,12 +117,20 @@ namespace :test do
       require 'mongo'
       client = Mongo::MongoClient.new(ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost',
                                       ENV['MONGO_RUBY_DRIVER_PORT'] || Mongo::MongoClient::DEFAULT_PORT)
+      admin = client.db('admin')
+      cmd = BSON::OrderedHash.new
+      cmd[:createUser] = 'TheBoss'
+      cmd[:pwd] = 'bossy'
+      cmd[:roles] = [ 'userAdminAnyDatabase', 'dbAdminAnyDatabase' ]
+      admin.authenticate("TheBoss", "bossy")
       client.database_names.each do |db_name|
         if db_name =~ /^ruby_test*/
           puts "[CLEAN-UP] Dropping '#{db_name}'..."
           client.drop_database(db_name)
         end
       end
+      admin.command({ :dropAllUsersFromDatabase => 1 })
+      admin.logout
     rescue Mongo::ConnectionFailure => e
       # moving on anyway
     end

--- a/test/helpers/test_unit.rb
+++ b/test/helpers/test_unit.rb
@@ -234,7 +234,15 @@ class Test::Unit::TestCase
   end
 
   def with_auth(client, &block)
-    cmd_line_args = client['admin'].command({ :getCmdLineOpts => 1 })['parsed']
+    cmd_line_args = []
+    begin
+      cmd_line_args = client['admin'].command({ :getCmdLineOpts => 1 })['parsed']
+    rescue OperationFailure
+      # With --auth and under the localhost exception or not logged in
+      yield block
+      return
+    end
+    # When there is --auth, and we are logged in.
     yield if cmd_line_args.include?('auth')
   end
 

--- a/test/shared/authentication/bulk_api_auth_shared.rb
+++ b/test/shared/authentication/bulk_api_auth_shared.rb
@@ -19,9 +19,11 @@ module BulkAPIAuthTests
   def init_auth_bulk
     # enable authentication
     @admin = @client["admin"]
-    @admin.add_user('admin', 'password', nil, :roles => ['readWriteAnyDatabase',
-                                                         'userAdminAnyDatabase',
-                                                         'dbAdminAnyDatabase'])
+    cmd = BSON::OrderedHash.new
+    cmd[:createUser] = 'admin'
+    cmd[:pwd] = 'password'
+    cmd[:roles] = ['readWriteAnyDatabase', 'userAdminAnyDatabase', 'dbAdminAnyDatabase']
+    @admin.command(cmd)
     @admin.authenticate('admin', 'password')
 
     # Set up the test db


### PR DESCRIPTION
Most of these failures were due to a recent change in the scope of the localhost exception on the server.
