### PR TITLE
Proof of concept to have a connection pool per host/port pair. RUBY-1073

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -52,6 +52,7 @@ module Mongo
       :replica_set,
       :server_selection_timeout,
       :socket_timeout,
+      :share_connection,
       :ssl,
       :ssl_ca_cert,
       :ssl_cert,

--- a/lib/mongo/server/connection.rb
+++ b/lib/mongo/server/connection.rb
@@ -38,28 +38,13 @@ module Mongo
       # @since 2.1.0
       PING_BYTES = PING_MESSAGE.serialize.to_s.freeze
 
-      # @return [ Mongo::Auth::CR, Mongo::Auth::X509, Mongo::Auth:LDAP, Mongo::Auth::SCRAM ]
-      #   authenticator The authentication strategy.
-      attr_reader :authenticator
+      attr_reader :authentication_by_db
 
       def_delegators :@server,
                      :features,
                      :max_bson_object_size,
                      :max_message_size,
                      :mongos?
-
-      # Is this connection authenticated. Will return true if authorization
-      # details were provided and authentication passed.
-      #
-      # @example Is the connection authenticated?
-      #   connection.authenticated?
-      #
-      # @return [ true, false ] If the connection is authenticated.
-      #
-      # @since 2.0.0
-      def authenticated?
-        !!@authenticated
-      end
 
       # Tell the underlying socket to establish a connection to the host.
       #
@@ -76,12 +61,17 @@ module Mongo
         unless socket
           @socket = address.socket(timeout, ssl_options)
           socket.connect!
-          if authenticator
-            authenticator.login(self)
-            @authenticated = true
-          end
+          authenticate!
         end
         true
+      end
+
+      def authenticate!(opts = nil)
+        setup_authentication!(opts)
+        if @authenticator
+          @authenticator.login(self)
+          @authentication_by_db[@authenticator.user.database] = true
+        end
       end
 
       # Disconnect the connection.
@@ -100,6 +90,7 @@ module Mongo
           socket.close
           @socket = nil
           @authenticated = false
+          @authentication_by_db = {}
         end
         true
       end
@@ -151,7 +142,7 @@ module Mongo
         @ssl_options = options.reject { |k, v| !k.to_s.start_with?(SSL) }
         @socket = nil
         @pid = Process.pid
-        setup_authentication!
+        @authentication_by_db = {}
       end
 
       # Ping the connection to see if the server is responding to commands.
@@ -180,10 +171,11 @@ module Mongo
         messages.last.replyable? ? read : nil
       end
 
-      def setup_authentication!
-        if options[:user]
+      def setup_authentication!(opts = nil)
+        opts ||= options
+        if opts[:user]
           default_mechanism = @server.features.scram_sha_1_enabled? ? :scram : :mongodb_cr
-          user = Auth::User.new(Options::Redacted.new(:auth_mech => default_mechanism).merge(options))
+          user = Auth::User.new(Options::Redacted.new(:auth_mech => default_mechanism).merge(opts))
           @authenticator = Auth.get(user)
         end
       end

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -132,7 +132,7 @@ module Mongo
         # @since 2.0.0
         def get(server)
           MUTEX.synchronize do
-            pools[server.address] ||= create_pool(server)
+            pools[server.address.to_s] ||= create_pool(server)
           end
         end
 

--- a/lib/mongo/server/context.rb
+++ b/lib/mongo/server/context.rb
@@ -61,7 +61,7 @@ module Mongo
       # @since 2.0.0
       def with_connection(&block)
         server.pool.with_connection do |conn|
-          unless conn.authentication_by_db[server.options[:database]]
+          if server.cluster.share_connection? && !conn.authentication_by_db[server.options[:database]]
             conn.authenticate!(server.options)
           end
           block.call(conn)

--- a/lib/mongo/server/context.rb
+++ b/lib/mongo/server/context.rb
@@ -60,7 +60,12 @@ module Mongo
       #
       # @since 2.0.0
       def with_connection(&block)
-        server.pool.with_connection(&block)
+        server.pool.with_connection do |conn|
+          unless conn.authentication_by_db[server.options[:database]]
+            conn.authenticate!(server.options)
+          end
+          block.call(conn)
+        end
       end
     end
   end

--- a/lib/mongo/shared_connection_pool.rb
+++ b/lib/mongo/shared_connection_pool.rb
@@ -1,0 +1,12 @@
+module Mongo
+  class SharedConnectionPool
+    MUTEX = Mutex.new
+    @pools = {}
+
+    def get(server)
+      MUTEX.synchronize do
+        pools[server.address] ||= Server::ConnectionPool.get(server)
+      end
+    end
+  end
+end

--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -378,6 +378,7 @@ module Mongo
     uri_option 'minpoolsize', :min_pool_size
     uri_option 'maxpoolsize', :max_pool_size
     uri_option 'waitqueuetimeoutms', :wait_queue_timeout, :type => :ms_convert
+    uri_option 'shareconnection', :share_connection
 
     # Security Options
     uri_option 'ssl', :ssl

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -142,7 +142,7 @@ describe Mongo::Server::Connection do
         end
 
         it 'sets the connection as authenticated' do
-          expect(connection).to be_authenticated
+          expect(connection.authentication_by_db[TEST_DB]).to eql(true)
         end
       end
     end
@@ -435,7 +435,9 @@ describe Mongo::Server::Connection do
       end
 
       it 'sets the authentication strategy for the connection' do
-        expect(connection.authenticator.user).to eq(user)
+        allow_any_instance_of(Mongo::Auth::CR).to receive(:login)
+        connection.connect!
+        expect(connection.instance_variable_get(:@authenticator).user).to eq(user)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,10 @@ RSpec.configure do |config|
   config.formatter = 'documentation'
   config.include(Authorization)
 
+  config.before(:each) do
+    Mongo::Server::ConnectionPool.instance_variable_set(:@pools, {})
+  end
+
   config.before(:suite) do
 
     begin

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,7 @@ require 'support/crud'
 require 'support/command_monitoring'
 require 'support/connection_string'
 require 'support/gridfs'
+require 'mongo/shared_connection_pool'
 
 RSpec.configure do |config|
   config.color     = true
@@ -38,7 +39,7 @@ RSpec.configure do |config|
   config.include(Authorization)
 
   config.before(:each) do
-    Mongo::Server::ConnectionPool.instance_variable_set(:@pools, {})
+    Mongo::SharedConnectionPool.instance_variable_set(:@pools, {})
   end
 
   config.before(:suite) do


### PR DESCRIPTION
Hey @estolfo, take a look at this. I tested it out in our staging environment and it cut down the connections to 1 per cluster host instead of 1 per database. I also did some basic tests on a production box and it worked great there as well.

This is a bit messy in terms of how it works because the authentication is stored in the `Connection` instead of injected in, so I had to add that. Also, when I run all the specs, I get a failure in this test, but if I run the entire file or spec itself, it passes. My guess is that there's some sort of state leakage now between the test run or something via `ConnectionPool.pools`, but I don't know much about that part of the code.

```
  1) Mongo::Grid::FSBucket when a read stream is opened #open_download_stream_by_name when a block is provided when revision is 0 returns the original stored file
     Failure/Error: expect(io.string).to eq('hello 1')

       expected: "hello 1"
            got: "hello 2"

       (compared using ==)
     # ./spec/mongo/grid/fs_bucket_spec.rb:741:in `block (6 levels) in <top (required)>'
```