### PR TITLE
RUBY-897 Print first 250 chars of query selector when logging and rescue inspect error

### DIFF
--- a/lib/mongo/protocol/query.rb
+++ b/lib/mongo/protocol/query.rb
@@ -30,6 +30,12 @@ module Mongo
     # @api semipublic
     class Query < Message
 
+      # Constant for the max number of characters to print when inspecting
+      # a query field.
+      #
+      # @since 2.0.3
+      LOG_STRING_LIMIT = 250
+
       # Creates a new Query message
       #
       # @example Find all users named Tyler.
@@ -78,7 +84,7 @@ module Mongo
         fields = []
         fields << ["%s |", query_type]
         fields << ["namespace=%s", namespace]
-        fields << ["selector=%s", selector.inspect]
+        fields << ["selector=%s", formatted_selector]
         fields << ["flags=%s", flags.inspect]
         fields << ["limit=%s", limit.inspect]
         fields << ["skip=%s", skip.inspect]
@@ -109,6 +115,13 @@ module Mongo
 
       def query_type
         namespace.include?(Database::COMMAND) ? 'COMMAND' : 'QUERY'
+      end
+
+      def formatted_selector
+        ( (str = selector.inspect).length > LOG_STRING_LIMIT ) ?
+          "#{str[0..LOG_STRING_LIMIT]}..." : str
+      rescue ArgumentError
+        '<Unable to inspect selector>'
       end
 
       # Available flags for a Query message.

--- a/spec/mongo/protocol/query_spec.rb
+++ b/spec/mongo/protocol/query_spec.rb
@@ -282,4 +282,33 @@ describe Mongo::Protocol::Query do
       end
     end
   end
+
+  describe '#log_message' do
+
+    context 'when the selector is greater than LOG_STRING_LIMIT characters' do
+
+      let(:selector) do
+        'z'*260
+      end
+
+      it 'Only prints LOG_STRING_LIMIT number of characters' do
+        expect(message.log_message.scan(/z/).length).to eq(Mongo::Protocol::Query::LOG_STRING_LIMIT)
+      end
+    end
+
+    context 'when the selector cannot be inspected' do
+
+      let(:selector) do
+        'invalid string'
+      end
+
+      before do
+        allow(selector).to receive(:inspect).and_raise(ArgumentError)
+      end
+
+      it 'Does not include the selector in the log message' do
+        expect(message.log_message.scan(/invalid string/).length).to eq(0)
+      end
+    end
+  end
 end


### PR DESCRIPTION
I guessed that 250 characters was a decent limit on the selector field when logging an error with a query but am open to suggestions for that limit to be decreased or increased.

