### PR TITLE
Found typo in `conversation.rb`

### DIFF
--- a/lib/mongo/auth/scram/conversation.rb
+++ b/lib/mongo/auth/scram/conversation.rb
@@ -417,7 +417,7 @@ module Mongo
         #
         # @since 2.0.0
         def without_proof
-          @withoout_proof ||= "c=biws,r=#{rnonce}"
+          @without_proof ||= "c=biws,r=#{rnonce}"
         end
 
         # XOR operation for two strings.

--- a/lib/mongo/monitoring/command_log_subscriber.rb
+++ b/lib/mongo/monitoring/command_log_subscriber.rb
@@ -85,7 +85,7 @@ module Mongo
       def format_command(args)
         begin
           truncating? ? truncate(args) : args.inspect
-        rescue ArgumentError
+        rescue Exception
           '<Unable to inspect arguments>'
         end
       end


### PR DESCRIPTION
I was looking at the implementation of the SCRAM auth for reference in writing the Rust driver authentication when I noticed this typo.