### PR TITLE
Stop monitor on server garbage collection.

### DIFF
--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -63,6 +63,10 @@ module Mongo
       host == other.host && port == other.port
     end
 
+    def eql?(other)
+      self == other
+    end
+
     # Calculate the hash value for the address.
     #
     # @example Calculate the hash value.

--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -63,6 +63,16 @@ module Mongo
       host == other.host && port == other.port
     end
 
+    # Check equality for hashing.
+    #
+    # @example Check hashing equality.
+    #   address.eql?(other)
+    #
+    # @param [ Object ] other The other object.
+    #
+    # @return [ true, false ] If the objects are equal.
+    #
+    # @since 2.2.0
     def eql?(other)
       self == other
     end

--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -106,6 +106,7 @@ module Mongo
       @options = options.freeze
       @topology = Topology.initial(seeds, options)
       @update_lock = Mutex.new
+      @pool_lock = Mutex.new
 
       subscribe_to(Event::STANDALONE_DISCOVERED, Event::StandaloneDiscovered.new(self))
       subscribe_to(Event::DESCRIPTION_CHANGED, Event::DescriptionChanged.new(self))
@@ -166,6 +167,22 @@ module Mongo
     # @since 2.1.1
     def max_read_retries
       options[:max_read_retries] || MAX_READ_RETRIES
+    end
+
+    # Get the scoped connection pool for the server.
+    #
+    # @example Get the connection pool.
+    #   cluster.pool(server)
+    #
+    # @param [ Server ] server The server.
+    #
+    # @return [ Server::ConnectionPool ] The connection pool.
+    #
+    # @since 2.2.0
+    def pool(server)
+      @pool_lock.synchronize do
+        pools[server.address] ||= Server::ConnectionPool.get(server)
+      end
     end
 
     # Get the interval, in seconds, in which a mongos read operation is
@@ -337,6 +354,10 @@ module Mongo
 
     def addition_allowed?(address)
       !@topology.single? || direct_connection?(address)
+    end
+
+    def pools
+      @pools ||= {}
     end
 
     def servers_list

--- a/lib/mongo/server.rb
+++ b/lib/mongo/server.rb
@@ -27,7 +27,6 @@ module Mongo
   # @since 2.0.0
   class Server
     extend Forwardable
-    include Loggable
 
     # @return [ String ] The configured address for the server.
     attr_reader :address

--- a/lib/mongo/server.rb
+++ b/lib/mongo/server.rb
@@ -182,7 +182,7 @@ module Mongo
     #
     # @since 2.0.0
     def pool
-      @pool ||= ConnectionPool.get(self)
+      @pool ||= cluster.pool(self)
     end
 
     # Determine if the provided tags are a subset of the server's tags.

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -23,9 +23,6 @@ module Mongo
     class ConnectionPool
       include Loggable
 
-      # Used for synchronization of pools access.
-      MUTEX = Mutex.new
-
       # @return [ Hash ] options The pool options.
       attr_reader :options
 
@@ -131,21 +128,9 @@ module Mongo
         #
         # @since 2.0.0
         def get(server)
-          MUTEX.synchronize do
-            pools[server.address] ||= create_pool(server)
-          end
-        end
-
-        private
-
-        def create_pool(server)
           ConnectionPool.new(server.options) do
             Connection.new(server, server.options)
           end
-        end
-
-        def pools
-          @pools ||= {}
         end
       end
     end

--- a/spec/mongo/server/connection_pool_spec.rb
+++ b/spec/mongo/server/connection_pool_spec.rb
@@ -18,10 +18,14 @@ describe Mongo::Server::ConnectionPool do
     Mongo::Event::Listeners.new
   end
 
+  let(:cluster) do
+    double('cluster')
+  end
+
   describe '#checkin' do
 
     let(:server) do
-      Mongo::Server.new(address, double('cluster'), monitoring, listeners, options)
+      Mongo::Server.new(address, cluster, monitoring, listeners, options)
     end
 
     let!(:pool) do
@@ -29,6 +33,7 @@ describe Mongo::Server::ConnectionPool do
     end
 
     after do
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
       server.disconnect!
     end
 
@@ -55,7 +60,7 @@ describe Mongo::Server::ConnectionPool do
   describe '#checkout' do
 
     let(:server) do
-      Mongo::Server.new(address, double('cluster'), monitoring, listeners, options)
+      Mongo::Server.new(address, cluster, monitoring, listeners, options)
     end
 
     let!(:pool) do
@@ -103,27 +108,24 @@ describe Mongo::Server::ConnectionPool do
   describe '#disconnect!' do
 
     let(:server) do
-      Mongo::Server.new(address, double('cluster'), monitoring, listeners, options)
+      Mongo::Server.new(address, cluster, monitoring, listeners, options)
     end
 
     let!(:pool) do
       described_class.get(server)
     end
 
-    after do
-      server.disconnect!
-    end
-
     it 'disconnects the queue' do
-      expect(pool.send(:queue)).to receive(:disconnect!).twice.and_call_original
-      pool.disconnect!
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
+      expect(pool.send(:queue)).to receive(:disconnect!).once.and_call_original
+      server.disconnect!
     end
   end
 
   describe '.get' do
 
     let(:server) do
-      Mongo::Server.new(address, double('cluster'), monitoring, listeners, options)
+      Mongo::Server.new(address, cluster, monitoring, listeners, options)
     end
 
     let!(:pool) do
@@ -131,18 +133,19 @@ describe Mongo::Server::ConnectionPool do
     end
 
     after do
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
       server.disconnect!
     end
 
     it 'returns the pool for the server' do
-      expect(pool).to eql(described_class.get(server))
+      expect(pool).to_not be_nil
     end
   end
 
   describe '#inspect' do
 
     let(:server) do
-      Mongo::Server.new(address, double('cluster'), monitoring, listeners, options)
+      Mongo::Server.new(address, cluster, monitoring, listeners, options)
     end
 
     let!(:pool) do
@@ -150,6 +153,7 @@ describe Mongo::Server::ConnectionPool do
     end
 
     after do
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
       server.disconnect!
     end
 
@@ -165,7 +169,7 @@ describe Mongo::Server::ConnectionPool do
   describe '#with_connection' do
 
     let(:server) do
-      Mongo::Server.new(address, double('cluster'), monitoring, listeners, options)
+      Mongo::Server.new(address, cluster, monitoring, listeners, options)
     end
 
     let!(:pool) do

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -14,26 +14,25 @@ describe Mongo::Server::Connection do
     Mongo::Event::Listeners.new
   end
 
+  let(:cluster) do
+    double('cluster')
+  end
+
   let(:server) do
-    Mongo::Server.new(address, double('cluster'), monitoring, listeners, TEST_OPTIONS)
+    Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+  end
+
+  let(:pool) do
+    double('pool')
   end
 
   after do
+    expect(cluster).to receive(:pool).with(server).and_return(pool)
+    expect(pool).to receive(:disconnect!).and_return(true)
     server.disconnect!
   end
 
   describe '#connectable?' do
-
-    # context 'when the connection is connectable' do
-
-    #   let(:connection) do
-    #     described_class.new(server)
-    #   end
-
-    #   it 'returns true' do
-    #     expect(connection).to be_connectable
-    #   end
-    # end
 
     context 'when the connection is not connectable' do
 
@@ -42,7 +41,7 @@ describe Mongo::Server::Connection do
       end
 
       let(:bad_server) do
-        Mongo::Server.new(bad_address, double('cluster'), monitoring, listeners, TEST_OPTIONS)
+        Mongo::Server.new(bad_address, cluster, monitoring, listeners, TEST_OPTIONS)
       end
 
       let(:connection) do

--- a/spec/mongo/server_spec.rb
+++ b/spec/mongo/server_spec.rb
@@ -18,6 +18,10 @@ describe Mongo::Server do
     Mongo::Address.new('127.0.0.1:27017')
   end
 
+  let(:pool) do
+    Mongo::Server::ConnectionPool.get(server)
+  end
+
   describe '#==' do
 
     let(:server) do
@@ -25,6 +29,7 @@ describe Mongo::Server do
     end
 
     after do
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
       server.disconnect!
     end
 
@@ -81,6 +86,10 @@ describe Mongo::Server do
         server.disconnect!
       end
 
+      before do
+        expect(cluster).to receive(:pool).with(server).and_return(pool)
+      end
+
       it 'returns true' do
         expect(server).to be_connectable
       end
@@ -97,6 +106,7 @@ describe Mongo::Server do
       end
 
       before do
+        expect(cluster).to receive(:pool).with(server).and_return(pool)
         server.disconnect!
       end
 
@@ -117,6 +127,7 @@ describe Mongo::Server do
     end
 
     after do
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
       server.disconnect!
     end
 
@@ -133,6 +144,7 @@ describe Mongo::Server do
 
     it 'stops the monitor instance' do
       expect(server.instance_variable_get(:@monitor)).to receive(:stop!).and_return(true)
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
       server.disconnect!
     end
   end
@@ -150,6 +162,7 @@ describe Mongo::Server do
     end
 
     after do
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
       server.disconnect!
     end
 
@@ -166,25 +179,6 @@ describe Mongo::Server do
     end
   end
 
-  describe '#pool' do
-
-    let(:server) do
-      described_class.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
-    end
-
-    let(:pool) do
-      server.pool
-    end
-
-    after do
-      server.disconnect!
-    end
-
-    it 'returns the connection pool for the server' do
-      expect(pool).to be_a(Mongo::Server::ConnectionPool)
-    end
-  end
-
   describe '#scan!' do
 
     let(:server) do
@@ -192,6 +186,7 @@ describe Mongo::Server do
     end
 
     after do
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
       server.disconnect!
     end
 
@@ -211,6 +206,7 @@ describe Mongo::Server do
     end
 
     after do
+      expect(cluster).to receive(:pool).with(server).and_return(pool)
       server.disconnect!
     end
 


### PR DESCRIPTION
- Stops server monitor when Server is marked for GC.
- Scopes connection pools to cluster and fixes the Address equality as hash keys bug (was leaking pools)