### PR TITLE
A couple more retries.

### DIFF
--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -37,7 +37,9 @@ module Mongo
         'error querying',
         'could not get last error',
         'connection attempt failed',
-        'interrupted at shutdown'
+        'interrupted at shutdown',
+        'unknown replica set',
+        'dbclient error communicating with server'
       ].freeze
 
       # Can the operation that caused the error be retried?


### PR DESCRIPTION
Some more errors we've seen during failovers or crashes. I've added them to retry on my fork.

* `Mongo::Error::OperationFailure: unknown replica set d303f52f76534680956e00a707bbca89 (71)`
* `Mongo::Error::OperationFailure: dbclient error communicating with server: REDACTED (10278)`