### PR TITLE
RUBY-891 Single topology type servers and slaveOk bit

### DIFF
--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -69,7 +69,8 @@ module Mongo
       unless addresses.include?(address)
         log_debug([ "Adding #{address.to_s} to the cluster." ])
         addresses.push(address)
-        server = Server.new(address, event_listeners, options)
+        server = Server.new(address, event_listeners,
+                            options.merge(slave_ok: @slave_ok))
         @servers.push(server)
         server
       end
@@ -90,6 +91,7 @@ module Mongo
       @event_listeners = Event::Listeners.new
       @options = options.freeze
       @topology = Topology.initial(seeds, options)
+      @slave_ok = @topology.single? unless options[:read]
 
       subscribe_to(Event::SERVER_ADDED, Event::ServerAdded.new(self))
       subscribe_to(Event::SERVER_REMOVED, Event::ServerRemoved.new(self))

--- a/lib/mongo/cluster/topology/single.rb
+++ b/lib/mongo/cluster/topology/single.rb
@@ -94,9 +94,7 @@ module Mongo
         #
         # @since 2.0.0
         def servers(servers, name = nil)
-          [ servers.detect do |server|
-              !server.unknown? && !server.arbiter? && !server.ghost?
-            end ]
+          [ servers.detect { |server| !server.unknown? } ]
         end
 
         # A single topology is not sharded.

--- a/lib/mongo/server.rb
+++ b/lib/mongo/server.rb
@@ -159,5 +159,17 @@ module Mongo
         tags[k] && tags[k] == tag_set[k]
       end
     end
+
+    # Whether the slaveOk bit must be set for all queries sent to the server.
+    #
+    # @example Does the slaveOk bit need to be set for all queries sent to the server.
+    #   server.slave_ok?
+    #
+    # @return [ true, false ] If the slaveOk bit needs to be set for all queries.
+    #
+    # @since 2.0.0
+    def slave_ok?
+      options[:slave_ok]
+    end
   end
 end

--- a/lib/mongo/server/context.rb
+++ b/lib/mongo/server/context.rb
@@ -33,7 +33,8 @@ module Mongo
                      :mongos?,
                      :primary?,
                      :secondary?,
-                     :standalone?
+                     :standalone?,
+                     :slave_ok?
 
       # Instantiate a server context.
       #

--- a/spec/support/shared/operation.rb
+++ b/spec/support/shared/operation.rb
@@ -43,6 +43,7 @@ shared_context 'operation' do
       allow(cxt).to receive(:primary?) { true }
       allow(cxt).to receive(:secondary?) { false }
       allow(cxt).to receive(:standalone?) { false }
+      allow(cxt).to receive(:slave_ok?) { false }
     end
   end
   let(:secondary_context) do
@@ -54,6 +55,7 @@ shared_context 'operation' do
       allow(cxt).to receive(:secondary?) { true }
       allow(cxt).to receive(:primary?) { false }
       allow(cxt).to receive(:standalone?) { false }
+      allow(cxt).to receive(:slave_ok?) { false }
     end
   end
   let(:primary_context_2_4_version) do
@@ -64,6 +66,7 @@ shared_context 'operation' do
       allow(cxt).to receive(:primary?) { true }
       allow(cxt).to receive(:secondary?) { false }
       allow(cxt).to receive(:standalone?) { false }
+      allow(cxt).to receive(:slave_ok?) { false }
       allow(cxt).to receive(:features) { features_2_4 }
     end
   end


### PR DESCRIPTION
Allow Single Topology type to return all servers not Unknown.

Always set the slaveOk bit for queries sent in a Single Topology if read preference is not set and the server is not a mongos.