### PR TITLE
Install mongo_console again

### DIFF
--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.files             += %w[mongo.gemspec LICENSE README.md CONTRIBUTING.md Rakefile]
   s.test_files        = Dir.glob('spec/**/*')
 
+  s.executables       = ['mongo_console']
   s.require_paths     = ['lib']
   s.has_rdoc          = 'yard'
   s.bindir            = 'bin'


### PR DESCRIPTION
With the import of mongo-ruby-driver v2.0 (1fc62d949269231e8e7639589a336276390dcc65), the mongo_console was removed. While the executable was later reintroduced (a30d72cfc17a23c95a08e1f275ae395120b3d3c7), the RubyGems wrapper was not installed into /usr/bin anymore, since it was never specified in .gemspec again.

This PR fixes the situation, since this seems to be non-intentional overlook.