### PR TITLE
max_read_retries and read_retry_interval are methods on Cluster.

### DIFF
--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -48,10 +48,10 @@ module Mongo
         retry_operation(&block)
       rescue Error::OperationFailure => e
         if cluster.sharded? && e.retryable?
-          if attempt < max_read_retries
+          if attempt < cluster.max_read_retries
             # We don't scan the cluster in this case as Mongos always returns
             # ready after a ping no matter what the state behind it is.
-            sleep(read_retry_interval)
+            sleep(cluster.read_retry_interval)
             read_with_retry(attempt - 1, &block)
           end
         else


### PR DESCRIPTION
Graceful stepdowns and `kill -9` of mongod primaries now work great in my setup, you just need to update this. :grin: 