### PR TITLE
RUBY-741 Make connection pool queue LIFO

### DIFF
--- a/lib/mongo/server/connection_pool/queue.rb
+++ b/lib/mongo/server/connection_pool/queue.rb
@@ -170,7 +170,7 @@ module Mongo
         def dequeue_connection
           deadline = Time.now + wait_timeout
           loop do
-            return queue.pop unless queue.empty?
+            return queue.shift unless queue.empty?
             connection = create_connection
             return connection if connection
             wait_for_next!(deadline)


### PR DESCRIPTION
As per the discussion on our driver's slack channel, this changes our queue from FIFO to LIFO. Also the queue needs to be LIFO in order to support `maxIdleTimeMS` configuration and idle connection reaping down to the `minPoolSize` configuration option.
