### PR TITLE
reduce the sleep on timeout test to not block operations on after block

### DIFF
--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -417,7 +417,7 @@ describe Mongo::Server::Connection do
         start = Time.now
         expect {
           Timeout::timeout(3) do
-            client[authorized_collection.name].find("$where" => "sleep(10000) || true").first
+            client[authorized_collection.name].find("$where" => "sleep(2000) || true").first
           end
         }.to raise_exception(Timeout::Error, "Took more than 1.5 seconds to receive data.")
         end_time = Time.now


### PR DESCRIPTION
Like @estolfo said on #809 the sleep is too high blocking `after` block operations