### PR TITLE
Adds a spec that tests for broken projections.

### DIFF
--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -600,6 +600,11 @@ describe Mongo::Collection::View::Readable do
       it 'returns a new View' do
         expect(view.projection(new_projection)).not_to be(view)
       end
+
+      it 'returns only that field on the collection' do
+        authorized_collection.insert_one({v: 'value', a: 'other_value'})
+        view.projection(new_projection).first.keys.should =~ ['_id', 'v']
+      end
     end
 
     context 'when projection is not specified' do


### PR DESCRIPTION
`projection`s are broken on HEAD. I couldn't immediately trace why, but this adds a test which is red. All fields get returned even if you specify a projection.

```
2.2.1 :014 > MyModel.collection.find({:foo => "bar"}).projection(:_id => 1, :x => 1).first
D, [2015-11-09T15:15:10.061515 #8222] DEBUG -- : MONGODB | 127.0.0.1:27017 | development.find | STARTED | {"find"=>"my_models", "filter"=>{"foo"=>"bar"}}
D, [2015-11-09T15:15:10.062543 #8222] DEBUG -- : MONGODB | 127.0.0.1:27017 | development.find | SUCCEEDED | 0.000931s
```