### PR TITLE
When using connection URI, authSource should be used correctly

### DIFF
--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -387,7 +387,7 @@ module Mongo
     uri_option 'connect', :connect
 
     # Auth Options
-    uri_option 'authsource', :source, :group => :auth, :type => :auth_source
+    uri_option 'authsource', :auth_source, :type => :auth_source
     uri_option 'authmechanism', :auth_mech, :type => :auth_mech
     uri_option 'authmechanismproperties', :auth_mech_properties, :group => :auth,
                  :type => :auth_mech_props

--- a/spec/mongo/uri_spec.rb
+++ b/spec/mongo/uri_spec.rb
@@ -544,19 +544,19 @@ describe 'invalid uris' do
 
       context 'regular db' do
         let(:source) { 'foo' }
-        let(:auth) { Mongo::Options::Redacted.new(:source => 'foo') }
+        let(:auth) { Mongo::Options::Redacted.new(:auth_source => 'foo') }
 
         it 'sets the auth source to the database' do
-          expect(uri.uri_options[:auth]).to eq(auth)
+          expect(uri.uri_options).to eq(auth)
         end
       end
 
       context '$external' do
         let(:source) { '$external' }
-        let(:auth) { Mongo::Options::Redacted.new(:source => :external) }
+        let(:auth) { Mongo::Options::Redacted.new(:auth_source => :external) }
 
         it 'sets the auth source to :external' do
-          expect(uri.uri_options[:auth]).to eq(auth)
+          expect(uri.uri_options).to eq(auth)
         end
       end
     end


### PR DESCRIPTION
With mongo shell, no problem:

```
└> mongo 'mongodb://admin:admin-secret@localhost:27020/api_development?authSource=admin'
MongoDB shell version: 3.2.6
connecting to: mongodb://admin:admin-secret@localhost:27020/api_development?authSource=admin
> 
```

ruby-mongo 2.2.5:

```
└> MONGO_URL='mongodb://admin:admin-secret@127.0.0.1:27020/api_development?authSource=admin' pry -r "mongo"
[1] pry(main)> client = Mongo::Client.new(ENV["MONGO_URL"])
D, [2016-06-13T16:20:51.510134 #20220] DEBUG -- : MONGODB | Adding 127.0.0.1:27020 to the cluster.
=> #<Mongo::Client:0x47061919412960 cluster=127.0.0.1:27020>
[2] pry(main)> client.database.collection("foo").count
D, [2016-06-13T16:20:56.331311 #20220] DEBUG -- : MONGODB | 127.0.0.1:27020 | api_development.count | STARTED | {"count"=>"foo", "query"=>{}}
D, [2016-06-13T16:20:56.332309 #20220] DEBUG -- : MONGODB | 127.0.0.1:27020 | api_development.saslStart | STARTED | {}
D, [2016-06-13T16:20:56.335454 #20220] DEBUG -- : MONGODB | 127.0.0.1:27020 | api_development.saslStart | FAILED | Authentication failed. (18) | 0.002983692s
D, [2016-06-13T16:20:56.335603 #20220] DEBUG -- : MONGODB | 127.0.0.1:27020 | api_development.count | FAILED | User admin is not authorized to access api_development. | 0.0042112239999999995s
Mongo::Auth::Unauthorized: User admin is not authorized to access api_development.
from /home/leo/.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/mongo-2.2.5/lib/mongo/auth/scram/conversation.rb:451:in `validate!'
```

With this change:

```
└> MONGO_URL='mongodb://admin:admin-secret@127.0.0.1:27020/scalingo_api_development?authSource=admin' pry -r "mongo"
[1] pry(main)> client = Mongo::Client.new(ENV["MONGO_URL"])
D, [2016-06-13T16:28:20.310010 #20419] DEBUG -- : MONGODB | Adding 127.0.0.1:27020 to the cluster.
=> #<Mongo::Client:0x47383194408020 cluster=127.0.0.1:27020>
[2] pry(main)> client.database.collection("foo").count
D, [2016-06-13T16:28:39.998695 #20419] DEBUG -- : MONGODB | 127.0.0.1:27020 | scalingo_api_development.count | STARTED | {"count"=>"foo", "query"=>{}}
D, [2016-06-13T16:28:40.000634 #20419] DEBUG -- : MONGODB | 127.0.0.1:27020 | admin.saslStart | STARTED | {}
D, [2016-06-13T16:28:40.008319 #20419] DEBUG -- : MONGODB | 127.0.0.1:27020 | admin.saslStart | SUCCEEDED | 0.007368245s
D, [2016-06-13T16:28:40.040426 #20419] DEBUG -- : MONGODB | 127.0.0.1:27020 | admin.saslContinue | STARTED | {}
D, [2016-06-13T16:28:40.042295 #20419] DEBUG -- : MONGODB | 127.0.0.1:27020 | admin.saslContinue | SUCCEEDED | 0.00155186s
D, [2016-06-13T16:28:40.042797 #20419] DEBUG -- : MONGODB | 127.0.0.1:27020 | admin.saslContinue | STARTED | {}
D, [2016-06-13T16:28:40.045235 #20419] DEBUG -- : MONGODB | 127.0.0.1:27020 | admin.saslContinue | SUCCEEDED | 0.002150166s
D, [2016-06-13T16:28:40.047434 #20419] DEBUG -- : MONGODB | 127.0.0.1:27020 | scalingo_api_development.count | SUCCEEDED | 0.048438906s
=> 0
```

According to the blame information is seems to be here for a long time now, but it really seems to be buggy.