### PR TITLE
RUBY-1120 Don't set a default timeout on a socket and fix logic

### DIFF
--- a/lib/mongo/server/connectable.rb
+++ b/lib/mongo/server/connectable.rb
@@ -73,7 +73,7 @@ module Mongo
       #
       # @since 2.0.0
       def timeout
-        @timeout ||= options[:socket_timeout] || TIMEOUT
+        @timeout ||= options[:socket_timeout]
       end
 
       private

--- a/lib/mongo/server/connectable.rb
+++ b/lib/mongo/server/connectable.rb
@@ -28,6 +28,10 @@ module Mongo
       # The default time in seconds to timeout an operation executed on a socket.
       #
       # @since 2.0.0
+      #
+      # @deprecated Timeouts on Ruby sockets aren't effective so this default option is
+      #   no longer used.
+      #   Will be removed in driver version 3.0.
       TIMEOUT = 5.freeze
 
       # @return [ Mongo::Address ] address The address to connect to.

--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -169,21 +169,25 @@ module Mongo
     private
 
     def read_from_socket(length)
-      # Block on data to read for timeout seconds
-      # using the suggested implementation of http://www.ruby-doc.org/core-2.1.3/Kernel.html#method-i-select
-      # to work with SSL connections and some OSs like Ubuntu, CentOS and Red Hat
       data = String.new
       deadline = (Time.now + timeout) if timeout
       begin
         while (data.length < length)
-          if deadline
-            raise Timeout::Error.new("Took more than #{timeout} seconds to receive data.") if (deadline - Time.now) <= 0
-          end
           data << @socket.read_nonblock(length - data.length)
         end
       rescue IO::WaitReadable
-        Kernel::select([@socket], nil, [@socket], 0.1)
-        retry
+        if deadline
+          now = Time.now
+          if deadline - now <= 0
+            raise Timeout::Error.new("Took more than #{timeout} seconds to receive data.")
+          else
+            Kernel::select([@socket], nil, [@socket], (deadline - now))
+            retry
+          end
+        else
+          Kernel::select([@socket], nil, [@socket])
+          retry
+        end
       end
 
       data
@@ -195,12 +199,6 @@ module Mongo
 
     def set_socket_options(sock)
       sock.set_encoding(BSON::BINARY)
-
-      if timeout && !(unix_socket?(sock) && BSON::Environment.jruby?)
-        encoded_timeout = [ timeout, 0 ].pack(TIMEOUT_PACK)
-        sock.setsockopt(SOL_SOCKET, SO_RCVTIMEO, encoded_timeout)
-        sock.setsockopt(SOL_SOCKET, SO_SNDTIMEO, encoded_timeout)
-      end
     end
 
     def handle_errors

--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -172,14 +172,14 @@ module Mongo
       # Block on data to read for timeout seconds
       # using the suggested implementation of http://www.ruby-doc.org/core-2.1.3/Kernel.html#method-i-select
       # to work with SSL connections and some OSs like Ubuntu, CentOS and Red Hat
-      time_left = timeout.to_f
       data = String.new
+      deadline = Time.now + timeout
       begin
-        while data.length < length
+        while (data.length < length)
+          raise Timeout::Error.new("Took more than #{timeout} seconds to receive data.") if (deadline - Time.now) <= 0
           data << @socket.read_nonblock(length - data.length)
         end
       rescue IO::WaitReadable
-        raise Timeout::Error.new("Took more than #{timeout} seconds to receive data.") if (time_left -= 0.1) <= 0
         Kernel::select([@socket], nil, [@socket], 0.1)
         retry
       end

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -483,8 +483,8 @@ describe Mongo::Server::Connection do
         expect(connection.send(:socket)).to be_nil
       end
 
-      it 'sets the timeout to the default' do
-        expect(connection.timeout).to eq(5)
+      it 'does not set the timeout to the default' do
+        expect(connection.timeout).to be_nil
       end
     end
 

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -61,7 +61,7 @@ SSL_OPTIONS = {
 BASE_OPTIONS = {
                   max_pool_size: 1,
                   write: WRITE_CONCERN,
-                  heartbeat_frequency: 5,
+                  heartbeat_frequency: 20,
                   max_read_retries: 5
                }
 


### PR DESCRIPTION
The time_left variable was only ever decremented if a WaitReadable error was raised.
This changes the logic so that timeout is taken into account regardless of whether bytes are successfully read or if there is a timeout when selecting.

Remove the default socket timeout, as it doesn't work in Ruby and was effectively infinite before.