### PR TITLE
Refactor bulk write to match CRUD spec

### DIFF
--- a/lib/mongo/bulk_write.rb
+++ b/lib/mongo/bulk_write.rb
@@ -15,6 +15,7 @@
 require 'mongo/bulk_write/bulk_writable'
 require 'mongo/bulk_write/ordered_bulk_write'
 require 'mongo/bulk_write/unordered_bulk_write'
+require 'mongo/bulk_write/result'
 
 module Mongo
   module BulkWrite

--- a/lib/mongo/bulk_write/bulk_writable.rb
+++ b/lib/mongo/bulk_write/bulk_writable.rb
@@ -230,6 +230,10 @@ module Mongo
             results.merge!(INSERTED_IDS => result.inserted_ids)
           end
 
+          if result.respond_to?(Operation::Write::BulkUpdate::Result::UPSERTED)
+            results.merge!(UPSERTED_IDS => result.upserted.map{ |doc| doc['_id'] })
+          end
+
           if write_errors
             results.merge!(
               Error::WRITE_ERRORS => ((results[Error::WRITE_ERRORS] || []) << write_errors).flatten

--- a/lib/mongo/bulk_write/bulk_writable.rb
+++ b/lib/mongo/bulk_write/bulk_writable.rb
@@ -30,19 +30,60 @@ module Mongo
       include Replacable
       extend Forwardable
 
-      # Delegate various methods to the collection.
-      def_delegators :@collection, :database, :cluster, :next_primary
+      # Constant for number removed.
+      #
+      # @since 2.1.0
+      REMOVED_COUNT = 'n_removed'.freeze
+
+      # Constant for number inserted.
+      #
+      # @since 2.1.0
+      INSERTED_COUNT = 'n_inserted'.freeze
+
+      # Constant for inserted ids.
+      #
+      # @since 2.1.0
+      INSERTED_IDS = 'inserted_ids'.freeze
+
+      # Constant for number matched.
+      #
+      # @since 2.1.0
+      MATCHED_COUNT = 'n_matched'.freeze
+
+      # Constant for number modified.
+      #
+      # @since 2.1.0
+      MODIFIED_COUNT = 'n_modified'.freeze
+
+      # Constant for number upserted.
+      #
+      # @since 2.1.0
+      UPSERTED_COUNT = 'n_upserted'.freeze
+
+      # Constant for upserted ids.
+      #
+      # @since 2.1.0
+      UPSERTED_IDS = 'upserted_ids'.freeze
+
+      # Constant for indexes.
+      #
+      # @since 2.1.0
+      INDEXES = 'indexes'.freeze
 
       # The fields contained in the result document returned from executing the
       # operations.
       #
       # @since 2.0.0.
-      RESULT_FIELDS = [ :n_inserted,
-                        :n_removed,
-                        :n_modified,
-                        :n_upserted,
-                        :n_matched ]
+      RESULT_FIELDS = [
+        INSERTED_COUNT,
+        REMOVED_COUNT,
+        MODIFIED_COUNT,
+        UPSERTED_COUNT,
+        MATCHED_COUNT
+      ].freeze
 
+      # Delegate various methods to the collection.
+      def_delegators :@collection, :database, :cluster, :next_primary
 
       # Initialize a bulk write object.
       #
@@ -85,6 +126,10 @@ module Mongo
 
       private
 
+      def valid_doc?(doc)
+        doc.respond_to?(:keys) || doc.respond_to?(:document)
+      end
+
       def write_concern
         @write_concern ||= WriteConcern.get(@options[:write_concern]) ||
                             @collection.write_concern
@@ -106,18 +151,19 @@ module Mongo
         type = op.keys.first
         ops = []
         while op[type].size > server.max_write_batch_size
-          ops << { type => op[type].shift(server.max_write_batch_size),
-                   :indexes => op[:indexes].shift(server.max_write_batch_size) }
+          ops << {
+            type => op[type].shift(server.max_write_batch_size),
+            INDEXES => op[INDEXES].shift(server.max_write_batch_size)
+          }
         end
         ops << op
       end
 
       def split(op, type)
         n = op[type].size/2
-        [ { type => op[type].shift(n),
-            :indexes => op[:indexes].shift(n) },
-          { type => op[type],
-            :indexes => op[:indexes] }
+        [
+          { type => op[type].shift(n), INDEXES => op[INDEXES].shift(n) },
+          { type => op[type], INDEXES => op[INDEXES] }
         ]
       end
 
@@ -128,7 +174,7 @@ module Mongo
           op = ops.shift
           type = op.keys.first
           begin
-            process(send(type, op, server), op[:indexes])
+            process(send(type, op, server), op[INDEXES])
           rescue Error::MaxBSONSize, Error::MaxMessageSize => ex
             raise ex if op[type].size < 2
             ops = split(op, type) + ops
@@ -139,15 +185,16 @@ module Mongo
       def merge_consecutive_ops(ops)
         ops.each_with_index.inject([]) do |merged, (op, i)|
           type = op.keys.first
-          op[:indexes] ||= [ i ]
+          op[INDEXES] ||= [ i ]
           previous = merged.last
           if previous && previous.keys.first == type
-            merged[-1].merge!(type => previous[type] << op[type],
-                             :indexes => previous[:indexes] + op[:indexes])
+            merged[-1].merge!(
+              type => previous[type] << op[type],
+              INDEXES => previous[INDEXES] + op[INDEXES]
+            )
             merged
           else
-            merged << { type => [ op[type] ].flatten,
-                        :indexes => op[:indexes] }
+            merged << { type => [ op[type] ].flatten, INDEXES => op[INDEXES] }
           end
         end
       end
@@ -161,7 +208,7 @@ module Mongo
           merged
         end
         ops_hash.keys.reduce([]) do |ops_list, type|
-          ops_list << { type => ops_hash[type], :indexes => indexes[type] }
+          ops_list << { type => ops_hash[type], INDEXES => indexes[type] }
         end
       end
 
@@ -179,11 +226,19 @@ module Mongo
             ) if result.respond_to?(field)
           end
 
-          results.merge!(
-            write_errors: ((results[:write_errors] || []) << write_errors).flatten
-          ) if write_errors
+          if result.respond_to?(INSERTED_IDS)
+            results.merge!(INSERTED_IDS => result.inserted_ids)
+          end
 
-          results.merge!(write_concern_errors: @write_concern_errors) if @write_concern_errors
+          if write_errors
+            results.merge!(
+              Error::WRITE_ERRORS => ((results[Error::WRITE_ERRORS] || []) << write_errors).flatten
+            )
+          end
+
+          if @write_concern_errors
+            results.merge!(Error::WRITE_CONCERN_ERRORS => @write_concern_errors)
+          end
         end
       end
     end

--- a/lib/mongo/bulk_write/deletable.rb
+++ b/lib/mongo/bulk_write/deletable.rb
@@ -22,10 +22,6 @@ module Mongo
 
       private
 
-      def valid_doc?(doc)
-        doc.respond_to?(:keys)
-      end
-
       def validate_delete_op!(type, d)
         raise Error::InvalidBulkOperation.new(type, d) unless valid_doc?(d)
       end

--- a/lib/mongo/bulk_write/insertable.rb
+++ b/lib/mongo/bulk_write/insertable.rb
@@ -22,10 +22,6 @@ module Mongo
 
       private
 
-      def valid_doc?(doc)
-        doc.respond_to?(:keys)
-      end
-
       def validate_insert_ops!(type, inserts)
         if inserts.empty?
           raise Error::InvalidBulkOperation.new(type, inserts)

--- a/lib/mongo/bulk_write/ordered_bulk_write.rb
+++ b/lib/mongo/bulk_write/ordered_bulk_write.rb
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 module Mongo
-
   module BulkWrite
 
+    # Encapsulates behaviour around an ordered bulk write operation.
+    #
+    # @since 2.0.0
     class OrderedBulkWrite
-
       include BulkWritable
 
       private
@@ -36,12 +37,11 @@ module Mongo
       end
 
       def stop?
-        @results.keys.include?(:write_errors)
+        @results.keys.include?(Error::WRITE_ERRORS)
       end
 
       def finalize
-        raise Error::BulkWriteError.new(@results) if @results[:write_concern_errors]
-        @results
+        Result.new(@results).validate!
       end
     end
   end

--- a/lib/mongo/bulk_write/result.rb
+++ b/lib/mongo/bulk_write/result.rb
@@ -1,0 +1,138 @@
+# Copyright (C) 2015 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  module BulkWrite
+
+    # Wraps a series of bulk write operations in a result object.
+    #
+    # @since 2.0.6
+    class Result
+
+      # Returns the number of documents deleted.
+      #
+      # @example Get the number of deleted documents.
+      #   result.deleted_count
+      #
+      # @return [ Integer ] The number deleted.
+      #
+      # @since 2.1.0
+      def deleted_count
+        @results[BulkWritable::REMOVED_COUNT]
+      end
+
+      # Create the new result object from the results document.
+      #
+      # @example Create the new result.
+      #   Result.new({ 'n_inserted' => 10 })
+      #
+      # @param [ BSON::Document, Hash ] results The results document.
+      #
+      # @since 2.1.0
+      def initialize(results)
+        @results = results
+      end
+
+      # Returns the number of documents inserted.
+      #
+      # @example Get the number of inserted documents.
+      #   result.inserted_count
+      #
+      # @return [ Integer ] The number inserted.
+      #
+      # @since 2.1.0
+      def inserted_count
+        @results[BulkWritable::INSERTED_COUNT]
+      end
+
+      # Get the inserted document ids, if the operation has inserts.
+      #
+      # @example Get the inserted ids.
+      #   result.inserted_ids
+      #
+      # @return [ Array<BSON::ObjectId> ] The inserted ids.
+      #
+      # @since 2.1.0
+      def inserted_ids
+        @results[BulkWritable::INSERTED_IDS]
+      end
+
+      # Returns the number of documents matched.
+      #
+      # @example Get the number of matched documents.
+      #   result.matched_count
+      #
+      # @return [ Integer ] The number matched.
+      #
+      # @since 2.1.0
+      def matched_count
+        @results[BulkWritable::MATCHED_COUNT]
+      end
+
+      # Returns the number of documents modified.
+      #
+      # @example Get the number of modified documents.
+      #   result.modified_count
+      #
+      # @return [ Integer ] The number modified.
+      #
+      # @since 2.1.0
+      def modified_count
+        @results[BulkWritable::MODIFIED_COUNT]
+      end
+
+      # Returns the number of documents upserted.
+      #
+      # @example Get the number of upserted documents.
+      #   result.upserted_count
+      #
+      # @return [ Integer ] The number upserted.
+      #
+      # @since 2.1.0
+      def upserted_count
+        @results[BulkWritable::UPSERTED_COUNT]
+      end
+
+      # Get the upserted document ids, if the operation has inserts.
+      #
+      # @example Get the upserted ids.
+      #   result.upserted_ids
+      #
+      # @return [ Array<BSON::ObjectId> ] The upserted ids.
+      #
+      # @since 2.1.0
+      def upserted_ids
+        @results[BulkWritable::UPSERTED_IDS]
+      end
+
+      # Validates the bulk write result.
+      #
+      # @example Validate the result.
+      #   result.validate!
+      #
+      # @raise [ Error::BulkWriteError ] If the result contains errors.
+      #
+      # @return [ Result ] The result.
+      #
+      # @since 2.1.0
+      def validate!
+        if @results[Error::WRITE_ERRORS] || @results[Error::WRITE_CONCERN_ERRORS]
+          raise Error::BulkWriteError.new(@results)
+        else
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/mongo/bulk_write/unordered_bulk_write.rb
+++ b/lib/mongo/bulk_write/unordered_bulk_write.rb
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 module Mongo
-
   module BulkWrite
 
+    # Encapsulates behaviour around an unordered bulk write operation.
+    #
+    # @since 2.0.0
     class UnorderedBulkWrite
-
       include BulkWritable
 
       private
@@ -35,11 +36,7 @@ module Mongo
       end
 
       def finalize
-        @results.tap do |results|
-          if results[:write_errors] || results[:write_concern_errors]
-            raise Error::BulkWriteError.new(results)
-          end
-        end
+        Result.new(@results).validate!
       end
     end
   end

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -205,7 +205,7 @@ module Mongo
     # @param [ Array<Hash> ] operations The operations.
     # @param [ Hash ] options The options.
     #
-    # @return [ BSON::Document ] The result of the operation.
+    # @return [ BulkWrite::Result ] The result of the operation.
     #
     # @since 2.0.0
     def bulk_write(operations, options = {})

--- a/lib/mongo/error.rb
+++ b/lib/mongo/error.rb
@@ -43,10 +43,15 @@ module Mongo
     # @since 2.0.0
     WRITE_ERRORS = 'writeErrors'.freeze
 
-    # The constant for write concern errors.
+    # The constant for a write concern error.
     #
     # @since 2.0.0
     WRITE_CONCERN_ERROR = 'writeConcernError'.freeze
+
+    # The constant for write concern errors.
+    #
+    # @since 2.1.0
+    WRITE_CONCERN_ERRORS = 'writeConcernErrors'.freeze
 
     # Constant for an unknown error.
     #

--- a/lib/mongo/operation/write/bulk/bulk_mergable.rb
+++ b/lib/mongo/operation/write/bulk/bulk_mergable.rb
@@ -32,7 +32,7 @@ module Mongo
         def aggregate_write_errors(indexes)
           @replies.reduce(nil) do |errors, reply|
             if reply.documents.first['writeErrors']
-              write_errors = reply.documents.first['writeErrors'].collect do |we|
+              write_errors = reply.documents.first[Error::WRITE_ERRORS].collect do |we|
                 we.merge!('index' => indexes[we['index']])
               end
               (errors || []) << write_errors if write_errors
@@ -53,7 +53,7 @@ module Mongo
         # @since 2.0.0
         def aggregate_write_concern_errors(indexes)
           @replies.each_with_index.reduce(nil) do |errors, (reply, i)|
-            if write_concern_errors = reply.documents.first['writeConcernErrors']
+            if write_concern_errors = reply.documents.first[Error::WRITE_CONCERN_ERRORS]
               (errors || []) << write_concern_errors.reduce(nil) do |errs, wce|
                   wce.merge!('index' => indexes[wce['index']])
                   (errs || []) << write_concern_error

--- a/lib/mongo/operation/write/bulk/bulk_update/result.rb
+++ b/lib/mongo/operation/write/bulk/bulk_update/result.rb
@@ -89,10 +89,22 @@ module Mongo
             end
           end
 
+          # Get the upserted documents.
+          #
+          # @example Get upserted documents.
+          #   result.upserted
+          #
+          # @return [ Array<BSON::Document> ] The upserted document info
+          #
+          # @since 2.1.0
+          def upserted
+            reply.documents.first[UPSERTED] || []
+          end
+
           private
 
           def upsert?(reply)
-            reply.documents.first[UPSERTED]
+            upserted.any?
           end
         end
 

--- a/spec/mongo/bulk_write_spec.rb
+++ b/spec/mongo/bulk_write_spec.rb
@@ -59,13 +59,13 @@ describe Mongo::BulkWrite do
     let(:options) do
        { ordered: true }
     end
-     
+
     it_behaves_like 'a bulk write object'
-    
+
     context 'when the batch requires splitting' do
-    
+
       context 'when the operations are the same type' do
-    
+
         let(:error) do
           begin
             bulk.execute
@@ -73,7 +73,7 @@ describe Mongo::BulkWrite do
             ex
           end
         end
-    
+
         let(:operations) do
           [].tap do |ops|
             3000.times do |i|
@@ -83,13 +83,13 @@ describe Mongo::BulkWrite do
             ops << { insert_one: { _id: 3001 } }
           end
         end
-    
+
         it 'raises a BulkWriteError' do
           expect(error).to be_a(Mongo::Error::BulkWriteError)
         end
 
         it 'halts execution after first error and reports correct index' do
-          expect(error.result[:write_errors].first['index']).to eq(3000)
+          expect(error.result[Mongo::Error::WRITE_ERRORS].first['index']).to eq(3000)
           expect(authorized_collection.find.count).to eq(3000)
         end
       end
@@ -120,7 +120,7 @@ describe Mongo::BulkWrite do
         end
 
         it 'halts execution after first error and reports correct index' do
-          expect(error.result[:write_errors].first['index']).to eq(2001)
+          expect(error.result[Mongo::Error::WRITE_ERRORS].first['index']).to eq(2001)
           expect(authorized_collection.find.count).to eq(1999)
         end
       end
@@ -134,7 +134,7 @@ describe Mongo::BulkWrite do
             ex
           end
         end
-    
+
         let(:operations) do
           [].tap do |ops|
             6.times do |i|
@@ -144,11 +144,11 @@ describe Mongo::BulkWrite do
             ops << { insert_one: { _id: 100 } }
           end
         end
-    
+
         it 'raises a BulkWriteError error' do
           expect(error).to be_a(Mongo::Error::BulkWriteError)
         end
-    
+
         it 'splits messages into multiple messages' do
           error
           expect(authorized_collection.find.count).to eq(6)
@@ -192,7 +192,7 @@ describe Mongo::BulkWrite do
         end
 
         it 'does not halt execution after first error' do
-          expect(error.result[:write_errors].first['index']).to eq(3000)
+          expect(error.result[Mongo::Error::WRITE_ERRORS].first['index']).to eq(3000)
           expect(authorized_collection.find.count).to eq(3001)
         end
       end
@@ -223,7 +223,7 @@ describe Mongo::BulkWrite do
         end
 
         it 'does not halt execution after first error' do
-          expect(error.result[:write_errors].first['index']).to eq(2001)
+          expect(error.result[Mongo::Error::WRITE_ERRORS].first['index']).to eq(2001)
           expect(authorized_collection.find.count).to eq(2000)
         end
       end

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -307,12 +307,8 @@ describe Mongo::Collection do
       authorized_collection.insert_many([{ name: 'test1' }, { name: 'test2' }])
     end
 
-    it 'inserts the documents into the collection', if: write_command_enabled? do
+    it 'inserts the documents into the collection' do
       expect(result.inserted_count).to eq(2)
-    end
-
-    it 'inserts the documents into the collection', unless: write_command_enabled? do
-      expect(result.inserted_count).to eq(0)
     end
 
     it 'contains the ids in the result' do

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -308,11 +308,11 @@ describe Mongo::Collection do
     end
 
     it 'inserts the documents into the collection', if: write_command_enabled? do
-      expect(result.written_count).to eq(2)
+      expect(result.inserted_count).to eq(2)
     end
 
     it 'inserts the documents into the collection', unless: write_command_enabled? do
-      expect(result.written_count).to eq(0)
+      expect(result.inserted_count).to eq(0)
     end
 
     it 'contains the ids in the result' do

--- a/spec/support/shared/bulk_write.rb
+++ b/spec/support/shared/bulk_write.rb
@@ -35,7 +35,7 @@ shared_examples 'a bulk write object' do
       end
 
       it 'returns n_inserted of 1' do
-        expect(bulk.execute[:n_inserted]).to eq(1)
+        expect(bulk.execute.inserted_count).to eq(1)
       end
 
       it 'only inserts that document' do
@@ -94,7 +94,7 @@ shared_examples 'a bulk write object' do
     context 'when multiple documents match delete selector' do
 
       it 'reports n_removed correctly' do
-        expect(bulk.execute[:n_removed]).to eq(1)
+        expect(bulk.execute.deleted_count).to eq(1)
       end
 
       it 'deletes only matching documents' do
@@ -136,7 +136,7 @@ shared_examples 'a bulk write object' do
       context 'when multiple documents match delete selector' do
 
         it 'reports n_removed correctly' do
-          expect(bulk.execute[:n_removed]).to eq(2)
+          expect(bulk.execute.deleted_count).to eq(2)
         end
 
         it 'deletes all matching documents' do
@@ -156,7 +156,7 @@ shared_examples 'a bulk write object' do
         end
 
         it 'reports n_removed correctly' do
-          expect(bulk.execute[:n_removed]).to eq(1)
+          expect(bulk.execute.deleted_count).to eq(1)
         end
 
         it 'deletes all matching documents' do
@@ -233,7 +233,7 @@ shared_examples 'a bulk write object' do
       end
 
       it 'reports n_matched correctly' do
-        expect(bulk.execute[:n_matched]).to eq(1)
+        expect(bulk.execute.matched_count).to eq(1)
       end
 
       it 'only applies the replacement to one matching document' do
@@ -260,7 +260,7 @@ shared_examples 'a bulk write object' do
         end
 
         it 'reports n_matched correctly' do
-          expect(bulk.execute[:n_matched]).to eq(0)
+          expect(bulk.execute.matched_count).to eq(0)
         end
 
         it 'does not replace any documents' do
@@ -331,19 +331,19 @@ shared_examples 'a bulk write object' do
     context 'when a valid update document is specified' do
 
       it 'reports n_modified correctly', if: write_command_enabled?  do
-        expect(bulk.execute[:n_modified]).to eq(1)
+        expect(bulk.execute.modified_count).to eq(1)
       end
 
       it 'reports n_modified correctly', unless: write_command_enabled?  do
-        expect(bulk.execute[:n_modified]).to eq(nil)
+        expect(bulk.execute.modified_count).to eq(nil)
       end
 
       it 'reports n_upserted correctly' do
-        expect(bulk.execute[:n_upserted]).to eq(0)
+        expect(bulk.execute.upserted_count).to eq(0)
       end
 
       it 'reports n_matched correctly' do
-        expect(bulk.execute[:n_matched]).to eq(1)
+        expect(bulk.execute.matched_count).to eq(1)
       end
 
       it 'applies the correct writes' do
@@ -365,19 +365,19 @@ shared_examples 'a bulk write object' do
         end
 
         it 'reports n_modified correctly', if: write_command_enabled?  do
-          expect(bulk.execute[:n_modified]).to eq(0)
+          expect(bulk.execute.modified_count).to eq(0)
         end
 
         it 'reports n_modified correctly', unless: write_command_enabled?  do
-          expect(bulk.execute[:n_modified]).to eq(nil)
+          expect(bulk.execute.modified_count).to eq(nil)
         end
 
         it 'reports n_upserted correctly' do
-          expect(bulk.execute[:n_upserted]).to eq(1)
+          expect(bulk.execute.upserted_count).to eq(1)
         end
 
         it 'reports n_matched correctly' do
-          expect(bulk.execute[:n_matched]).to eq(0)
+          expect(bulk.execute.matched_count).to eq(0)
         end
 
         it 'applies the correct writes' do
@@ -444,19 +444,19 @@ shared_examples 'a bulk write object' do
     context 'when a valid update document is specified' do
 
       it 'reports n_modified correctly', if: write_command_enabled?  do
-        expect(bulk.execute[:n_modified]).to eq(2)
+        expect(bulk.execute.modified_count).to eq(2)
       end
 
       it 'reports n_modified correctly', unless: write_command_enabled?  do
-        expect(bulk.execute[:n_modified]).to eq(nil)
+        expect(bulk.execute.modified_count).to eq(nil)
       end
 
       it 'reports n_upserted correctly' do
-        expect(bulk.execute[:n_upserted]).to eq(0)
+        expect(bulk.execute.upserted_count).to eq(0)
       end
 
       it 'reports n_matched correctly' do
-        expect(bulk.execute[:n_matched]).to eq(2)
+        expect(bulk.execute.matched_count).to eq(2)
       end
 
       it 'applies the correct writes' do
@@ -478,19 +478,19 @@ shared_examples 'a bulk write object' do
         end
 
         it 'reports n_modified correctly', if: write_command_enabled?  do
-          expect(bulk.execute[:n_modified]).to eq(0)
+          expect(bulk.execute.modified_count).to eq(0)
         end
 
         it 'reports n_modified correctly', unless: write_command_enabled?  do
-          expect(bulk.execute[:n_modified]).to eq(nil)
+          expect(bulk.execute.modified_count).to eq(nil)
         end
 
         it 'reports n_upserted correctly' do
-          expect(bulk.execute[:n_upserted]).to eq(1)
+          expect(bulk.execute.upserted_count).to eq(1)
         end
 
         it 'reports n_matched correctly' do
-          expect(bulk.execute[:n_matched]).to eq(0)
+          expect(bulk.execute.matched_count).to eq(0)
         end
 
         it 'applies the correct writes' do

--- a/spec/support/shared/bulk_write.rb
+++ b/spec/support/shared/bulk_write.rb
@@ -376,7 +376,7 @@ shared_examples 'a bulk write object' do
           expect(bulk.execute.upserted_count).to eq(1)
         end
 
-        it 'returns the upserted ids' do
+        it 'returns the upserted ids', if: write_command_enabled? do
           expect(bulk.execute.upserted_ids.size).to eq(1)
         end
 

--- a/spec/support/shared/bulk_write.rb
+++ b/spec/support/shared/bulk_write.rb
@@ -376,6 +376,10 @@ shared_examples 'a bulk write object' do
           expect(bulk.execute.upserted_count).to eq(1)
         end
 
+        it 'returns the upserted ids' do
+          expect(bulk.execute.upserted_ids.size).to eq(1)
+        end
+
         it 'reports n_matched correctly' do
           expect(bulk.execute.matched_count).to eq(0)
         end


### PR DESCRIPTION
This makes the bulk write result now a proper `Result` object according to the CRUD spec and allows for the inserted and upserted document ids to be preset. This also instroduces constants for most of the bulk write fields being utilized.

This also addresses RUBY-946 on master as `insert_many` now delegates to the bulk API.