### PR TITLE
Add dependency on 'pry'

### DIFF
--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -31,4 +31,5 @@ Gem::Specification.new do |s|
   s.bindir            = 'bin'
 
   s.add_dependency 'bson', '~> 4.0'
+  s.add_dependency 'pry'
 end


### PR DESCRIPTION
'pry' is required and used by mongo_console executable[1], but is not installed by running `gem install mongo`, therefore leaving the executable unusable. 

[1] https://github.com/mongodb/mongo-ruby-driver/blob/15eb4b28462870bc8d54925e745c8da0b73543c7/bin/mongo_console#L4