### PR TITLE
Add method to update MongoReplicaSetClient list of seeds

### DIFF
--- a/lib/mongo/mongo_replica_set_client.rb
+++ b/lib/mongo/mongo_replica_set_client.rb
@@ -176,6 +176,21 @@ module Mongo
       setup(opts.dup)
     end
 
+    # Replace the list of nodes to use as seeds in the event of a lost connection
+    #
+    # @param [Array<String>] new seeds
+    #
+    # @raise [MongoArgumentError] This is raised if the list of seeds is empty
+    def update_seeds!(seeds)
+      if seeds.length.zero?
+        raise MongoArgumentError, "Updating seeds requires at least one seed node."
+      end
+
+      @seeds = Support.normalize_seeds(seeds).freeze
+      connect(true)
+      nil
+    end
+
     def valid_opts
       super + REPL_SET_OPTS - CLIENT_ONLY_OPTS
     end


### PR DESCRIPTION
This is somewhat speculative, but would solve a problem we've recently run into. I'm happy to do polish work or cleanup as desired if the interface is viable.

This is useful when you know that the list of seeds on the connectionis no longer valid - for instance, if the old list of seeds were IP addresses referring to instances that have been rebuilt or decommissioned. Without some option like this, if all connections are closed (due to, e.g., a stepdown), the MongoDB client will attempt to connect to the old, decommissioned nodes, delaying recovery.