### PR TITLE
RUBY-1049: reauthenticate and retry when receiving a 'not authorized'…

### DIFF
--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -38,6 +38,11 @@ module Mongo
         'connection attempt failed'
       ].freeze
 
+      UNAUTHORIZED_MESSAGES = [
+        'unauthorized',
+        'not authorized'
+      ].freeze
+
       # Can the operation that caused the error be retried?
       #
       # @example Is the error retryable?
@@ -48,6 +53,10 @@ module Mongo
       # @since 2.1.1
       def retryable?
         RETRY_MESSAGES.any?{ |m| message.include?(m) }
+      end
+
+      def unauthorized?
+        UNAUTHORIZED_MESSAGES.any?{ |m| message.include?(m) }
       end
     end
   end

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -48,10 +48,11 @@ module Mongo
         retry_operation(&block)
       rescue Error::OperationFailure => e
         if cluster.sharded? && (e.retryable? || e.unauthorized?)
-          if e.unauthorized?
-            cluster.servers.each {|server| server.context.with_connection {|conn| conn.authenticate! } }
-          end
           if attempt < cluster.max_read_retries
+            if e.unauthorized?
+              cluster.servers.each {|server| server.context.with_connection {|conn| conn.authenticate! } }
+            end
+
             # We don't scan the cluster in this case as Mongos always returns
             # ready after a ping no matter what the state behind it is.
             sleep(cluster.read_retry_interval)

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -57,6 +57,8 @@ module Mongo
             # ready after a ping no matter what the state behind it is.
             sleep(cluster.read_retry_interval)
             read_with_retry(attempt - 1, &block)
+          else
+            raise e
           end
         else
           raise e

--- a/lib/mongo/server/connection.rb
+++ b/lib/mongo/server/connection.rb
@@ -76,12 +76,22 @@ module Mongo
         unless socket
           @socket = address.socket(timeout, ssl_options)
           socket.connect!
-          if authenticator
-            authenticator.login(self)
-            @authenticated = true
-          end
+          authenticate!
         end
         true
+      end
+
+      # If there is an authentication mechanism in place, attempt to log in
+      #
+      # @example Authenticate or reauthenticate the connection
+      #   connection.authenticate!
+      #
+      # @since 2.2.0
+      def authenticate!
+        if authenticator
+          authenticator.login(self)
+          @authenticated = true
+        end
       end
 
       # Disconnect the connection.


### PR DESCRIPTION
… or 'unauthorized' response from MongoDB.