### PR TITLE
Documentation updates for yard doc errors

### DIFF
--- a/lib/mongo/auth/cr/conversation.rb
+++ b/lib/mongo/auth/cr/conversation.rb
@@ -102,7 +102,6 @@ module Mongo
         #   Conversation.new(user, "admin")
         #
         # @param [ Auth::User ] user The user to converse about.
-        # @param [ String ] database The database to authenticate against.
         #
         # @since 2.0.0
         def initialize(user)

--- a/lib/mongo/error/invalid_bulk_operation.rb
+++ b/lib/mongo/error/invalid_bulk_operation.rb
@@ -25,7 +25,8 @@ module Mongo
       # @example Instantiate the exception.
       #   Mongo::Error::InvalidBulkOperation.new(name)
       #
-      # @param [ String ] name The attempted operation name.
+      # @param [ String ] type The bulk operation type.
+      # @param [ Hash ] operation The bulk operation.
       #
       # @since 2.0.0
       def initialize(type, operation)

--- a/lib/mongo/operation/aggregate.rb
+++ b/lib/mongo/operation/aggregate.rb
@@ -31,12 +31,13 @@ module Mongo
     #     :db_name => 'test_db'
     #   })
     #
-    # @param [ Hash ] spec The specifications for the operation.
+    # Initialization:
+    #   param [ Hash ] spec The specifications for the operation.
     #
-    # @option spec :selector [ Hash ] The aggregate selector.
-    # @option spec :db_name [ String ] The name of the database on which
-    #   the operation should be executed.
-    # @option spec :options [ Hash ] Options for the aggregate command.
+    #   option spec :selector [ Hash ] The aggregate selector.
+    #   option spec :db_name [ String ] The name of the database on which
+    #     the operation should be executed.
+    #   option spec :options [ Hash ] Options for the aggregate command.
     #
     # @since 2.0.0
     class Aggregate

--- a/lib/mongo/operation/command.rb
+++ b/lib/mongo/operation/command.rb
@@ -20,14 +20,13 @@ module Mongo
     # @example Create the command operation.
     #   Mongo::Operation::Command.new({ :selector => { :isMaster => 1 } })
     #
-    # @note A command is actually a query on the virtual '$cmd' collection.
+    # Initialization:
+    #   param [ Hash ] spec The specifications for the command.
     #
-    # @param [ Hash ] spec The specifications for the command.
-    #
-    # @option spec :selector [ Hash ] The command selector.
-    # @option spec :db_name [ String ] The name of the database on which
+    #   option spec :selector [ Hash ] The command selector.
+    #   option spec :db_name [ String ] The name of the database on which
     #   the command should be executed.
-    # @option spec :options [ Hash ] Options for the command.
+    #   option spec :options [ Hash ] Options for the command.
     #
     # @since 2.0.0
     class Command

--- a/lib/mongo/operation/kill_cursors.rb
+++ b/lib/mongo/operation/kill_cursors.rb
@@ -20,9 +20,10 @@ module Mongo
     # @example Create the kill cursors operation.
     #   Mongo::Operation::KillCursor.new({ :cursor_ids => [1, 2] })
     #
-    # @param [ Hash ] spec The specifications for the operation.
+    # Initialization:
+    #   param [ Hash ] spec The specifications for the operation.
     #
-    # @option spec :cursor_ids [ Array ] The ids of cursors to kill.
+    #   option spec :cursor_ids [ Array ] The ids of cursors to kill.
     #
     # @since 2.0.0
     class KillCursors

--- a/lib/mongo/operation/map_reduce.rb
+++ b/lib/mongo/operation/map_reduce.rb
@@ -33,12 +33,13 @@ module Mongo
     #     :db_name  => 'test_db'
     #   })
     #
-    # @param [ Hash ] spec The specifications for the operation.
+    # Initialization:
+    #   param [ Hash ] spec The specifications for the operation.
     #
-    # @option spec :selector [ Hash ] The map reduce selector.
-    # @option spec :db_name [ String ] The name of the database on which
-    #   the operation should be executed.
-    # @option spec :options [ Hash ] Options for the map reduce command.
+    #   option spec :selector [ Hash ] The map reduce selector.
+    #   option spec :db_name [ String ] The name of the database on which
+    #     the operation should be executed.
+    #   option spec :options [ Hash ] Options for the map reduce command.
     #
     # @since 2.0.0
     class MapReduce

--- a/lib/mongo/operation/read/collections_info.rb
+++ b/lib/mongo/operation/read/collections_info.rb
@@ -21,11 +21,12 @@ module Mongo
       # @example Create the collection names operation.
       #   Read::CollectionNames.new(:db_name => 'test-db')
       #
-      # @param [ Hash ] spec The specifications for the collection names operation.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the collection names operation.
       #
-      # @option spec :db_name [ String ] The name of the database whose collection
-      #   names is requested.
-      # @option spec :options [ Hash ] Options for the operation.
+      #   option spec :db_name [ String ] The name of the database whose collection
+      #     names is requested.
+      #   option spec :options [ Hash ] Options for the operation.
       #
       # @since 2.0.0
       class CollectionsInfo

--- a/lib/mongo/operation/read/get_more.rb
+++ b/lib/mongo/operation/read/get_more.rb
@@ -26,14 +26,15 @@ module Mongo
       #     :coll_name => 'test_coll'
       #   })
       #
-      # @param [ Hash ] spec The specifications for the operation.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the operation.
       #
-      # @option spec :to_return [ Integer ] The number of results to return.
-      # @option spec :cursor_id [ Integer ] The id of the cursor.
-      # @option spec :db_name [ String ] The name of the database on which
-      #   the operation should be executed.
-      # @option spec :coll_name [ String ] The name of the collection on which
-      #   the operation should be executed.
+      #   option spec :to_return [ Integer ] The number of results to return.
+      #   option spec :cursor_id [ Integer ] The id of the cursor.
+      #   option spec :db_name [ String ] The name of the database on which
+      #     the operation should be executed.
+      #   option spec :coll_name [ String ] The name of the collection on which
+      #     the operation should be executed.
       #
       # @since 2.0.0
       class GetMore

--- a/lib/mongo/operation/read/indexes.rb
+++ b/lib/mongo/operation/read/indexes.rb
@@ -23,10 +23,11 @@ module Mongo
       # @example Instantiate the operation.
       #   Read::Indexes.new(:db_name => 'test', :coll_name => 'test_coll')
       #
-      # @param [ Hash ] spec The specifications for the insert.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the insert.
       #
-      # @option spec :db_name [ String ] The name of the database.
-      # @option spec :coll_name [ String ] The name of the collection.
+      #   option spec :db_name [ String ] The name of the database.
+      #   option spec :coll_name [ String ] The name of the collection.
       #
       # @since 2.0.0
       class Indexes

--- a/lib/mongo/operation/read/list_collections.rb
+++ b/lib/mongo/operation/read/list_collections.rb
@@ -25,11 +25,12 @@ module Mongo
       #
       # @note A command is actually a query on the virtual '$cmd' collection.
       #
-      # @param [ Hash ] spec The specifications for the command.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the command.
       #
-      # @option spec :db_name [ String ] The name of the database whose list of
-      #   collection names is requested.
-      # @option spec :options [ Hash ] Options for the command.
+      #   option spec :db_name [ String ] The name of the database whose list of
+      #     collection names is requested.
+      #   option spec :options [ Hash ] Options for the command.
       #
       # @since 2.0.0
       class ListCollections

--- a/lib/mongo/operation/read/list_indexes.rb
+++ b/lib/mongo/operation/read/list_indexes.rb
@@ -25,13 +25,14 @@ module Mongo
       #
       # @note A command is actually a query on the virtual '$cmd' collection.
       #
-      # @param [ Hash ] spec The specifications for the command.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the command.
       #
-      # @option spec :coll_name [ Hash ] The name of the collection whose index
-      #   info is requested.
-      # @option spec :db_name [ String ] The name of the database on which
-      #   the command should be executed.
-      # @option spec :options [ Hash ] Options for the command.
+      #   option spec :coll_name [ Hash ] The name of the collection whose index
+      #     info is requested.
+      #   option spec :db_name [ String ] The name of the database on which
+      #     the command should be executed.
+      #   option spec :options [ Hash ] Options for the command.
       #
       # @since 2.0.0
       class ListIndexes

--- a/lib/mongo/operation/read/query.rb
+++ b/lib/mongo/operation/read/query.rb
@@ -26,14 +26,15 @@ module Mongo
       #     :options => { :limit => 2 }
       #   })
       #
-      # @param [ Hash ] spec The specifications for the query.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the query.
       #
-      # @option spec :selector [ Hash ] The query selector.
-      # @option spec :db_name [ String ] The name of the database on which
-      #   the query should be run.
-      # @option spec :coll_name [ String ] The name of the collection on which
-      #   the query should be run.
-      # @option spec :options [ Hash ] Options for the query.
+      #   option spec :selector [ Hash ] The query selector.
+      #   option spec :db_name [ String ] The name of the database on which
+      #     the query should be run.
+      #   option spec :coll_name [ String ] The name of the collection on which
+      #     the query should be run.
+      #   option spec :options [ Hash ] Options for the query.
       #
       # @since 2.0.0
       class Query

--- a/lib/mongo/operation/write/bulk/bulk_delete.rb
+++ b/lib/mongo/operation/write/bulk/bulk_delete.rb
@@ -31,19 +31,20 @@ module Mongo
       #     :write_concern => write_concern
       #   })
       #
-      # @param [ Hash ] spec The specifications for the delete.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the delete.
       #
-      # @option spec :deletes [ Array ] The delete documents.
-      # @option spec :db_name [ String ] The name of the database on which
-      #   the delete should be executed.
-      # @option spec :coll_name [ String ] The name of the collection on which
-      #   the delete should be executed.
-      # @option spec :write_concern [ Mongo::WriteConcern ] The write concern
-      #   for this operation.
-      # @option spec :ordered [ true, false ] Whether the operations should be
-      #   executed in order.
-      # @option spec :options [Hash] Options for the command, if it ends up being a
-      #   write command.
+      #   option spec :deletes [ Array ] The delete documents.
+      #   option spec :db_name [ String ] The name of the database on which
+      #     the delete should be executed.
+      #   option spec :coll_name [ String ] The name of the collection on which
+      #     the delete should be executed.
+      #   option spec :write_concern [ Mongo::WriteConcern ] The write concern
+      #     for this operation.
+      #   option spec :ordered [ true, false ] Whether the operations should be
+      #     executed in order.
+      #   option spec :options [Hash] Options for the command, if it ends up being a
+      #     write command.
       #
       # @since 2.0.0
       class BulkDelete

--- a/lib/mongo/operation/write/bulk/bulk_insert.rb
+++ b/lib/mongo/operation/write/bulk/bulk_insert.rb
@@ -33,16 +33,17 @@ module Mongo
       #     :ordered => false
       #   })
       #
-      # @param [ Hash ] spec The specifications for the insert.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the insert.
       #
-      # @option spec :documents [ Array ] The documents to insert.
-      # @option spec :db_name [ String ] The name of the database.
-      # @option spec :coll_name [ String ] The name of the collection.
-      # @option spec :write_concern [ Mongo::WriteConcern ] The write concern.
-      # @option spec :ordered [ true, false ] Whether the operations should be
-      #   executed in order.
-      # @option spec :options [ Hash ] Options for the command, if it ends up being a
-      #   write command.
+      #   option spec :documents [ Array ] The documents to insert.
+      #   option spec :db_name [ String ] The name of the database.
+      #   option spec :coll_name [ String ] The name of the collection.
+      #   option spec :write_concern [ Mongo::WriteConcern ] The write concern.
+      #   option spec :ordered [ true, false ] Whether the operations should be
+      #     executed in order.
+      #   option spec :options [ Hash ] Options for the command, if it ends up being a
+      #     write command.
       #
       # @since 2.0.0
       class BulkInsert

--- a/lib/mongo/operation/write/bulk/bulk_insert/result.rb
+++ b/lib/mongo/operation/write/bulk/bulk_insert/result.rb
@@ -37,7 +37,7 @@ module Mongo
           #   Result.new(replies, inserted_ids)
           #
           # @param [ Protocol::Reply ] replies The wire protocol replies.
-          # @params [ Array<Object> ] ids The ids of the inserted documents.
+          # @param [ Array<Object> ] ids The ids of the inserted documents.
           #
           # @since 2.0.0
           def initialize(replies, ids)
@@ -88,7 +88,7 @@ module Mongo
           #   Result.new(replies, inserted_ids)
           #
           # @param [ Protocol::Reply ] replies The wire protocol replies.
-          # @params [ Array<Object> ] ids The ids of the inserted documents.
+          # @param [ Array<Object> ] ids The ids of the inserted documents.
           #
           # @since 2.0.0
           def initialize(replies, ids)

--- a/lib/mongo/operation/write/bulk/bulk_update.rb
+++ b/lib/mongo/operation/write/bulk/bulk_update.rb
@@ -39,18 +39,19 @@ module Mongo
       #     :ordered => false
       #   })
       #
-      # @param [ Hash ] spec The specifications for the update.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the update.
       #
-      # @option spec :updates [ Array ] The update documents.
-      # @option spec :db_name [ String ] The name of the database on which
-      #   the query should be run.
-      # @option spec :coll_name [ String ] The name of the collection on which
-      #   the query should be run.
-      # @option spec :write_concern [ Mongo::WriteConcern ] The write concern.
-      # @option spec :ordered [ true, false ] Whether the operations should be
-      #   executed in order.
-      # @option spec :options [ Hash ] Options for the command, if it ends up being a
-      #   write command.
+      #   option spec :updates [ Array ] The update documents.
+      #   option spec :db_name [ String ] The name of the database on which
+      #     the query should be run.
+      #   option spec :coll_name [ String ] The name of the collection on which
+      #     the query should be run.
+      #   option spec :write_concern [ Mongo::WriteConcern ] The write concern.
+      #   option spec :ordered [ true, false ] Whether the operations should be
+      #     executed in order.
+      #   option spec :options [ Hash ] Options for the command, if it ends up being a
+      #     write command.
       #
       # @since 2.0.0
       class BulkUpdate

--- a/lib/mongo/operation/write/create_index.rb
+++ b/lib/mongo/operation/write/create_index.rb
@@ -30,14 +30,15 @@ module Mongo
       #     :index_name => 'name_1_age_-1'
       #   })
       #
-      # @param [ Hash ] spec The specifications for the insert.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the insert.
       #
-      # @option spec :index [ Hash ] The index spec to create.
-      # @option spec :db_name [ String ] The name of the database.
-      # @option spec :coll_name [ String ] The name of the collection.
-      # @option spec :index_name [ String ] The name of the index.
-      # @option spec :options [ Hash ] Options for the command, if it ends up being a
-      #   write command.
+      #   option spec :index [ Hash ] The index spec to create.
+      #   option spec :db_name [ String ] The name of the database.
+      #   option spec :coll_name [ String ] The name of the collection.
+      #   option spec :index_name [ String ] The name of the index.
+      #   option spec :options [ Hash ] Options for the command, if it ends up being a
+      #     write command.
       #
       # @since 2.0.0
       class CreateIndex

--- a/lib/mongo/operation/write/create_user.rb
+++ b/lib/mongo/operation/write/create_user.rb
@@ -22,10 +22,11 @@ module Mongo
       # @example Initialize the operation.
       #   Write::CreateUser.new(:db_name => 'test', :user => user)
       #
-      # @param [ Hash ] spec The specifications for the create.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the create.
       #
-      # @option spec :user [ Auth::User ] The user to create.
-      # @option spec :db_name [ String ] The name of the database.
+      #   option spec :user [ Auth::User ] The user to create.
+      #   option spec :db_name [ String ] The name of the database.
       #
       # @since 2.0.0
       class CreateUser

--- a/lib/mongo/operation/write/delete.rb
+++ b/lib/mongo/operation/write/delete.rb
@@ -31,19 +31,20 @@ module Mongo
       #     :write_concern => write_concern
       #   })
       #
-      # @param [ Hash ] spec The specifications for the delete.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the delete.
       #
-      # @option spec :delete [ Hash ] The delete document.
-      # @option spec :db_name [ String ] The name of the database on which
-      #   the delete should be executed.
-      # @option spec :coll_name [ String ] The name of the collection on which
-      #   the delete should be executed.
-      # @option spec :write_concern [ Mongo::WriteConcern ] The write concern
-      #   for this operation.
-      # @option spec :ordered [ true, false ] Whether the operations should be
-      #   executed in order.
-      # @option spec :options [Hash] Options for the command, if it ends up being a
-      #   write command.
+      #   option spec :delete [ Hash ] The delete document.
+      #   option spec :db_name [ String ] The name of the database on which
+      #     the delete should be executed.
+      #   option spec :coll_name [ String ] The name of the collection on which
+      #     the delete should be executed.
+      #   option spec :write_concern [ Mongo::WriteConcern ] The write concern
+      #     for this operation.
+      #   option spec :ordered [ true, false ] Whether the operations should be
+      #     executed in order.
+      #   option spec :options [Hash] Options for the command, if it ends up being a
+      #     write command.
       #
       # @since 2.0.0
       class Delete

--- a/lib/mongo/operation/write/drop_index.rb
+++ b/lib/mongo/operation/write/drop_index.rb
@@ -25,12 +25,13 @@ module Mongo
       #     :index_name => 'name_1_age_-1'
       #   })
       #
-      # @param [ Hash ] spec The specifications for the drop.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the drop.
       #
-      # @option spec :index [ Hash ] The index spec to create.
-      # @option spec :db_name [ String ] The name of the database.
-      # @option spec :coll_name [ String ] The name of the collection.
-      # @option spec :index_name [ String ] The name of the index.
+      #   option spec :index [ Hash ] The index spec to create.
+      #   option spec :db_name [ String ] The name of the database.
+      #   option spec :coll_name [ String ] The name of the collection.
+      #   option spec :index_name [ String ] The name of the index.
       #
       # @since 2.0.0
       class DropIndex

--- a/lib/mongo/operation/write/insert.rb
+++ b/lib/mongo/operation/write/insert.rb
@@ -31,14 +31,15 @@ module Mongo
       #     :write_concern => write_concern
       #   })
       #
-      # @param [ Hash ] spec The specifications for the insert.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the insert.
       #
-      # @option spec :documents [ Array ] The documents to insert.
-      # @option spec :db_name [ String ] The name of the database.
-      # @option spec :coll_name [ String ] The name of the collection.
-      # @option spec :write_concern [ Mongo::WriteConcern ] The write concern.
-      # @option spec :options [ Hash ] Options for the command, if it ends up being a
-      #   write command.
+      #   option spec :documents [ Array ] The documents to insert.
+      #   option spec :db_name [ String ] The name of the database.
+      #   option spec :coll_name [ String ] The name of the collection.
+      #   option spec :write_concern [ Mongo::WriteConcern ] The write concern.
+      #   option spec :options [ Hash ] Options for the command, if it ends up being a
+      #     write command.
       #
       # @since 2.0.0
       class Insert

--- a/lib/mongo/operation/write/insert/result.rb
+++ b/lib/mongo/operation/write/insert/result.rb
@@ -36,7 +36,7 @@ module Mongo
           #   Result.new(replies, inserted_ids)
           #
           # @param [ Protocol::Reply ] replies The wire protocol replies.
-          # @params [ Array<Object> ] ids The ids of the inserted documents.
+          # @param [ Array<Object> ] ids The ids of the inserted documents.
           #
           # @since 2.0.0
           def initialize(replies, ids)

--- a/lib/mongo/operation/write/remove_user.rb
+++ b/lib/mongo/operation/write/remove_user.rb
@@ -21,10 +21,11 @@ module Mongo
       # @example Create the remove user operation.
       #   Write::RemoveUser.new(:db_name => 'test', :name => name)
       #
-      # @param [ Hash ] spec The specifications for the remove.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the remove.
       #
-      # @option spec :name [ String ] The user name.
-      # @option spec :db_name [ String ] The name of the database.
+      #   option spec :name [ String ] The user name.
+      #   option spec :db_name [ String ] The name of the database.
       #
       # @since 2.0.0
       class RemoveUser

--- a/lib/mongo/operation/write/update.rb
+++ b/lib/mongo/operation/write/update.rb
@@ -37,16 +37,17 @@ module Mongo
       #     :write_concern => write_concern
       #   })
       #
-      # @param [ Hash ] spec The specifications for the update.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the update.
       #
-      # @option spec :update [ Hash ] The update document.
-      # @option spec :db_name [ String ] The name of the database on which
-      #   the query should be run.
-      # @option spec :coll_name [ String ] The name of the collection on which
-      #   the query should be run.
-      # @option spec :write_concern [ Mongo::WriteConcern ] The write concern.
-      # @option spec :options [ Hash ] Options for the command, if it ends up being a
-      #   write command.
+      #   option spec :update [ Hash ] The update document.
+      #   option spec :db_name [ String ] The name of the database on which
+      #     the query should be run.
+      #   option spec :coll_name [ String ] The name of the collection on which
+      #     the query should be run.
+      #   option spec :write_concern [ Mongo::WriteConcern ] The write concern.
+      #   option spec :options [ Hash ] Options for the command, if it ends up being a
+      #     write command.
       #
       # @since 2.0.0
       class Update

--- a/lib/mongo/operation/write/update_user.rb
+++ b/lib/mongo/operation/write/update_user.rb
@@ -22,10 +22,11 @@ module Mongo
       # @example Initialize the operation.
       #   Write::UpdateUser.new(:db_name => 'test', :user => user)
       #
-      # @param [ Hash ] spec The specifications for the update.
+      # Initialization:
+      #   param [ Hash ] spec The specifications for the update.
       #
-      # @option spec :user [ Auth::User ] The user to update.
-      # @option spec :db_name [ String ] The name of the database.
+      #   option spec :user [ Auth::User ] The user to update.
+      #   option spec :db_name [ String ] The name of the database.
       #
       # @since 2.0.0
       class UpdateUser


### PR DESCRIPTION
Some doc pages weren't being generated because of errors. These changes fix the errors. 
For example, this redirects to the main page:
http://api.mongodb.org/ruby/current/Mongo/Operation/Write/BulkUpdate.html
