### PR TITLE
Don't freeze caller's hashes

### DIFF
--- a/lib/mongo/collection/view.rb
+++ b/lib/mongo/collection/view.rb
@@ -132,7 +132,7 @@ module Mongo
       def initialize(collection, filter = {}, options = {})
         validate_doc!(filter)
         @collection = collection
-        parse_parameters!(BSON::Document.new(filter.freeze), BSON::Document.new(options.freeze))
+        parse_parameters!(BSON::Document.new(filter.dup.freeze), BSON::Document.new(options.dup.freeze))
       end
 
       # Get a human-readable string representation of +View+.


### PR DESCRIPTION
Caller's hashes are now dup'ed before freezing for use in the database view to eliminate side effects for the client.