### PR TITLE
Split write operations into a specified number of children operations

### DIFF
--- a/spec/mongo/operation/write/delete_spec.rb
+++ b/spec/mongo/operation/write/delete_spec.rb
@@ -246,6 +246,65 @@ describe Mongo::Operation::Write::Delete do
     end
   end
 
+  describe '#split' do
+
+    context 'number of deletes is evenly divisble by divisor' do
+      let(:deletes) do
+        [ {:q => { :a => 1 } },
+          {:q => { :b => 1 } },
+          {:q => { :c => 1 } },
+          {:q => { :d => 1 } },
+          {:q => { :e => 1 } },
+          {:q => { :f => 1 } } ]
+      end
+      let(:divisor) { 3 }
+
+      it 'splits the op into the divisor number of children ops' do
+        expect(op.split(divisor).size).to eq(divisor)
+      end
+
+      it 'divides the deletes evenly between children ops' do
+        ops = op.split(divisor)
+        batch_size = deletes.size / divisor
+
+        divisor.times do |i|
+          start_index = i * batch_size
+          expect(ops[i].spec[:deletes]).to eq(deletes[start_index, batch_size])
+        end
+      end
+    end
+
+    context 'number of deletes is not evenly divisble by divisor' do
+      let(:deletes) do
+        [ {:q => { :a => 1 } },
+          {:q => { :b => 1 } },
+          {:q => { :c => 1 } },
+          {:q => { :d => 1 } },
+          {:q => { :e => 1 } },
+          {:q => { :f => 1 } } ]
+      end
+      let(:divisor) { 4 }
+
+      it 'splits the op into the divisor number of children ops' do
+        expect(op.split(divisor).size).to eq(divisor)
+      end
+
+      it 'divides the deletes evenly between children ops' do
+        ops = op.split(divisor)
+        batch_size = deletes.size / divisor
+
+        divisor.times do |i|
+          start_index = i * batch_size
+          if i == divisor - 1
+            expect(ops[i].spec[:deletes]).to eq(deletes[start_index..-1])
+          else
+            expect(ops[i].spec[:deletes]).to eq(deletes[start_index, batch_size])
+          end
+        end
+      end
+    end
+  end
+
   describe '#execute' do
 
     context 'server' do


### PR DESCRIPTION
Not the prettiest bit of code but I need this for the Bulk API:
If a write operation is too large to send, I'll want to split it into multiple children operations to be sent individually instead.
