### PR TITLE
Only retry max_read_retries times, not infinitely.

### DIFF
--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -52,7 +52,7 @@ module Mongo
             # We don't scan the cluster in this case as Mongos always returns
             # ready after a ping no matter what the state behind it is.
             sleep(cluster.read_retry_interval)
-            read_with_retry(attempt - 1, &block)
+            read_with_retry(attempt + 1, &block)
           end
         else
           raise e

--- a/spec/mongo/retryable_spec.rb
+++ b/spec/mongo/retryable_spec.rb
@@ -149,11 +149,11 @@ describe Mongo::Retryable do
             before do
               expect(operation).to receive(:execute).and_raise(error).ordered
               expect(cluster).to receive(:sharded?).and_return(true)
-              expect(cluster).to receive(:max_read_retries).and_return(1).ordered
+              expect(cluster).to receive(:max_read_retries).and_return(2).ordered
               expect(cluster).to receive(:read_retry_interval).and_return(0.1).ordered
               expect(operation).to receive(:execute).and_raise(error).ordered
               expect(cluster).to receive(:sharded?).and_return(true)
-              expect(cluster).to receive(:max_read_retries).and_return(1).ordered
+              expect(cluster).to receive(:max_read_retries).and_return(2).ordered
               expect(cluster).to receive(:read_retry_interval).and_return(0.1).ordered
               expect(operation).to receive(:execute).and_return(true).ordered
             end


### PR DESCRIPTION
@durran quick logic fix for https://github.com/mongodb/mongo-ruby-driver/pull/692.