### PR TITLE
Adds more resiliency to retrying read operations during failures.

### DIFF
--- a/lib/mongo/server/connectable.rb
+++ b/lib/mongo/server/connectable.rb
@@ -20,6 +20,10 @@ module Mongo
     # @since 2.0.0
     module Connectable
 
+      def self.included(base)
+        base.__send__(:include, Mongo::Retryable)
+      end
+
       # The ssl option prefix.
       #
       # @since 2.1.0
@@ -103,7 +107,9 @@ module Mongo
       end
 
       def read
-        ensure_connected{ |socket| Protocol::Reply.deserialize(socket) }
+        read_with_retry do
+          ensure_connected{ |socket| Protocol::Reply.deserialize(socket) }
+        end
       end
     end
   end

--- a/spec/mongo/retryable_spec.rb
+++ b/spec/mongo/retryable_spec.rb
@@ -66,6 +66,58 @@ describe Mongo::Retryable do
       end
     end
 
+    context 'when an operation error occurs that could not get last error' do
+
+      before do
+        expect(operation).to receive(:execute).and_raise(Mongo::Error::OperationFailure.new("could not get last error")).ordered
+        expect(cluster).to receive(:scan!).and_return(true).ordered
+        expect(operation).to receive(:execute).and_return(true).ordered
+      end
+
+      it 'executes the operation twice' do
+        expect(retryable.read).to be true
+      end
+    end
+
+    context 'when an operation error occurs that had a connection attempt failed' do
+
+      before do
+        expect(operation).to receive(:execute).and_raise(Mongo::Error::OperationFailure.new("connection attempt failed")).ordered
+        expect(cluster).to receive(:scan!).and_return(true).ordered
+        expect(operation).to receive(:execute).and_return(true).ordered
+      end
+
+      it 'executes the operation twice' do
+        expect(retryable.read).to be true
+      end
+    end
+
+    context 'when an operation error occurs with code 15988' do
+
+      before do
+        expect(operation).to receive(:execute).and_raise(Mongo::Error::OperationFailure.new("error querying server (15988)")).ordered
+        expect(cluster).to receive(:scan!).and_return(true).ordered
+        expect(operation).to receive(:execute).and_return(true).ordered
+      end
+
+      it 'executes the operation twice' do
+        expect(retryable.read).to be true
+      end
+    end
+
+    context 'when an operation error occurs with code 13639' do
+
+      before do
+        expect(operation).to receive(:execute).and_raise(Mongo::Error::OperationFailure.new("connection attempt failed (13639)")).ordered
+        expect(cluster).to receive(:scan!).and_return(true).ordered
+        expect(operation).to receive(:execute).and_return(true).ordered
+      end
+
+      it 'executes the operation twice' do
+        expect(retryable.read).to be true
+      end
+    end
+
     context 'when a socket timeout error occurs' do
 
       before do


### PR DESCRIPTION
Adds some failover support code from Moped which handles reads during failovers better. 

We've been doing failover testing with the new driver (add8a77a48aa). While doing a `kill -9` of the mongod primary, we saw this error:

```
D, [2015-09-01T17:58:43.370391 #2194] DEBUG -- : MONGODB | REDACTED | staging.find | STARTED | {"find"=>"my_collection", "filter"=>{}}
D, [2015-09-01T17:58:43.374908 #2194] DEBUG -- : MONGODB | REDACTED | staging.find | FAILED | can't connect to new replica set master [REDACTED], err: couldn't connect to server REDACTED (REDACTED), connection attempt failed (13639) | 0.004322347000000001s
Mongo::Error::OperationFailure: can't connect to new replica set master [REDACTED], err: couldn't connect to server REDACTED (REDACTED), connection attempt failed (13639)
  from /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-add8a77a48aa/lib/mongo/operation/result.rb:226:in `validate!'
  from /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-add8a77a48aa/lib/mongo/operation/executable.rb:36:in `block in execute'
  from /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-add8a77a48aa/lib/mongo/server/connection_pool.rb:111:in `with_connection'
```

While doing a stepdown of a primary, we got the same stack trace but the error was 

```
D, [2015-09-01T18:05:43.974336 #2194] DEBUG -- : MONGODB | REDACTED | staging.find | FAILED | error querying server (15988) | 0.0012782479999999998s
Mongo::Error::OperationFailure: error querying server (15988)
from /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-add8a77a48aa/lib/mongo/operation/result.rb:226:in `validate!'
```

This pull should fix these issues.