### PR TITLE
RUBY-1078 Use default max message size when value is nil

### DIFF
--- a/lib/mongo/protocol/message.rb
+++ b/lib/mongo/protocol/message.rb
@@ -114,7 +114,7 @@ module Mongo
 
         # Protection from potential DOS man-in-the-middle attacks. See
         # DRIVERS-276.
-        if length > max_message_size
+        if length > (max_message_size || MAX_MESSAGE_SIZE)
           raise Error::MaxMessageSize.new(max_message_size)
         end
 

--- a/spec/mongo/protocol/reply_spec.rb
+++ b/spec/mongo/protocol/reply_spec.rb
@@ -97,6 +97,19 @@ describe Mongo::Protocol::Reply do
       end
     end
 
+    context 'when the max message size is nil' do
+
+      let(:reply) { described_class.deserialize(io, nil) }
+
+      let(:length) { Mongo::Protocol::Message::MAX_MESSAGE_SIZE + 1 }
+
+      it 'uses the default max message size for comparison' do
+        expect {
+          reply
+        }.to raise_error(Mongo::Error::MaxMessageSize)
+      end
+    end
+
     describe 'response flags' do
 
       context 'no flags' do


### PR DESCRIPTION
Thanks to @jonhyman for reporting this and pointing us to the solution