### PR TITLE
Don't memoize logger in Loggable so Mongo::Logger.logger changes can …

### DIFF
--- a/lib/mongo/loggable.rb
+++ b/lib/mongo/loggable.rb
@@ -93,7 +93,7 @@ module Mongo
     #
     # @since 2.1.0
     def logger
-      @logger ||= (options[:logger] || Logger.logger)
+      (options[:logger] || Logger.logger)
     end
 
     private


### PR DESCRIPTION
…be propagated to existing clients.

After https://jira.mongodb.org/browse/RUBY-990 (01b1ee81254a7272066b672f6c288bedf261a270), if your application starts up and you want to change the logger after a `Client` has been created, the only way I could find to do it is to do

```ruby
client.cluster.servers.each {|s| s.monitoring.subscribers['Command'][0].instance_variable_set(:@logger, new_logger)}
```

It's much simpler to instead simply update `Mongo::Logger.logger` and have it be updated in all the `Client`s that _do not_ explicitly set their own loggers. For those that set their own loggers explicitly, altering `Mongo::Logger.logger` will not affect them.