### PR TITLE
RUBY-1064: Add maxAwaitTimeMS

### DIFF
--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -388,6 +388,21 @@ module Mongo
           new(options.merge(Builder::Modifiers.map_driver_options(doc)))
         end
 
+        # A cumulative time limit in milliseconds for processing get more operations
+        # on a cursor.
+        #
+        # @example Set the max await time ms value.
+        #   view.max_await_time_ms(500)
+        #
+        # @param [ Integer ] max The max time in milliseconds.
+        #
+        # @return [ Integer, View ] Either the max await time ms value or a new +View+.
+        #
+        # @since 2.1.0
+        def max_await_time_ms(max = nil)
+          configure(:max_await_time_ms, max)
+        end
+
         # A cumulative time limit in milliseconds for processing operations on a cursor.
         #
         # @example Set the max time ms value.

--- a/lib/mongo/cursor/builder/get_more_command.rb
+++ b/lib/mongo/cursor/builder/get_more_command.rb
@@ -56,10 +56,11 @@ module Mongo
         def get_more_command
           command = { :getMore => cursor.id, :collection => collection_name }
           command[:batchSize] = batch_size if batch_size
-          # @see http://bit.ly/1OY26LL on this behaviour.
-          if view.respond_to?(:max_time_ms)
-            if (max_time_ms = view.max_time_ms) && view.options[:await_data]
-              command[:maxTimeMS] = max_time_ms
+          # If the max_await_time_ms option is set, then we set maxTimeMS on
+          # the get more command.
+          if view.respond_to?(:max_await_time_ms)
+            if view.max_await_time_ms && view.options[:await_data]
+              command[:maxTimeMS] = view.max_await_time_ms
             end
           end
           command

--- a/spec/mongo/cursor/builder/get_more_command_spec.rb
+++ b/spec/mongo/cursor/builder/get_more_command_spec.rb
@@ -77,18 +77,22 @@ describe Mongo::Cursor::Builder::GetMoreCommand do
       end
     end
 
-    context 'when a max time is specified' do
+    context 'when a max await time is specified' do
 
       context 'when the cursor is not tailable' do
 
         let(:view) do
-          Mongo::Collection::View.new(authorized_collection, {}, max_time_ms: 100)
+          Mongo::Collection::View.new(authorized_collection, {}, max_await_time_ms: 100)
         end
 
         it_behaves_like 'a getmore command builder'
 
         it 'does not include max time' do
           expect(selector[:maxTimeMS]).to be_nil
+        end
+
+        it 'does not include max await time' do
+          expect(selector[:maxAwaitTimeMS]).to be_nil
         end
 
         it 'does not include batch size' do
@@ -106,14 +110,18 @@ describe Mongo::Cursor::Builder::GetMoreCommand do
               {},
               await_data: true,
               tailable: true,
-              max_time_ms: 100
+              max_await_time_ms: 100
             )
           end
 
           it_behaves_like 'a getmore command builder'
 
-          it 'includes max time' do
+          it 'does not include max time' do
             expect(selector[:maxTimeMS]).to eq(100)
+          end
+
+          it 'includes max await time' do
+            expect(selector[:maxAwaitTimeMS]).to be_nil
           end
 
           it 'does not include batch size' do
@@ -128,7 +136,7 @@ describe Mongo::Cursor::Builder::GetMoreCommand do
               authorized_collection,
               {},
               tailable: true,
-              max_time_ms: 100
+              max_await_time_ms: 100
             )
           end
 
@@ -136,6 +144,10 @@ describe Mongo::Cursor::Builder::GetMoreCommand do
 
           it 'does not include max time' do
             expect(selector[:maxTimeMS]).to be_nil
+          end
+
+          it 'does not include max await time' do
+            expect(selector[:maxAwaitTimeMS]).to be_nil
           end
 
           it 'does not include batch size' do

--- a/spec/mongo/cursor/builder/get_more_command_spec.rb
+++ b/spec/mongo/cursor/builder/get_more_command_spec.rb
@@ -116,11 +116,11 @@ describe Mongo::Cursor::Builder::GetMoreCommand do
 
           it_behaves_like 'a getmore command builder'
 
-          it 'does not include max time' do
+          it 'includes max time' do
             expect(selector[:maxTimeMS]).to eq(100)
           end
 
-          it 'includes max await time' do
+          it 'does not include max await time' do
             expect(selector[:maxAwaitTimeMS]).to be_nil
           end
 


### PR DESCRIPTION
- Add the ability to add the option in the view fluid interface.
- Adds maxTimeMS to the getmore command is maxAwaitTimeMS is set as an
  option.
- Ignores the option in all other cases.