### PR TITLE
Consider env variables so test suite can run with other topologies

### DIFF
--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -183,8 +183,8 @@ describe Mongo::Client do
     end
 
     it 'returns the cluster information' do
-      expect(client.inspect).to eq(
-        "<Mongo::Client:0x#{client.object_id} cluster=127.0.0.1:27017>"
+      expect(client.inspect).to include(
+        "<Mongo::Client:0x#{client.object_id} cluster=127.0.0.1:27017"
       )
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -84,6 +84,30 @@ SERVER_DISCOVERY_TESTS = Dir.glob("#{CURRENT_PATH}/support/sdam/**/*.yml")
 SERVER_SELECTION_RTT_TESTS = Dir.glob("#{CURRENT_PATH}/support/server_selection/rtt/*.yml")
 SERVER_SELECTION_TESTS = Dir.glob("#{CURRENT_PATH}/support/server_selection/selection/**/*.yml")
 
+# Determine whether the test clients are connecting to a standlone.
+#
+# @since 2.0.0
+def standlone?
+  $mongo_client ||= initialize_scanned_client!
+  $standalone ||= $mongo_client.cluster.standalone?
+end
+
+# Determine whether the test clients are connecting to a replica set.
+#
+# @since 2.0.0
+def replica_set?
+  $mongo_client ||= initialize_scanned_client!
+  $replica_set ||= $mongo_client.cluster.replica_set?
+end
+
+# Determine whether the test clients are connecting to a sharded cluster.
+#
+# @since 2.0.0
+def sharded?
+  $mongo_client ||= initialize_scanned_client!
+  $sharded ||= $mongo_client.cluster.sharded?
+end
+
 # For instances where behaviour is different on different versions, we need to
 # determine in the specs if we are 2.6 or higher.
 #
@@ -117,7 +141,7 @@ end
 #
 # @since 2.0.0
 def initialize_scanned_client!
-  Mongo::Client.new([ '127.0.0.1:27017' ], database: TEST_DB)
+  Mongo::Client.new(ADDRESSES, database: TEST_DB, connect: CONNECT)
 end
 
 def initialize_mo_standalone!(path = nil)

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -22,6 +22,19 @@ TEST_DB = 'ruby-driver'.freeze
 # @since 2.0.0
 TEST_COLL = 'test'.freeze
 
+# The seed addresses to be used when creating a client.
+#
+# @since 2.0.0
+ADDRESSES = ENV['MONGODB_ADDRESSES'] ? ENV['MONGODB_ADDRESSES'].split(',').freeze :
+              [ '127.0.0.1:27017' ].freeze
+
+# The topology type.
+#
+# @since 2.0.0
+CONNECT = ENV['RS_ENABLED'] == 'true' ? :replica_set.freeze :
+            ENV['SHARDED'] == 'true' ? :sharded.freeze :
+            :direct.freeze
+
 # Gets the root system administrator user.
 #
 # @since 2.0.0
@@ -69,11 +82,12 @@ TEST_READ_WRITE_USER = Mongo::Auth::User.new(
 #
 # @since 2.0.0
 AUTHORIZED_CLIENT = Mongo::Client.new(
-  [ '127.0.0.1:27017' ],
+  ADDRESSES,
   database: TEST_DB,
   user: TEST_USER.name,
   password: TEST_USER.password,
-  max_pool_size: 1
+  max_pool_size: 1,
+  connect: CONNECT
 )
 
 # Provides an authorized mongo client on the default test database for the
@@ -81,21 +95,23 @@ AUTHORIZED_CLIENT = Mongo::Client.new(
 #
 # @since 2.0.0
 ROOT_AUTHORIZED_CLIENT = Mongo::Client.new(
-  [ '127.0.0.1:27017' ],
+  ADDRESSES,
   auth_source: Mongo::Database::ADMIN,
   database: TEST_DB,
   user: ROOT_USER.name,
   password: ROOT_USER.password,
-  max_pool_size: 1
+  max_pool_size: 1,
+  connect: CONNECT
 )
 
 # Provides an unauthorized mongo client on the default test database.
 #
 # @since 2.0.0
 UNAUTHORIZED_CLIENT = Mongo::Client.new(
-  [ '127.0.0.1:27017' ],
+  ADDRESSES,
   database: TEST_DB,
-  max_pool_size: 1
+  max_pool_size: 1,
+  connect: CONNECT
 )
 
 # Provides an unauthorized mongo client on the admin database, for use in
@@ -103,9 +119,10 @@ UNAUTHORIZED_CLIENT = Mongo::Client.new(
 #
 # @since 2.0.0
 ADMIN_UNAUTHORIZED_CLIENT = Mongo::Client.new(
-  [ '127.0.0.1:27017' ],
+  ADDRESSES,
   database: Mongo::Database::ADMIN,
-  max_pool_size: 1
+  max_pool_size: 1,
+  connect: CONNECT
 )
 
 # Get an authorized client on the admin database logged in as the admin


### PR DESCRIPTION
I'm setting up jenkins to run our specs on different topologies so I've added some places where we consider env variables.