### PR TITLE
RUBY-925 Support all required options by the CRUD spec in Collection#find

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -108,12 +108,35 @@ module Mongo
     #   collection.find
     #
     # @param [ Hash ] filter The filter to use in the find.
+    # @param [ Hash ] options The options for the find.
+    #
+    # @option options [ true, false ] :allow_partial_results Allows the query to get partial
+    #   results if some shards are down.
+    # @option options [ Integer ] :batch_size The number of documents returned in each batch
+    #   of results from MongoDB.
+    # @option options [ String ] :comment Associate a comment with the query.
+    # @option options [ :tailable, :tailable_await ] :cursor_type The type of cursor to use.
+    # @option options [ Integer ] :limit The max number of docs to return from the query.
+    # @option options [ Integer ] :max_time_ms The maximum amount of time to allow the query
+    #   to run in milliseconds.
+    # @option options [ Hash ] :modifiers Meta-operators modifying the output or behavior
+    #   of a query.
+    # @option options [ true, false ] :no_cursor_timeout The server normally times out idle
+    #   cursors after an inactivity period (10 minutes) to prevent excess memory use.
+    #   Set this option to prevent that.
+    # @option options [ true, false ] :oplog_replay Internal replication use only - driver
+    #   should not set.
+    # @option options [ Hash ] :projection The fields to include or exclude from each doc
+    #   in the result set.
+    # @option options [ Integer ] :skip The number of docs to skip before returning results.
+    # @option options [ Hash ] :sort The key and direction pairs by which the result set
+    #   will be sorted.
     #
     # @return [ CollectionView ] The collection view.
     #
     # @since 2.0.0
-    def find(filter = nil)
-      View.new(self, filter || {})
+    def find(filter = nil, options = {})
+      View.new(self, filter || {}, options)
     end
 
     # Get a view of all indexes for this collection. Can be iterated or has

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -568,12 +568,91 @@ describe Mongo::Collection::View::Readable do
 
   describe '#show_disk_loc' do
 
-    let(:new_view) do
-      view.show_disk_loc(true)
+    let(:options) do
+      { :show_disk_loc => true }
     end
 
-    it 'sets the value in the options' do
-      expect(new_view.show_disk_loc).to be true
+    context 'when show_disk_loc is specified' do
+
+      let(:new_show_disk_loc) do
+        false
+      end
+
+      it 'sets the show_disk_loc value' do
+        new_view = view.show_disk_loc(new_show_disk_loc)
+        expect(new_view.show_disk_loc).to eq(new_show_disk_loc)
+      end
+
+      it 'returns a new View' do
+        expect(view.show_disk_loc(new_show_disk_loc)).not_to be(view)
+      end
+    end
+
+    context 'when show_disk_loc is not specified' do
+
+      it 'returns the show_disk_loc value' do
+        expect(view.show_disk_loc).to eq(options[:show_disk_loc])
+      end
+    end
+  end
+
+  describe '#modifiers' do
+
+    let(:options) do
+      { :modifiers => { :$orderby => Mongo::Index::ASCENDING } }
+    end
+
+    context 'when a modifiers document is specified' do
+
+      let(:new_modifiers) do
+        { :modifiers => { :$orderby => Mongo::Index::DESCENDING } }
+      end
+
+      it 'sets the new_modifiers document' do
+        new_view = view.modifiers(new_modifiers)
+        expect(new_view.modifiers).to eq(new_modifiers)
+      end
+
+      it 'returns a new View' do
+        expect(view.modifiers(new_modifiers)).not_to be(view)
+      end
+    end
+
+    context 'when a modifiers document is not specified' do
+
+      it 'returns the modifiers value' do
+        expect(view.modifiers).to eq(options[:modifiers])
+      end
+    end
+  end
+
+  describe '#max_time_ms' do
+
+    let(:options) do
+      { :max_time_ms => 200 }
+    end
+
+    context 'when max_time_ms is specified' do
+
+      let(:new_max_time_ms) do
+        300
+      end
+
+      it 'sets the max_time_ms value' do
+        new_view = view.max_time_ms(new_max_time_ms)
+        expect(new_view.max_time_ms).to eq(new_max_time_ms)
+      end
+
+      it 'returns a new View' do
+        expect(view.max_time_ms(new_max_time_ms)).not_to be(view)
+      end
+    end
+
+    context 'when max_time_ms is not specified' do
+
+      it 'returns the max_time_ms value' do
+        expect(view.max_time_ms).to eq(options[:max_time_ms])
+      end
     end
   end
 

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -733,5 +733,81 @@ describe Mongo::Collection::View::Readable do
         expect(view.sort).to eq(options[:sort])
       end
     end
+
+    context 'when an option is a cursor flag' do
+
+      let(:query_spec_options) do
+        view.send(:query_spec)[:options]
+      end
+
+      context 'when allow_partial_results is set as an option' do
+
+        let(:options) do
+          { :allow_partial_results => true }
+        end
+
+        it 'sets the cursor flag' do
+          expect(query_spec_options[:flags]).to eq([:partial])
+        end
+
+        context 'when allow_partial_results is also called as a method' do
+
+          before do
+            view.allow_partial_results
+          end
+
+          it 'sets only one cursor flag' do
+            expect(query_spec_options[:flags]).to eq([:partial])
+          end
+        end
+      end
+
+      context 'when oplog_replay is set as an option' do
+
+        let(:options) do
+          { :oplog_replay => true }
+        end
+
+        it 'sets the cursor flag' do
+          expect(query_spec_options[:flags]).to eq([:oplog_replay])
+        end
+      end
+
+      context 'when oplog_replay is set as an option' do
+
+        let(:options) do
+          { :no_cursor_timeout => true }
+        end
+
+        it 'sets the cursor flag' do
+          expect(query_spec_options[:flags]).to eq([:no_cursor_timeout])
+        end
+      end
+
+      context 'when cursor_type is set as an option' do
+
+        context 'when :tailable is the cursor type' do
+
+          let(:options) do
+            { :cursor_type => :tailable }
+          end
+
+          it 'sets the cursor flag' do
+            expect(query_spec_options[:flags]).to eq([:tailable_cursor])
+          end
+        end
+
+        context 'when :tailable_await is the cursor type' do
+
+          let(:options) do
+            { :cursor_type => :tailable_await }
+          end
+
+          it 'sets the cursor flag' do
+            expect(query_spec_options[:flags]).to eq([:await_data, :tailable_cursor])
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -295,6 +295,134 @@ describe Mongo::Collection do
         end
       end
     end
+
+    context 'when provided options' do
+
+      let(:view) do
+        authorized_collection.find({}, options)
+      end
+
+      context 'when provided :allow_partial_results' do
+
+        let(:options) do
+          { allow_partial_results: true }
+        end
+
+        it 'returns a view with :allow_partial_results set' do
+          expect(view.options[:allow_partial_results]).to be(options[:allow_partial_results])
+        end
+      end
+
+      context 'when provided :batch_size' do
+
+        let(:options) do
+          { batch_size: 100 }
+        end
+
+        it 'returns a view with :batch_size set' do
+          expect(view.options[:batch_size]).to be(options[:batch_size])
+        end
+      end
+
+      context 'when provided :comment' do
+
+        let(:options) do
+          { comment: 'slow query' }
+        end
+
+        it 'returns a view with :comment set' do
+          expect(view.options[:comment]).to be(options[:comment])
+        end
+      end
+
+      context 'when provided :cursor_type' do
+
+        let(:options) do
+          { cursor_type: :tailable }
+        end
+
+        it 'returns a view with :cursor_type set' do
+          expect(view.options[:cursor_type]).to be(options[:cursor_type])
+        end
+      end
+
+      context 'when provided :max_time_ms' do
+
+        let(:options) do
+          { max_time_ms: 500 }
+        end
+
+        it 'returns a view with :max_time_ms set' do
+          expect(view.options[:max_time_ms]).to be(options[:max_time_ms])
+        end
+      end
+
+      context 'when provided :modifiers' do
+
+        let(:options) do
+          { modifiers: { :$orderby => Mongo::Index::ASCENDING } }
+        end
+
+        it 'returns a view with modifiers set' do
+          expect(view.options[:modifiers]).to be(options[:modifiers])
+        end
+      end
+
+      context 'when provided :no_cursor_timeout' do
+
+        let(:options) do
+          { no_cursor_timeout: true }
+        end
+
+        it 'returns a view with :no_cursor_timeout set' do
+          expect(view.options[:no_cursor_timeout]).to be(options[:no_cursor_timeout])
+        end
+      end
+
+      context 'when provided :oplog_replay' do
+
+        let(:options) do
+          { oplog_replay: false }
+        end
+
+        it 'returns a view with :oplog_replay set' do
+          expect(view.options[:oplog_replay]).to be(options[:oplog_replay])
+        end
+      end
+
+      context 'when provided :projection' do
+
+        let(:options) do
+          { projection:  { 'x' => 1 } }
+        end
+
+        it 'returns a view with :projection set' do
+          expect(view.options[:projection]).to be(options[:projection])
+        end
+      end
+
+      context 'when provided :skip' do
+
+        let(:options) do
+          { skip:  5 }
+        end
+
+        it 'returns a view with :skip set' do
+          expect(view.options[:skip]).to be(options[:skip])
+        end
+      end
+
+      context 'when provided :sort' do
+
+        let(:options) do
+          { sort:  { 'x' => Mongo::Index::ASCENDING } }
+        end
+
+        it 'returns a view with :sort set' do
+          expect(view.options[:sort]).to be(options[:sort])
+        end
+      end
+    end
   end
 
   describe '#insert_many' do


### PR DESCRIPTION
Still need to add support in Operation::Read::Query for tailable_cursor, oplog_replay, no_cursor_timeout, await_data, partial 