### PR TITLE
Fix client instantiation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Here is a quick example of basic usage for the Ruby driver:
 require 'mongo'
 
 # connecting to the database
-client = Mongo::Client.new # defaults to localhost:27017
+client = Mongo::MongoClient.new # defaults to localhost:27017
 db     = client['example-db']
 coll   = db['example-collection']
 


### PR DESCRIPTION
I'm not sure why, so I might be wrong when reporting this as an issue.

Using `client = Mongo::Client.new`
Gives the following error `NameError: uninitialized constant Mongo::Client`

The documentation seems to indicate `Class: Mongo::MongoClient`
[Documentation source](http://api.mongodb.org/ruby/current/Mongo/MongoClient.html)