### PR TITLE
RUBY-986 Fallback to IPv4 if IPv6 isn't supported

### DIFF
--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -146,12 +146,12 @@ module Mongo
     def initialize_resolver!(timeout, ssl_options)
       family = (host == 'localhost') ? ::Socket::AF_INET : ::Socket::AF_UNSPEC
       error = nil
-      ::Socket.getaddrinfo(host, nil, family, ::Socket::SOCK_STREAM).detect do |info|
+      ::Socket.getaddrinfo(host, nil, family, ::Socket::SOCK_STREAM).each do |info|
         begin
-          return FAMILY_MAP[info[4]].new(info[3], port, host).tap do |res|
-            res.socket(timeout, ssl_options).connect!
-          end
-        rescue IOError, SystemCallError => e
+          res = FAMILY_MAP[info[4]].new(info[3], port, host)
+          res.socket(timeout, ssl_options).connect!
+          return res
+        rescue IOError, SystemCallError, Error::SocketError => e
           error = e
         end
       end

--- a/spec/mongo/address_spec.rb
+++ b/spec/mongo/address_spec.rb
@@ -203,4 +203,23 @@ describe Mongo::Address do
       end
     end
   end
+
+  describe "#socket" do
+    context 'when providing a DNS entry that resolves to both IPv6 and IPv4' do
+      let(:address) do
+        described_class.new('localhost:27017')
+      end
+
+      before do
+        allow(::Socket).to receive(:getaddrinfo).and_return(
+          [ ["AF_INET6", 0, "::1", "::1", ::Socket::AF_INET6, 1, 6],
+            ["AF_INET", 0, "127.0.0.1", "127.0.0.1", ::Socket::AF_INET, 1, 6]]
+        )
+      end
+
+      it "attempts to use IPv6 and fallbacks to IPv4" do
+        expect(address.socket(0.0)).not_to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Prior to this change, if the provided server address resolved to IPv6
but the mongo server wasn't configured for IPv6, the client would
continuously attempt to connect  to the IPv6 address until the
server_selection_timeout was hit and never fallback to IPv4.

This fixes the behavior to try all the different protocol families in
the list.


Fixes https://jira.mongodb.org/browse/RUBY-986.
