### PR TITLE
Fix round trip time units mismatch

### DIFF
--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -239,7 +239,7 @@ module Mongo
       #
       # @param [ Address ] address The server address.
       # @param [ Hash ] config The result of the ismaster command.
-      # @param [ Float ] average_round_trip_time The moving average time (ms) the ismaster
+      # @param [ Float ] average_round_trip_time The moving average time (sec) the ismaster
       #   call took to complete.
       #
       # @since 2.0.0

--- a/lib/mongo/server/description/inspector.rb
+++ b/lib/mongo/server/description/inspector.rb
@@ -61,7 +61,7 @@ module Mongo
         #
         # @param [ Description ] description The old description.
         # @param [ Hash ] ismaster The updated ismaster.
-        # @param [ Float ] average_round_trip_time The moving average round trip time (ms).
+        # @param [ Float ] average_round_trip_time The moving average round trip time (sec).
         #
         # @return [ Description ] The new description.
         #

--- a/lib/mongo/server_selector/selectable.rb
+++ b/lib/mongo/server_selector/selectable.rb
@@ -200,7 +200,7 @@ module Mongo
       def near_servers(candidates = [])
         return candidates if candidates.empty?
         nearest_server = candidates.min_by(&:average_round_trip_time)
-        threshold = nearest_server.average_round_trip_time + (local_threshold * 1000)
+        threshold = nearest_server.average_round_trip_time + local_threshold
         candidates.select { |server| server.average_round_trip_time <= threshold }.shuffle!
       end
 

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -158,7 +158,7 @@ describe Mongo::Client do
       described_class.new(
         ['127.0.0.1:27017'],
         :read => { :mode => :primary },
-        :local_threshold => 10,
+        :local_threshold => 0.010,
         :server_selection_timeout => 10000,
         :database => TEST_DB
       )
@@ -166,7 +166,7 @@ describe Mongo::Client do
 
     let(:options) do
       Mongo::Options::Redacted.new(:read => { :mode => :primary },
-                                    :local_threshold => 10,
+                                    :local_threshold => 0.010,
                                     :server_selection_timeout => 10000,
                                     :database => TEST_DB)
     end

--- a/spec/mongo/max_staleness_spec.rb
+++ b/spec/mongo/max_staleness_spec.rb
@@ -51,7 +51,7 @@ describe 'Max Staleness Spec' do
           end
           address = Mongo::Address.new(server['address'])
           Mongo::Server.new(address, cluster, monitoring, listeners, options).tap do |s|
-            allow(s).to receive(:average_round_trip_time).and_return(server['avg_rtt_ms'])
+            allow(s).to receive(:average_round_trip_time).and_return(server['avg_rtt_ms'] / 1000.0)
             allow(s).to receive(:tags).and_return(server['tags'])
             allow(s).to receive(:secondary?).and_return(server['type'] == 'RSSecondary')
             allow(s).to receive(:primary?).and_return(server['type'] == 'RSPrimary')

--- a/spec/mongo/server_selection_spec.rb
+++ b/spec/mongo/server_selection_spec.rb
@@ -36,7 +36,7 @@ describe 'Server Selection' do
         spec.candidate_servers.collect do |server|
           address = Mongo::Address.new(server['address'])
           Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS).tap do |s|
-            allow(s).to receive(:average_round_trip_time).and_return(server['avg_rtt_ms'])
+            allow(s).to receive(:average_round_trip_time).and_return(server['avg_rtt_ms'] / 1000.0)
             allow(s).to receive(:tags).and_return(server['tags'])
             allow(s).to receive(:secondary?).and_return(server['type'] == 'RSSecondary')
             allow(s).to receive(:primary?).and_return(server['type'] == 'RSPrimary')
@@ -49,7 +49,7 @@ describe 'Server Selection' do
         spec.in_latency_window.collect do |server|
           address = Mongo::Address.new(server['address'])
           Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS).tap do |s|
-            allow(s).to receive(:average_round_trip_time).and_return(server['avg_rtt_ms'])
+            allow(s).to receive(:average_round_trip_time).and_return(server['avg_rtt_ms'] / 1000.0)
             allow(s).to receive(:tags).and_return(server['tags'])
             allow(s).to receive(:connectable?).and_return(true)
           end

--- a/spec/mongo/server_selector/nearest_spec.rb
+++ b/spec/mongo/server_selector/nearest_spec.rb
@@ -246,8 +246,8 @@ describe Mongo::ServerSelector::Nearest do
     end
 
     context 'high latency servers' do
-      let(:far_primary) { make_server(:primary, :average_round_trip_time => 113, address: default_address) }
-      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 114, address: default_address) }
+      let(:far_primary) { make_server(:primary, :average_round_trip_time => 0.113, address: default_address) }
+      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 0.114, address: default_address) }
 
       context 'single candidate' do
 

--- a/spec/mongo/server_selector/primary_preferred_spec.rb
+++ b/spec/mongo/server_selector/primary_preferred_spec.rb
@@ -244,8 +244,8 @@ describe Mongo::ServerSelector::PrimaryPreferred do
     end
 
     context 'high latency servers' do
-      let(:far_primary) { make_server(:primary, :average_round_trip_time => 100, address: default_address) }
-      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 113, address: default_address) }
+      let(:far_primary) { make_server(:primary, :average_round_trip_time => 0.100, address: default_address) }
+      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 0.113, address: default_address) }
 
       context 'single candidate' do
 

--- a/spec/mongo/server_selector/primary_spec.rb
+++ b/spec/mongo/server_selector/primary_spec.rb
@@ -112,8 +112,8 @@ describe Mongo::ServerSelector::Primary do
     end
 
     context 'high latency candidates' do
-      let(:far_primary) { make_server(:primary, :average_round_trip_time => 100, address: default_address) }
-      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 120, address: default_address) }
+      let(:far_primary) { make_server(:primary, :average_round_trip_time => 0.100, address: default_address) }
+      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 0.120, address: default_address) }
 
       context 'single candidate' do
 

--- a/spec/mongo/server_selector/secondary_preferred_spec.rb
+++ b/spec/mongo/server_selector/secondary_preferred_spec.rb
@@ -243,8 +243,8 @@ describe Mongo::ServerSelector::SecondaryPreferred do
     end
 
     context 'high latency servers' do
-      let(:far_primary) { make_server(:primary, :average_round_trip_time => 100, address: default_address) }
-      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 113, address: default_address) }
+      let(:far_primary) { make_server(:primary, :average_round_trip_time => 0.100, address: default_address) }
+      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 0.113, address: default_address) }
 
       context 'single candidate' do
 

--- a/spec/mongo/server_selector/secondary_spec.rb
+++ b/spec/mongo/server_selector/secondary_spec.rb
@@ -207,8 +207,8 @@ describe Mongo::ServerSelector::Secondary do
     end
 
     context 'high latency servers' do
-      let(:far_primary) { make_server(:primary, :average_round_trip_time => 100, address: default_address) }
-      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 113, address: default_address) }
+      let(:far_primary) { make_server(:primary, :average_round_trip_time => 0.100, address: default_address) }
+      let(:far_secondary) { make_server(:secondary, :average_round_trip_time => 0.113, address: default_address) }
 
       context 'single candidate' do
 


### PR DESCRIPTION
Hi, it's me again with another bug in the ruby driver (I think) ☺

I tried using the `nearest` for my geo-redundant RS (2 servers with 1ms latency, 1 with 180ms) and noticed that it simply didn't work, it selects randomly any of my servers, including the 180ms one.

I dug a bit in the code and found out that there seems to be some mismatch in the units, some variables are supposed to contains ms but contains sec, so when the threshold (0.015s) was added to the slowest latency (ex: 0.001s) it is first multiplied by 1000, leading to a 15.001 sec threshold ^^

I fixed this by removing the multiplication and fixing all the specs stubbing ms whereas the real code works with seconds:
```ruby
production> Mongoid.default_client.cluster.servers.map &:average_round_trip_time
=> [0.00290229132, 0.18428593504000002, 0.0012378256400000004]
```