### PR TITLE
[v 3.0.0] let authentication errors subclass Mongo::Error

### DIFF
--- a/lib/mongo/auth.rb
+++ b/lib/mongo/auth.rb
@@ -71,7 +71,7 @@ module Mongo
     # Raised when trying to get an invalid authorization mechanism.
     #
     # @since 2.0.0
-    class InvalidMechanism < RuntimeError
+    class InvalidMechanism < ::Mongo::Error
 
       # Instantiate the new error.
       #
@@ -89,7 +89,7 @@ module Mongo
     # Raised when a user is not authorized on a database.
     #
     # @since 2.0.0
-    class Unauthorized < RuntimeError
+    class Unauthorized < ::Mongo::Error
 
       # Instantiate the new error.
       #


### PR DESCRIPTION
- allows to uniformly deal with all MongoDB errors
