### PR TITLE
Fix RUBY-1051: fails if exists a toplevel Result class

### DIFF
--- a/lib/mongo/operation/executable.rb
+++ b/lib/mongo/operation/executable.rb
@@ -32,7 +32,7 @@ module Mongo
       # @since 2.0.0
       def execute(context)
         context.with_connection do |connection|
-          result_class = defined?(self.class::Result) ? self.class::Result : Result
+          result_class = self.class.const_defined?(:Result, false) ? self.class::Result : Result
           result_class.new(connection.dispatch([ message(context) ], operation_id)).validate!
         end
       end


### PR DESCRIPTION
By using const_defined? instead of defined, we can restrict the searching for Result class under current namespace.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mongodb/mongo-ruby-driver/703)
<!-- Reviewable:end -->
