### PR TITLE
Don't pass ruby-formatted opts through to createIndex command

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -547,13 +547,13 @@ module Mongo
     #
     # @return [String] the name of the index created.
     def create_index(spec, opts={})
-      opts[:dropDups]   = opts[:drop_dups] if opts[:drop_dups]
-      opts[:bucketSize] = opts[:bucket_size] if opts[:bucket_size]
-      field_spec        = parse_index_spec(spec)
-      opts              = opts.dup
-      name              = opts.delete(:name) || generate_index_name(field_spec)
-      name              = name.to_s if name
-      generate_indexes(field_spec, name, opts)
+      options              = opts.dup
+      options[:dropDups]   = options.delete(:drop_dups) if options[:drop_dups]
+      options[:bucketSize] = options.delete(:bucket_size) if options[:bucket_size]
+      field_spec           = parse_index_spec(spec)
+      name                 = options.delete(:name) || generate_index_name(field_spec)
+      name                 = name.to_s if name
+      generate_indexes(field_spec, name, options)
       name
     end
 


### PR DESCRIPTION
This failure made me aware of an issue in our create_index method : 
https://jenkins.10gen.com/view/Ruby/job/mongo-ruby-driver-emilys-fork/59/mongodb_server=master-nightly-release,os_arch=linux64,ruby_language_version=2.0.0,test_type=without-ext/console

The drop_dups and bucket_size options were not being deleted from the opts passed through to the createIndex command.
