### PR TITLE
Remove unnecessary string allocation

### DIFF
--- a/lib/mongo/grid/stream/read.rb
+++ b/lib/mongo/grid/stream/read.rb
@@ -74,7 +74,7 @@ module Mongo
             view.each_with_index.reduce(0) do |length_read, (doc, index)|
               chunk = Grid::File::Chunk.new(doc)
               validate!(index, num_chunks, chunk, length_read)
-              data = Grid::File::Chunk.assemble([ chunk ])
+              data = chunk.data.data
               yield data
               length_read += data.size
             end if block_given?


### PR DESCRIPTION
When streaming the chunked GridFS file, instead of assembling the chunk contents into a new string, we can just return the already allocated string. Normally I'm not pedantic about string allocations, but since these strings are parts of a file they're relatively large (default is 255 KB, but people can set it to more).