### PR TITLE
Improve Socket alive? behaviour

### DIFF
--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -56,12 +56,15 @@ module Mongo
     #
     # @since 2.0.0
     def alive?
+      return false if @socket.nil?
       sock_arr = [ @socket ]
       if Kernel::select(sock_arr, nil, sock_arr, 0)
         eof?
       else
         true
       end
+    rescue IOError
+      false
     end
 
     # Close the socket.

--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -165,7 +165,7 @@ module Mongo
     # @since 2.0.5
     def eof?
       @socket.eof?
-    rescue IOError, SystemCallError => e
+    rescue IOError, SystemCallError, OpenSSL::SSL::SSLError => e
       true
     end
 

--- a/spec/mongo/socket/ssl_spec.rb
+++ b/spec/mongo/socket/ssl_spec.rb
@@ -1,12 +1,11 @@
 require 'spec_helper'
 
 describe Mongo::Socket::SSL do
+  let(:socket) do
+    described_class.new(*DEFAULT_ADDRESS.split(":"), DEFAULT_ADDRESS.split(":")[0], 5, Socket::PF_INET, options)
+  end
 
   describe '#connect!', if: running_ssl? do
-
-    let(:socket) do
-      described_class.new(*DEFAULT_ADDRESS.split(":"), DEFAULT_ADDRESS.split(":")[0], 5, Socket::PF_INET, options)
-    end
 
     context 'when a certificate is provided' do
 
@@ -149,5 +148,77 @@ describe Mongo::Socket::SSL do
         expect(socket).to be_alive
       end
     end
+
   end
+
+
+  describe '#alive?', if: running_ssl? do
+
+    context 'when connected' do
+
+      let(:options) do
+        {
+            :ssl => true,
+            :ssl_cert => CLIENT_PEM,
+            :ssl_key => CLIENT_PEM,
+            :ssl_verify => false
+        }
+      end
+
+      before do
+        socket.connect!
+      end
+
+      it 'is alive' do
+        expect(socket).to be_alive
+      end
+    end
+
+    context 'when not connected' do
+
+      let(:options) do
+        {
+            :ssl => true,
+            :ssl_cert => CLIENT_PEM,
+            :ssl_key => CLIENT_PEM,
+            :ssl_verify => false
+        }
+      end
+
+      before do
+        # Don't connect. Same behaviour as a timeout.
+        # Alternatively, mock the Timeout call to immediate timeout before
+        # being able to connect?
+      end
+
+      it 'is not alive' do
+        expect(socket).to_not be_alive
+      end
+    end
+
+
+    context 'when disconnected' do
+
+      let(:options) do
+        {
+            :ssl => true,
+            :ssl_cert => CLIENT_PEM,
+            :ssl_key => CLIENT_PEM,
+            :ssl_verify => false
+        }
+      end
+
+      before do
+        socket.connect!
+        socket.close
+      end
+
+      it 'is not alive' do
+        expect(socket).to_not be_alive
+      end
+    end
+
+
+  end
+
 end

--- a/spec/mongo/socket/ssl_spec.rb
+++ b/spec/mongo/socket/ssl_spec.rb
@@ -218,7 +218,32 @@ describe Mongo::Socket::SSL do
       end
     end
 
+  end
+
+  describe '#eof?', if: running_ssl? do
+
+    context 'when raising SSL Error' do
+
+      let(:options) do
+        {
+            :ssl => true,
+            :ssl_cert => CLIENT_PEM,
+            :ssl_key => CLIENT_PEM,
+            :ssl_verify => false
+        }
+      end
+
+      before do
+        socket.connect!
+        expect(socket.socket).to receive(:eof?).and_raise(OpenSSL::SSL::SSLError)
+      end
+
+      it 'is not alive' do
+        expect(socket).to be_eof
+      end
+    end
 
   end
+
 
 end

--- a/spec/mongo/socket/tcp_spec.rb
+++ b/spec/mongo/socket/tcp_spec.rb
@@ -1,9 +1,9 @@
 require 'spec_helper'
 
-describe Mongo::Socket::Unix do
+describe Mongo::Socket::TCP do
 
   let(:socket) do
-    described_class.new("/tmp/mongodb-27017.sock", 5)
+    described_class.new('127.0.0.1', 27017, 30, Socket::PF_INET)
   end
 
   describe '#connect!' do


### PR DESCRIPTION
The root of the issue seems to be that Socket#alive? raised an error in some cases, instead of returning false. This prevents reconnection from happening.

See:
https://jira.mongodb.org/browse/RUBY-1011
https://jira.mongodb.org/browse/RUBY-1012
