### PR TITLE
ServerSelector refactor

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -182,7 +182,7 @@ module Mongo
     #
     # @since 2.0.0
     def read_preference
-      @read_preference ||= ServerSelector.get(options[:read] || {}, options)
+      @read_preference ||= ServerSelector.get((options[:read] || {}).merge(options))
     end
 
     # Use the database with the provided name. This will switch the current

--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -125,7 +125,7 @@ module Mongo
     #
     # @since 2.0.0
     def next_primary
-      ServerSelector.get({ mode: :primary }, options).select_server(self)
+      ServerSelector.get({ mode: :primary }.merge(options)).select_server(self)
     end
 
     # Elect a primary server from the description that has just changed to a

--- a/lib/mongo/collection/view/aggregation.rb
+++ b/lib/mongo/collection/view/aggregation.rb
@@ -139,7 +139,7 @@ module Mongo
             log_warn([
               'Rerouting the Aggregation operation to the primary server.'
             ])
-            server = ServerSelector.get(mode: :primary).select_server(cluster)
+            server = cluster.next_primary
             initial_query_op.execute(server.context)
           end
         end

--- a/lib/mongo/collection/view/map_reduce.rb
+++ b/lib/mongo/collection/view/map_reduce.rb
@@ -180,7 +180,7 @@ module Mongo
               log_warn([
                 'Rerouting the MapReduce operation to the primary server.'
               ])
-              server = ServerSelector.get(mode: :primary).select_server(cluster)
+              server = cluster.next_primary
               initial_query_op.execute(server.context)
             end
           if inline?

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -138,7 +138,7 @@ module Mongo
     #
     # @return [ Hash ] The result of the command execution.
     def command(operation, opts = {})
-      preference = opts[:read] ? ServerSelector.get(opts[:read], options) : read_preference
+      preference = opts[:read] ? ServerSelector.get(opts[:read].merge(options)) : read_preference
       server = preference.select_server(cluster)
       Operation::Command.new({
         :selector => operation,

--- a/lib/mongo/server_selector.rb
+++ b/lib/mongo/server_selector.rb
@@ -27,6 +27,17 @@ module Mongo
   module ServerSelector
     extend self
 
+    # The max latency in seconds between the closest server and other servers
+    # considered for selection.
+    #
+    # @since 2.0.0
+    LOCAL_THRESHOLD = 0.015.freeze
+
+    # How long to block for server selection before throwing an exception.
+    #
+    # @since 2.0.0
+    SERVER_SELECTION_TIMEOUT = 30.freeze
+
     # Hash lookup for the selector classes based off the symbols
     #   provided in configuration.
     #
@@ -43,7 +54,7 @@ module Mongo
     #
     # @example Get a server selector object for selecting a secondary with
     #   specific tag sets.
-    #   Mongo::ServerSelector.get({ :mode => :secondary, :tag_sets => [{'dc' => 'nyc'}] })
+    #   Mongo::ServerSelector.get(:mode => :secondary, :tag_sets => [{'dc' => 'nyc'}])
     #
     # @param [ Hash ] preference The server preference.
     # @param [ Hash ] options The preference options.
@@ -52,11 +63,8 @@ module Mongo
     # @option preference :tag_sets [ Array<Hash> ] The tag sets.
     #
     # @since 2.0.0
-    def get(preference = {}, options = {})
-      PREFERENCES.fetch(preference[:mode] || :primary).new(
-        preference[:tag_sets] || [],
-        options
-      )
+    def get(preference = {})
+      PREFERENCES.fetch(preference[:mode] || :primary).new(preference)
     end
   end
 end

--- a/spec/mongo/server_selection_spec.rb
+++ b/spec/mongo/server_selection_spec.rb
@@ -54,9 +54,9 @@ describe 'Server Selection' do
       end
 
       let(:server_selector) do
-        Mongo::ServerSelector.get({ :mode => spec.read_preference['mode'],
-                                    :tag_sets => spec.read_preference['tag_sets'] },
-                                    :server_selection_timeout => 1)
+        Mongo::ServerSelector.get(:mode => spec.read_preference['mode'],
+                                  :tag_sets => spec.read_preference['tag_sets'],
+                                  :server_selection_timeout => 1)
       end
 
       before do

--- a/spec/mongo/server_selector/nearest_spec.rb
+++ b/spec/mongo/server_selector/nearest_spec.rb
@@ -2,30 +2,37 @@ require 'spec_helper'
 
 describe Mongo::ServerSelector::Nearest do
 
+  let(:name) { :nearest }
+
   include_context 'server selector'
 
-  it_behaves_like 'a read preference mode' do
-    let(:name) { :nearest }
+  it_behaves_like 'a server selector mode' do
     let(:slave_ok) { true }
   end
 
-  it_behaves_like 'a read preference mode accepting tag sets'
+  it_behaves_like 'a server selector accepting tag sets'
 
   describe '#to_mongos' do
 
     context 'tag set not provided' do
+
+      let(:expected) do
+        { :mode => 'nearest' }
+      end
+
       it 'returns a read preference formatted for mongos' do
-        expect(read_pref.to_mongos).to eq({ :mode => 'nearest' })
+        expect(selector.to_mongos).to eq(expected)
       end
     end
 
     context 'tag set provided' do
+
       let(:tag_sets) do
         [tag_set]
       end
 
       it 'returns a read preference formatted for mongos' do
-        expect(read_pref.to_mongos).to eq(
+        expect(selector.to_mongos).to eq(
           { :mode => 'nearest', :tags => tag_sets }
         )
       end
@@ -38,7 +45,7 @@ describe Mongo::ServerSelector::Nearest do
       let(:candidates) { [] }
 
       it 'returns an empty array' do
-        expect(read_pref.send(:select, candidates)).to be_empty
+        expect(selector.send(:select, candidates)).to be_empty
       end
     end
 
@@ -46,7 +53,7 @@ describe Mongo::ServerSelector::Nearest do
       let(:candidates) { [primary] }
 
       it 'returns an array with the primary' do
-        expect(read_pref.send(:select, candidates)).to eq([primary])
+        expect(selector.send(:select, candidates)).to eq([primary])
       end
     end
 
@@ -54,7 +61,7 @@ describe Mongo::ServerSelector::Nearest do
       let(:candidates) { [secondary] }
 
       it 'returns an array with the secondary' do
-        expect(read_pref.send(:select, candidates)).to eq([secondary])
+        expect(selector.send(:select, candidates)).to eq([secondary])
       end
     end
 
@@ -62,7 +69,7 @@ describe Mongo::ServerSelector::Nearest do
       let(:candidates) { [primary, secondary] }
 
       it 'returns an array with the primary and secondary' do
-        expect(read_pref.send(:select, candidates)).to match_array([primary, secondary])
+        expect(selector.send(:select, candidates)).to match_array([primary, secondary])
       end
     end
 
@@ -70,7 +77,7 @@ describe Mongo::ServerSelector::Nearest do
       let(:candidates) { [secondary, secondary] }
 
       it 'returns an array with the secondaries' do
-        expect(read_pref.send(:select, candidates)).to match_array([secondary, secondary])
+        expect(selector.send(:select, candidates)).to match_array([secondary, secondary])
       end
     end
 
@@ -89,7 +96,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [primary] }
 
           it 'returns an empty array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
 
@@ -97,7 +104,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [matching_primary] }
 
           it 'returns an array with the primary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_primary])
+            expect(selector.send(:select, candidates)).to eq([matching_primary])
           end
         end
 
@@ -105,7 +112,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [secondary] }
 
           it 'returns an empty array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
 
@@ -113,7 +120,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [matching_secondary] }
 
           it 'returns an array with the matching secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_secondary])
+            expect(selector.send(:select, candidates)).to eq([matching_secondary])
           end
         end
       end
@@ -124,7 +131,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [primary, secondary, secondary] }
 
           it 'returns an empty array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
 
@@ -132,7 +139,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [matching_primary, secondary, secondary] }
 
           it 'returns an array with the matching primary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_primary])
+            expect(selector.send(:select, candidates)).to eq([matching_primary])
           end
         end
 
@@ -140,7 +147,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [primary, matching_secondary, secondary] }
 
           it 'returns an array with the matching secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_secondary])
+            expect(selector.send(:select, candidates)).to eq([matching_secondary])
           end
         end
 
@@ -149,7 +156,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:expected) { [matching_secondary, matching_secondary] }
 
           it 'returns an array with the matching secondaries' do
-            expect(read_pref.send(:select, candidates)).to eq(expected)
+            expect(selector.send(:select, candidates)).to eq(expected)
           end
         end
 
@@ -158,7 +165,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:expected) { [matching_primary, matching_secondary] }
 
           it 'returns an array with the matching primary and secondary' do
-            expect(read_pref.send(:select, candidates)).to match_array(expected)
+            expect(selector.send(:select, candidates)).to match_array(expected)
           end
         end
       end
@@ -174,7 +181,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [far_primary] }
 
           it 'returns array with far primary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_primary])
+            expect(selector.send(:select, candidates)).to eq([far_primary])
           end
         end
 
@@ -182,7 +189,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [far_secondary] }
 
           it 'returns array with far primary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_secondary])
+            expect(selector.send(:select, candidates)).to eq([far_secondary])
           end
         end
       end
@@ -193,7 +200,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [primary, secondary] }
 
           it 'returns array with primary and secondary' do
-            expect(read_pref.send(:select, candidates)).to match_array(
+            expect(selector.send(:select, candidates)).to match_array(
               [primary, secondary]
             )
           end
@@ -203,7 +210,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [primary, far_secondary] }
 
           it 'returns array with local primary' do
-            expect(read_pref.send(:select, candidates)).to eq([primary])
+            expect(selector.send(:select, candidates)).to eq([primary])
           end
         end
 
@@ -211,7 +218,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:candidates) { [far_primary, secondary] }
 
           it 'returns array with local secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([secondary])
+            expect(selector.send(:select, candidates)).to eq([secondary])
           end
         end
 
@@ -220,7 +227,7 @@ describe Mongo::ServerSelector::Nearest do
           let(:expected) { [far_primary, far_secondary] }
 
           it 'returns array with both servers' do
-            expect(read_pref.send(:select, candidates)).to match_array(expected)
+            expect(selector.send(:select, candidates)).to match_array(expected)
           end
         end
 
@@ -231,7 +238,7 @@ describe Mongo::ServerSelector::Nearest do
             let(:expected) { [primary, secondary] }
 
             it 'returns array with local primary and local secondary' do
-              expect(read_pref.send(:select, candidates)).to match_array(expected)
+              expect(selector.send(:select, candidates)).to match_array(expected)
             end
           end
 
@@ -240,7 +247,7 @@ describe Mongo::ServerSelector::Nearest do
             let(:expected) { [secondary, secondary] }
 
             it 'returns array with the two local secondaries' do
-              expect(read_pref.send(:select, candidates)).to match_array(expected)
+              expect(selector.send(:select, candidates)).to match_array(expected)
             end
           end
         end

--- a/spec/mongo/server_selector/primary_preferred_spec.rb
+++ b/spec/mongo/server_selector/primary_preferred_spec.rb
@@ -2,21 +2,22 @@ require 'spec_helper'
 
 describe Mongo::ServerSelector::PrimaryPreferred do
 
+  let(:name) { :primary_preferred }
+
   include_context 'server selector'
 
-  it_behaves_like 'a read preference mode' do
-    let(:name) { :primary_preferred }
+  it_behaves_like 'a server selector mode' do
     let(:slave_ok) { true }
   end
 
-  it_behaves_like 'a read preference mode accepting tag sets'
+  it_behaves_like 'a server selector accepting tag sets'
 
   describe '#to_mongos' do
 
     context 'tag sets not provided' do
 
       it 'returns a read preference formatted for mongos' do
-        expect(read_pref.to_mongos).to eq({ :mode => 'primaryPreferred' })
+        expect(selector.to_mongos).to eq({ :mode => 'primaryPreferred' })
       end
     end
 
@@ -24,7 +25,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
       let(:tag_sets) { [tag_set] }
 
       it 'returns a read preference formatted for mongos' do
-        expect(read_pref.to_mongos).to eq(
+        expect(selector.to_mongos).to eq(
           { :mode => 'primaryPreferred', :tags => tag_sets}
         )
       end
@@ -37,7 +38,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
       let(:candidates) { [] }
 
       it 'returns an empty array' do
-        expect(read_pref.send(:select, candidates)).to be_empty
+        expect(selector.send(:select, candidates)).to be_empty
       end
     end
 
@@ -45,7 +46,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
       let(:candidates) { [primary] }
 
       it 'returns an array with the primary' do
-        expect(read_pref.send(:select, candidates)).to eq( [primary] )
+        expect(selector.send(:select, candidates)).to eq( [primary] )
       end
     end
 
@@ -53,7 +54,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
       let(:candidates) { [secondary] }
 
       it 'returns an array with the secondary' do
-        expect(read_pref.send(:select, candidates)).to eq( [secondary] )
+        expect(selector.send(:select, candidates)).to eq( [secondary] )
       end
     end
 
@@ -62,7 +63,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
       let(:expected) { [primary] }
 
       it 'returns an array with the primary' do
-        expect(read_pref.send(:select, candidates)).to eq(expected)
+        expect(selector.send(:select, candidates)).to eq(expected)
       end
     end
 
@@ -71,7 +72,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
       let(:expected) { [primary] }
 
       it 'returns an array with the primary' do
-        expect(read_pref.send(:select, candidates)).to eq(expected)
+        expect(selector.send(:select, candidates)).to eq(expected)
       end
     end
 
@@ -92,7 +93,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:candidates) { [primary] }
 
           it 'returns array with primary' do
-            expect(read_pref.send(:select, candidates)).to eq([primary])
+            expect(selector.send(:select, candidates)).to eq([primary])
           end
         end
 
@@ -100,7 +101,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:candidates) { [matching_primary] }
 
           it 'returns array with matching primary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_primary])
+            expect(selector.send(:select, candidates)).to eq([matching_primary])
           end
         end
 
@@ -108,7 +109,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:candidates) { [matching_secondary] }
 
           it 'returns array with matching secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_secondary])
+            expect(selector.send(:select, candidates)).to eq([matching_secondary])
           end
         end
 
@@ -116,7 +117,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:candidates) { [secondary] }
 
           it 'returns an empty array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
       end
@@ -127,7 +128,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:candidates) { [primary, secondary, secondary] }
 
           it 'returns an array with the primary' do
-            expect(read_pref.send(:select, candidates)).to eq([primary])
+            expect(selector.send(:select, candidates)).to eq([primary])
           end
         end
 
@@ -135,7 +136,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:candidates) { [matching_primary, secondary, secondary] }
 
           it 'returns an array of the primary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_primary])
+            expect(selector.send(:select, candidates)).to eq([matching_primary])
           end
         end
 
@@ -144,7 +145,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:expected) { [primary] }
 
           it 'returns an array of the primary' do
-            expect(read_pref.send(:select, candidates)).to eq(expected)
+            expect(selector.send(:select, candidates)).to eq(expected)
           end
         end
 
@@ -153,7 +154,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:expected) { [primary] }
 
           it 'returns an array of the primary ' do
-            expect(read_pref.send(:select, candidates)).to eq(expected)
+            expect(selector.send(:select, candidates)).to eq(expected)
           end
         end
 
@@ -162,7 +163,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:expected) { [primary] }
 
           it 'returns an array of the primary' do
-            expect(read_pref.send(:select, candidates)).to eq(expected)
+            expect(selector.send(:select, candidates)).to eq(expected)
           end
         end
       end
@@ -178,7 +179,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:candidates) { [far_primary] }
 
           it 'returns array with far primary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_primary])
+            expect(selector.send(:select, candidates)).to eq([far_primary])
           end
         end
 
@@ -186,7 +187,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
           let(:candidates) { [far_secondary] }
 
           it 'returns array with far primary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_secondary])
+            expect(selector.send(:select, candidates)).to eq([far_secondary])
           end
 
         end
@@ -201,7 +202,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
             let(:expected) { [primary] }
 
             it 'returns an array of the primary' do
-              expect(read_pref.send(:select, candidates)).to eq(expected)
+              expect(selector.send(:select, candidates)).to eq(expected)
             end
           end
 
@@ -210,7 +211,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
             let(:expected) { [primary] }
 
             it 'returns an array of the primary' do
-              expect(read_pref.send(:select, candidates)).to eq(expected)
+              expect(selector.send(:select, candidates)).to eq(expected)
             end
           end
 
@@ -219,7 +220,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
             let(:expected) { [far_primary] }
 
             it 'returns an array of the far primary' do
-              expect(read_pref.send(:select, candidates)).to eq(expected)
+              expect(selector.send(:select, candidates)).to eq(expected)
             end
           end
 
@@ -228,7 +229,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
             let(:expected) { [far_primary] }
 
             it 'returns an array of the far primary' do
-              expect(read_pref.send(:select, candidates)).to eq(expected)
+              expect(selector.send(:select, candidates)).to eq(expected)
             end
           end
 
@@ -239,7 +240,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
               let(:expected) { [primary] }
 
               it 'returns an array of the primary' do
-                expect(read_pref.send(:select, candidates)).to eq(expected)
+                expect(selector.send(:select, candidates)).to eq(expected)
               end
             end
 
@@ -248,7 +249,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
               let(:expected) { [far_primary] }
 
               it 'returns an array with primary' do
-                expect(read_pref.send(:select, candidates)).to eq(expected)
+                expect(selector.send(:select, candidates)).to eq(expected)
               end
             end
           end
@@ -261,7 +262,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
             let(:expected) { [secondary] }
 
             it 'returns an array with the secondary' do
-              expect(read_pref.send(:select, candidates)).to eq(expected)
+              expect(selector.send(:select, candidates)).to eq(expected)
             end
           end
 
@@ -270,7 +271,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
             let(:expected) { [secondary] }
 
             it 'returns an array of the secondary' do
-              expect(read_pref.send(:select, candidates)).to eq(expected)
+              expect(selector.send(:select, candidates)).to eq(expected)
             end
           end
 
@@ -279,7 +280,7 @@ describe Mongo::ServerSelector::PrimaryPreferred do
             let(:expected) { [secondary, secondary] }
 
             it 'returns an array of the secondary' do
-              expect(read_pref.send(:select, candidates)).to eq(expected)
+              expect(selector.send(:select, candidates)).to eq(expected)
             end
           end
         end

--- a/spec/mongo/server_selector/primary_spec.rb
+++ b/spec/mongo/server_selector/primary_spec.rb
@@ -2,10 +2,11 @@ require 'spec_helper'
 
 describe Mongo::ServerSelector::Primary do
 
+  let(:name) { :primary }
+
   include_context 'server selector'
 
-  it_behaves_like 'a read preference mode' do
-    let(:name) { :primary }
+  it_behaves_like 'a server selector mode' do
     let(:slave_ok) { false }
   end
 
@@ -14,7 +15,7 @@ describe Mongo::ServerSelector::Primary do
     context 'tags not provided' do
 
       it 'returns an empty array' do
-        expect(read_pref.tag_sets).to be_empty
+        expect(selector.tag_sets).to be_empty
       end
     end
 
@@ -22,7 +23,7 @@ describe Mongo::ServerSelector::Primary do
       let(:tag_sets) { [tag_set] }
 
       it 'raises an error' do
-        expect{read_pref.tag_sets}.to raise_error
+        expect{selector.tag_sets}.to raise_error
       end
     end
   end
@@ -30,7 +31,7 @@ describe Mongo::ServerSelector::Primary do
   describe '#to_mongos' do
 
     it 'returns nil' do
-      expect(read_pref.to_mongos).to be_nil
+      expect(selector.to_mongos).to be_nil
     end
   end
 
@@ -40,7 +41,7 @@ describe Mongo::ServerSelector::Primary do
       let(:candidates) { [] }
 
       it 'returns an empty array' do
-        expect(read_pref.send(:select, candidates)).to be_empty
+        expect(selector.send(:select, candidates)).to be_empty
       end
     end
 
@@ -48,7 +49,7 @@ describe Mongo::ServerSelector::Primary do
       let(:candidates) { [secondary] }
 
       it 'returns an empty array' do
-        expect(read_pref.send(:select, candidates)).to be_empty
+        expect(selector.send(:select, candidates)).to be_empty
       end
     end
 
@@ -56,7 +57,7 @@ describe Mongo::ServerSelector::Primary do
       let(:candidates) { [primary] }
 
       it 'returns an array with the primary' do
-        expect(read_pref.send(:select, candidates)).to eq([primary])
+        expect(selector.send(:select, candidates)).to eq([primary])
       end
     end
 
@@ -64,7 +65,7 @@ describe Mongo::ServerSelector::Primary do
       let(:candidates) { [secondary, primary] }
 
       it 'returns an array with the primary' do
-        expect(read_pref.send(:select, candidates)).to eq([primary])
+        expect(selector.send(:select, candidates)).to eq([primary])
       end
     end
 
@@ -78,7 +79,7 @@ describe Mongo::ServerSelector::Primary do
           let(:candidates) { [far_primary] }
 
           it 'returns array with the primary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_primary])
+            expect(selector.send(:select, candidates)).to eq([far_primary])
           end
         end
 
@@ -86,7 +87,7 @@ describe Mongo::ServerSelector::Primary do
           let(:candidates) { [far_secondary] }
 
           it 'returns empty array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
       end
@@ -97,7 +98,7 @@ describe Mongo::ServerSelector::Primary do
           let(:candidates) { [far_primary, far_secondary] }
 
           it 'returns an array with the primary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_primary])
+            expect(selector.send(:select, candidates)).to eq([far_primary])
           end
         end
 
@@ -105,7 +106,7 @@ describe Mongo::ServerSelector::Primary do
           let(:candidates) { [far_primary, far_secondary] }
 
           it 'returns an array with the primary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_primary])
+            expect(selector.send(:select, candidates)).to eq([far_primary])
           end
         end
       end

--- a/spec/mongo/server_selector/secondary_preferred_spec.rb
+++ b/spec/mongo/server_selector/secondary_preferred_spec.rb
@@ -2,14 +2,15 @@ require 'spec_helper'
 
 describe Mongo::ServerSelector::SecondaryPreferred do
 
+  let(:name) { :secondary_preferred }
+
   include_context 'server selector'
 
-  it_behaves_like 'a read preference mode' do
-    let(:name) { :secondary_preferred }
+  it_behaves_like 'a server selector mode' do
     let(:slave_ok) { true }
   end
 
-  it_behaves_like 'a read preference mode accepting tag sets'
+  it_behaves_like 'a server selector accepting tag sets'
 
   describe '#to_mongos' do
 
@@ -20,7 +21,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
       end
 
       it 'returns a read preference formatted for mongos' do
-        expect(read_pref.to_mongos).to eq(
+        expect(selector.to_mongos).to eq(
           { :mode => 'secondaryPreferred', :tags => tag_sets }
         )
       end
@@ -29,7 +30,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
     context 'tag sets not provided' do
 
       it 'returns nil' do
-        expect(read_pref.to_mongos).to be_nil
+        expect(selector.to_mongos).to be_nil
       end
     end
   end
@@ -40,7 +41,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
       let(:candidates) { [] }
 
       it 'returns an empty array' do
-        expect(read_pref.send(:select, candidates)).to be_empty
+        expect(selector.send(:select, candidates)).to be_empty
       end
     end
 
@@ -48,7 +49,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
       let(:candidates) { [primary] }
 
       it 'returns array with primary' do
-        expect(read_pref.send(:select, candidates)).to eq([primary])
+        expect(selector.send(:select, candidates)).to eq([primary])
       end
     end
 
@@ -56,7 +57,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
       let(:candidates) { [secondary] }
 
       it 'returns array with secondary' do
-        expect(read_pref.send(:select, candidates)).to eq([secondary])
+        expect(selector.send(:select, candidates)).to eq([secondary])
       end
     end
 
@@ -65,7 +66,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
       let(:expected) { [secondary, primary] }
 
       it 'returns array with secondary first, then primary' do
-        expect(read_pref.send(:select, candidates)).to eq(expected)
+        expect(selector.send(:select, candidates)).to eq(expected)
       end
     end
 
@@ -74,7 +75,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
       let(:expected) { [secondary, primary] }
 
       it 'returns array with secondary and primary' do
-        expect(read_pref.send(:select, candidates)).to eq(expected)
+        expect(selector.send(:select, candidates)).to eq(expected)
       end
     end
 
@@ -98,7 +99,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [primary] }
 
           it 'returns array with primary' do
-            expect(read_pref.send(:select, candidates)).to eq([primary])
+            expect(selector.send(:select, candidates)).to eq([primary])
           end
         end
 
@@ -106,7 +107,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [matching_primary] }
 
           it 'returns array with matching primary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_primary])
+            expect(selector.send(:select, candidates)).to eq([matching_primary])
           end
         end
 
@@ -114,7 +115,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [matching_secondary] }
 
           it 'returns array with matching secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_secondary])
+            expect(selector.send(:select, candidates)).to eq([matching_secondary])
           end
         end
 
@@ -122,7 +123,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [secondary] }
 
           it 'returns an empty array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
       end
@@ -133,7 +134,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [primary, secondary, secondary] }
 
           it 'returns an array with the primary' do
-            expect(read_pref.send(:select, candidates)).to eq([primary])
+            expect(selector.send(:select, candidates)).to eq([primary])
           end
         end
 
@@ -141,7 +142,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [primary, matching_secondary] }
 
           it 'returns an array of the matching secondary, then primary' do
-            expect(read_pref.send(:select, candidates)).to eq(
+            expect(selector.send(:select, candidates)).to eq(
               [matching_secondary, primary]
             )
           end
@@ -152,7 +153,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:expected) { [matching_secondary, matching_secondary, primary] }
 
           it 'returns an array of the matching secondaries, then primary' do
-            expect(read_pref.send(:select, candidates)).to eq(expected)
+            expect(selector.send(:select, candidates)).to eq(expected)
           end
         end
 
@@ -161,7 +162,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:expected) {[matching_secondary, matching_primary] }
 
           it 'returns an array of the matching secondary, then the primary' do
-            expect(read_pref.send(:select, candidates)).to eq(expected)
+            expect(selector.send(:select, candidates)).to eq(expected)
           end
         end
       end
@@ -177,7 +178,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [far_primary] }
 
           it 'returns array with primary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_primary])
+            expect(selector.send(:select, candidates)).to eq([far_primary])
           end
         end
 
@@ -185,7 +186,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [far_secondary] }
 
           it 'returns an array with the secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_secondary])
+            expect(selector.send(:select, candidates)).to eq([far_secondary])
           end
         end
       end
@@ -196,7 +197,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [primary, secondary] }
 
           it 'returns an array with secondary, then primary' do
-            expect(read_pref.send(:select, candidates)).to eq([secondary, primary])
+            expect(selector.send(:select, candidates)).to eq([secondary, primary])
           end
         end
 
@@ -204,7 +205,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:candidates) { [primary, far_secondary] }
 
           it 'returns an array with the secondary, then primary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_secondary, primary])
+            expect(selector.send(:select, candidates)).to eq([far_secondary, primary])
           end
         end
 
@@ -213,7 +214,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:expected) { [secondary, far_primary] }
 
           it 'returns an array with secondary, then primary' do
-            expect(read_pref.send(:select, candidates)).to eq(expected)
+            expect(selector.send(:select, candidates)).to eq(expected)
           end
         end
 
@@ -222,7 +223,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
           let(:expected) { [far_secondary, far_primary] }
 
           it 'returns an array with secondary, then primary' do
-            expect(read_pref.send(:select, candidates)).to eq(expected)
+            expect(selector.send(:select, candidates)).to eq(expected)
           end
         end
 
@@ -233,7 +234,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
             let(:expected) { [secondary, primary] }
 
             it 'returns an array with near secondary, then primary' do
-              expect(read_pref.send(:select, candidates)).to eq(expected)
+              expect(selector.send(:select, candidates)).to eq(expected)
             end
           end
 
@@ -242,7 +243,7 @@ describe Mongo::ServerSelector::SecondaryPreferred do
             let(:expected) { [secondary, secondary, far_primary] }
 
             it 'returns an array with secondaries, then primary' do
-              expect(read_pref.send(:select, candidates)).to eq(expected)
+              expect(selector.send(:select, candidates)).to eq(expected)
             end
           end
         end

--- a/spec/mongo/server_selector/secondary_spec.rb
+++ b/spec/mongo/server_selector/secondary_spec.rb
@@ -2,19 +2,20 @@ require 'spec_helper'
 
 describe Mongo::ServerSelector::Secondary do
 
+  let(:name) { :secondary }
+
   include_context 'server selector'
 
-  it_behaves_like 'a read preference mode' do
-    let(:name) { :secondary }
+  it_behaves_like 'a server selector mode' do
     let(:slave_ok) { true }
   end
 
-  it_behaves_like 'a read preference mode accepting tag sets'
+  it_behaves_like 'a server selector accepting tag sets'
 
   describe '#to_mongos' do
 
     it 'returns read preference formatted for mongos' do
-      expect(read_pref.to_mongos).to eq(
+      expect(selector.to_mongos).to eq(
         { :mode => 'secondary' }
       )
     end
@@ -23,7 +24,7 @@ describe Mongo::ServerSelector::Secondary do
       let(:tag_sets) { [tag_set] }
 
       it 'returns read preference formatted for mongos with tag sets' do
-        expect(read_pref.to_mongos).to eq(
+        expect(selector.to_mongos).to eq(
           { :mode => 'secondary', :tags => tag_sets}
         )
       end
@@ -36,7 +37,7 @@ describe Mongo::ServerSelector::Secondary do
       let(:candidates) { [] }
 
       it 'returns an empty array' do
-        expect(read_pref.send(:select, candidates)).to be_empty
+        expect(selector.send(:select, candidates)).to be_empty
       end
     end
 
@@ -44,7 +45,7 @@ describe Mongo::ServerSelector::Secondary do
       let(:candidates) { [primary] }
 
       it 'returns an empty array' do
-        expect(read_pref.send(:select, candidates)).to be_empty
+        expect(selector.send(:select, candidates)).to be_empty
       end
     end
 
@@ -52,7 +53,7 @@ describe Mongo::ServerSelector::Secondary do
       let(:candidates) { [secondary] }
 
       it 'returns array with secondary' do
-        expect(read_pref.send(:select, candidates)).to eq([secondary])
+        expect(selector.send(:select, candidates)).to eq([secondary])
       end
     end
 
@@ -60,7 +61,7 @@ describe Mongo::ServerSelector::Secondary do
       let(:candidates) { [primary, secondary] }
 
       it 'returns array with secondary' do
-        expect(read_pref.send(:select, candidates)).to eq([secondary])
+        expect(selector.send(:select, candidates)).to eq([secondary])
       end
     end
 
@@ -68,7 +69,7 @@ describe Mongo::ServerSelector::Secondary do
       let(:candidates) { [secondary, secondary, primary] }
 
       it 'returns array with all secondaries' do
-        expect(read_pref.send(:select, candidates)).to eq([secondary, secondary])
+        expect(selector.send(:select, candidates)).to eq([secondary, secondary])
       end
     end
 
@@ -82,7 +83,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [primary] }
 
           it 'returns an empty array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
 
@@ -90,7 +91,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [secondary] }
 
           it 'returns an empty array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
 
@@ -98,7 +99,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [matching_secondary] }
 
           it 'returns an array with matching secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_secondary])
+            expect(selector.send(:select, candidates)).to eq([matching_secondary])
           end
         end
       end
@@ -109,7 +110,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [primary, secondary, secondary] }
 
           it 'returns an emtpy array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
 
@@ -117,7 +118,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [secondary, matching_secondary]}
 
           it 'returns array with matching secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_secondary])
+            expect(selector.send(:select, candidates)).to eq([matching_secondary])
           end
         end
 
@@ -125,7 +126,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [matching_secondary, matching_secondary] }
 
           it 'returns an array with both matching secondaries' do
-            expect(read_pref.send(:select, candidates)).to eq([matching_secondary, matching_secondary])
+            expect(selector.send(:select, candidates)).to eq([matching_secondary, matching_secondary])
           end
         end
       end
@@ -141,7 +142,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [far_primary] }
 
           it 'returns an empty array' do
-            expect(read_pref.send(:select, candidates)).to be_empty
+            expect(selector.send(:select, candidates)).to be_empty
           end
         end
 
@@ -149,7 +150,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [far_secondary] }
 
           it 'returns an array with the secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_secondary])
+            expect(selector.send(:select, candidates)).to eq([far_secondary])
           end
         end
       end
@@ -160,7 +161,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [primary, far_secondary] }
 
           it 'returns an array with the secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_secondary])
+            expect(selector.send(:select, candidates)).to eq([far_secondary])
           end
         end
 
@@ -168,7 +169,7 @@ describe Mongo::ServerSelector::Secondary do
           let(:candidates) { [far_primary, far_secondary] }
 
           it 'returns an array with the secondary' do
-            expect(read_pref.send(:select, candidates)).to eq([far_secondary])
+            expect(selector.send(:select, candidates)).to eq([far_secondary])
           end
         end
 
@@ -178,7 +179,7 @@ describe Mongo::ServerSelector::Secondary do
             let(:candidates) { [primary, secondary, far_secondary] }
 
             it 'returns an array with near secondary' do
-              expect(read_pref.send(:select, candidates)).to eq([secondary])
+              expect(selector.send(:select, candidates)).to eq([secondary])
             end
           end
 
@@ -186,7 +187,7 @@ describe Mongo::ServerSelector::Secondary do
             let(:candidates) { [far_primary, secondary, secondary] }
 
             it 'returns an array with two secondaries' do
-              expect(read_pref.send(:select, candidates)).to eq([secondary, secondary])
+              expect(selector.send(:select, candidates)).to eq([secondary, secondary])
             end
           end
         end

--- a/spec/support/shared/server_selector.rb
+++ b/spec/support/shared/server_selector.rb
@@ -22,7 +22,7 @@ def server(mode, options = {})
 end
 
 shared_context 'server selector' do
-  let(:read_pref) { described_class.new(tag_sets) }
+
   let(:tag_sets) { [] }
   let(:tag_set) do
     { 'test' => 'tag' }
@@ -32,37 +32,43 @@ shared_context 'server selector' do
   end
   let(:primary) { server(:primary) }
   let(:secondary) { server(:secondary) }
+  let(:selector) { described_class.new(:mode => name, :tag_sets => tag_sets) }
 end
 
-shared_examples 'a read preference mode' do
+shared_examples 'a server selector mode' do
 
   describe '#name' do
 
     it 'returns the name' do
-      expect(read_pref.name).to eq(name)
+      expect(selector.name).to eq(name)
     end
   end
 
   describe '#slave_ok?' do
 
     it 'returns whether the slave_ok bit should be set' do
-      expect(read_pref.slave_ok?).to eq(slave_ok)
+      expect(selector.slave_ok?).to eq(slave_ok)
     end
   end
 
   describe '#==' do
 
     context 'when mode is the same' do
-      let(:other) { described_class.new }
+
+      let(:other) do
+        described_class.new
+      end
 
       context 'tag sets are the same' do
+
         it 'returns true' do
-          expect(read_pref).to eq(other)
+          expect(selector).to eq(other)
         end
       end
     end
 
     context 'mode is different' do
+
       let(:other) do
         double('selectable').tap do |mode|
           allow(mode).to receive(:name).and_return(:other)
@@ -70,28 +76,31 @@ shared_examples 'a read preference mode' do
       end
 
       it 'returns false' do
-        expect(read_pref).not_to eq(other)
+        expect(selector).not_to eq(other)
       end
     end
   end
 end
 
-shared_examples 'a read preference mode accepting tag sets' do
+shared_examples 'a server selector accepting tag sets' do
 
   describe '#tag_sets' do
 
     context 'tags not provided' do
 
       it 'returns an empty array' do
-        expect(read_pref.tag_sets).to be_empty
+        expect(selector.tag_sets).to be_empty
       end
     end
 
     context 'tag sets provided' do
-      let(:tag_sets) { [tag_set] }
+
+      let(:tag_sets) do
+        [ tag_set ]
+      end
 
       it 'returns the tag sets' do
-        expect(read_pref.tag_sets).to eq(tag_sets)
+        expect(selector.tag_sets).to eq(tag_sets)
       end
     end
   end
@@ -104,7 +113,7 @@ shared_examples 'a read preference mode accepting tag sets' do
         let(:tag_sets) { { 'other' => 'tag'  } }
 
         it 'returns false' do
-          expect(read_pref).not_to eq(other)
+          expect(selector).not_to eq(other)
         end
       end
     end


### PR DESCRIPTION
I changed the API of ServerSelector to make it simpler. It was awkward by having multiple arguments and was preventing me from easily creating a ServerSelector object in the GridFS refactor.