### PR TITLE
RUBY-1066 Don't override previously-defined Hash#assert_valid_keys

### DIFF
--- a/lib/mongo/utils/core_ext.rb
+++ b/lib/mongo/utils/core_ext.rb
@@ -30,7 +30,7 @@ class Hash
   def assert_valid_keys(*valid_keys)
     unknown_keys = keys - [valid_keys].flatten
     raise(ArgumentError, "Unknown key(s): #{unknown_keys.join(", ")}") unless unknown_keys.empty?
-  end
+  end unless instance_methods.include?(:assert_valid_keys)
 
 end
 


### PR DESCRIPTION
Don't override ActiveSupport assert_valid_keys if defined

See https://jira.mongodb.org/browse/RUBY-1066