### PR TITLE
RUBY-1049: reauthenticate and retry when receiving unauthorized response.

### DIFF
--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -42,6 +42,14 @@ module Mongo
         'dbclient error communicating with server'
       ].freeze
 
+      # These error messages indicate that the requests are unauthorized.
+      #
+      # @since 2.3.0
+      UNAUTHORIZED_MESSAGES = [
+        'unauthorized',
+        'not authorized'
+      ].freeze
+
       # Can the operation that caused the error be retried?
       #
       # @example Is the error retryable?
@@ -52,6 +60,15 @@ module Mongo
       # @since 2.1.1
       def retryable?
         RETRY_MESSAGES.any?{ |m| message.include?(m) }
+      end
+
+      # Is the error due to an unauthorized request?
+      #
+      # @return [ true, false ] If the error is an unauthorized request.
+      #
+      # @since 2.3.0
+      def unauthorized?
+        UNAUTHORIZED_MESSAGES.any?{ |m| message.include?(m) }
       end
     end
   end

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -52,8 +52,12 @@ module Mongo
       rescue Error::SocketError, Error::SocketTimeoutError
         retry_operation(&block)
       rescue Error::OperationFailure => e
-        if cluster.sharded? && e.retryable?
+        if cluster.sharded? && (e.retryable? || e.unauthorized?)
           if attempt < cluster.max_read_retries
+            if e.unauthorized?
+              cluster.servers.each {|server| server.context.with_connection {|conn| conn.authenticate! } }
+            end
+
             # We don't scan the cluster in this case as Mongos always returns
             # ready after a ping no matter what the state behind it is.
             sleep(cluster.read_retry_interval)

--- a/spec/mongo/retryable_spec.rb
+++ b/spec/mongo/retryable_spec.rb
@@ -108,7 +108,7 @@ describe Mongo::Retryable do
         context 'when the operation failure is not retryable' do
 
           let(:error) do
-            Mongo::Error::OperationFailure.new('not authorized')
+            Mongo::Error::OperationFailure.new('cursor not found')
           end
 
           before do
@@ -120,6 +120,31 @@ describe Mongo::Retryable do
             expect {
               retryable.read
             }.to raise_error(Mongo::Error::OperationFailure)
+          end
+        end
+
+        context 'when there is an authentication failure' do
+          let(:error) do
+            Mongo::Error::OperationFailure.new('not authorized')
+          end
+
+          before do
+            expect(operation).to receive(:execute).and_raise(error).ordered
+            expect(cluster).to receive(:sharded?).and_return(true)
+            expect(cluster).to receive(:max_read_retries).and_return(1).ordered
+            expect(cluster).to receive(:read_retry_interval).and_return(0.1).ordered
+            expect(operation).to receive(:execute).and_return(true).ordered
+
+            mock_context = double(Mongo::Server::Context)
+            mock_connection = double(Mongo::Server::Connection)
+            mock_server = double(Mongo::Server, :context => mock_context)
+            expect(mock_context).to receive(:with_connection).and_yield(mock_connection)
+            expect(cluster).to receive(:servers).and_return([mock_server])
+            expect(mock_connection).to receive(:authenticate!)
+          end
+
+          it 're-authenticates and retries the operation' do
+            expect(retryable.read).to be true
           end
         end
 


### PR DESCRIPTION
I am re-opening https://github.com/mongodb/mongo-ruby-driver/pull/695. This is a critical bug that is causing issues for us in production, and is still unresolved as discussed [here](https://jira.mongodb.org/browse/RUBY-1100).