### PR TITLE
RUBY-734 Validate API consistency between auths in uri and in client init

### DIFF
--- a/test/functional/client_test.rb
+++ b/test/functional/client_test.rb
@@ -74,6 +74,17 @@ class ClientTest < Test::Unit::TestCase
     end
   end
 
+  def test_initialize_with_auths
+    auth = { :username  => TEST_USER,
+             :password  => TEST_USER_PWD,
+             :db_name   => TEST_DB,
+             :source    => TEST_DB,
+             :mechanism => 'MONGODB-CR'}
+
+    client = MongoClient.new(:auths => Set.new([auth]))
+    assert client['test']['test'].find.to_a
+  end
+
   def test_connection_uri
     con = MongoClient.from_uri("mongodb://#{host_port}")
     assert_equal mongo_host, con.primary_pool.host


### PR DESCRIPTION
When investigating RUBY-734 (creating a client with auth creds through a URI versus calling MongoClient#new), I wanted to double check that the behavior was consistent.
This is a test that verifies that you can provide auth credentials to the initialize method of MongoClient. It's the same as providing auth creds in a URI.
