### PR TITLE
Bring Socket::SSL#readbyte in line with Socket / IO#readbyte

### DIFF
--- a/lib/mongo/socket/ssl.rb
+++ b/lib/mongo/socket/ssl.rb
@@ -93,7 +93,10 @@ module Mongo
       #
       # @since 2.0.0
       def readbyte
-        handle_errors { socket.read(1) }
+        handle_errors do
+          byte = socket.read(1).bytes[0]
+          byte.nil? ? raise(EOFError) : byte
+        end
       end
 
       private

--- a/spec/mongo/socket/ssl_spec.rb
+++ b/spec/mongo/socket/ssl_spec.rb
@@ -1,24 +1,23 @@
 require 'spec_helper'
 
-describe Mongo::Socket::SSL do
+describe Mongo::Socket::SSL, if: running_ssl? do
 
-  describe '#connect!', if: running_ssl? do
+  let(:socket) do
+    described_class.new(*DEFAULT_ADDRESS.split(":"), DEFAULT_ADDRESS.split(":")[0], 5, Socket::PF_INET, options)
+  end
 
-    let(:socket) do
-      described_class.new(*DEFAULT_ADDRESS.split(":"), DEFAULT_ADDRESS.split(":")[0], 5, Socket::PF_INET, options)
-    end
+  let(:options) do
+    {
+      :ssl => true,
+      :ssl_cert => CLIENT_PEM,
+      :ssl_key => CLIENT_PEM,
+      :ssl_verify => false
+    }
+  end
+
+  describe '#connect!' do
 
     context 'when a certificate is provided' do
-
-      let(:options) do
-        {
-            :ssl => true,
-            :ssl_cert => CLIENT_PEM,
-            :ssl_key => CLIENT_PEM,
-            :ssl_verify => false
-        }
-      end
-
 
       context 'when connecting the tcp socket is successful' do
 
@@ -55,12 +54,9 @@ describe Mongo::Socket::SSL do
     context 'when a bad certificate is provided' do
 
       let(:options) do
-        {
-            :ssl => true,
-            :ssl_cert => CLIENT_PEM,
-            :ssl_key => CRL_PEM,
-            :ssl_verify => false
-        }
+        super().merge({
+          :ssl_key => CRL_PEM
+        })
       end
 
       it 'raises an exception' do
@@ -73,13 +69,10 @@ describe Mongo::Socket::SSL do
     context 'when a CA certificate is provided', if: testing_ssl_locally? do
 
       let(:options) do
-        {
-            :ssl => true,
-            :ssl_cert => CLIENT_PEM,
-            :ssl_key => CLIENT_PEM,
-            :ssl_ca_cert => CA_PEM,
-            :ssl_verify => true
-        }
+        super().merge({
+          :ssl_ca_cert => CA_PEM,
+          :ssl_verify => true
+        })
       end
 
       before do
@@ -94,12 +87,9 @@ describe Mongo::Socket::SSL do
     context 'when a CA certificate is not provided', if: testing_ssl_locally? do
 
       let(:options) do
-        {
-            :ssl => true,
-            :ssl_cert => CLIENT_PEM,
-            :ssl_key => CLIENT_PEM,
-            :ssl_verify => true
-        }
+        super().merge({
+          :ssl_verify => true
+        })
       end
 
       before do
@@ -115,12 +105,9 @@ describe Mongo::Socket::SSL do
     context 'when ssl_verify is not specified', if: testing_ssl_locally? do
 
       let(:options) do
-        {
-            :ssl => true,
-            :ssl_cert => CLIENT_PEM,
-            :ssl_key => CLIENT_PEM,
-            :ssl_ca_cert => CA_PEM
-        }
+        super().merge({
+          :ssl_ca_cert => CA_PEM
+        }).tap { |options| options.delete(:ssl_verify) }
       end
 
       before do
@@ -135,13 +122,10 @@ describe Mongo::Socket::SSL do
     context 'when ssl_verify is true', if: testing_ssl_locally? do
 
       let(:options) do
-        {
-            :ssl => true,
-            :ssl_cert => CLIENT_PEM,
-            :ssl_key => CLIENT_PEM,
-            :ssl_ca_cert => CA_PEM,
-            :ssl_verify => true
-        }
+        super().merge({
+          :ssl_ca_cert => CA_PEM,
+          :ssl_verify => true
+        })
       end
 
       before do
@@ -156,13 +140,10 @@ describe Mongo::Socket::SSL do
     context 'when ssl_verify is false' do
 
       let(:options) do
-        {
-            :ssl => true,
-            :ssl_cert => CLIENT_PEM,
-            :ssl_key => CLIENT_PEM,
-            :ssl_ca_cert => 'invalid',
-            :ssl_verify => false
-        }
+        super().merge({
+          :ssl_ca_cert => 'invalid',
+          :ssl_verify => false
+        })
       end
 
       before do

--- a/spec/mongo/socket/ssl_spec.rb
+++ b/spec/mongo/socket/ssl_spec.rb
@@ -155,4 +155,43 @@ describe Mongo::Socket::SSL, if: running_ssl? do
       end
     end
   end
+
+  describe '#readbyte' do
+
+    before do
+      allow_message_expectations_on_nil
+
+      allow(socket.socket).to receive(:read) do |length|
+        socket_content[0, length]
+      end
+    end
+
+    context 'with the socket providing "abc"' do
+
+      let(:socket_content) { "abc" }
+
+      it 'should return 97 (the byte for "a")' do
+        expect(socket.readbyte).to eq(97)
+      end
+    end
+
+    context 'with the socket providing "\x00" (NULL_BYTE)' do
+
+      let(:socket_content) { "\x00" }
+
+      it 'should return 0' do
+        expect(socket.readbyte).to eq(0)
+      end
+    end
+
+    context 'with the socket providing no data' do
+
+      let(:socket_content) { "" }
+
+      it 'should raise EOFError' do
+        expect { socket.readbyte }
+          .to raise_error(Mongo::Error::SocketError).with_message("EOFError")
+      end
+    end
+  end
 end


### PR DESCRIPTION
[IO#readbyte](http://docs.rubydocs.org/ruby-2-2-3/Ruby%202.2.3/classes/IO.html#method-i-readbyte) – and thus [Mongo::Socket#readbyte](https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/socket.rb#L143) – behave as follows:

1. Return the next 8-bit byte (0..255) as an Integer if data is present.
2. Raise EOFError if EOF was reached before then.

[Mongo::Socket::SSL overrides this](https://github.com/mongodb/mongo-ruby-driver/blob/master/lib/mongo/socket/ssl.rb#L95) to simply call [OpenSSL::Buffering](http://docs.rubydocs.org/ruby-2-2-3/Ruby%202.2.3/classes/OpenSSL/Buffering.html#method-i-read) resp. [IO#read](http://docs.rubydocs.org/ruby-2-2-3/Ruby%202.2.3/classes/IO.html#method-i-read) which behave markedly different:

1. Return the String representation of the first 8-bit byte if data is present.
2. Return `nil` if EOF was reached before then.

This patch brings Mongo::Socker::SSL#readbyte in line with IO#readbyte thus unifying #readbyte behaviour across all socket types in this driver.

The difference in behaviour between SSL and non-SSL connections led to bugs such as https://jira.mongodb.org/browse/RUBY-1048. Also see https://github.com/mongodb/bson-ruby/pull/44 for a previous workaround for a specific edge-case. This patch however fixes the root cause.