### PR TITLE
RUBY-981: Add support for Unix domain sockets

### DIFF
--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -144,6 +144,8 @@ module Mongo
     private
 
     def initialize_resolver!(timeout, ssl_options)
+      return Unix.new(seed.downcase) if seed.downcase =~ Unix::MATCH
+
       family = (host == 'localhost') ? ::Socket::AF_INET : ::Socket::AF_UNSPEC
       error = nil
       ::Socket.getaddrinfo(host, nil, family, ::Socket::SOCK_STREAM).each do |info|

--- a/lib/mongo/address/unix.rb
+++ b/lib/mongo/address/unix.rb
@@ -60,7 +60,7 @@ module Mongo
       # Get a socket for the provided address type, given the options.
       #
       # @example Get a Unix socket.
-      #   ipv4.socket(5)
+      #   address.socket(5)
       #
       # @param [ Float ] timeout The socket timeout.
       # @param [ Hash ] ssl_options SSL options - ignored.
@@ -69,7 +69,7 @@ module Mongo
       #
       # @since 2.0.0
       def socket(timeout, ssl_options = {})
-        Socket::Unix.new(host, timeout, Socket::AF_UNIX)
+        Socket::Unix.new(host, timeout)
       end
     end
   end

--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -173,10 +173,13 @@ module Mongo
     end
 
     def set_socket_options(sock)
-      encoded_timeout = [ timeout, 0 ].pack(TIMEOUT_PACK)
       sock.set_encoding(BSON::BINARY)
-      sock.setsockopt(SOL_SOCKET, SO_RCVTIMEO, encoded_timeout)
-      sock.setsockopt(SOL_SOCKET, SO_SNDTIMEO, encoded_timeout)
+
+      unless sock.is_a?(UNIXSocket) && BSON::Environment.jruby?
+        encoded_timeout = [ timeout, 0 ].pack(TIMEOUT_PACK)
+        sock.setsockopt(SOL_SOCKET, SO_RCVTIMEO, encoded_timeout)
+        sock.setsockopt(SOL_SOCKET, SO_SNDTIMEO, encoded_timeout)
+      end
     end
 
     def handle_errors

--- a/lib/mongo/socket/unix.rb
+++ b/lib/mongo/socket/unix.rb
@@ -38,25 +38,22 @@ module Mongo
       #
       # @since 2.0.0
       def connect!
-        Timeout.timeout(timeout, Error::SocketTimeoutError) do
-          handle_errors { socket.connect(path) }
-          self
-        end
+        self
       end
 
       # Initializes a new Unix socket.
       #
       # @example Create the Unix socket.
-      #   Unix.new('/path/to.sock', 27017, 30)
+      #   Unix.new('/path/to.sock', 5)
       #
       # @param [ String ] path The path.
       # @param [ Float ] timeout The socket timeout value.
-      # @param [ Integer ] family The socket family.
       #
       # @since 2.0.0
-      def initialize(path, timeout, family)
+      def initialize(path, timeout)
         @path, @timeout = path, timeout
-        super(family)
+        @socket = ::UNIXSocket.new(path)
+        set_socket_options(@socket)
       end
     end
   end

--- a/spec/mongo/address/unix_spec.rb
+++ b/spec/mongo/address/unix_spec.rb
@@ -27,7 +27,7 @@ describe Mongo::Address::Unix do
   describe '#socket' do
 
     let(:address) do
-      '/path/to/socket.sock'
+      '/tmp/mongodb-27017.sock'
     end
 
     let(:socket) do

--- a/spec/mongo/socket/unix_spec.rb
+++ b/spec/mongo/socket/unix_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe Mongo::Socket::Unix do
+
+  let(:socket) do
+    described_class.new("/tmp/mongodb-27017.sock", 5)
+  end
+
+  describe '#connect!' do
+
+    before do
+      socket.connect!
+    end
+
+    it 'connects to the server' do
+      expect(socket).to be_alive
+    end
+  end
+
+  describe '#alive?' do
+
+    context 'when the socket is connected' do
+
+      before do
+        socket.connect!
+      end
+
+      it 'returns true' do
+        expect(socket).to be_alive
+      end
+    end
+
+    context 'when the socket is not connected' do
+
+      before do
+        socket.close
+      end
+
+      it 'raises error' do
+        expect { socket.alive? }.to raise_error(IOError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an initial take on supporting Unix domain sockets.

Although with this patch the driver seems to work fine with unix sockets, it's far from complete. However I can go on and work on it if it's on the right track.

What do you think?