### PR TITLE
Don't ping in server selection on reads:

### DIFF
--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -131,11 +131,13 @@ module Mongo
     # @example Get the next primary server.
     #   cluster.next_primary
     #
+    # @param [ true, false ] ping Whether to ping the server before selection.
+    #
     # @return [ Mongo::Server ] A primary server.
     #
     # @since 2.0.0
-    def next_primary
-      ServerSelector.get(ServerSelector::PRIMARY.merge(options)).select_server(self)
+    def next_primary(ping = true)
+      ServerSelector.get(ServerSelector::PRIMARY.merge(options)).select_server(self, ping)
     end
 
     # Elect a primary server from the description that has just changed to a

--- a/lib/mongo/collection/view/aggregation.rb
+++ b/lib/mongo/collection/view/aggregation.rb
@@ -113,7 +113,7 @@ module Mongo
         def send_initial_query(server)
           unless valid_server?(server)
             log_warn(REROUTE)
-            server = cluster.next_primary
+            server = cluster.next_primary(false)
           end
           initial_query_op.execute(server.context)
         end

--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -37,7 +37,7 @@ module Mongo
         def each
           @cursor = nil
           read_with_retry do
-            server = read.select_server(cluster)
+            server = read.select_server(cluster, false)
             result = send_initial_query(server)
             @cursor = Cursor.new(view, result, server)
           end

--- a/lib/mongo/collection/view/map_reduce.rb
+++ b/lib/mongo/collection/view/map_reduce.rb
@@ -67,7 +67,7 @@ module Mongo
         def each
           @cursor = nil
           write_with_retry do
-            server = read.select_server(cluster)
+            server = read.select_server(cluster, false)
             result = send_initial_query(server)
             @cursor = Cursor.new(view, result, server)
           end
@@ -209,7 +209,7 @@ module Mongo
         def send_initial_query(server)
           unless valid_server?(server)
             log_warn(REROUTE)
-            server = cluster.next_primary
+            server = cluster.next_primary(false)
           end
           result = initial_query_op.execute(server.context)
           inline? ? result : send_fetch_query(server)

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -424,7 +424,7 @@ module Mongo
         end
 
         def parallel_scan(cursor_count)
-          server = read.select_server(cluster)
+          server = read.select_server(cluster, false)
           Operation::Commands::ParallelScan.new(
             :coll_name => collection.name,
             :db_name => database.name,

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -149,7 +149,7 @@ module Mongo
     # @return [ Hash ] The result of the command execution.
     def command(operation, opts = {})
       preference = ServerSelector.get(client.options.merge(opts[:read])) if opts[:read]
-      server = preference ? preference.select_server(cluster) : cluster.next_primary
+      server = preference ? preference.select_server(cluster, false) : cluster.next_primary(false)
       Operation::Commands::Command.new({
         :selector => operation,
         :db_name => name,

--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -50,7 +50,7 @@ module Mongo
       # @since 2.0.0
       def collection_names(options = {})
         @batch_size = options[:batch_size]
-        server = next_primary
+        server = next_primary(false)
         @limit = -1 if server.features.list_collections_enabled?
         collections_info(server).collect do |info|
           if server.features.list_collections_enabled?
@@ -71,7 +71,7 @@ module Mongo
       #
       # @since 2.0.5
       def list_collections
-        collections_info(next_primary)
+        collections_info(next_primary(false))
       end
 
       # Create the new database view.

--- a/lib/mongo/index/view.rb
+++ b/lib/mongo/index/view.rb
@@ -182,7 +182,7 @@ module Mongo
       #
       # @since 2.0.0
       def each(&block)
-        server = next_primary
+        server = next_primary(false)
         cursor = Cursor.new(self, send_initial_query(server), server).to_enum
         cursor.each do |doc|
           yield doc

--- a/lib/mongo/server_selector/selectable.rb
+++ b/lib/mongo/server_selector/selectable.rb
@@ -90,13 +90,17 @@ module Mongo
       # @return [ Mongo::Server ] A server matching the server preference.
       #
       # @since 2.0.0
-      def select_server(cluster)
+      def select_server(cluster, ping = true)
         deadline = Time.now + server_selection_timeout
         while (deadline - Time.now) > 0
           servers = candidates(cluster)
           if servers && !servers.compact.empty?
             server = servers.first
-            return server if server.connectable?
+            if ping
+              return server if server.connectable?
+            else
+              return server
+            end
           end
           cluster.scan!
         end


### PR DESCRIPTION
- The retryable module code will handle the socket exceptions so there
  is no need for the overhead to ping before a read.