### PR TITLE
DOCS-9398: updates compat. table for 3.4

### DIFF
--- a/docs/reference/driver-compatibility.txt
+++ b/docs/reference/driver-compatibility.txt
@@ -16,7 +16,6 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :widths: 20 20 20 20 20
    :class: compatibility
 
    * - Ruby Driver
@@ -24,23 +23,41 @@ MongoDB Compatibility
      - MongoDB 2.6
      - MongoDB 3.0
      - MongoDB 3.2
+     - MongoDB 3.4
+
+   * - 2.4
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
 
    * - 2.3
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
 
    * - 2.2
      - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
+
+   * - 2.1
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     - 
 
    * - 2.0
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
 
    * - 1.12
@@ -48,10 +65,12 @@ MongoDB Compatibility
      - |checkmark|
      - |checkmark|
      -
+     -
 
    * - 1.11
      - |checkmark|
      - |checkmark|
+     -
      -
      -
 
@@ -60,15 +79,18 @@ MongoDB Compatibility
      - |checkmark|
      -
      -
+     -
 
    * - 1.9
      - |checkmark|
      -
      -
      -
+     -
 
    * - 1.8
      - |checkmark|
+     -
      -
      -
      -
@@ -96,7 +118,7 @@ Language Compatibility
      - Ruby 2.3
      - JRuby
 
-   * - 2.0
+   * - 2.4
      -
      - |checkmark|
      - |checkmark|
@@ -105,7 +127,43 @@ Language Compatibility
      - |checkmark|
      - |checkmark|
 
-   * - 1.12 - 1.9
+   * - 2.3
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 2.2
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - 2.1
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     - |checkmark|
+
+   * - 2.0
+     -
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - 
+     - 
+     - |checkmark|
+
+   * - 1.9 - 1.12
      - |checkmark|
      - |checkmark|
      - |checkmark|


### PR DESCRIPTION
Copies the updated table from docs-ecosystem to here!