### PR TITLE
Inject an order value into spec documents

### DIFF
--- a/lib/mongo/operation/slicable.rb
+++ b/lib/mongo/operation/slicable.rb
@@ -51,6 +51,15 @@ module Mongo
           children << self.class.new(spec_copy)
         end
       end
+
+      # Set a field :ord in the spec that keeps track of a higher-level ordering.
+      #
+      # @param [ Integer ] order The higher-level ordering of this op.
+      #
+      # @since 2.0.0
+      def set_order(order)
+        spec[slicable_key].each { |doc| doc[:ord] = order }
+      end
     end
   end
 end

--- a/spec/mongo/operation/write/delete_spec.rb
+++ b/spec/mongo/operation/write/delete_spec.rb
@@ -305,6 +305,28 @@ describe Mongo::Operation::Write::Delete do
     end
   end
 
+  describe '#set_order' do
+
+    context 'when an order has been set' do
+      let(:order) { 5 }
+      let(:deletes) do
+        [ {:q => { :a => 1 } },
+          {:q => { :b => 1 } },
+          {:q => { :c => 1 } } ]
+      end
+      let(:expected) do
+        [ {:q => { :a => 1 }, :ord => order },
+          {:q => { :b => 1 }, :ord => order },
+          {:q => { :c => 1 }, :ord => order } ]
+      end
+
+      it 'sets the order on each op spec document' do
+        op.set_order(order)
+        expect(op.spec[:deletes]).to eq(expected)
+      end
+    end
+  end
+
   describe '#execute' do
 
     context 'server' do

--- a/spec/mongo/operation/write/insert_spec.rb
+++ b/spec/mongo/operation/write/insert_spec.rb
@@ -307,6 +307,28 @@ describe Mongo::Operation::Write::Insert do
     end
   end
 
+  describe '#set_order' do
+
+    context 'when an order has been set' do
+      let(:order) { 5 }
+      let(:documents) do
+        [ { :a => 1 },
+          { :b => 1 },
+          { :c => 1 } ]
+      end
+      let(:expected) do
+        [ { :a => 1, :ord => order },
+          { :b => 1, :ord => order },
+          { :c => 1, :ord => order } ]
+      end
+
+      it 'sets the order on each op spec document' do
+        op.set_order(order)
+        expect(op.spec[:documents]).to eq(expected)
+      end
+    end
+  end
+
   describe '#execute' do
 
     context 'server' do

--- a/spec/mongo/operation/write/update_spec.rb
+++ b/spec/mongo/operation/write/update_spec.rb
@@ -383,6 +383,49 @@ describe Mongo::Operation::Write::Update do
     end
   end
 
+  describe '#set_order' do
+
+    context 'when an order has been set' do
+      let(:order) { 5 }
+      let(:updates) do
+        [{ :q => { :a => 1 },
+           :u => { :$set => { :a => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :b => 1 },
+           :u => { :$set => { :b => 2 } },
+           :multi => true,
+           :upsert => false },
+         { :q => { :c => 1 },
+           :u => { :$set => { :c => 2 } },
+           :multi => true,
+           :upsert => false } ]
+      end
+      let(:expected) do
+        [{ :q => { :a => 1 },
+           :u => { :$set => { :a => 2 } },
+           :multi => true,
+           :upsert => false,
+           :ord => order },
+         { :q => { :b => 1 },
+           :u => { :$set => { :b => 2 } },
+           :multi => true,
+           :upsert => false,
+           :ord => order },
+         { :q => { :c => 1 },
+           :u => { :$set => { :c => 2 } },
+           :multi => true,
+           :upsert => false,
+           :ord => order } ]
+      end
+
+      it 'sets the order on each op spec document' do
+        op.set_order(order)
+        expect(op.spec[:updates]).to eq(expected)
+      end
+    end
+  end
+
   describe '#execute' do
 
     context 'server' do


### PR DESCRIPTION
This is necessary to keep track of the order in which ops are defined by the user when doing a bulk write. 

The BulkWrite object may split up operations into different messages to the server or reorder the operations. The error message returned by the server will refer to operations with indexes, but the indexes don't exactly map to the order in which the user defined the op.

I put this on the slicable module because the :ord key needs to be added to each element in the array at #slicable_key and is only relevant to ops that are slicable.
