### PR TITLE
RUBY-1088: Sync Pool#with_connection

### DIFF
--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -23,9 +23,6 @@ module Mongo
     class ConnectionPool
       include Loggable
 
-      # @return [ Mutex ] mutex The mutex used for synchronization.
-      attr_reader :mutex
-
       # @return [ Hash ] options The pool options.
       attr_reader :options
 
@@ -107,7 +104,7 @@ module Mongo
       #
       # @since 2.0.0
       def with_connection
-        mutex.synchronize do
+        @mutex.synchronize do
           begin
             connection = checkout
             yield(connection)


### PR DESCRIPTION
Not only the queue needs to be synchronized, the #with_connection which checks out from the queue also needs to since the code path could have entry from multiple threads at the same time.

Refactor of the `ConnectionPool` introduced this in 2.2.x