### PR TITLE
[v 2.2.6] RUBY-1122 Disconnect socket when auth fails

### DIFF
--- a/lib/mongo/server/connection.rb
+++ b/lib/mongo/server/connection.rb
@@ -63,6 +63,9 @@ module Mongo
           authenticate!
         end
         true
+      rescue Mongo::Auth::Unauthorized => e
+        disconnect!
+        raise e
       end
 
       # Disconnect the connection.

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -117,10 +117,21 @@ describe Mongo::Server::Connection do
           )
         end
 
+        let!(:error) do
+          e = begin; connection.connect!; rescue => ex; ex; end
+        end
+
         it 'raises an error' do
-          expect {
-            connection.connect!
-          }.to raise_error(Mongo::Auth::Unauthorized)
+          expect(error).to be_a(Mongo::Auth::Unauthorized)
+        end
+
+        it 'disconnects the socket' do
+          expect(connection.send(:socket)).to be(nil)
+        end
+
+        it 'marks the server as unknown' do
+          pending 'Server must be set as unknown'
+          expect(server).to be_unknown
         end
       end
 


### PR DESCRIPTION
as sayeth the spec: https://github.com/mongodb/specifications/blob/master/source/auth/auth.rst#authentication