### PR TITLE
RUBY-813 Pin pool after parallel collection scan and aggregation with cu...

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -717,11 +717,13 @@ module Mongo
 
       if result.key?('cursor')
         cursor_info = result['cursor']
+        pinned_pool = @connection.pinned_pool
+        pinned_pool = pinned_pool[:pool] if pinned_pool.respond_to?(:keys)
 
         seed = {
           :cursor_id => cursor_info['id'],
           :first_batch => cursor_info['firstBatch'],
-          :pool => @connection.pinned_pool
+          :pool => pinned_pool
         }
 
         return Cursor.new(self, seed.merge!(opts))
@@ -887,10 +889,13 @@ module Mongo
       result                       = @db.command(cmd, command_options(opts))
 
       result['cursors'].collect do |cursor_info|
+        pinned_pool = @connection.pinned_pool
+        pinned_pool = pinned_pool[:pool] if pinned_pool.respond_to?(:keys)
+
         seed = {
           :cursor_id   => cursor_info['cursor']['id'],
           :first_batch => cursor_info['cursor']['firstBatch'],
-          :pool        => @connection.pinned_pool
+          :pool        => pinned_pool
         }
         Cursor.new(self, seed.merge!(opts))
       end

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -564,9 +564,11 @@ module Mongo
         ensure
           socket.checkin unless @socket || socket.nil?
         end
-        if !@socket && !@command
+
+        if pin_pool?(results.first)
           @connection.pin_pool(socket.pool, read_preference)
         end
+
         @returned += @n_received
         @cache += results
         @query_run = true
@@ -727,6 +729,11 @@ module Mongo
         indexes.push("#{field}_#{type}")
       end
       indexes.join("_")
+    end
+
+    def pin_pool?(response)
+      ( response && (response['cursor'] || response['cursors']) ) ||
+        ( !@socket && !@command )
     end
   end
 end


### PR DESCRIPTION
This fixes RUBY-813:
When iterating over a cursor returned from a command (parallelCollectionScan or aggregate), the getmore will fail because a pool has not been pinned.

This pull request checks the initial result from the server and if there is cursor info returned, the pool will be pinned regardless of whether a command was executed.
