### PR TITLE
Make sure that Exception#message is not hidden

### DIFF
--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -230,12 +230,12 @@ module Mongo
       #
       # @since 2.0.0
       def initialize(uri)
-        super(message(uri))
+        super(self.class.message(uri))
       end
 
       private
 
-      def message(uri)
+      def self.message(uri)
         "MongoDB URI must be in the following format: #{FORMAT}\n" +
         "Please see the following URL for more information: #{HELP}\n" +
         "Bad URI: #{uri}"

--- a/spec/mongo/uri_spec.rb
+++ b/spec/mongo/uri_spec.rb
@@ -7,8 +7,10 @@ describe Mongo::URI do
   describe '#initialize' do
     context 'string is not uri' do
       let(:string) { 'tyler' }
+      let(:expected_message) { %r{^MongoDB URI must be in the following format:} }
+
       it 'raises an error' do
-        expect { uri }.to raise_error(Mongo::URI::Invalid)
+        expect { uri }.to raise_error(Mongo::URI::Invalid, expected_message)
       end
     end
   end


### PR DESCRIPTION
Whenever the Mongo::URI::Invalid error is risen it is not possible to call its `message`:

    NoMethodError: private method `message' called for #<Mongo::URI::Invalid:0x7e7fc4bd>

I opted for a class method because it does not rely on any instance
variables.