### PR TITLE
Remove Rubyforge project from gemspec

### DIFF
--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -4,7 +4,6 @@ require 'mongo/version'
 
 Gem::Specification.new do |s|
   s.name              = 'mongo'
-  s.rubyforge_project = 'mongo'
   s.version           = Mongo::VERSION
   s.platform          = Gem::Platform::RUBY
 


### PR DESCRIPTION
Rubyforge isn't used anymore, it has been replaced by Rubygems.org