### PR TITLE
Delegate collections to the current database

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -36,8 +36,8 @@ module Mongo
     # @return [ Hash ] options The configuration options.
     attr_reader :options
 
-    # Delegate command execution to the current database.
-    def_delegators :@database, :command
+    # Delegate command and collections execution to the current database.
+    def_delegators :@database, :command, :collections
 
     # Delegate subscription to monitoring.
     def_delegators :@monitoring, :subscribe, :unsubscribe

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -742,4 +742,24 @@ describe Mongo::Client do
       expect(client.dup.options).to be_a(Mongo::Options::Redacted)
     end
   end
+
+  describe '#collections' do
+
+    before do
+      authorized_client.database[:users].create
+    end
+
+    after do
+      authorized_client.database[:users].drop
+    end
+
+    let(:collection) do
+      Mongo::Collection.new(authorized_client.database, 'users')
+    end
+
+    it 'refers the current database collections' do
+      expect(authorized_client.collections).to include(collection)
+      expect(authorized_client.collections).to all(be_a(Mongo::Collection))
+    end
+  end
 end


### PR DESCRIPTION
Hi,
I'd like to use `collections` as an instance method of `Mongo::Client`.
The use-case example is [here](https://github.com/padrino/padrino-framework/blob/592fd760619ba86af1c4de5fa0b3f5170c418ab1/padrino-gen/lib/padrino-gen/padrino-tasks/mongoid.rb#L6-L60).

Thanks.