### PR TITLE
Add docs-source for ruby driver manual

### DIFF
--- a/docs-source/aggregation-framework.txt
+++ b/docs-source/aggregation-framework.txt
@@ -1,0 +1,366 @@
+=====================
+Aggregation Framework
+=====================
+
+.. default-domain:: mongodb
+
+This document provides a number of practical examples that display the
+capabilities of the aggregation framework.
+
+The `*Aggregations using the Zip Codes Data
+Set* <https://docs.mongodb.com/manual/tutorial/aggregation-examples/#aggregations-using-the-zip-code-data-set>`_
+examples uses a publicly available data set of all zipcodes and
+populations in the United States. These data are available at:
+`zips.json <http://media.mongodb.org/zips.json>`_.
+
+Requirements
+============
+
+`MongoDB <http://www.mongodb.org/downloads>`_, version 2.2.0 or later.
+`Ruby MongoDB Driver <https://github.com/mongodb/mongo-ruby-driver>`_,
+version 1.7.0 or later. Ruby, version 1.8.7 or later.
+
+Let’s check if everything is installed.
+
+Use the following command to load *zips.json* data set into mongod
+instance:
+
+.. code:: sh
+
+    mongoimport --drop -d test -c zipcodes zips.json
+
+On the *irb* console run:
+
+.. code:: ruby
+
+    require "mongo"
+    include Mongo
+
+    db = MongoClient.new("localhost", 27017, w: 1).db("test")
+    coll = db.collection("zipcodes")
+    coll.count     #=> should return 29467
+    coll.find_one
+
+Aggregations using the Zip Codes Data Set
+=========================================
+
+Each document in this collection has the following form:
+
+.. code:: json
+
+    {
+      "_id" : "35004",
+      "city" : "Acmar",
+      "state" : "AL",
+      "pop" : 6055,
+      "loc" : [-86.51557, 33.584132]
+    }
+
+In these documents:
+
+-  The ``_id`` field holds the zipcode as a string.
+-  The ``city`` field holds the city name.
+-  The ``state`` field holds the two letter state abbreviation.
+-  The ``pop`` field holds the population.
+-  The ``loc`` field holds the location as a ``[latitude, longitude]``
+   array.
+
+States with Populations Over 10 Million
+---------------------------------------
+
+To get all states with a population greater than 10 million, use the
+following aggregation pipeline:
+
+.. code:: ruby
+
+    puts coll.aggregate([
+      {"$group" => {_id: "$state", total_pop: {"$sum" => "$pop"}}},
+      {"$match" => {total_pop: {"$gte" => 10_000_000}}}
+    ])
+
+The result:
+
+.. code:: ruby
+
+    {"_id"=>"PA", "total_pop"=>11881643}
+    {"_id"=>"OH", "total_pop"=>10847115}
+    {"_id"=>"NY", "total_pop"=>17990455}
+    {"_id"=>"FL", "total_pop"=>12937284}
+    {"_id"=>"TX", "total_pop"=>16986510}
+    {"_id"=>"IL", "total_pop"=>11430472}
+    {"_id"=>"CA", "total_pop"=>29760021}
+
+The above aggregation pipeline is build from two pipeline operators:
+``$group`` and ``$match``.
+
+The ``$group`` pipeline operator requires ``_id`` field where we specify
+grouping; remaining fields specify how to generate composite value and
+must use one of `the group aggregation
+functions <https://docs.mongodb.com/manual/reference/aggregation/#group-operators>`_:
+``$addToSet``, ``$first``, ``$last``, ``$max``, ``$min``, ``$avg``,
+``$push``, ``$sum``. The ``$match`` pipeline operator syntax is the same
+as the `read
+operation <https://docs.mongodb.com/manual/core/read-operations/>`_
+query syntax.
+
+The ``$group`` process reads all documents and for each state it creates
+a separate document, for example:
+
+.. code:: ruby
+
+    {"_id"=>"WA", "total_pop"=>4866692}
+
+The ``total_pop`` field uses the ``$sum`` aggregation function to sum
+the values of all ``pop`` fields in the source documents.
+
+Documents created by ``$group`` are piped to the ``$match`` pipeline
+operator. It returns the documents with the value of ``total_pop`` field
+greater than or equal to 10 million.
+
+Average City Population by State
+--------------------------------
+
+To get the first three states with the greatest average population per
+city, use the following aggregation:
+
+.. code:: ruby
+
+    puts coll.aggregate([
+      {"$group" => {_id: {state: "$state", city: "$city"}, pop: {"$sum" => "$pop"}}},
+      {"$group" => {_id: "$_id.state", avg_city_pop: {"$avg" => "$pop"}}},
+      {"$sort" => {avg_city_pop: -1}},
+      {"$limit" => 3}
+    ])
+
+This aggregate pipeline produces:
+
+.. code:: ruby
+
+    {"_id"=>"DC", "avg_city_pop"=>303450.0}
+    {"_id"=>"FL", "avg_city_pop"=>27942.29805615551}
+    {"_id"=>"CA", "avg_city_pop"=>27735.341099720412}
+
+The above aggregation pipeline is build from three pipeline operators:
+``$group``, ``$sort`` and ``$limit``.
+
+The first ``$group`` operator creates the following documents:
+
+.. code:: ruby
+
+    {"_id"=>{"state"=>"WY", "city"=>"Smoot"}, "pop"=>414}
+
+Note, that the ``$group`` operator can’t use nested documents except the
+``_id`` field.
+
+The second ``$group`` uses these documents to create the following
+documents:
+
+.. code:: ruby
+
+    {"_id"=>"FL", "avg_city_pop"=>27942.29805615551}
+
+These documents are sorted by the ``avg_city_pop`` field in descending
+order. Finally, the ``$limit`` pipeline operator returns the first 3
+documents from the sorted set.
+
+Largest and Smallest Cities by State
+------------------------------------
+
+To get the smallest and largest cities by population for each state, use
+the following aggregate pipeline:
+
+.. code:: ruby
+
+    puts coll.aggregate([
+      {"$group" => {_id: {state: "$state", city: "$city"}, pop: {"$sum" => "$pop"}}},
+      {"$sort" => {pop: 1}},
+      {"$group" => {
+                    _id: "$_id.state",
+          smallest_city: {"$first" => "$_id.city"},
+           smallest_pop: {"$first" => "$pop"},
+           biggest_city: { "$last" => "$_id.city"},
+            biggest_pop: { "$last" => "$pop"}
+        }
+      }
+    ])
+
+The first ``$group`` operator creates a new document for every
+combination of the ``state`` and ``city`` fields from the source
+documents. Each document created at this stage has the field ``pop``
+which is set to the value computed by the ``$sum`` operator. It sums the
+values of the ``pop`` field in the grouped documents.
+
+The sample document created at this stage looks like:
+
+.. code:: ruby
+
+    {"_id"=>{"state"=>"AL", "city"=>"Cottondale"}, "pop"=>4727}
+
+*Note*: To preserve the values of the ``state`` and ``city`` fields for
+later use in the pipeline we specify the value of ``_id`` as a nested
+document which contains both values.
+
+The second ``$group`` operator groups the documents by the value of
+``_id.state``.
+
+The sorting order is preserved within grouped documents. So, ``$first``
+operators return name of the city with the smallest population and the
+city population. The ``$last`` operators return the city name with the
+biggest population and the city population.
+
+The sample document created at this stage looks like:
+
+.. code:: ruby
+
+    {
+      "_id"=>"OH",
+      "smallest_city" => "Isle Saint Georg", "smallest_pop" =>     38,
+      "biggest_city"  =>        "Cleveland", "biggest_pop"  => 536759
+    }
+
+Unwinding data in the Name Days Data Set
+========================================
+
+To run the examples below you need this data set:
+`name\_days.json <https://raw.github.com/wiki/mongodb/mongo-ruby-driver/data/name_days.json>`_.
+
+Use *mongoimport* to import this data set into MongoDB:
+
+.. code:: sh
+
+    mongoimport --drop --db test --collection cal name_days.json
+
+After import, the collection *cal* should contain 364 documents in the
+following format:
+
+.. code:: json
+
+    {
+      "date" : {"day": 1, "month": 1},
+      "names": ["Mieszka", "Mieczysława", "Marii"]
+    }
+
+The 6 most common name days
+---------------------------
+
+The following aggregation pipeline computes this:
+
+.. code:: ruby
+
+    coll = db.collection("cal") # switch collection
+
+    puts coll.aggregate([
+      {"$project" => {names: 1, _id: 0}},
+      {"$unwind" => "$names" },
+      {"$group" => {_id: "$names", count: {"$sum" => 1}}},
+      {"$sort" => {count: -1}},
+      {"$limit" => 6}
+    ])
+
+The sample document created by the ``$project`` pipeline operator looks
+like:
+
+.. code:: ruby
+
+    {"names"=>["Sylwestra", "Melanii", "Mariusza"]}
+
+The ``$unwind`` operator creates one document for every member of
+*names* array. For example, the above document is unwinded into three
+documents:
+
+.. code:: ruby
+
+    {"names"=>"Sylwestra"}
+    {"names"=>"Melanii"}
+    {"names"=>"Mariusza"}
+
+These documents are grouped by the ``names`` field and the documents in
+each group are counted by the ``$sum`` operator.
+
+The sample document created at this stage looks like:
+
+.. code:: ruby
+
+    {"_id"=>"Jacka", "count"=>4}
+
+Finally, the ``$sort`` operator sorts these documents by the ``count``
+field in descending order, and the ``$limit`` operator outputs the first
+6 documents:
+
+.. code:: ruby
+
+    {"_id"=>"Jana",       "count"=>21}
+    {"_id"=>"Marii",      "count"=>16}
+    {"_id"=>"Grzegorza",  "count"=> 9}
+    {"_id"=>"Piotra",     "count"=> 9}
+    {"_id"=>"Feliksa",    "count"=> 8}
+    {"_id"=>"Leona",      "count"=> 8}
+
+Pivot date ↺ names
+------------------
+
+We want to pivot the *name\_days.json* data set. Precisely, we want to
+convert documents from this format:
+
+.. code:: ruby
+
+    { "date"=>{"day"=>1, "month"=>1}, "names"=>["Mieszka", "Mieczysława", "Marii"] }
+
+into this format:
+
+.. code:: ruby
+
+    { "name"=>"Mateusza", "dates"=>[{"day"=>13, "month"=>11}, {"day"=>21, "month"=>9}]}
+
+The following aggregation pipeline does the trick:
+
+.. code:: ruby
+
+    puts coll.aggregate([
+      {"$project" => {_id: 0, date: 1, names: 1}},
+      {"$unwind" => "$names"},
+      {"$group" => {_id: "$names", dates: {"$addToSet" => "$date"}}},
+      {"$project" => {name: "$_id", dates: 1, _id: 0}},
+      {"$sort" => {name: 1}}
+    ])
+
+The sample document created by the unwinding stage looks like:
+
+.. code:: ruby
+
+    {"names"=>"Eugeniusza", "date"=>{"day"=>30, "month"=>12}}
+
+The ``$group`` pipeline operator groups these documents by the ``names``
+field. The ``$addToSet`` operator returns an array of all unique values
+of the ``date`` field found in the set of grouped documents. The sample
+document created at this stage of the pipeline looks like:
+
+.. code:: ruby
+
+    {"_id"=>"Maksymiliana", "dates"=>[{"day"=>12, "month"=>10}, {"day"=>14, "month"=>8}]}
+
+In the last two stages we sort and reshape these documents to the
+requested format:
+
+.. code:: ruby
+
+    {"dates"=>[{"day"=>11, "month"=>8}, {"day"=>24, "month"=>5}], "name"=>"Zuzanny"}
+
+Quiz
+====
+
+1. What is the result of running the empty aggregation pipeline:
+
+.. code:: ruby
+
+    coll.aggregate([])
+
+2. For the *zipcodes* collection, the aggregation below computes
+``248_690_240``. What does this number mean?
+
+.. code:: ruby
+
+    puts coll.aggregate([ {"$group" => {_id: 0, sum: {"$sum" => "$pop"}}} ])
+    #=> {"_id"=>0, "sum"=>248690240}
+
+3. How many different names are in the *cal* collection?

--- a/docs-source/authentication.txt
+++ b/docs-source/authentication.txt
@@ -1,0 +1,230 @@
+==============
+Authentication
+==============
+
+.. default-domain:: mongodb
+
+MongoDB supports a wide variety of `authentication
+mechanisms <https://docs.mongodb.com/master/core/access-control/>`__. The
+following examples demonstrate each of the authentication modes
+currently supported by the Ruby driver.
+
+For more information about configuring your MongoDB server for each of
+these authentication mechanisms please see MongoDB's `online
+documentation <https://docs.mongodb.com/master/tutorial/enable-authentication/>`__.
+
+For more detailed info on ``Mongo::DB#authenticate()`` please see the
+`API
+reference <http://api.mongodb.org/ruby/current/Mongo/DB.html#authenticate-instance_method>`__.
+
+MONGODB-CR
+==========
+
+MONGODB-CR is the default authentication mechanism for MongoDB and all
+drivers. As is the case for all authentication mechanisms, credentials
+are handled by the client instance on a per-database level.
+
+.. code:: ruby
+
+    # basic authentication
+    client = MongoClient.new
+    db     = client['example']
+    db.authenticate('sally', 'secret')
+
+    # basic authentication from uri
+    uri    = 'mongodb://sally:secret@localhost:27017/example'
+    client = MongoClient.from_uri(uri)
+
+User management with MONGODB-CR is easily handled through the driver:
+
+.. code:: ruby
+
+    # add a new user to the db
+    db.add_user('emily','password', nil, :roles => ['read'])
+
+    # create a custom role, then add a user with that role
+    cmd = BSON::OrderedHash.new
+    cmd[:createRole] = "insertAndFind"
+    cmd[:privileges] = [{ :resources => { :db => db_name, :collection => coll_name },
+                          :actions => [ "insert", "find" ] }]
+    cmd[:roles] = []
+    db.command(cmd)
+    db.add_user('insertAndFindUser', 'password', nil, :roles => ['insertAndFind'])
+
+    # remove a user from the db
+    db.remove_user('mark')
+
+When using MongoDB 2.4.x and the `delegated
+credentials <https://docs.mongodb.com/manual/reference/privilege-documents/#delegated-credentials>`__
+feature, you can log in using a separate source database with the
+examples below.
+
+.. code:: ruby
+
+    # basic delegated authentication
+    client = MongoClient.new
+    db     = client['example']
+    db.authenticate('sally', 'secret', nil, 'source-db')
+
+    # basic delegated authentication from uri
+    uri    = 'mongodb://sally:secret@localhost:27017/example?authSource=source-db' 
+    client = MongoClient.from_uri(uri)
+
+MONGODB-X509
+============
+
+*Requires MongoDB v2.6 or greater.*
+
+The MONGODB-X509 mechanism authenticates a username derived from the
+distinguished subject name of the X.509 certificate presented by the
+driver during SSL negotiation. This authentication method requires the
+use of SSL connections with certificate validation.
+
+For more information about configuring X.509 authentication in MongoDB,
+please see `this
+tutorial <https://docs.mongodb.com/master/tutorial/configure-x509/>`__.
+
+.. code:: ruby
+
+    # basic X509 authentication
+    ssl_opts = {
+      :ssl         => true,
+      :ssl_cert    => '/path/to/client.pem',
+      :ssl_ca_cert => '/path/to/ca.pem'
+    }
+
+    client = Mongo::MongoClient.new('example.com', 27017, ssl_opts)
+    db     = client['example']
+    db.authenticate('<X509-derived-name>', nil, nil, nil, 'MONGODB-X509')
+
+    # basic X509 authentication from a uri
+    # MONGODB-X509 authenticates against the $external virtual database, so you do not have to specify
+    #   a database in the URI.
+    uri        = "mongodb://<X509-derived-name>@example.com/?authMechanism=MONGODB-X509"
+    client     = MongoClient.from_uri(uri, ssl_opts)
+
+SASL PLAIN (LDAP)
+=================
+
+*Requires MongoDB Enterprise Edition v2.6 or greater.*
+
+MongoDB Enterprise Edition supports the SASL PLAIN authentication
+mechanism which allows you to delegate authentication using a
+Lightweight Directory Access Protocol
+(`LDAP <http://en.wikipedia.org/wiki/LDAP>`__) server. When using SASL
+PLAIN, passwords are sent to the server in plain text. For this reason,
+we strongly recommend enabling SSL when using SASL PLAIN as your
+authentication mechanism.
+
+For more information about configuring SASL PLAIN authentication in
+MongoDB, please see `this
+tutorial <https://docs.mongodb.com/master/tutorial/configure-ldap-sasl-authentication/>`__.
+
+.. code:: ruby
+
+    # basic SASL PLAIN authentication
+    ssl_opts = {
+      :ssl         => true,
+      :ssl_verify  => true,
+      :ssl_cert    => '/path/to/client.pem',
+      :ssl_ca_cert => '/path/to/ca.pem'
+    }
+
+    client = MongoClient.new('example.com', 27017, ssl_opts)
+    db     = client['example']
+    db.authenticate('sally', 'secret', nil, '$external', 'PLAIN')
+
+    # basic SASL PLAIN authentication from uri
+    username   = 'sally'
+    password   = 'secret'
+    host_port  = 'example.com:27017'
+    source     = '$external'
+    mechanism  = 'PLAIN'
+
+    uri        = "mongodb://#{username}:#{password}@#{host_port}/example?authSource=#{source}&authMechanism=#{mechanism}"
+    client     = MongoClient.from_uri(uri, ssl_opts)
+
+GSSAPI (Kerberos)
+=================
+
+*Requires MongoDB Enterprise Edition v2.4 or greater and the separate
+mongo\_kerberos gem.*
+
+To be able to use the driver with Kerberos authentication enabled,
+install the ``mongo_kerberos`` gem and add it instead of mongo to your
+application:
+
+.. code:: bash
+
+    gem install mongo_kerberos
+
+.. code:: ruby
+
+    require 'mongo_kerberos'
+
+MongoDB Enterprise Edition v2.4+ supports GSSAPI (Kerberos)
+authentication.
+
+In order to use it in the Ruby driver with **JRuby**, you must do the
+following:
+
+1. Specify several system properties so that the underlying GSSAPI Java
+   libraries can acquire a Kerberos ticket. Please see `this
+   documentation <https://docs.mongodb.com/ecosystem/tutorial/authenticate-with-java-driver/#kerberos-authentication>`__
+   for more information.
+
+2. Either provide a password OR set the
+   'java.security.auth.login.config' system property to a config file
+   that references a keytab file.
+
+In order to use it in the Ruby driver with **MRI**, you must do the
+following:
+
+1. Create a ticket-granting ticket using kinit. Please see `this
+   documentation <http://linux.die.net/man/1/kinit>`__ for more
+   information.
+
+For more information about deploying MongoDB with Kerberos
+authentication, please see `this
+documentation <https://docs.mongodb.com/manual/tutorial/control-access-to-mongodb-with-kerberos-authentication/>`__.
+
+.. code:: ruby
+
+    # GSSAPI authentication
+    client = MongoClient.new
+    db     = client['example']
+    db.authenticate('sally', 'secret', nil, nil, 'GSSAPI')
+
+    # GSSAPI authentication from uri
+    uri    = 'mongodb://mongodbuser%40EXAMPLE.COM@example.com/?authMechanism=GSSAPI' 
+    client = MongoClient.from_uri(uri)
+
+The default service name used by MongoDB and the Ruby driver is
+'mongodb'. You can specify a custom service name with the
+'gssapi\_service\_name' option:
+
+.. code:: ruby
+
+    client = MongoClient.new
+    db     = client['example']
+    db.authenticate('sally', 'secret', nil, nil, 'GSSAPI', :gssapi_service_name => 'myservicename')
+
+    # from uri
+    uri    = 'mongodb://mongodbuser%40EXAMPLE.COM@example.com/?authMechanism=GSSAPI&gssapiServiceName=myservicename' 
+    client = MongoClient.from_uri(uri)
+
+**Applies to JRuby only**
+
+By default, the driver won't canonicalize the hostname. You can specify
+that you would like it canonicalized by setting the
+'canonicalize\_host\_name' option to true:
+
+.. code:: ruby
+
+    client = MongoClient.new
+    db     = client['example']
+    db.authenticate('sally', 'secret', nil, nil, 'GSSAPI', :canonicalize_host_name => true)
+
+    # from uri
+    uri    = 'mongodb://mongodbuser%40EXAMPLE.COM@example.com/?authMechanism=GSSAPI&canonicalizeHostName=true' 
+    client = MongoClient.from_uri(uri)

--- a/docs-source/bulk-write-operations.txt
+++ b/docs-source/bulk-write-operations.txt
@@ -1,0 +1,343 @@
+=====================
+Bulk Write Operations
+=====================
+
+.. default-domain:: mongodb
+
+This tutorial explains how to take advantage of MongoDB's bulk write
+operation feature with the Ruby driver. Executing write operations in
+batches reduces the number of network round trips and increases write
+throughput. Bulk write operations are available as of MongoDB server
+release 2.6.
+
+Bulk Insert How-To
+==================
+
+The following setup is assumed for each of the following code examples.
+
+.. code:: ruby
+
+    require 'mongo'
+    require 'pp'
+    mongo_client = Mongo::MongoClient.new
+    coll = mongo_client['test_db']['test_collection']
+    coll.remove
+
+Here's how to do an ordered bulk insert - the unordered bulk insert will
+be shown later.
+
+.. code:: ruby
+
+    bulk = coll.initialize_ordered_bulk_op
+    bulk.insert({'_id' => 1})
+    bulk.insert({'_id' => 2})
+    bulk.insert({'_id' => 3})
+    p bulk.execute
+
+On ``bulk.execute``, only one request is sent to the database server for
+the batch of three insert operations. In contrast, individual insert
+operations would take three requests, one request each per insert. The
+``bulk.execute`` above returns the following result indicating
+successful insertion of three documents.
+
+.. code:: ruby
+
+    {"ok"=>1, "n"=>3, "nInserted"=>3}
+
+Ordered Bulk Write Operation
+----------------------------
+
+In an ordered bulk write operation, the database server will stop
+execution on the first error. For example, the following results in an
+exception.
+
+.. code:: ruby
+
+    begin
+      bulk = coll.initialize_ordered_bulk_op
+      bulk.insert({'_id' => 1})
+      bulk.insert({'_id' => 1}) # cause a duplicate key error here
+      bulk.insert({'_id' => 3})
+      bulk.execute
+    rescue => ex
+      p ex
+      pp ex.result
+    end
+    puts "collection count: #{coll.count}"
+
+This is the output from executing the above code example.
+
+.. code:: ruby
+
+    #<Mongo::BulkWriteError: batch item errors occurred>
+    {"ok"=>1,
+     "n"=>1,
+     "code"=>65,
+     "errmsg"=>"batch item errors occurred",
+     "nInserted"=>1,
+     "writeErrors"=>
+      [{"index"=>1,
+        "code"=>11000,
+        "errmsg"=>
+         "insertDocument :: caused by :: 11000 E11000 duplicate key error index: bulk_write_example.bulk_write_test.$_id_  dup key: { : 1 }"}]}
+    collection count: 1
+
+The exception is a ``Mongo::BulkWriteError`` indicating that
+``batch item errors occurred``. Result details can be found in the
+``result`` member for the exception and indicate that one document was
+inserted. The ``writeErrors`` value includes the zero-base ``index``
+that indicates where the error occurred in the sequence. The collection
+count verifies that only one document was inserted as the batch
+terminated on error.
+
+Unordered Bulk Write Operation
+------------------------------
+
+To have the database server continue even if there is an error, use
+``initialize_unordered_bulk_op`` for an unordered bulk write operation.
+With a sharded MongoDB installation, the unordered operation permits
+``mongos`` to simultaneously submit operations to multiple shards in
+parallel and the resulting performance advantage can be significant.
+
+.. code:: ruby
+
+    begin
+      bulk = coll.initialize_unordered_bulk_op
+      bulk.insert({'_id' => 1})
+      bulk.insert({'_id' => 1}) # duplicate key
+      bulk.insert({'_id' => 3})
+      bulk.insert({'_id' => 3}) # duplicate key
+      bulk.execute
+    rescue => ex
+      p ex
+      pp ex.result
+    end
+    puts "collection count: #{coll.count}"
+
+Output:
+
+.. code:: ruby
+
+    #<Mongo::BulkWriteError: batch item errors occurred>
+    {"ok"=>1,
+     "n"=>2,
+     "code"=>65,
+     "errmsg"=>"batch item errors occurred",
+     "nInserted"=>2,
+     "writeErrors"=>
+      [{"index"=>1,
+        "code"=>11000,
+        "errmsg"=>
+         "insertDocument :: caused by :: 11000 E11000 duplicate key error index: test_db.test_collection.$_id_  dup key: { : 1 }"},
+       {"index"=>3,
+        "code"=>11000,
+        "errmsg"=>
+         "insertDocument :: caused by :: 11000 E11000 duplicate key error index: test_db.test_collection.$_id_  dup key: { : 3 }"}]}
+    collection count: 2
+
+There is a ``writeErrors`` element for each error that occurred. The
+result document and the collection count verify that two documents were
+inserted.
+
+Bulk Insert Performance Advantage
+---------------------------------
+
+The performance advantage of bulk write operations is demonstrated by
+the following program.
+
+.. code:: ruby
+
+    #!/usr/bin/env ruby
+    require 'mongo'
+    require 'benchmark'
+
+    TEST_SIZE = 100_000
+    DB_NAME = 'bulk_write_example'
+    COLLECTION_NAME = 'bulk_write_test'
+
+    $mongo_client = Mongo::MongoClient.new
+    $mongo_database = $mongo_client[DB_NAME]
+    $collection = $mongo_database[COLLECTION_NAME]
+    $norm_real = nil
+
+    def benchmark_real(title)
+      $mongo_database.drop_collection(COLLECTION_NAME)
+      real = Benchmark.measure { yield }.real
+      puts ("%2.1f" % (($norm_real || real)/real) + ' ' + title)
+      real
+    end
+
+    docs = TEST_SIZE.times.collect{|i| {i.to_s => i} }
+
+    $norm_real = benchmark_real("insert single"){ docs.each {|doc| $collection.insert(doc)} }
+
+    [1, 2, 10, 100, 1000, 10_000].each do |bulk_size|
+      [:ordered, :unordered].each do |order|
+        benchmark_real("bulk #{order} size #{bulk_size}") do
+          docs.each_slice(bulk_size) do |docs_slice|
+            bulk = (order == :ordered) ? $collection.initialize_ordered_bulk_op : $collection.initialize_unordered_bulk_op
+            docs_slice.each {|doc| bulk.insert(doc)}
+            bulk.execute
+          end
+        end
+      end
+    end
+
+    benchmark_real("insert batch") { $collection.insert(docs) }
+
+    $mongo_client.drop_database(DB_NAME)
+    $mongo_client.close
+
+Output:
+
+.. code:: ruby
+
+    1.0 insert single
+    0.7 bulk ordered size 1
+    0.7 bulk unordered size 1
+    1.3 bulk ordered size 2
+    1.3 bulk unordered size 2
+    5.0 bulk ordered size 10
+    4.9 bulk unordered size 10
+    15.1 bulk ordered size 100
+    14.6 bulk unordered size 100
+    20.0 bulk ordered size 1000
+    20.1 bulk unordered size 1000
+    19.8 bulk ordered size 10000
+    18.8 bulk unordered size 10000
+    22.9 insert batch
+
+This measurement was made with both the client and a single MongoDB
+server on the same local machine. Your results may vary with client and
+server on separate machines, with different network latency, with
+various cluster configurations, and with various document sizes.
+
+While there is some overhead for a bulk write operation, even a batch
+size of two shows benefit. The size of the user bulk operation is not
+restricted, and the driver will automatically split large operations
+into batches that will be accepted by the MongoDB server. At present,
+there is a ``max_write_batch_size`` of 1000, and this is reflected in
+the slightly lower benefit with batch size of 10\_000. A larger
+``max_write_batch_size`` may give a bit more advantage but is in the
+vicinity of diminishing returns.
+
+With this configuration, there is little difference between ordered and
+unordered performance. However with a sharded cluster, the unordered
+bulk write operation permits ``mongos`` to send simultaneous operations
+in parallel to multiple shards and the performance advantage can be
+significant.
+
+The collection ``insert`` method can also take an array for batch
+insertion and performance advantage. The measurement here shows that it
+has less overhead than the bulk write operation, but the performance is
+close for large batch sizes.
+
+Mixed Bulk Write Operations
+===========================
+
+The bulk write operation also permits mixing various ``update`` and
+``remove`` operations using a fluent API. Please see the Ruby driver API
+docs for full details - http://api.mongodb.org/ruby. So you can now
+realize performance gains with batches not just for ``insert``, but also
+for ``update`` and ``remove`` operations, or a mix of operation types.
+Here's a big example that illustrates the range of available expressions
+for operations.
+
+.. code:: ruby
+
+      def big_example(bulk)
+        bulk.insert({:a => 1})
+        bulk.insert({:a => 2})
+        bulk.insert({:a => 3})
+        bulk.insert({:a => 4})
+        bulk.insert({:a => 5})
+        # Update one document matching the selector
+        bulk.find({:a => 1}).update_one({"$inc" => {:x => 1}})
+        # Update all documents matching the selector
+        bulk.find({:a => 2}).update({"$inc" => {:x => 2}})
+        # Replace entire document (update with whole doc replaced)
+        bulk.find({:a => 3}).replace_one({:x => 3})
+        # Update one document matching the selector or upsert
+        bulk.find({:a => 1}).upsert.update_one({"$inc" => {:x => 1}})
+        # Update all documents matching the selector or upsert
+        bulk.find({:a => 2}).upsert.update({"$inc" => {:x => 2}})
+        # Replaces a single document matching the selector or upsert
+        bulk.find({:a => 3}).upsert.replace_one({:x => 3})
+        # Remove a single document matching the selector
+        bulk.find({:a => 4}).remove_one()
+        # Remove all documents matching the selector
+        bulk.find({:a => 5}).remove()
+        # Insert a document
+        bulk.insert({:x => 4})
+      end
+
+At present, the Ruby driver splits mixed bulk write operations into a
+sequence of ``insert``, ``update``, and ``remove`` requests.
+
+.. code:: ruby
+
+    bulk = coll.initialize_ordered_bulk_op
+    big_example(bulk)
+    bulk.execute
+
+For the above ordered bulk operation of the big example, this would be a
+sequence of four requests - ``insert`` ops 0-4, ``update`` ops 5-10,
+``remove`` ops 11-12, and ``insert`` op 13.
+
+.. code:: ruby
+
+    bulk = coll.initialize_unordered_bulk_op
+    big_example(bulk)
+    bulk.execute
+
+For the above unordered bulk operation of the big example, this would be
+reduced to a sequence of three requests with a single ``insert`` request
+for ops 0-4 and 13, a single ``update`` request for ops 5-10, and a
+single ``remove`` request for ops 11-12. In the absence of splitting due
+to large size, an unordered bulk operation will have at most three
+requests, one per type of operation. In contrast, an ordered bulk
+operation can only submit a request containing contiguous operations of
+the same type. So to maximize performance, minimize requests by
+maximizing contiguous operations by type.
+
+Write Concern
+=============
+
+By default bulk operations are executed with the ``write_concern``
+inherited from the collection. A custom write concern can be passed to
+the ``execute`` method. More detail on write concern can be found in the
+MongoDB `Manual <https://docs.mongodb.com/manual/core/write-concern/>`_
+or in the
+`wiki <https://github.com/mongodb/mongo-ruby-driver/wiki/Write-Concern>`_.
+Write concern errors, e.g.
+`wtimeout <https://docs.mongodb.com/manual/reference/write-concern/>`_,
+will be reported after all operations are attempted, regardless of
+execution order.
+
+.. code:: ruby
+
+    bulk = coll.initialize_ordered_bulk_op
+    bulk.insert({'a' => 0})
+    bulk.insert({'a' => 1})
+    bulk.insert({'a' => 2})
+    bulk.insert({'a' => 3})
+    begin
+      bulk.execute({:w => 4, :wtimeout => 1})
+    rescue Mongo::BulkWriteError => ex
+      pp ex.result
+    end
+
+Output:
+
+.. code:: ruby
+
+    {"ok"=>1,
+     "n"=>1,
+     "code"=>65,
+     "errmsg"=>"batch item errors occurred",
+     "nInserted"=>4,
+     "writeConcernError"=>
+      [{"errmsg"=>"timed out waiting for slaves",
+        "code"=>64,
+        "errInfo"=>{"wtimeout"=>true},
+        "index"=>0}]}}

--- a/docs-source/credits.txt
+++ b/docs-source/credits.txt
@@ -1,0 +1,133 @@
+=======
+Credits
+=======
+
+.. default-domain:: mongodb
+
+
+Adrian Madrid, aemadrid@gmail.com
+
+-  bin/mongo\_console
+-  examples/benchmarks.rb
+-  examples/irb.rb
+-  Modifications to examples/simple.rb
+-  Found plenty of bugs and missing features.
+-  Ruby 1.9 support.
+-  Gem support.
+-  Many other code suggestions and improvements.
+
+Aman Gupta, aman@tmm1.net
+
+-  Collection#save
+-  Noted bug in returning query batch size.
+
+Jon Crosby, jon@joncrosby.me
+
+-  Some code clean-up
+
+John Nunemaker, http://railstips.org
+
+-  Collection#create\_index takes symbols as well as strings
+-  Fix for Collection#save
+-  Add logger convenience methods to connection and database
+
+David James, djames@sunlightfoundation.com
+
+-  Fix dates to return as UTC
+
+Paul Dlug, paul.dlug@gmail.com
+
+-  Generate \_id on the client side if not provided
+-  Collection#insert and Collection#save return \_id
+
+Durran Jordan, durran@gmail.com
+
+-  DB#collections
+-  Support for specifying sort order as array of [key, direction] pairs
+-  OrderedHash#update aliases to merge!
+
+Cyril Mougel, cyril.mougel@gmail.com
+
+-  Initial logging support
+-  Test case
+
+Jack Chen, chendo on github
+
+-  Test case + fix for deserializing pre-epoch Time instances
+
+Michael Bernstein, mrb on github
+
+-  Cursor#sort
+
+Paulo Ahahgon, pahagon on github
+
+-  removed hard limit
+
+Les Hill, leshill on github
+
+-  OrderedHash#each returns self
+
+Sean Cribbs, seancribbs on github
+
+-  Modified standard\_benchmark to allow profiling
+-  C ext for faster ObjectID creation
+
+Sunny Hirai
+
+-  Suggested hashcode fix for Mongo::ObjectID
+-  Noted index ordering bug.
+-  GridFS performance boost
+
+Christos Trochalakis
+
+-  Added map/reduce helper
+
+Blythe Dunham
+
+-  Added finalize option to map/reduce
+
+Matt Powell (fauxparse)
+
+-  Added GridStore#mv
+
+Patrick Collison
+
+-  Added safe mode for Collection#remove
+
+Chuck Remes
+
+-  Extraction of BSON into separate gems
+-  Extensions compile on Rubinius
+-  Performance improvements for INT in C extensions
+-  Performance improvements for JRuby BSON encoder and callback classes
+
+Dmitrii Golub (Houdini) and Jacques Crocker (railsjedi)
+
+-  Support open to exclude fields on query
+
+dfitzgibbon
+
+-  patch for ensuring bson\_ext compatibility with early release of Ruby
+   1.8.5
+
+Matt Taylor
+
+-  Noticed excessive calls to ObjectId#to\_s. As a result, stopped
+   creating log messages when no logger was passed to Mongo::Connection.
+   Resulted in a significant performance improvement.
+
+Hongli Lai (Phusion)
+
+-  Significant performance improvements. See commits.
+
+Mislav Marohnić
+
+-  Replaced returning with each\_with\_object
+
+Alex Stupka
+
+-  Replica set port bug
+
+Wlodek Bzyl
+
+-  Aggregation Framework tutorial and examples

--- a/docs-source/examples.txt
+++ b/docs-source/examples.txt
@@ -1,0 +1,430 @@
+=============
+Admin Example
+=============
+
+.. default-domain:: mongodb
+
+.. code:: ruby
+
+    require 'mongo'
+    require 'pp'
+
+    include Mongo
+
+    host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+    port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+    puts "Connecting to #{host}:#{port}"
+    client  = MongoClient.new(host, port)
+    db   = client.db('ruby-mongo-examples')
+    coll = db.create_collection('test')
+
+    # Erase all records from collection, if any
+    coll.remove
+
+    admin = client['admin']
+
+    # Profiling level set/get
+    puts "Profiling level: #{admin.profiling_level}"
+
+    # Start profiling everything
+    admin.profiling_level = :all
+
+    # Read records, creating a profiling event
+    coll.find().to_a
+
+    # Stop profiling
+    admin.profiling_level = :off
+
+    # Print all profiling info
+    pp admin.profiling_info
+
+    # Validate returns a hash if all is well and
+    # raises an exception if there is a problem.
+    info = db.validate_collection(coll.name)
+    puts "valid = #{info['ok']}"
+    puts info['result']
+
+    # Destroy the collection
+    coll.drop
+
+Capped Collection Example
+-------------------------
+
+.. code:: ruby
+
+    require 'mongo'
+
+    include Mongo
+
+    host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+    port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+    puts "Connecting to #{host}:#{port}"
+    db = MongoClient.new(host, port).db('ruby-mongo-examples')
+    db.drop_collection('test')
+
+    # A capped collection has a max size and, optionally, a max number of records.
+    # Old records get pushed out by new ones once the size or max num records is reached.
+    coll = db.create_collection('test', :capped => true, :size => 1024, :max => 12)
+
+    100.times { |i| coll.insert('a' => i+1) }
+
+    # We will only see the last 12 records
+    coll.find().each { |row| p row }
+
+    coll.drop
+
+Working with Cursors
+--------------------
+
+.. code:: ruby
+
+    require 'mongo'
+    require 'pp'
+
+    include Mongo
+
+    host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+    port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+    puts "Connecting to #{host}:#{port}"
+    db = MongoClient.new(host, port).db('ruby-mongo-examples')
+    coll = db.collection('test')
+
+    # Erase all records from collection, if any
+    coll.remove
+
+    # Insert 3 records
+    3.times { |i| coll.insert({'a' => i+1}) }
+
+    # Cursors don't run their queries until you actually attempt to retrieve data
+    # from them.
+
+    # Find returns a Cursor, which is Enumerable. You can iterate:
+    coll.find().each { |row| pp row }
+
+    # You can turn it into an array:
+    array = coll.find().to_a
+
+    # You can iterate after turning it into an array (the cursor will iterate over
+    # the copy of the array that it saves internally.)
+    cursor = coll.find()
+    array = cursor.to_a
+    cursor.each { |row| pp row }
+
+    # You can get the next object
+    first_object = coll.find().next_document
+
+    # next_document returns nil if there are no more objects that match
+    cursor = coll.find()
+    obj = cursor.next_document
+    while obj
+      pp obj
+      obj = cursor.next_document
+    end
+
+    # Destroy the collection
+    coll.drop
+
+GridFS
+------
+
+.. code:: ruby
+
+    def assert
+      raise "Failed!" unless yield
+    end
+
+    require 'mongo'
+    include Mongo
+
+    host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+    port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+    puts "Connecting to #{host}:#{port}"
+    db = MongoClient.new(host, port).db('ruby-mongo-examples')
+
+    data = "hello, world!"
+
+    grid = Grid.new(db)
+
+    # Write a new file. data can be a string or an io object responding to #read.
+    id = grid.put(data, :filename => 'hello.txt')
+
+    # Read it and print out the contents
+    file = grid.get(id)
+    puts file.read
+
+    # Delete the file
+    grid.delete(id)
+
+    begin
+    grid.get(id)
+    rescue => e
+      assert {e.class == Mongo::GridError}
+    end
+
+    # Metadata
+    id = grid.put(data, :filename => 'hello.txt', :content_type => 'text/plain', :metadata => {'name' => 'hello'})
+    file = grid.get(id)
+
+    p file.content_type
+    p file.metadata.inspect
+    p file.chunk_size
+    p file.file_length
+    p file.filename
+    p file.data
+
+Gathering Information
+---------------------
+
+.. code:: ruby
+
+    require 'mongo'
+
+    include Mongo
+
+    host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+    port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+    puts "Connecting to #{host}:#{port}"
+    db = MongoClient.new(host, port).db('ruby-mongo-examples')
+    coll = db.collection('test')
+
+    # Erase all records from collection, if any
+    coll.remove
+
+    # Insert 3 records
+    3.times { |i| coll.insert({'a' => i+1}) }
+
+    # Collection names in database
+    p db.collection_names
+
+    # More information about each collection
+    p db.collections_info
+
+    # Index information
+    coll.create_index('a')
+    p db.index_information('test')
+
+    # Destroy the collection
+    coll.drop
+
+Queries
+-------
+
+.. code:: ruby
+
+    require 'mongo'
+    require 'pp'
+
+    include Mongo
+
+    host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+    port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+    puts "Connecting to #{host}:#{port}"
+    db = MongoClient.new(host, port).db('ruby-mongo-examples')
+    coll = db.collection('test')
+
+    # Remove all records, if any
+    coll.remove
+
+    # Insert five records
+    coll.insert('a' => 1)
+    coll.insert('a' => 2)
+    coll.insert('b' => 3)
+    coll.insert('c' => 'foo')
+    coll.insert('c' => 'bar')
+
+    # Count.
+    puts "There are #{coll.count} records."
+
+    # Find all records. find() returns a Cursor.
+    puts "Find all records:"
+    pp cursor = coll.find.to_a
+
+    # Print them. Note that all records have an _id automatically added by the
+    # database. See pk.rb for an example of how to use a primary key factory to
+    # generate your own values for _id.
+    puts "Print each document individually:"
+    pp cursor.each { |row| pp row }
+
+    # See Collection#find. From now on in this file, we won't be printing the
+    # records we find.
+    puts "Find one record:"
+    pp coll.find('a' => 1).to_a
+
+    # Find records sort by 'a', skip 1, limit 2 records.
+    # Sort can be single name, array, or hash.
+    puts "Skip 1, limit 2, sort by 'a':"
+    pp coll.find({}, {:skip => 1, :limit => 2, :sort => 'a'}).to_a
+
+    # Find all records with 'a' > 1. There is also $lt, $gte, and $lte.
+    coll.find({'a' => {'$gt' => 1}})
+    coll.find({'a' => {'$gt' => 1, '$lte' => 3}})
+
+    # Find all records with 'a' in a set of values.
+    puts "Find all records where a is $in [1, 2]:"
+    pp coll.find('a' => {'$in' => [1,2]}).to_a
+
+    puts "Find by regex:"
+    pp coll.find({'c' => /f/}).to_a
+
+    # Print query explanation
+    puts "Print an explain:"
+    pp coll.find({'c' => /f/}).explain
+
+    # Use a hint with a query. Need an index. Hints can be stored with the
+    # collection, in which case they will be used with all queries, or they can be
+    # specified per query, in which case that hint overrides the hint associated
+    # with the collection if any.
+    coll.create_index('c')
+    coll.hint = 'c'
+
+    puts "Print an explain with index:"
+    pp coll.find('c' => /[f|b]/).explain
+
+    puts "Print an explain with natural order hint:"
+    pp coll.find({'c' => /[f|b]/}, :hint => '$natural').explain
+
+Replica Sets
+------------
+
+.. code:: ruby
+
+    # This code assumes a running replica set with at least one node at localhost:27017.
+    require 'mongo'
+
+    include Mongo
+
+    cons = []
+
+    10.times do
+      cons << MongoReplicaSetClient(['localhost:27017'], :read => :secondary)
+    end
+
+    ports = cons.map do |con|
+      con.read_pool.port
+    end
+
+    puts "These ten connections will read from the following ports:"
+    p ports
+
+    cons[rand(10)]['foo']['bar'].remove
+    100.times do |n|
+      cons[rand(10)]['foo']['bar'].insert({:a => n})
+    end
+
+    100.times do |n|
+      p cons[rand(10)]['foo']['bar'].find_one({:a => n})
+    end
+
+Simple
+------
+
+.. code:: ruby
+
+    require 'rubygems'
+    require 'mongo'
+
+    include Mongo
+
+    host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+    port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+    puts "Connecting to #{host}:#{port}"
+    db = MongoClient.new(host, port).db('ruby-mongo-examples')
+    coll = db.collection('test')
+
+    # Erase all records from collection, if any
+    coll.remove
+
+    # Insert 3 records
+    3.times { |i| coll.insert({'a' => i+1}) }
+
+    puts "There are #{coll.count()} records in the test collection. Here they are:"
+    coll.find().each { |doc| puts doc.inspect }
+
+    # Destroy the collection
+    coll.drop
+
+Strict Mode
+-----------
+
+.. code:: ruby
+
+    require 'mongo'
+
+    include Mongo
+
+    host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+    port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+    puts "Connecting to #{host}:#{port}"
+    db = MongoClient.new(host, port).db('ruby-mongo-examples')
+
+    db.drop_collection('does-not-exist')
+    db.create_collection('test')
+
+    db.strict = true
+
+    begin
+      # Can't reference collection that does not exist
+      db.collection('does-not-exist')
+      puts "error: expected exception"
+    rescue => ex
+      puts "expected exception: #{ex}"
+    end
+
+    begin
+      # Can't create collection that already exists
+      db.create_collection('test')
+      puts "error: expected exception"
+    rescue => ex
+      puts "expected exception: #{ex}"
+    end
+
+    db.strict = false
+    db.drop_collection('test')
+
+Types
+-----
+
+.. code:: ruby
+
+    require 'mongo'
+    require 'pp'
+
+    include Mongo
+
+    host = ENV['MONGO_RUBY_DRIVER_HOST'] || 'localhost'
+    port = ENV['MONGO_RUBY_DRIVER_PORT'] || MongoClient::DEFAULT_PORT
+
+    puts "Connecting to #{host}:#{port}"
+    db = MongoClient.new(host, port).db('ruby-mongo-examples')
+    coll = db.collection('test')
+
+    # Remove all records, if any
+    coll.remove
+
+    # Insert record with all sorts of values
+    coll.insert('array' => [1, 2, 3],
+                'string' => 'hello',
+                'hash' => {'a' => 1, 'b' => 2},
+                'date' => Time.now, # milliseconds only; microseconds are not stored
+                'oid' => ObjectID.new,
+                'binary' => Binary.new([1, 2, 3]),
+                'int' => 42,
+                'float' => 33.33333,
+                'regex' => /foobar/i,
+                'boolean' => true,
+                'where' => Code.new('this.x == 3'),
+                'dbref' => DBRef.new(coll.name, ObjectID.new),
+                'null' => nil,
+                'symbol' => :zildjian)
+
+    pp coll.find().next_document
+
+    coll.remove

--- a/docs-source/faq.txt
+++ b/docs-source/faq.txt
@@ -1,0 +1,285 @@
+================
+Ruby MongoDB FAQ
+================
+
+.. default-domain:: mongodb
+
+This is a list of frequently asked questions about using Ruby with
+MongoDB. If you have a question you'd like to have answered here, please
+post your question to the `mongodb-user
+list <http://groups.google.com/group/mongodb-user>`_.
+
+Can I run (insert command name here) from the Ruby driver?
+----------------------------------------------------------
+
+Yes. You can run any of the `available database
+commands <https://docs.mongodb.com/manual/reference/command/>`_ from the
+driver using the DB#command method. The only trick is to use an
+OrderedHash when specifying the command. For example, here's how you'd
+run an asynchronous fsync from the driver:
+
+.. code:: ruby
+
+    include Mongo
+
+    # This command is run on the admin database.
+    @db = MongoClient.new('localhost', 27017).db('admin')
+
+    # Build the command.
+    cmd = OrderedHash.new
+    cmd['fsync'] = 1
+
+    # Run it.
+    @db.command(cmd)
+
+It's important to keep in mind that some commands, like ``fsync``, must
+be run on the ``admin`` database, while other commands can be run on any
+database. If you're having trouble, check the [command reference\|List
+of Database Commands] to make sure you're using the command correctly.
+
+Does the Ruby driver support an EXPLAIN command?
+------------------------------------------------
+
+Yes. ``explain`` is, technically speaking, an option sent to a query
+that tells MongoDB to return an explain plan rather than the query's
+results. You can use ``explain`` by constructing a query and calling
+explain at the end:
+
+.. code:: ruby
+
+    @collection = @db['users']
+    result = @collection.find({:name => "jones"}).explain
+
+Because this collection has an index on the "name" field, the query uses
+that index, only having to scan a single record. "n" is the number of
+records the query will return. "millis" is the time the query takes, in
+milliseconds. "oldPlan" indicates that the query optimizer has already
+seen this kind of query and has, therefore, saved an efficient query
+plan. "allPlans" shows all the plans considered for this query.
+
+I see that BSON supports a symbol type. Does this mean that I can store Ruby symbols in MongoDB?
+------------------------------------------------------------------------------------------------
+
+You can store Ruby symbols in MongoDB, but only as values. BSON
+specifies that document keys must be strings. So, for instance, you can
+do this:
+
+.. code:: ruby
+
+    @collection = @db['test']
+
+    boat_id = @collection.save({:vehicle  => :boat})
+    car_id  = @collection.save({"vehicle" => "car"})
+
+    @collection.find_one('_id' => boat_id)
+    {"_id" => ObjectID('4bb372a8238d3b5c8c000001'), "vehicle" => :boat}
+
+
+    @collection.find_one('_id' => car_id)
+    {"_id" => ObjectID('4bb372a8238d3b5c8c000002'), "vehicle" => "car"}
+
+Notice that the symbol values are returned as expected, but that symbol
+keys are treated as strings.
+
+I see BSON documents with identical keys. What happened?
+--------------------------------------------------------
+
+As a rule of thumb, always use ALL symbols or ALL strings as Ruby hash
+keys, never a mix of the two. As noted above, Ruby symbols are
+serialized into BSON strings. You could feasibly end up in the following
+situation:
+
+.. code:: ruby
+
+    record = collection.find_one({ :_id => "an_id" })
+    record.update(:something_to_update => "my_original_value")
+    # The record document now looks like this in Ruby: { "_id" => "an_id", :something_to_update => "my_original_value" }
+    # Note that the _id is a string because the original Ruby document's symbol keys were converted to BSON strings.
+    # You have a mix of symbol and string keys here (which breaks the rule of thumb).
+
+    collection.update({ :_id => "an_id" }, record)
+    # The record is serialized into BSON as: { "_id" => "an_id", "something_to_update" => "my_original_value"}
+    # Note that the key, "something_to_update" is now a string.
+
+    record = collection.find_one({ :_id => "an_id" })
+    # The record document looks like this in Ruby when deserialized: { "_id" => "an_id", "something_to_update" => "my_original_value" }
+    # Note that the key "something_to_update" is a string.
+
+    record.update(:something_to_update => "a_more_recent_value")
+    # This is allowed because the Ruby hash has a key "something_to_update" as a string and adding the symbol :something_to_update is allowed.
+    # The Ruby hash is now: { "_id" => "an_id", "something_to_update" => "my_original_value", :something_to_update => "a_more_recent_value" }
+
+    collection.update({ :_id => "an_id" }, record})
+    # The document gets serialized to { "_id" => "an_id", "something_to_update" => "my_original_value", "something_to_update" => "a_more_recent_value"}
+    # because keys and values are just written to a buffer upon serialization. There is no validation on key uniqueness done either by the driver or MongoDB.
+
+As mentioned above, make sure you use ALL symbols or ALL strings as keys
+in Ruby hashes being converted to BSON documents. In this particular
+case, another way to avoid this problem is to use update operators.
+Update operators have the added benefit of requiring only one trip to
+the server. For example:
+
+.. code:: ruby
+
+    collection.update({ :_id => "an_id"}, { "$set" => { :something_to_update => "a_more_recent_value" } } )
+
+Why can't I access random elements within a cursor?
+---------------------------------------------------
+
+MongoDB cursors are designed for sequentially iterating over a result
+set, and all the drivers, including the Ruby driver, stick closely to
+this directive. Internally, a Ruby cursor fetches results in batches by
+running a MongoDB ``getmore`` operation. The results are buffered for
+efficient iteration on the application-side.
+
+What this means is that a cursor is nothing more than a device for
+returning a result set on a query that's been initiated on the server.
+Cursors are not containers for result sets. If we allow a cursor to be
+randomly accessed, then we run into issues regarding the freshness of
+the data. For instance, if I iterate over a cursor and then want to
+retrieve the cursor's first element, should a stored copy be returned,
+or should the cursor re-run the query? If we returned a stored copy, it
+may not be fresh. And if the the query is re-run, then we're technically
+dealing with a new cursor.
+
+To avoid those issues, we're saying that anyone who needs flexible
+access to the results of a query should store those results in an array
+and then access the data as needed.
+
+Why can't I save an instance of TimeWithZone?
+---------------------------------------------
+
+MongoDB stores times in UTC as the number of milliseconds since the
+epoch. This means that the Ruby driver serializes Ruby Time objects
+only. While it would certainly be possible to serialize a TimeWithZone,
+this isn't preferable since the driver would still deserialize to a Time
+object.
+
+All that said, if necessary, it'd be easy to write a thin wrapper over
+the driver that would store an extra time zone attribute and handle the
+serialization/deserialization of TimeWithZone transparently.
+
+I keep getting CURSOR\_NOT\_FOUND exceptions. What's happening?
+---------------------------------------------------------------
+
+The most likely culprit here is that the cursor is timing out on the
+server. Whenever you issue a query, a cursor is created on the server.
+Cursor naturally time out after ten minutes, which means that if you
+happen to be iterating over a cursor for more than ten minutes, you risk
+a CURSOR\_NOT\_FOUND exception.
+
+There are two solutions to this problem. You can either:
+
+1. Limit your query. Use some combination of ``limit`` and ``skip`` to
+   reduce the total number of query results. This will, obviously, bring
+   down the time it takes to iterate.
+
+2. Turn off the cursor timeout. To do that, invoke ``find`` with a
+   block, and pass ``:timeout => false``:
+
+.. code:: ruby
+
+    @collection.find({}, :timeout => false) do |cursor|
+      cursor.each do |document
+        # Process documents here
+      end
+    end
+
+I periodically see connection failures between the driver and MongoDB. Why can't the driver retry the operation automatically?
+------------------------------------------------------------------------------------------------------------------------------
+
+A connection failure can indicate any number of failure scenarios. Has
+the server crashed? Are we experiencing a temporary network partition?
+Is there a bug in our ssh tunnel?
+
+Without further investigation, it's impossible to know exactly what has
+caused the connection failure. Furthermore, when we do see a connection
+failure, it's impossible to know how many operations prior to the
+failure succeeded. For example, imagine that we are expecting writes to
+be acknowledged, and we send an ``$inc`` operation to the server. It's
+entirely possible that the server has received the ``$inc`` but failed
+on the call to ``getLastError``. In that case, retrying the operation
+would result in a double-increment.
+
+Because of the indeterminacy involved, the MongoDB drivers will not
+retry operations on connection failure. How connection failures should
+be handled is entirely dependent on the application. Therefore, we leave
+it to the application developers to make the best decision in this case.
+
+The drivers will reconnect on the subsequent operation.
+
+Why is the 'm' option always set when Ruby regexes are serialized to BSON regexes?
+----------------------------------------------------------------------------------
+
+You should always first consider using the BSON::Regex class over
+defining regexes in Ruby if you are going to save them to the database
+or use them in a query.
+
+Concerning deserializaton, consider setting the compile\_regex option to
+false in case a BSON regular expression won't compile correctly to a
+Ruby regular expression.
+
+.. code:: ruby
+
+    coll.find({}, :compile_regex => false)
+
+With this option set to false, BSON regular expressions will be
+deserialized to instances of the BSON::Regex class. BSON::Regex
+instances define the regex and flags separately and aren't compiled,
+unless you call the #try\_compile method on them.
+
+In Ruby, the ^ and $ characters ALWAYS match the start and end of a
+line. This is not configurable. BSON regular expressions (and many other
+regex implementations) do make this an option and refer to it as the
+MULTILINE mode ('m').
+
+Since Ruby does not allow this as an option for regular expressions, it
+instead uses the MULTILINE flag to mean that the dot (.) matches
+newlines. BSON regular expressions refer to this as the DOTALL mode
+('s').
+
+As an example, consider the following regular expression defined in your
+Ruby code:
+
+.. code:: ruby
+
+    collection.find({ name: /^Mich/ })
+
+Because what BSON regular expressions consider the "m" option is always
+on in Ruby regular expressions, the above expression translates to:
+
+.. code:: ruby
+
+    query: { $query: { name: /^Mich/m } }
+
+If you are looking to create a BSON regular expression without the m
+flag, you should use the BSON::Regex class:
+
+.. code:: ruby
+
+    collection.find({ name: BSON::Regex.new("^Mich") })
+
+will correspond to the following expression on the server:
+
+.. code:: ruby
+
+    query: { $query: { name: /^Mich/ } }
+
+Additionally, be aware that defining a Ruby regular expression with the
+"m" option will translate to an expression with the "s" option on the
+server:
+
+.. code:: ruby
+
+    collection.find({ name: /^Mich/m })
+
+will become:
+
+.. code:: ruby
+
+    query: { $query: { name: /^Mich/ms } }
+
+I occasionally get an error saying that responses are out of order. What's happening?
+-------------------------------------------------------------------------------------
+
+See (this JIRA issue)[http://jira.mongodb.org/browse/RUBY-221].

--- a/docs-source/gridfs.txt
+++ b/docs-source/gridfs.txt
@@ -1,0 +1,218 @@
+==============
+GridFS in Ruby
+==============
+
+.. default-domain:: mongodb
+
+GridFS, which stands for "Grid File Store," is a specification for
+storing large files in MongoDB. It works by dividing a file into
+manageable chunks and storing each of those chunks as a separate
+document. GridFS requires two collections to achieve this: one
+collection stores each file's metadata (e.g., name, size, etc.) and
+another stores the chunks themselves. If you're interested in more
+details, check out the `GridFS
+Specification <http://www.mongodb.org/display/DOCS/GridFS+Specification>`_.
+
+The Grid class
+--------------
+
+The `Grid class <Mongo/Grid.html>`_ represents the core GridFS
+implementation. Grid gives you a simple file store, keyed on a unique
+ID. This means that duplicate filenames aren't a problem. To use the
+Grid class, first make sure you have a database, and then instantiate a
+Grid:
+
+::
+
+    require 'mongo'
+    include Mongo
+
+    @db = MongoClient.new('localhost', 27017).db('social_site')
+    @grid = Grid.new(@db)
+
+Saving files
+~~~~~~~~~~~~
+
+Once you have a Grid object, you can start saving data to it. The data
+can be either a string or an IO-like object that responds to a #read
+method:
+
+::
+
+    # Saving string data
+    id = @grid.put("here's some string / binary data")
+
+    # Saving IO data and including the optional filename
+    image = File.open("me.jpg")
+    id2   = @grid.put(image, :filename => "me.jpg")
+
+Grid#put returns an object id, which you can use to retrieve the file:
+
+::
+
+    # Get the string we saved
+    file = @grid.get(id)
+
+    # Get the file we saved
+    image = @grid.get(id2)
+
+File metadata
+~~~~~~~~~~~~~
+
+There are accessors for the various file attributes:
+
+::
+
+    image.filename
+    # => "me.jpg"
+
+    image.content_type
+    # => "image/jpg"
+
+    image.file_length
+    # => 502357
+
+    image.upload_date
+    # => Mon Mar 01 16:18:30 UTC 2010
+
+    # Read all the image's data at once
+    image.read
+
+    # Read the first 100k bytes of the image
+    image.read(100 * 1024)
+
+When putting a file, you can set many of these attributes and write
+arbitrary metadata:
+
+::
+
+    # Saving IO data
+    file = File.open("me.jpg")
+    id2  = @grid.put(file,
+             :filename     => "my-avatar.jpg"
+             :content_type => "application/jpg",
+             :_id          => 'a-unique-id-to-use-in-lieu-of-a-random-one',
+             :chunk_size   => 100 * 1024,
+             :metadata     => {'description' => "taken after a game of ultimate"})
+
+Write Concern
+~~~~~~~~~~~~~
+
+A kind of write concern is built into the GridFS specification. When you
+save a file, a MD5 hash is created on the server. If you save the file
+with writes acknowledged, a MD5 will be created by the driver for
+comparison with the server version. If the two hashes don't match, an
+exception will be raised. Writes are acknowledged by default in versions
+> 1.8 of the driver. You can change write concern with the :w option.
+See [`Write Concern <#write-concern>`_]
+
+::
+
+    image = File.open("me.jpg")
+    id2   = @grid.put(image, "my-avatar.jpg")
+
+Deleting files
+~~~~~~~~~~~~~~
+
+Deleting a file is as simple as providing the id:
+
+::
+
+    @grid.delete(id2)
+
+The GridFileSystem class
+------------------------
+
+`GridFileSystem <Mongo/GridFileSystem.html>`_ is a light emulation of a
+file system and therefore has a couple of unique properties. The first
+is that filenames are assumed to be unique. The second, a consequence of
+the first, is that files are versioned. To see what this means, let's
+create a GridFileSystem instance:
+
+Saving files
+~~~~~~~~~~~~
+
+::
+
+    require 'mongo'
+    include Mongo
+
+    @db = MongoClient.new('localhost', 27017).db("social_site")
+    @fs = GridFileSystem.new(@db)
+
+Now suppose we want to save the file 'me.jpg.' This is easily done using
+a filesystem-like API:
+
+::
+
+    image = File.open("me.jpg")
+    @fs.open("me.jpg", "w") do |f|
+      f.write image
+    end
+
+We can then retrieve the file by filename:
+
+::
+
+    image = @fs.open("me.jpg", "r") {|f| f.read }
+
+No problems there. But what if we need to replace the file? That too is
+straightforward:
+
+::
+
+    image = File.open("me-dancing.jpg")
+    @fs.open("me.jpg", "w") do |f|
+      f.write image
+    end
+
+But a couple things need to be kept in mind. First is that the original
+'me.jpg' will be available until the new 'me.jpg' saves. From then on,
+calls to the #open method will always return the most recently saved
+version of a file. But-- and this the second point-- old versions of the
+file won't be deleted. So if you're going to be rewriting files often,
+you could end up with a lot of old versions piling up. One solution to
+this is to use the :delete\_old options when writing a file:
+
+::
+
+    image = File.open("me-dancing.jpg")
+    @fs.open("me.jpg", "w", :delete_old => true) do |f|
+      f.write image
+    end
+
+This will delete all but the latest version of the file.
+
+Deleting files
+~~~~~~~~~~~~~~
+
+When you delete a file by name, you delete all versions of that file:
+
+::
+
+    @fs.delete("me.jpg")
+
+Metadata and acknowledged writes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+All of the options for storing metadata and acknowledging writes are
+available for the GridFileSystem class:
+
+::
+
+    image = File.open("me.jpg")
+    @fs.open('my-avatar.jpg', w,
+               :content_type => "application/jpg",
+               :metadata     => {'description' => "taken on 3/1/2010 after a game of ultimate"},
+               :_id          => 'a-unique-id-to-use-instead-of-the-automatically-generated-one'
+               ) { |f| f.write image }
+
+Advanced Users
+--------------
+
+Astute code readers will notice that the Grid and GridFileSystem classes
+are merely thin wrappers around an underlying `GridIO
+class <Mongo/GridIO.html>`_. This means that it's easy to customize the
+GridFS implementation presented here; just use GridIO for all the
+low-level work, and build the API you need in an external manager class
+similar to Grid or GridFileSystem.

--- a/docs-source/index.txt
+++ b/docs-source/index.txt
@@ -1,0 +1,60 @@
+.. http://www.mongodb.org/display/DOCS/Ruby+Language+Center
+
+.. _ruby-language-center:
+
+===================
+Ruby MongoDB Driver
+===================
+
+.. default-domain:: mongodb
+
+The MongoDB Ruby driver is the officially supported Ruby driver for
+MongoDB. It is written in pure Ruby and is optimized for simplicity. It
+can be used on its own, but it also serves as the basis of several
+object mapping libraries.
+
+
+Basic Features
+--------------
+
+- :doc:`/quick-start`
+- :doc:`/aggregation-framework`
+- :doc:`/examples`
+- :doc:`/authentication`
+- :doc:`/web-examples`
+- :doc:`/faq`
+
+Multiple Nodes
+--------------
+
+-  :doc:`/replica-sets`
+-  :doc:`/read-preference`
+-  :doc:`/write-concern`
+
+Advanced Features
+-----------------
+
+-  :doc:`/bulk-write-operations`
+-  :doc:`/tailable-cursors`
+-  :doc:`/gridfs`
+
+.. class:: hidden
+
+   .. toctree::
+      :titlesonly:
+
+      /quick-start
+      /aggregation-framework
+      /examples
+      /replica-sets
+      /read-preference
+      /write-concern
+      /bulk-write-operations
+      /authentication
+      /gridfs
+      /tailable-cursors
+      /web-examples
+      /faq
+      /style-guide
+      /credits
+

--- a/docs-source/quick-start.txt
+++ b/docs-source/quick-start.txt
@@ -1,0 +1,603 @@
+===========
+Quick Start
+===========
+
+.. default-domain:: mongodb
+
+This tutorial gives many common examples of using MongoDB with the Ruby
+driver. If you're looking for information on data modeling, see `MongoDB
+Data Modeling and
+Rails <http://www.mongodb.org/display/DOCS/MongoDB+Data+Modeling+and+Rails>`_.
+
+Installation
+------------
+
+The mongo-ruby-driver gem is served through Rubygems.org. To install,
+make sure you have the latest version of rubygems.
+
+.. code:: sh
+
+    gem update --system
+
+Next, install the mongo rubygem:
+
+.. code:: sh
+
+    gem install mongo
+
+The required ``bson`` gem will be installed automatically.
+
+For optimum performance, install the bson\_ext gem:
+
+.. code:: sh
+
+    gem install bson_ext
+
+After installing, you may want to look at the [[examples]] page. These
+examples walk through some of the basics of using the Ruby driver.
+
+Getting started
+---------------
+
+Note that the output in the following has been updated to Ruby 1.9, so
+if you are using Ruby 1.8, you will see some minor differences. To
+follow this tutorial interactively, at the command line, run the
+Interactive Ruby Shell.
+
+.. code:: sh
+
+    irb
+
+As you execute commands, irb will output the result using the
+``inspect`` method. If you are editing and running a script for this
+tutorial, you can view output using the ``puts`` or ``p`` methods.
+
+Using the gem
+~~~~~~~~~~~~~
+
+Use the ``mongo`` gem via the ``require`` kernel method.
+
+.. code:: ruby
+
+    require 'rubygems'  # not necessary for Ruby 1.9
+    require 'mongo'
+
+Include Mongo so that the Mongo classes are available without having to
+specify the Mongo namespace.
+
+::
+
+    include Mongo
+
+Making a Connection
+~~~~~~~~~~~~~~~~~~~
+
+A MongoClient instance represents a connection to MongoDB.
+
+.. code:: ruby
+
+    mongo_client = MongoClient.new("localhost", 27017)
+
+The driver will send a getlasterror command after every write to ensure
+that the write succeeded by default. Prior to version 1.8 of the driver,
+writes were not acknowledged by default and it was necessary to
+explicitly specify the option ':safe => true' for write confirmation.
+This is no longer the case.
+
+You can optionally specify the MongoDB server address and port when
+connecting. The following example shows three ways to connect to the
+local machine:
+
+.. code:: ruby
+
+    mongo_client = MongoClient.new # (optional host/port args)
+    mongo_client = MongoClient.new("localhost")
+    mongo_client = MongoClient.new("localhost", 27017)
+
+Note: in each of these cases, writes are confirmed by default.
+
+Listing All Databases
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: ruby
+
+    mongo_client.database_names     # lists all database names
+    mongo_client.database_info.each { |info| puts info.inspect }
+
+The database\_info method returns a hash mapping database names to the
+size of the database in bytes.
+
+Using a Database
+----------------
+
+You use a Mongo::MongoClient instance to obtain an Mongo::DB instance,
+which represents a named database. The database doesn't have to exist -
+if it doesn't, MongoDB will create it for you. The following examples
+use the database "mydb":
+
+.. code:: ruby
+
+    db = mongo_client.db("mydb")
+    db = MongoClient.new("localhost", 27017).db("mydb")
+
+At this point, the db object will be a connection to a MongoDB server
+for the specified database. Each DB instance uses a separate socket
+connection to the server.
+
+If you're trying to connect to a replica set, see `Replica Sets in
+Ruby <http://www.mongodb.org/display/DOCS/Replica+Sets+in+Ruby>`_.
+
+Authentication
+~~~~~~~~~~~~~~
+
+MongoDB can be run in a secure mode where access to databases is
+controlled through name and password authentication. When running in
+this mode, any client application must provide a name and password
+before doing any operations. In the Ruby driver, you simply do the
+following with the mongo client object:
+
+.. code:: ruby
+
+    auth = db.authenticate(my_user_name, my_password)
+
+If the name and password are valid for the database, auth will be true.
+Otherwise, it will be false. You should look at the MongoDB log for
+further information if available.
+
+Using a Collection
+------------------
+
+You can get a collection using the collection method:
+
+.. code:: ruby
+
+    coll = db.collection("testCollection")
+
+This is aliased to the [] method:
+
+.. code:: ruby
+
+    coll = db["testCollection"]
+
+Once you have this collection object, you can now do create, read,
+update, and delete (CRUD) functions on persistent storage.
+
+Creating Documents with ``insert``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Once you have the collection object, you can create or ``insert``
+documents into the collection. For example, lets make a little document
+that in JSON would be represented as
+
+.. code:: ruby
+
+    {
+      "name" : "MongoDB",
+      "type" : "database",
+      "count" : 1,
+      "info" : {
+        x : 203,
+        y : 102
+      }
+    }
+
+Notice that the above has an "inner" document embedded within it. To do
+this, we can use a Hash or the driver's OrderedHash (which preserves key
+order) to create the document (including the inner document), and then
+just simply insert it into the collection using the ``insert`` method.
+
+.. code:: ruby
+
+    doc = {"name" => "MongoDB", "type" => "database", "count" => 1, "info" => {"x" => 203, "y" => '102'}}
+    id = coll.insert(doc)
+
+We have saved the ``id`` for future use below. Now the collection has
+been created and you can list it.
+
+Getting a List Of Collections
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each database has zero or more collections. You can retrieve a list of
+them from the db (and print out any that are there):
+
+.. code:: ruby
+
+    db.collection_names
+
+You should see
+
+.. code:: ruby
+
+    ["testCollection", "system.indexes"]
+
+Adding Multiple Documents
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To demonstrate some more interesting queries, let's add multiple simple
+documents to the collection. These documents will have the following
+form:
+
+.. code:: ruby
+
+    {
+      "i" : value
+    }
+
+Here's how to insert them:
+
+.. code:: ruby
+
+    100.times { |i| coll.insert("i" => i) }
+
+Notice that we can insert documents of different "shapes" into the same
+collection. These records are in the same collection as the complex
+record we inserted above. This aspect is what we mean when we say that
+MongoDB is "schema-free".
+
+Reading Documents with find\_one and find
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Reading the First Document in a Collection using find\_one
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To retrieve the document that we inserted, we can do a simple find\_one
+method to get the first document in the collection. This method returns
+a single document directly.
+
+.. code:: ruby
+
+    coll.find_one
+
+and you should something like:
+
+.. code:: ruby
+
+    { "_id" => BSON::ObjectId('4f7b1ea6e4d30b35c9000001'), "name"=>"MongoDB", "type"=>"database", "count"=>1, "info"=>{"x"=>203, "y"=>"102"}}
+
+Note the \_id element has been added automatically by MongoDB to your
+document.
+
+Reading All of the Documents with a Cursor using find
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To get all the documents from the collection, we use the find method.
+find returns a Cursor object, which allows us to iterate over the set of
+documents that matches our query. The Ruby driver's Cursor implements
+Enumerable, which allows us to use Enumerable#each, Enumerable#map, etc.
+For instance:
+
+.. code:: ruby
+
+    coll.find.each { |row| puts row.inspect }
+
+and that should print all 101 documents in the collection. You can also
+take advantage of Enumerable#to\_a.
+
+.. code:: ruby
+
+    puts coll.find.to_a
+
+or use #each\_slice to get chunks of documents and process them in a
+batch:
+
+.. code:: ruby
+
+    # retrieve and process 10 documents at a time from cursor
+    coll.find.each_slice(10) do |slice|
+      puts slice.inspect
+    end
+
+Important note - using ``to_a`` pulls all of the full result set into
+memory and is inefficient if you can process by each individual
+document. To process with more memory efficiency, use the ``each``
+method with a code block for the cursor.
+
+Specific Queries
+^^^^^^^^^^^^^^^^
+
+We can create a *query* hash to pass to the find method to get a subset
+of the documents in our collection. To check that our update worked,
+find the document by id:
+
+.. code:: ruby
+
+    coll.find("_id" => id).to_a
+
+If we wanted to find the document for which the value of the "i" field
+is 71, we would do the following:
+
+.. code:: ruby
+
+    coll.find("i" => 71).to_a
+
+and it should just print just one document:
+
+.. code:: ruby
+
+    {"_id"=>BSON::ObjectId('4f7b20b4e4d30b35c9000049'), "i"=>71}
+
+Sorting Documents in a Collection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+To sort documents, simply use the ``sort`` method. The method can either
+take a key or an array of [key, direction] pairs to sort by.
+
+Direction defaults to ascending order but can be specified as
+Mongo::ASCENDING, :ascending, or :asc whereas descending order can be
+specified with Mongo::DESCENDING, :descending, or :desc.
+
+.. code:: ruby
+
+    # Sort in ascending order by :i
+    coll.find.sort(:i)
+
+    # Sort in descending order by :i
+    coll.find.sort(:i => :desc)
+
+Counting Documents in a Collection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Now that we've inserted 101 documents (the 100 we did in the loop, plus
+the first one), we can check to see if we have them all using the
+``count`` method.
+
+.. code:: ruby
+
+    coll.count
+
+and it should print 101.
+
+Getting a Set of Documents With a Query
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We can use the query to get a set of documents from our collection. For
+example, if we wanted to get all documents where "i" > 50, we could
+write:
+
+.. code:: ruby
+
+    puts coll.find("i" => {"$gt" => 50}).to_a
+
+which should print the documents where i > 50. We could also get a
+range, say 20 < i <= 30:
+
+.. code:: ruby
+
+    puts coll.find("i" => {"$gt" => 20, "$lte" => 30}).to_a
+
+Selecting a Subset of Fields for a Query
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Use the :fields option to specify fields to return.
+
+.. code:: ruby
+
+    puts coll.find({"_id" => id}, :fields => ["name", "type"]).to_a
+
+Querying with Regular Expressions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Regular expressions can be used to query MongoDB. To find all names that
+begin with 'M':
+
+.. code:: ruby
+
+    puts coll.find({"name" => /^M/}).to_a
+
+You can also construct a regular expression dynamically. To match a
+given search string:
+
+.. code:: ruby
+
+    params = {'search' => 'DB'}
+    search_string = params['search']
+
+    # Constructor syntax
+    puts coll.find({"name" => Regexp.new(search_string)}).to_a
+
+    # Literal syntax
+    puts coll.find({"name" => /#{search_string}/}).to_a
+
+Although MongoDB isn't vulnerable to anything like SQL-injection, it may
+be worth checking the search string for anything malicious.
+
+Updating Documents with ``update``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We can update the previous document using the ``update`` method. There
+are a couple ways to update a document. We can rewrite it:
+
+.. code:: ruby
+
+    doc["name"] = "MongoDB Ruby"
+    coll.update({"_id" => id}, doc)
+
+Or we can use an atomic operator to change a single value:
+
+.. code:: ruby
+
+    coll.update({"_id" => id}, {"$set" => {"name" => "MongoDB Ruby"}})
+
+Verify the update.
+
+.. code:: ruby
+
+    puts coll.find("_id" => id).to_a
+
+Read [more about updating documents\|Updating].
+
+Deleting Documents with ``remove``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use the remove method to delete documents.
+
+.. code:: ruby
+
+    coll.count
+    coll.remove("i" => 71)
+    coll.count
+    puts coll.find("i" => 71).to_a
+
+The above shows that the count has been reduced and that the document
+can no longer be found.
+
+Without arguments, the remove method deletes all documents.
+
+.. code:: ruby
+
+    coll.remove
+    coll.count
+
+Please program carefully.
+
+Indexing
+--------
+
+Creating An Index
+~~~~~~~~~~~~~~~~~
+
+MongoDB supports indexes, and they are very easy to add on a collection.
+To create an index, you specify an index name and an array of field
+names to be indexed, or a single field name. The following creates an
+ascending index on the "i" field:
+
+.. code:: ruby
+
+    # create_index assumes ascending order; see method docs
+    # for details
+    coll.create_index("i")
+
+To specify complex indexes or a descending index you need to use a
+slightly more complex syntax - the index specifier must be an Array of
+[field name, direction] pairs. Directions should be specified as
+Mongo::ASCENDING or Mongo::DESCENDING:
+
+.. code:: ruby
+
+    # Explicit "ascending"
+    coll.create_index([["i", Mongo::ASCENDING]]) # ruby 1.8
+    coll.create_index(:i => Mongo::ASCENDING) # ruby 1.9 and greater
+
+Use the explain method on the cursor to show how MongoDB will run the
+query.
+
+.. code:: ruby
+
+    coll.find("_id" => id).explain
+    coll.find("i" => 71).explain
+    coll.find("type" => "database").explain
+
+The above shows that the query by \_id and i will use faster indexed
+BtreeCursor, while the query by type will use a slower BasicCursor.
+
+Getting a List of Indexes on a Collection
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can get a list of the indexes on a collection.
+
+.. code:: ruby
+
+    coll.index_information
+
+Creating and Querying on a Geospatial Index
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+First, create the index on a field containing long-lat values:
+
+.. code:: ruby
+
+    # ruby 1.8
+    people.create_index([["loc", Mongo::GEO2D]])
+
+    # ruby 1.9 and greater
+    people.create_index(:loc => Mongo::GEO2D)
+
+Then get a list of the twenty locations nearest to the point 50, 50:
+
+.. code:: ruby
+
+    people.find({"loc" => {"$near" => [50, 50]}}, {:limit => 20}).each do |p|
+      puts p.inspect
+    end
+
+Dropping
+--------
+
+Drop an Index
+~~~~~~~~~~~~~
+
+To drop a secondary index, use the ``drop_index`` method on the
+collection.
+
+.. code:: ruby
+
+    coll.drop_index("i_1")
+    coll.index_information
+
+The dropped index is no longer listed.
+
+Drop All Indexes
+~~~~~~~~~~~~~~~~
+
+To drop all secondary indexes, use the drop\_indexes method on the
+collection.
+
+.. code:: ruby
+
+    coll.drop_indexes
+    coll.index_information
+
+Only the primary index "*id*" is listed.
+
+Drop a Collection
+~~~~~~~~~~~~~~~~~
+
+To drop a collection, use the drop method on the collection.
+
+.. code:: ruby
+
+    coll.drop
+    db.collection_names
+
+The dropped collection is no longer listed. The drop\_collection method
+can be used on the database as an alternative.
+
+.. code:: ruby
+
+    db.drop_collection("testCollection")
+
+Drop a Database
+~~~~~~~~~~~~~~~
+
+To drop a database, use the drop\_database method on the mongo client.
+
+.. code:: ruby
+
+    mongo_client.drop_database("mydb")
+    mongo_client.database_names
+
+The dropped database is no longer listed.
+
+Database Administration
+-----------------------
+
+A database can have one of three profiling levels: off (:off), slow
+queries only (:slow\_only), or all (:all). To see the database level:
+
+.. code:: ruby
+
+    puts db.profiling_level   # => off (the symbol :off printed as a string)
+    db.profiling_level = :slow_only
+
+Validating a collection will return an interesting hash if all is well
+or raise an exception if there is a problem.
+
+.. code:: ruby
+
+    p db.validate_collection('coll_name')
+
+See Also
+--------
+
+-  `MongoDB
+   Manual <http://www.mongodb.org/display/DOCS/Developer+Zone>`_

--- a/docs-source/read-preference.txt
+++ b/docs-source/read-preference.txt
@@ -1,0 +1,188 @@
+=======================
+Read Preference in Ruby
+=======================
+
+.. default-domain:: mongodb
+
+About Read Preference
+---------------------
+
+Read preferences determine the candidate replica set members to which a
+query or command can be sent. They consist of a *mode* specified as a
+symbol and an array of hashes known as *tag\_sets*.
+
+Read preference mode is configured by providing the read option to a
+connection, database, collection, or cursor.
+
+.. code:: ruby
+
+    @collection.find({:doc => 'foo'}, :read => :primary)    # read from primary only
+    @collection.find({:doc => 'foo'}, :read => :secondary)  # read from secondaries only
+
+Used in conjunction with tag\_sets:
+
+.. code:: ruby
+
+    @collection.find({:name => 'foo'}, :read => :secondary_preferred, :tag_sets => [{:continent => 'USA'}])
+
+*Please Note*: Behavior of some read preference modes have changed in
+version 1.7.0:
+
+-  ``:secondary_preferred`` mode is now used to prefer reads from
+   secondary members (before this was the behavior of ``:secondary``).
+-  ``:secondary_only`` mode (which only allowed reads from secondaries)
+   is now called ``:secondary``.
+
+Read preference inheritance
+---------------------------
+
+The Ruby driver allows you to set read preference on each of four
+levels: the connection, database, collection, and cursor (or read
+operation). Objects will inherit the default read preference from their
+parents. Thus, if you set a read preference of ``{:read => :secondary}``
+when creating a new connection, then all databases and collections
+created from that connection will inherit the same setting. See this
+code example:
+
+.. code:: ruby
+
+    require 'mongo'
+    include Mongo
+
+    @mongo_client = MongoReplicaSetClient.new(['localhost:27017','localhost:27018'], :read => :secondary)
+    @db  = @mongo_client['test']
+    @collection = @db['foo']
+    @collection.find({:name => 'foo'})
+
+    @collection.find({:name => 'bar'}, :read => :primary)
+
+Here, the first call to Collection#find will use the inherited read
+preference, ``{:read => :secondary}``. But the second call to
+Collection#find overrides this setting by setting the preference to
+``:primary``.
+
+You can examine the read preference on any object by calling its
+``read_preference`` method:
+
+.. code:: ruby
+
+    @mongo_client.read_preference
+    @db.read_preference
+    @collection.read_preference
+
+Modes
+-----
+
+You can using the ``:read`` option to specify a query's read preference
+mode. There are five possible options.
+
+:primary
+~~~~~~~~
+
+With primary, all read operations from the application will use the
+primary member only. This is the default read preference.
+
+If the primary is unavailable, all operations with this preference
+produce an error or throw an exception. Primary read preference modes
+are not compatible with read preferences modes that use tag sets. If you
+specify a tag set with primary, the driver will produce an error.
+
+:primary\_preferred
+~~~~~~~~~~~~~~~~~~~
+
+With the primaryPreferred read preference mode, operations will read
+from the primary member of the set in most situations. However, if the
+primary is unavailable, as is the case during failover situations, then
+these read operations can read from secondary members.
+
+When the read preference includes a tag set, the application will first
+read from the primary, if it is available, and then from secondaries
+that match the specified tags. If there are no secondaries with tags
+that match the specified tags, this read operation will produce an
+error.
+
+:secondary
+~~~~~~~~~~
+
+With the secondary read preference mode, operations will read from the
+secondary member of the set if available. However, if there are no
+secondaries available, then these operations will produce an error or
+exception.
+
+Most sets have at least one secondary, but there are situations where
+there may not be an available secondary. For example, a set with a
+primary, a secondary, and an arbiter may not have any secondaries if a
+member is ever in recovering mode.
+
+When the read preference includes a tag set, the application will
+attempt to find a secondary members that match the specified tag set and
+directs reads to a random secondary from among the nearest group. If
+there are no secondaries with tags that match the specified tag set,
+this read operation will produce an error.
+
+:secondary\_preferred
+~~~~~~~~~~~~~~~~~~~~~
+
+With the secondaryPreferred, operations will read from secondary
+members, but in situations where the set only has a primary instance,
+the read operation will use the set’s primary.
+
+When secondaryPreferred reads from a secondary and the read preference
+includes a tag set, the client will attempt to find a secondary members
+that match the specified tag set and directs reads to a random secondary
+from among the nearest group. If there are no secondaries with tags that
+match the specified tag set, this read operation will produce an error.
+
+:nearest
+~~~~~~~~
+
+With the nearest, the driver will read from the nearest member of the
+set according to the member selection process nearest read operations
+will not have any consideration for the type of the set member. Reads in
+nearest mode may read from both primaries and secondaries.
+
+Set this mode when you want minimize the effect of network latency on
+read operations without preference for current or stale data.
+
+If you specify a tag set, the client will attempt to find a secondary
+members that match the specified tag set and directs reads to a random
+secondary from among the nearest group.
+
+Tag Sets
+--------
+
+Tag sets can be used in for data center awareness by filtering secondary
+read operations. Primary reads occur independent of any tags.
+
+A member matches a tag set if its tags match all the tags in the set.
+For example, a member tagged "{ dc: 'ny', rack: 2, size: 'large' }"
+matches the tag set "{ dc: 'ny', rack: 2 }". A member's extra tags don't
+affect whether it's a match.
+
+Here is an example of a query which sends read operations to members in
+rack 2.
+
+.. code:: ruby
+
+    @collection.find({:name => 'foo'}, :read => :secondary_preferred, :tag_sets => [{:rack => '2'}])
+
+Tag set keys may be symbols or strings. Tag set values should be
+specified using strings. The ``to_s`` method will be called on any
+values provided in the tag set.
+
+Tag sets are used in conjunction with read preference mode. In this
+example, because we specified a mode of secondary\_preferred, if no
+secondaries can be found that match the tag\_set ``{:rack => '2'}`` then
+the primary will be used for the query.
+
+If only one tag set is provided, the set can be passed as a single hash
+parameter itself without the enclosing array.
+
+.. code:: ruby
+
+    @collection.find({:name => 'foo'}, :read => :secondary_preferred, :tag_sets => {:rack => '2'})
+
+Specifying tag\_sets for mode ``:primary`` is considered an error and
+will raise a MongoArgumentError as tag\_sets do not affect selection of
+primary members and only primary members can be selected in that
+particular mode.

--- a/docs-source/replica-sets.txt
+++ b/docs-source/replica-sets.txt
@@ -1,0 +1,186 @@
+====================
+Replica Sets in Ruby
+====================
+
+.. default-domain:: mongodb
+
+Here follow a few considerations for those using the MongoDB Ruby driver
+with `replica
+sets <http://www.mongodb.org/display/DOCS/Replica+Sets>`_.
+
+Setup
+-----
+
+First, make sure that you've configured and initialized a replica set.
+
+Use ``MongoReplicaSetClient.new`` to connect to a replica set. This
+method, which accepts a variable number of arguments, takes a list of
+seed nodes followed by any connection options. You'll want to specify at
+least two seed nodes. This gives the driver more chances to connect in
+the event that any one seed node is offline. Once the driver connects,
+it will cache the replica set topology as reported by the given seed
+node and use that information if a failover is later required.
+
+.. code:: ruby
+
+    @mongo_client = MongoReplicaSetClient.new(
+      ['n1.mydb.net:27017', 'n2.mydb.net:27017', 'n3.mydb.net:27017']
+    )
+
+Note that in driver version >= 1.8, writes are confirmed by default.
+This can be changed with the :w option. For versions prior to 1.8, we
+recommended specifying :safe => true for write confirmation.
+
+Read slaves
+-----------
+
+If you want to read from a secondary node, you can pass :read =>
+:secondary to MongoReplicaSetClient#new.
+
+.. code:: ruby
+
+    @mongo_client = MongoReplicaSetClient.new(
+      ['n1.mydb.net:27017', 'n2.mydb.net:27017', 'n3.mydb.net:27017'],
+      :read => :secondary
+    )
+
+A random secondary will be chosen to be read from. In a typical
+multi-process Ruby application, you'll have a good distribution of reads
+across secondary nodes.
+
+Connection Failures
+-------------------
+
+Imagine that either the master node or one of the read nodes goes
+offline. How will the driver respond?
+
+If any read operation fails, the driver will raise a *ConnectionFailure*
+exception. It then becomes the application's responsibility to decide
+how to handle this.
+
+If the application decides to retry, it's not guaranteed that another
+member of the replica set will have been promoted to master right away,
+so it's still possible that the driver will raise another
+*ConnectionFailure*. However, once a member has been promoted to master,
+typically within a few seconds, subsequent operations will succeed.
+*Note that this does not prevent exception in the event of a primary
+failover.*
+
+The driver will essentially cycle through all known seed addresses until
+a node identifies itself as master.
+
+Refresh mode
+------------
+
+You can specify a refresh mode and refresh interval for a replica set
+connection. This will help to ensure that changes to a replica set's
+configuration are quickly reflected on the driver side. In particular,
+if you change the state of any secondary node, the automated refresh
+will ensure that this state is recorded on the client side.
+
+There are two scenarios in which refresh is helpful and does not raise
+exceptions:
+
+1. You add a new secondary node to an existing replica set
+2. You remove an unused secondary from an existing replica set
+
+If you are using MongoDB earlier than 2.0, any changes to replica set
+state will raise exceptions therefore refresh mode will not be useful.
+
+If you add a secondary that responds to pings much faster than the
+existing nodes, then the new secondary will be used for reads if
+:read\_preference is :secondary or :secondary\_preferred
+
+Refresh mode is disabled by default.
+
+However, if you expect to make live changes to your secondaries, and you
+want this to be reflected without having to manually restart your app
+server, then you should enable it. You can enable this mode
+synchronously, which will refresh the replica set data in a synchronous
+fashion (which may occasionally slow down your queries):
+
+.. code:: ruby
+
+    @mongo_client = MongoReplicaSetClient.new(['n1.mydb.net:27017'], :refresh_mode => :sync)
+
+If you want to change the default refresh interval of 90 seconds, you
+can do so like this:
+
+.. code:: ruby
+
+    @mongo_client = MongoReplicaSetClient.new(
+      ['n1.mydb.net:27017'],
+      :refresh_mode => :sync,
+      :refresh_interval => 60
+    )
+
+Do not set this value to anything lower than 30, or you may start to
+experience performance issues.
+
+You can also disable refresh mode altogether:
+
+.. code:: ruby
+
+    @mongo_client = MongoReplicaSetClient.new(
+      ['n1.mydb.net:27017'],
+      :refresh_mode => false
+    )
+
+And you can call ``refresh`` manually on any replica set connection:
+
+.. code:: ruby
+
+    @mongo_client.refresh
+
+Recovery
+--------
+
+Driver users may wish to wrap their database calls with failure recovery
+code. Here's one possibility, which will attempt to connect every half
+second and time out after thirty seconds.
+
+.. code:: ruby
+
+    # Ensure retry upon failure
+    def rescue_connection_failure(max_retries=60)
+      retries = 0
+      begin
+        yield
+      rescue Mongo::ConnectionFailure => ex
+        retries += 1
+        raise ex if retries > max_retries
+        sleep(0.5)
+        retry
+      end
+    end
+
+    # Wrapping a call to #count()
+    rescue_connection_failure do
+      @db.collection('users').count()
+    end
+
+Of course, the proper way to handle connection failures will always
+depend on the individual application. We encourage object-mapper and
+application developers to publish any promising results.
+
+Testing
+-------
+
+The Ruby driver (>= 1.1.5) includes unit tests for verifying replica set
+behavior. They reside in *tests/replica\_sets*. You can run them as a
+group with the following rake task:
+
+::
+
+    rake test:rs
+
+The suite will set up a five-node replica set by itself and ensure that
+driver behaves correctly even in the face of individual node failures.
+Note that the ``mongod`` executable must be in the search path for this
+to work.
+
+Further Reading
+---------------
+
+-  `Replica Set
+   Configuration <http://www.mongodb.org/display/DOCS/Replica+Set+Configuration>`_

--- a/docs-source/style-guide.txt
+++ b/docs-source/style-guide.txt
@@ -1,0 +1,185 @@
+===========
+Style Guide
+===========
+
+.. default-domain:: mongodb
+
+Ruby
+----
+
+Please see the community maintained `Ruby Style
+Guide <https://github.com/bbatsov/ruby-style-guide>`_. To check for
+style guide violations, you can run ``rake quality`` or ``rspec`` for a
+report (only for the 2.x driver).
+
+RSpec
+-----
+
+Do not use instance variables in specs, use ``let`` instead. Instance
+variables cause tests to have an order dependency in some cases where
+``before(:all)`` is used, either intentionally or not. let ensures that
+each example block has a fresh copy of the object being tested. Thus we
+can run RSpec with --order random and not get any surprises.
+
+.. code:: ruby
+
+    # do:
+    let(:object) do
+      Model.new
+    end
+
+    # do not:
+    before(:all) do
+      @object = Model.new
+    end
+
+Do not namespace specs under the same namespace as the library being
+tested. This causes the tests to be run under the same scope as the
+library itself, thus potentially providing false positives in the suite
+with respect to the scope in which things are accessed. We want the test
+quite to behave as if being accessed from another library or a users
+application, which would exist in the global scope or another namespace.
+
+.. code:: ruby
+
+    # do:
+    describe BSON::Binary do
+    end
+
+    # do not:
+    module BSON
+      describe Binary do
+      end
+    end
+
+Use ``described_class`` for instantiating the class under test, not a
+reference to the object itself. This makes refactoring much easier if
+you are to change the class namespace, name, etc, as only the describe
+block of the test needs to change. This also makes shared examples
+easier to write.
+
+.. code:: ruby
+
+    # do:
+    let(:binary) do
+      described_class.new(data, :generic)
+    end
+
+    # do not:
+    let(:binary) do
+      BSON::Binary.new(data, :generic)
+    end
+
+Do not use ``should`` anymore, this will be deprecated and removed as it
+pollutes Ruby's core Object class. Use ``expect``/``to`` instead.
+
+.. code:: ruby
+
+    # do:
+    expect(something).to eq(something)
+    expect { something.method }.to raise_error
+
+    # do not:
+    something.should eq(something)
+    lambda { something.method }.should raise_error
+
+Do not use ``==`` as a method for testing equality, use ``eq()``
+instead. ``==`` Causes ruby errors to be logged with "return value of
+blah is not used." You can run rspec with warnings turned on via
+``ruby -W -S rspec``.
+
+.. code:: ruby
+
+    # do:
+    expect(something).to eq(something)
+
+    # do not:
+    expect(something).to == something
+
+For us vim users, it would be nice if we leave spaces between code
+blocks, not scrunched into a single block. Code statistic tools do not
+count empty lines so there's really no reason to care about having an
+extra line between blocks or methods. Some of us have expectations when
+navigating via "{" and "}". Some spacing also is more readable in my
+opinion, and the test suite is part of the libaray as well - it should
+be just as clean and readable as the library code itself, since OSS
+users will be looking there to understand behaviour.
+
+.. code:: ruby
+
+    # instead of:
+    let(:something) { "something" }
+    let(:something_else) { "something else" }
+
+    # would be nice to do:
+    let(:something) do
+      "something"
+    end
+
+    let(:something_else) do
+      "something else"
+    end
+
+Do not use example blocks without a description, which really rules out
+using subject for that matter. The reason is with format --documentation
+if no description of the spec, you don't get anything meaningful as
+output, either in passing or failure. RSpec's documentation format
+should be just as readable and meaningful as cucumber features/output.
+
+.. code:: ruby
+
+    # do:
+    let(:object) do
+      described_class.new
+    end
+
+    it "returns something" do
+      expect(object.method).to eq(something)
+    end
+
+    # do not:
+    subject do
+      described_class.new
+    end
+
+    its(:method) { should eq(something) }
+
+More of semantics, but trying to be absolutely correct here... Don't use
+"should" in language anywhere in the specs. Nothing "should" exhibit
+behaviour, it *absolutely must* exhibit said behaviour in order for the
+specification to hold true.
+
+.. code:: ruby
+
+    # do:
+    it "returns nil" do
+    end
+
+    # do not:
+    it "should return nil" do
+    end
+
+Use ``describe`` for testing methods/constants, with the prefix ``#``
+for instance methods, ``.`` for class methods, and ``::`` for constants.
+``context`` should be used inside describe blocks to set up conditions.
+This keeps the language inline with what is being tested. "We describe
+the behaviour of a method, that within a certain context has an
+expectation".
+
+.. code:: ruby
+
+    Example:
+    describe "#instance_method" do
+
+      context "when some case holds true" do
+
+        it "returns something" do
+        end
+      end
+    end
+
+    describe ".class_method" do
+    end
+
+    describe "::CONSTANT" do
+    end

--- a/docs-source/tailable-cursors.txt
+++ b/docs-source/tailable-cursors.txt
@@ -1,0 +1,56 @@
+========================
+Tailable cursors in Ruby
+========================
+
+.. default-domain:: mongodb
+
+Tailable cursors are cursors that remain open even after they've
+returned a final result. This way, if more documents are added to a
+collection (i.e., to the cursor's result set), then you can continue to
+call ``Cursor#next`` to retrieve those results. Here's a complete test
+case that demonstrates the use of tailable cursors.
+
+Note that tailable cursors are for capped collections only.
+
+.. code:: ruby
+
+    require 'mongo'
+    require 'test/unit'
+
+    class TestTailable < Test::Unit::TestCase
+      include Mongo
+
+      def test_tailable
+
+        # Create a connection and capped collection.
+        @mongo_client = MongoClient.new('localhost', 27017)
+        @db  = @mongo_client['test']
+        @db.drop_collection('log')
+        @capped = @db.create_collection('log', :capped => true, :size => 1024)
+
+        # Insert 10 documents.
+        10.times do |n|
+          @capped.insert({:n => n})
+        end
+
+        # Create a tailable cursor that iterates the collection in natural order
+        @tail = Cursor.new(@capped, :tailable => true, :order => [['$natural', 1]])
+
+        # Call Cursor#next 10 times. Each call returns a document.
+        10.times do
+          assert @tail.next
+        end
+
+        # But the 11th time, the cursor returns nothing.
+        assert_nil @tail.next
+
+        # Add a document to the capped collection.
+        @capped.insert({:n => 100})
+
+        # Now call Cursor#next again. This will return the just-inserted result.
+        assert @tail.next
+
+        # Close the cursor.
+        @tail.close
+      end
+    end

--- a/docs-source/web-examples.txt
+++ b/docs-source/web-examples.txt
@@ -1,0 +1,53 @@
+============
+Web Examples
+============
+
+.. default-domain:: mongodb
+
+Thin
+====
+
+load.rb
+-------
+
+.. code:: ruby
+
+    require 'logger'
+
+    include Mongo
+
+    $con = MongoReplicaSetClient.new(
+      ['localhost:30000', 'localhost:30001'],
+      :read => :secondary,
+      :refresh_mode => :sync,
+      :refresh_interval => 30
+    )
+    $db = $con['foo']
+
+    class Load < Sinatra::Base
+
+      configure do
+        LOGGER = Logger.new("sinatra.log")
+        enable :logging, :dump_errors
+        set :raise_errors, true
+      end
+
+      get '/' do
+        $db['test'].insert({:a => rand(1000)})
+        $db['test'].find({:a => {'$gt' => rand(2)}}, :read => :secondary).limit(2).to_a
+        "ok"
+      end
+
+    end
+
+config.ru
+---------
+
+.. code:: ruby
+
+    require "rubygems"
+    require "sinatra"
+
+    require File.join(File.dirname(__FILE__), 'load.rb')
+
+    run Load

--- a/docs-source/write-concern.txt
+++ b/docs-source/write-concern.txt
@@ -1,0 +1,57 @@
+=====================
+Write Concern in Ruby
+=====================
+
+.. default-domain:: mongodb
+
+Setting the write concern
+-------------------------
+
+Write concern is set using the ``:w`` option. As of driver version 1.8,
+writes are acknowledged by default with :w => 1. There are several
+possible other options:
+
+.. code:: ruby
+
+    @mongo_client.save({:doc => 'foo'}, {:w => 0})  # writes are not acknowledged
+    @mongo_client.save({:doc => 'foo'}, {:w => 1})  # writes are acknowledged (MongoClient DEFAULT)
+    @mongo_client.save({:doc => 'foo'}, {:w => 2})  # replica set acknowledged
+
+    # replica set acknowledged, with 200 ms timeout
+    @mongo_client.save({:doc => 'foo'}, {:w => 2, :wtimeout => 200})
+
+    # replicaset acknowledged, with 200 ms timeout and journal write acknowledged
+    @mongo_client.save({:doc => 'foo'}, {:w => 2, :wtimeout => 200, :j => true})
+
+The option, :w => 0, indicates that writes are not acknowledged. The
+option, :w => 1, is the default setting for a mongo client and specifies
+that writes are acknowledged. The option, :w => 2, acknowledges a write
+to a replica set. Any integer can be provided for w that indicates the
+number of nodes to which the write must be applied before it is deemed
+successful. The options :j, :fsync and :wtimeout may be used with :w,
+when :w is greater than 0. In other words, the j, :fsync and :wtimeout
+options may be used in conjunction with acknowledged writes.
+
+Write concern inheritance
+-------------------------
+
+The Ruby driver allows you to set write concern on each of four levels:
+the mongo client, database, collection, and write operation. Objects
+inherit the default write concern from their direct parents. If you set
+a write concern of ``{:w => 0}`` when creating a new mongo client, then
+all databases and collections created from that connection will inherit
+the same setting. See this code example:
+
+.. code:: ruby
+
+    @mongo_client = MongoClient.new('localhost', 27017, :w => 0)  # include Mongo module above
+    @db  = @mongo_client['test']
+    @collection = @db['foo']
+    @collection.save({:name => 'foo'})
+
+    @collection.save({:name => 'bar'}, :w => 1)
+
+Here, the first call to Collection#save will use the inherited write
+concern, ``{:w => 0}`` and not acknowledge the write. But notice that
+the second call to Collection#save overrides this setting and confirms
+the write.


### PR DESCRIPTION
Because there was already a docs in the .gitignore, I added to the docs-source folder instead.