### PR TITLE
Don't use a client with op_timeout to set up user role

### DIFF
--- a/test/functional/timeout_test.rb
+++ b/test/functional/timeout_test.rb
@@ -17,8 +17,8 @@ require 'test_helper'
 class TimeoutTest < Test::Unit::TestCase
 
   def test_op_timeout
+    grant_admin_user_eval_role(standard_connection)
     connection = standard_connection(:op_timeout => 0.5)
-    grant_admin_user_eval_role(connection)
 
     admin = connection.db('admin')
 


### PR DESCRIPTION
[This](https://jenkins.10gen.com/view/Ruby/job/mongo-ruby-driver-emilys-fork/99/mongodb_server=master-nightly-release,os_arch=linux64,ruby_language_version=2.1.1,test_type=with-ext/console)  jenkins failure made me realize that we were using a client with an op_timeout set to grant the admin user db eval privileges.  I changed the test so it uses its own client to set up the role, then creates another client with the op_timeout to be used in the test.
