### PR TITLE
Retry on mongos operation failures

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -151,6 +151,10 @@ module Mongo
     # @option options [ Logger ] :logger A custom logger if desired.
     # @option options [ true, false ] :truncate_logs Whether to truncate the
     #   logs at the default 250 characters.
+    # @option options [ Integer ] :max_read_retries The maximum number of read
+    #   retries on mongos query failures.
+    # @option options [ Float ] :read_retry_interval The interval, in seconds,
+    #   in which reads on a mongos are retried.
     #
     # @since 2.0.0
     def initialize(addresses_or_uri, options = Options::Redacted.new)

--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -25,6 +25,16 @@ module Mongo
     include Event::Subscriber
     include Loggable
 
+    # The default number of mongos read retries.
+    #
+    # @since 2.1.1
+    MAX_READ_RETRIES = 1
+
+    # The default mongos read retry interval, in seconds.
+    #
+    # @since 2.1.1
+    READ_RETRY_INTERVAL = 5
+
     # @return [ Hash ] The options hash.
     attr_reader :options
 
@@ -141,6 +151,32 @@ module Mongo
     # @since 2.0.0
     def elect_primary!(description)
       @topology = topology.elect_primary(description, servers_list)
+    end
+
+    # Get the maximum number of times the cluster can retry a read operation on
+    # a mongos.
+    #
+    # @example Get the max read retries.
+    #   cluster.max_read_retries
+    #
+    # @return [ Integer ] The maximum retries.
+    #
+    # @since 2.1.1
+    def max_read_retries
+      options[:max_read_retries] || MAX_READ_RETRIES
+    end
+
+    # Get the interval, in seconds, in which a mongos read operation is
+    # retried.
+    #
+    # @example Get the read retry interval.
+    #   cluster.read_retry_interval
+    #
+    # @return [ Float ] The interval.
+    #
+    # @since 2.1.1
+    def read_retry_interval
+      options[:read_retry_interval] || READ_RETRY_INTERVAL
     end
 
     # Notify the cluster that a standalone server was discovered so that the

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -33,7 +33,9 @@ module Mongo
         'no master',
         'not master',
         'connect failed',
-        'error querying'
+        'error querying',
+        'could not get last error',
+        'connection attempt failed'
       ].freeze
 
       # Can the operation that caused the error be retried?

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -18,6 +18,35 @@ module Mongo
     # Raised when an operation fails for some reason.
     #
     # @since 2.0.0
-    class OperationFailure < Error; end
+    class OperationFailure < Error
+
+      # These are magic error messages that could indicate a cluster
+      # reconfiguration behind a mongos. We cannot check error codes as they
+      # change between versions, for example 15988 which has 2 completely
+      # different meanings between 2.4 and 3.0.
+      #
+      # @since 2.1.1
+      RETRY_MESSAGES = [
+        'transport error',
+        'socket exception',
+        "can't connect",
+        'no master',
+        'not master',
+        'connect failed',
+        'error querying'
+      ].freeze
+
+      # Can the operation that caused the error be retried?
+      #
+      # @example Is the error retryable?
+      #   error.retryable?
+      #
+      # @return [ true, false ] If the error is retryable.
+      #
+      # @since 2.1.1
+      def retryable?
+        RETRY_MESSAGES.any?{ |m| message.include?(m) }
+      end
+    end
   end
 end

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -48,10 +48,10 @@ module Mongo
         retry_operation(&block)
       rescue Error::OperationFailure => e
         if cluster.sharded? && e.retryable?
-          if attempt < max_read_retries
+          if attempt < cluster.max_read_retries
             # We don't scan the cluster in this case as Mongos always returns
             # ready after a ping no matter what the state behind it is.
-            sleep(read_retry_interval)
+            sleep(cluster.read_retry_interval)
             read_with_retry(attempt - 1, &block)
           end
         else

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -50,7 +50,7 @@ module Mongo
         if cluster.sharded? && e.retryable?
           if attempt < max_read_retries
             # We don't scan the cluster in this case as Mongos always returns
-            # ready after a ping whether no matter what the state behind it is.
+            # ready after a ping no matter what the state behind it is.
             sleep(read_retry_interval)
             read_with_retry(attempt - 1, &block)
           end

--- a/spec/mongo/retryable_spec.rb
+++ b/spec/mongo/retryable_spec.rb
@@ -14,6 +14,14 @@ describe Mongo::Retryable do
         @cluster = cluster
       end
 
+      def max_read_retries
+        cluster.max_read_retries
+      end
+
+      def read_retry_interval
+        cluster.read_retry_interval
+      end
+
       def read
         read_with_retry do
           operation.execute
@@ -81,14 +89,80 @@ describe Mongo::Retryable do
 
     context 'when an operation failure occurs' do
 
-      before do
-        expect(operation).to receive(:execute).and_raise(Mongo::Error::OperationFailure).ordered
+      context 'when the cluster is not a mongos' do
+
+        before do
+          expect(operation).to receive(:execute).and_raise(Mongo::Error::OperationFailure).ordered
+          expect(cluster).to receive(:sharded?).and_return(false)
+        end
+
+        it 'raises an exception' do
+          expect {
+            retryable.read
+          }.to raise_error(Mongo::Error::OperationFailure)
+        end
       end
 
-      it 'raises an exception' do
-        expect {
-          retryable.read
-        }.to raise_error(Mongo::Error::OperationFailure)
+      context 'when the cluster is a mongos' do
+
+        context 'when the operation failure is not retryable' do
+
+          let(:error) do
+            Mongo::Error::OperationFailure.new('not authorized')
+          end
+
+          before do
+            expect(operation).to receive(:execute).and_raise(error).ordered
+            expect(cluster).to receive(:sharded?).and_return(true)
+          end
+
+          it 'raises the exception' do
+            expect {
+              retryable.read
+            }.to raise_error(Mongo::Error::OperationFailure)
+          end
+        end
+
+        context 'when the operation failure is retryable' do
+
+          let(:error) do
+            Mongo::Error::OperationFailure.new('no master')
+          end
+
+          context 'when the retry succeeds' do
+
+            before do
+              expect(operation).to receive(:execute).and_raise(error).ordered
+              expect(cluster).to receive(:sharded?).and_return(true)
+              expect(cluster).to receive(:max_read_retries).and_return(1).ordered
+              expect(cluster).to receive(:read_retry_interval).and_return(0.1).ordered
+              expect(operation).to receive(:execute).and_return(true).ordered
+            end
+
+            it 'returns the result' do
+              expect(retryable.read).to be true
+            end
+          end
+
+          context 'when the retry fails once and then succeeds' do
+
+            before do
+              expect(operation).to receive(:execute).and_raise(error).ordered
+              expect(cluster).to receive(:sharded?).and_return(true)
+              expect(cluster).to receive(:max_read_retries).and_return(1).ordered
+              expect(cluster).to receive(:read_retry_interval).and_return(0.1).ordered
+              expect(operation).to receive(:execute).and_raise(error).ordered
+              expect(cluster).to receive(:sharded?).and_return(true)
+              expect(cluster).to receive(:max_read_retries).and_return(1).ordered
+              expect(cluster).to receive(:read_retry_interval).and_return(0.1).ordered
+              expect(operation).to receive(:execute).and_return(true).ordered
+            end
+
+            it 'returns the result' do
+              expect(retryable.read).to be true
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
This adds additional read retry scenarios on `OperationFailure`s coming from a mongos only. This is because the `ping` that is executed against a running mongos always returns ready no matter what the state of the cluster behind it is, and the normal server selection/socket retry will not cover this scenario.

1. Adds a `max_read_retries` configuration option that is only applicable to sharded clusters when specific `OperationFailure`s are raised.
2. Adds a `read_retry_interval` configuration option to set the wait time between retries.

Note that we can only look at the error messages themselves, and not the codes. The codes have changed between server versions and some are not relevant to the same scenario anymore, such as the commented 15988 - which was previously an "error querying server" in mongos but in 3.0 is a "FieldPath field names may not be empty strings", which is not a retryable error.

We don't scan the cluster in these scenarios as the mongos is up and running, and the scan would be a waste of a network call do to the `ping` reasons stated above. 