### PR TITLE
Don't store authenticator on connection instance.

### DIFF
--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -140,8 +140,8 @@ describe Mongo::Server::Connection do
           connection.connect!
         end
 
-        it 'sets the connection as authenticated' do
-          expect(connection).to be_authenticated
+        it 'sets the connection as connected' do
+          expect(connection).to be_connected
         end
       end
     end
@@ -433,8 +433,8 @@ describe Mongo::Server::Connection do
         )
       end
 
-      it 'sets the authentication strategy for the connection' do
-        expect(connection.authenticator.user).to eq(user)
+      it 'sets the auth options' do
+        expect(connection.options[:user]).to eq(user.name)
       end
     end
   end


### PR DESCRIPTION
This changes authenticator setup in the server connection to happen at
connect time, instead of connection instantiation. This fixes the
possibility of a running application with a connection open to a pre-3.0
server to get auth errors if the connection to the address was closed
and then reconnected against a server of 3.0 and higher and a different
auth mechanism.

The scenario to reproduce:
- Start an application against a MongoDB 2.6 server with MONGODB-CR
  authentication with no auth_mech option specified on the client.
- Stop the running server, but leave the application running. The first
  exception in the application will disconnect the connection.
- Upgrade the server to 3.0 and upgrade users to SCRAM-SHA-1. Restart
  the server.
- The next application call would connect to the server, and attempt to
  authenticate with MONGODB-CR instead of SCRAM-SHA-1 since the
  authenticator was previously set on the instance. An auth error would
  happen on this call.

This fixes the above scenario.