### PR TITLE
RUBY-1037 - Support sending write concern to findAndModify commands

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -507,6 +507,8 @@ module Mongo
     # @option options [ Hash ] :projection The fields to include or exclude in the returned doc.
     # @option options [ Hash ] :sort The key and direction pairs by which the result set
     #   will be sorted.
+    # @option options [ Hash ] :write_concern The write concern options.
+    #   Defaults to the collection's write concern.
     #
     # @return [ BSON::Document, nil ] The document, if found.
     #
@@ -537,6 +539,8 @@ module Mongo
     # @option options [ true, false ] :upsert Whether to upsert if the document doesn't exist.
     # @option options [ true, false ] :bypass_document_validation Whether or
     #   not to skip document level validation.
+    # @option options [ Hash ] :write_concern The write concern options.
+    #   Defaults to the collection's write concern.
     #
     # @return [ BSON::Document ] The document.
     #
@@ -567,6 +571,8 @@ module Mongo
     # @option options [ true, false ] :upsert Whether to upsert if the document doesn't exist.
     # @option options [ true, false ] :bypass_document_validation Whether or
     #   not to skip document level validation.
+    # @option options [ Hash ] :write_concern The write concern options.
+    #   Defaults to the collection's write concern.
     #
     # @return [ BSON::Document ] The document.
     #

--- a/lib/mongo/collection/view/writable.rb
+++ b/lib/mongo/collection/view/writable.rb
@@ -35,6 +35,7 @@ module Mongo
           cmd[:fields] = projection if projection
           cmd[:sort] = sort if sort
           cmd[:maxTimeMS] = max_time_ms if max_time_ms
+          cmd[:writeConcern] = options[:write_concern] || collection.write_concern.options
           write_with_retry do
             database.command(cmd).first['value']
           end
@@ -55,6 +56,8 @@ module Mongo
         # @option opts [ true, false ] :upsert Whether to upsert if the document doesn't exist.
         # @option opts [ true, false ] :bypass_document_validation Whether or
         #   not to skip document level validation.
+        # @option options [ Hash ] :write_concern The write concern options.
+        #   Defaults to the collection's write concern.
         #
         # @return [ BSON::Document ] The document.
         #
@@ -75,6 +78,8 @@ module Mongo
         # @option opts [ true, false ] :upsert Whether to upsert if the document doesn't exist.
         # @option opts [ true, false ] :bypass_document_validation Whether or
         #   not to skip document level validation.
+        # @option options [ Hash ] :write_concern The write concern options.
+        #   Defaults to the collection's write concern.
         #
         # @return [ BSON::Document ] The document.
         #
@@ -88,6 +93,7 @@ module Mongo
           cmd[:upsert] = opts[:upsert] if opts[:upsert]
           cmd[:maxTimeMS] = max_time_ms if max_time_ms
           cmd[:bypassDocumentValidation] = !!opts[:bypass_document_validation]
+          cmd[:writeConcern] = opts[:write_concern] || collection.write_concern.options
           write_with_retry do
             value = database.command(cmd).first['value']
             value unless value.nil? || value.empty?

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -1710,6 +1710,16 @@ describe Mongo::Collection do
         }.to raise_exception(Mongo::Error::OperationFailure)
       end
     end
+
+    context 'when write_concern is provided', if: find_command_enabled? && standalone? do
+
+      it 'uses the write concern' do
+        expect {
+          authorized_collection.find_one_and_delete(selector,
+                                                    write_concern: { w: 2 })
+        }.to raise_error(Mongo::Error::OperationFailure)
+      end
+    end
   end
 
   describe '#find_one_and_update' do
@@ -1918,6 +1928,16 @@ describe Mongo::Collection do
         end
       end
     end
+
+    context 'when write_concern is provided', if: find_command_enabled? && standalone? do
+
+      it 'uses the write concern' do
+        expect {
+          authorized_collection.find_one_and_delete(selector,
+                                                    write_concern: { w: 2 })
+        }.to raise_error(Mongo::Error::OperationFailure)
+      end
+    end
   end
 
   describe '#find_one_and_replace' do
@@ -2098,6 +2118,16 @@ describe Mongo::Collection do
             expect(result3[:a]).to be_nil
           end
         end
+      end
+    end
+
+    context 'when write_concern is provided', if: find_command_enabled? && standalone? do
+
+      it 'uses the write concern' do
+        expect {
+          authorized_collection.find_one_and_delete(selector,
+                                                    write_concern: { w: 2 })
+        }.to raise_error(Mongo::Error::OperationFailure)
       end
     end
   end


### PR DESCRIPTION
- Added write_concern option to find_one_and_delete, find_one_and_replace, find_one_and_update.