### PR TITLE
Slicable module for splitting ops into n children ops

### DIFF
--- a/lib/mongo/operation.rb
+++ b/lib/mongo/operation.rb
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Base Operations
+# Common functionality
 require 'mongo/operation/executable'
+require 'mongo/operation/slicable'
+
+# Base Operations
 require 'mongo/operation/read'
 require 'mongo/operation/write'
 

--- a/lib/mongo/operation/slicable.rb
+++ b/lib/mongo/operation/slicable.rb
@@ -1,0 +1,56 @@
+# Copyright (C) 2009-2014 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+
+  module Operation
+
+    # This module contains common functionality for splitting an operation
+    # into the specified number of children operations.
+    # An operation including this module must provide a method called
+    # #slicable_key. It specifies the key of the spec array element to split.
+    #
+    # @since 2.0.0
+    module Slicable
+
+      # Slices this operation into the specified number of children operations.
+      #
+      # @params [ Integer ] n_slices The number of children operations to split
+      #   this one into.
+      #
+      # @return [ Array ] An array of children operations.
+      #
+      # @since 2.0.0
+      def slice(n_slices)
+        items      = spec[slicable_key]
+        group_size = items.size / n_slices
+        divisions  = items.each_slice(group_size).to_a
+
+        # #each_slice makes groups containing exactly group_size number of items.
+        # You could therefore end up with more groups than n_slices, so put the
+        # remaining items in the last group.
+        if divisions.size > n_slices
+          divisions[n_slices - 1] << divisions.pop(divisions.size - n_slices)
+          divisions[-1].flatten!
+        end
+
+        divisions.inject([]) do |children, division|
+          spec_copy = spec.dup
+          spec_copy[slicable_key] = division
+          children << self.class.new(spec_copy)
+        end
+      end
+    end
+  end
+end

--- a/lib/mongo/operation/write/delete.rb
+++ b/lib/mongo/operation/write/delete.rb
@@ -26,6 +26,7 @@ module Mongo
       # @since 2.0.0
       class Delete
         include Executable
+        include Slicable
 
         # Initialize the delete operation.
         #
@@ -102,6 +103,14 @@ module Mongo
         end
 
         private
+
+        # The spec array element to split up when slicing this operation.
+        # This is used by the Slicable module.
+        #
+        # @return [ Symbol ] :deletes
+        def slicable_key
+          :deletes
+        end
 
         # Dup the list of deletes in the spec if this operation is copied/duped.
         def initialize_copy(original)

--- a/lib/mongo/operation/write/insert.rb
+++ b/lib/mongo/operation/write/insert.rb
@@ -26,6 +26,7 @@ module Mongo
       # @since 2.0.0
       class Insert
         include Executable
+        include Slicable
 
         # Initialize the insert operation.
         #
@@ -98,6 +99,14 @@ module Mongo
         end
 
         private
+
+        # The spec array element to split up when slicing this operation.
+        # This is used by the Slicable module.
+        #
+        # @return [ Symbol ] :documents
+        def slicable_key
+          :documents
+        end
 
         # Dup the list of documents in the spec if this operation is copied/duped.
         def initialize_copy(original)

--- a/lib/mongo/operation/write/update.rb
+++ b/lib/mongo/operation/write/update.rb
@@ -26,6 +26,7 @@ module Mongo
       # @since 2.0.0
       class Update
         include Executable
+        include Slicable
 
         # Initialize the update operation.
         #
@@ -104,6 +105,14 @@ module Mongo
         end
 
         private
+
+        # The spec array element to split up when slicing this operation.
+        # This is used by the Slicable module.
+        #
+        # @return [ Symbol ] :updates
+        def slicable_key
+          :updates
+        end
 
         # Dup the list of updates in the spec if this operation is copied/duped.
         def initialize_copy(original)

--- a/spec/mongo/operation/write/insert_spec.rb
+++ b/spec/mongo/operation/write/insert_spec.rb
@@ -248,6 +248,65 @@ describe Mongo::Operation::Write::Insert do
     end
   end
 
+  describe '#slice' do
+
+    context 'number of inserts is evenly divisible by divisor' do
+      let(:documents) do
+        [ { :a => 1 },
+          { :b => 1 },
+          { :c => 1 },
+          { :d => 1 },
+          { :e => 1 },
+          { :f => 1 } ]
+      end
+      let(:divisor) { 3 }
+
+      it 'slices the op into the divisor number of children ops' do
+        expect(op.slice(divisor).size).to eq(divisor)
+      end
+
+      it 'divides the inserts evenly between children ops' do
+        ops = op.slice(divisor)
+        slice_size = documents.size / divisor
+
+        divisor.times do |i|
+          start_index = i * slice_size
+          expect(ops[i].spec[:documents]).to eq(documents[start_index, slice_size])
+        end
+      end
+    end
+
+    context 'number of inserts is not evenly divisible by divisor' do
+      let(:documents) do
+        [ { :a => 1 },
+          { :b => 1 },
+          { :c => 1 },
+          { :d => 1 },
+          { :e => 1 },
+          { :f => 1 } ]
+      end
+      let(:divisor) { 4 }
+
+      it 'slices the op into the divisor number of children ops' do
+        expect(op.slice(divisor).size).to eq(divisor)
+      end
+
+      it 'divides the inserts evenly between children ops' do
+        ops = op.slice(divisor)
+        slice_size = documents.size / divisor
+
+        divisor.times do |i|
+          start_index = i * slice_size
+          if i == divisor - 1
+            expect(ops[i].spec[:documents]).to eq(documents[start_index..-1])
+          else
+            expect(ops[i].spec[:documents]).to eq(documents[start_index, slice_size])
+          end
+        end
+      end
+    end
+  end
+
   describe '#execute' do
 
     context 'server' do

--- a/spec/mongo/operation/write/update_spec.rb
+++ b/spec/mongo/operation/write/update_spec.rb
@@ -286,6 +286,103 @@ describe Mongo::Operation::Write::Update do
     end
   end
 
+  describe '#slice' do
+
+    context 'number of updates is evenly divisible by divisor' do
+      let(:updates) do
+        [{ :q => { :a => 1 },
+           :u => { :$set => { :a => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :b => 1 },
+           :u => { :$set => { :b => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :c => 1 },
+           :u => { :$set => { :c => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :d => 1 },
+           :u => { :$set => { :d => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :e => 1 },
+           :u => { :$set => { :e => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :f => 1 },
+           :u => { :$set => { :f => 2 } },
+           :multi => true,
+           :upsert => false }
+        ]
+      end
+      let(:divisor) { 3 }
+
+      it 'splits the op into the divisor number of children ops' do
+        expect(op.slice(divisor).size).to eq(divisor)
+      end
+
+      it 'divides the updates evenly between children ops' do
+        ops = op.slice(divisor)
+        slice_size = updates.size / divisor
+
+        divisor.times do |i|
+          start_index = i * slice_size
+          expect(ops[i].spec[:updates]).to eq(updates[start_index, slice_size])
+        end
+      end
+    end
+
+    context 'number of updates is not evenly divisible by divisor' do
+      let(:updates) do
+        [{ :q => { :a => 1 },
+           :u => { :$set => { :a => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :b => 1 },
+           :u => { :$set => { :b => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :c => 1 },
+           :u => { :$set => { :c => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :d => 1 },
+           :u => { :$set => { :d => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :e => 1 },
+           :u => { :$set => { :e => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :f => 1 },
+           :u => { :$set => { :f => 2 } },
+           :multi => true,
+           :upsert => false }
+        ]
+      end
+      let(:divisor) { 4 }
+
+      it 'splits the op into the divisor number of children ops' do
+        expect(op.slice(divisor).size).to eq(divisor)
+      end
+
+      it 'divides the updates evenly between children ops' do
+        ops = op.slice(divisor)
+        slice_size = updates.size / divisor
+
+        divisor.times do |i|
+          start_index = i * slice_size
+          if i == divisor - 1
+            expect(ops[i].spec[:updates]).to eq(updates[start_index..-1])
+          else
+            expect(ops[i].spec[:updates]).to eq(updates[start_index, slice_size])
+          end
+        end
+      end
+    end
+  end
+
   describe '#execute' do
 
     context 'server' do


### PR DESCRIPTION
If a write operation is too large to send, I'll want to split it into multiple children operations to be sent individually instead. This module can be included in an operation and it splits an array element of the spec between the children ops.
