### PR TITLE
Add 'interrupted at shutdown' to the list of retryable messages, as it…

### DIFF
--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -35,7 +35,8 @@ module Mongo
         'connect failed',
         'error querying',
         'could not get last error',
-        'connection attempt failed'
+        'connection attempt failed',
+        'interrupted at shutdown'
       ].freeze
 
       # Can the operation that caused the error be retried?


### PR DESCRIPTION
…can happen when taking a mongoD out of rotation for compaction.