### PR TITLE
Avoid sharing sockets between forked processes

### DIFF
--- a/lib/mongo.rb
+++ b/lib/mongo.rb
@@ -79,6 +79,7 @@ require 'bson'
 
 require 'set'
 require 'thread'
+require 'monitor'
 
 require 'mongo/utils'
 require 'mongo/exception'

--- a/lib/mongo/connection/node.rb
+++ b/lib/mongo/connection/node.rb
@@ -73,16 +73,6 @@ module Mongo
       end
     end
 
-    def usable_socket
-      if @socket && @socket.pid != Process.pid
-        @socket.close
-        @socket = nil
-        connect
-      else
-        @socket
-      end
-    end
-
     # This should only be called within a mutex
     def close
       if @socket && !@socket.closed?
@@ -237,6 +227,16 @@ module Mongo
     end
 
     private
+
+    def usable_socket
+      if @socket && @socket.pid != Process.pid
+        @socket.close
+        @socket = nil
+        connect
+      else
+        @socket
+      end
+    end
 
     def update_max_sizes
       @max_bson_size = config['maxBsonObjectSize'] || DEFAULT_MAX_BSON_SIZE

--- a/lib/mongo/connection/node.rb
+++ b/lib/mongo/connection/node.rb
@@ -73,7 +73,7 @@ module Mongo
       end
     end
 
-    def socket
+    def usable_socket
       if @socket && @socket.pid != Process.pid
         @socket.close
         @socket = nil
@@ -98,7 +98,7 @@ module Mongo
 
     def active?
       begin
-        result = @client['admin'].command({:ping => 1}, :socket => socket)
+        result = @client['admin'].command({:ping => 1}, :socket => usable_socket)
       rescue OperationFailure, SocketError, SystemCallError, IOError
         return nil
       end
@@ -117,10 +117,10 @@ module Mongo
 
           if @client.connect_timeout
             Timeout::timeout(@client.connect_timeout, OperationTimeout) do
-              @config = @client['admin'].command({:ismaster => 1}, :socket => socket)
+              @config = @client['admin'].command({:ismaster => 1}, :socket => usable_socket)
             end
           else
-            @config = @client['admin'].command({:ismaster => 1}, :socket => socket)
+            @config = @client['admin'].command({:ismaster => 1}, :socket => usable_socket)
           end
 
           update_max_sizes

--- a/lib/mongo/connection/node.rb
+++ b/lib/mongo/connection/node.rb
@@ -24,7 +24,7 @@ module Mongo
       @address = "#{@host}:#{@port}"
       @config = nil
       @socket = nil
-      @node_mutex = Mutex.new
+      @node_mutex = Monitor.new
     end
 
     def eql?(other)
@@ -73,6 +73,16 @@ module Mongo
       end
     end
 
+    def socket
+      if @socket && @socket.pid != Process.pid
+        @socket.close
+        @socket = nil
+        connect
+      else
+        @socket
+      end
+    end
+
     # This should only be called within a mutex
     def close
       if @socket && !@socket.closed?
@@ -88,7 +98,7 @@ module Mongo
 
     def active?
       begin
-        result = @client['admin'].command({:ping => 1}, :socket => @socket)
+        result = @client['admin'].command({:ping => 1}, :socket => socket)
       rescue OperationFailure, SocketError, SystemCallError, IOError
         return nil
       end
@@ -107,10 +117,10 @@ module Mongo
 
           if @client.connect_timeout
             Timeout::timeout(@client.connect_timeout, OperationTimeout) do
-              @config = @client['admin'].command({:ismaster => 1}, :socket => @socket)
+              @config = @client['admin'].command({:ismaster => 1}, :socket => socket)
             end
           else
-            @config = @client['admin'].command({:ismaster => 1}, :socket => @socket)
+            @config = @client['admin'].command({:ismaster => 1}, :socket => socket)
           end
 
           update_max_sizes

--- a/test/helpers/test_unit.rb
+++ b/test/helpers/test_unit.rb
@@ -164,6 +164,7 @@ class Test::Unit::TestCase
     socket.stubs(:closed?)
     socket.stubs(:checkin)
     socket.stubs(:pool)
+    socket.stubs(:pid)
     socket
   end
 

--- a/test/replica_set/basic_test.rb
+++ b/test/replica_set/basic_test.rb
@@ -110,6 +110,15 @@ class ReplicaSetBasicTest < Test::Unit::TestCase
     end
   end
 
+  def test_sockets_used_by_forked_process
+    @client = MongoReplicaSetClient.from_uri(@uri)
+    primary_node = @client.manager.primary_pool.node
+    primary_socket = primary_node.socket
+    primary_socket.instance_variable_set(:@pid, primary_socket.pid + 1)
+    primary_node.set_config
+    assert primary_socket != primary_node.socket
+  end
+
   context "Socket pools" do
     context "checking out writers" do
       setup do


### PR DESCRIPTION
Support for detecting when a socket was established in a different process and automatically discarding it was added to this driver in 997d9b8ae2f5f391ef23dc4d3792e7d863675eb8, and refined in a393557eeb8c1a9a049f4d289be51e50579ebf40.

Instances of the Node class maintain their own sockets for refreshing replica set data; they need to be protected from reuse in the same way.