### PR TITLE
Description comparision should respect empty config

### DIFF
--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -577,6 +577,7 @@ module Mongo
       private
 
       def compare_config(other)
+        return true if self.config.keys.empty? && other.config.keys.empty?
         !config.keys.empty? && config.keys.all? do |k|
           config[k] == other.config[k] || EXCLUDE_FOR_COMPARISON.include?(k)
         end


### PR DESCRIPTION
When both descriptions' config are empty, the comparison (`==`) for descriptions returns `false` while it should return `true`.

TODO:

- [ ] add tests

@estolfo please take a look, thanks!