### PR TITLE
Feature/other retries

### DIFF
--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -41,9 +41,11 @@ module Mongo
             result = send_initial_query(server)
             @cursor = Cursor.new(view, result, server)
           end
-          @cursor.each do |doc|
-            yield doc
-          end if block_given?
+          read_with_retry do
+            @cursor.each do |doc|
+              yield doc
+            end if block_given?
+          end
           @cursor.to_enum
         end
 

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -32,6 +32,7 @@ module Mongo
         "can't connect",
         'no master',
         'not master',
+        'could not contact primary',
         'connect failed',
         'error querying',
         'could not get last error',

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -24,6 +24,11 @@ module Mongo
     # @since 2.1.0
     NOT_MASTER = 'not master'.freeze
 
+    # Could not contact primary error message, seen on stepdowns
+    #
+    # @since 2.2.0
+    COULD_NOT_CONTACT_PRIMARY = 'could not contact primary'.freeze
+
     # Execute a read operation with a retry.
     #
     # @api private
@@ -83,7 +88,7 @@ module Mongo
       begin
         block.call
       rescue Error::OperationFailure => e
-        if e.message.include?(NOT_MASTER)
+        if e.message.include?(NOT_MASTER) || e.message.include?(COULD_NOT_CONTACT_PRIMARY)
           retry_operation(&block)
         else
           raise e


### PR DESCRIPTION
We've been doing more testing with the official Ruby driver, and here are a few more resiliency improvements:

* `Iterable#each` should add retry logic when iterating over the cursor because of getMores. You can see in the below stack trace that a `get_more` was called, and the code then errored out instead of retrying. This happened while doing a stepdown while iterating over a large query.
* Adds retry logic for "could not contact primary" which we saw during some stepdowns

```
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  Mongo::Error::OperationFailure: socket exception [CONNECT_ERROR] for REDACTED (11002)
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/operation/result.rb:256:in `validate!'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/operation/executable.rb:36:in `block in execute'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/server/context.rb:68:in `call'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/server/context.rb:68:in `block in with_connection'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/server/connection_pool.rb:108:in `with_connection'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/server/context.rb:63:in `with_connection'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/operation/executable.rb:34:in `execute'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/cursor.rb:160:in `get_more'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/cursor.rb:86:in `each'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongo-ruby-driver-b721473b693d/lib/mongo/collection/view/iterable.rb:44:in `each'
Dec 05 04:24:08 worker-maint-prd-iad-onmetal-02 sidekiq_10.log:  /var/www/platform/shared/dashboard/bundle/ruby/2.2.0/bundler/gems/mongoid-775da327de64/lib/mongoid/query_cache.rb:207:in `each'
```