### PR TITLE
RUBY-805 use listCollections with wire version >= 3

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -1029,7 +1029,7 @@ module Mongo
     #
     # @return [Hash] options that apply to this collection.
     def options
-      @db.collections_info(@name).next_document['options']
+      @db.collections_info(@name).first['options']
     end
 
     # Return stats on the collection. Uses MongoDB's collstats command.

--- a/test/functional/db_api_test.rb
+++ b/test/functional/db_api_test.rb
@@ -315,8 +315,23 @@ class DBAPITest < Test::Unit::TestCase
     cursor = @db.collections_info
     rows = cursor.to_a
     assert rows.length >= 1
-    row = rows.detect { |r| r['name'] == @coll_full_name }
+    if @client.server_version < '2.7.6'
+      row = rows.detect { |r| r['name'] == @coll_full_name }
+    else
+      row = rows.detect { |r| r['name'] == @coll.name }
+    end
     assert_not_nil row
+  end
+
+  def test_collections_info_with_name
+    cursor = @db.collections_info(@coll.name)
+    info = cursor.to_a
+    assert_equal 1, info.length
+    if @client.server_version < '2.7.6'
+      assert_equal "#{@db.name}.#{@coll.name}", info.first['name']
+    else
+      assert_equal @coll.name, info.first['name']
+    end
   end
 
   def test_collection_options


### PR DESCRIPTION
I'm not sure what to do about the DB#collections_info API. In the past, it returned a cursor, that when iterated, would iterate over the collection info documents.

In executing the listCollections command in the method instead, I could return a cursor, but then iterating over it wouldn't iterate over the collection info documents. I've chosen instead to return the list "collections" in the command result. This is an API change, but the object return is still enumerable so it's not really a big deal.

This problem is manifested when #next_document is attempted on the result of DB#collections_info.
