### PR TITLE
Bug fix: local_threshold should not be used as milliseconds

### DIFF
--- a/lib/mongo/server/description/inspector.rb
+++ b/lib/mongo/server/description/inspector.rb
@@ -61,7 +61,7 @@ module Mongo
         #
         # @param [ Description ] description The old description.
         # @param [ Hash ] ismaster The updated ismaster.
-        # @param [ Float ] average_round_trip_time The moving average round trip time (ms).
+        # @param [ Float ] average_round_trip_time The moving average round trip time (seconds).
         #
         # @return [ Description ] The new description.
         #

--- a/lib/mongo/server_selector/selectable.rb
+++ b/lib/mongo/server_selector/selectable.rb
@@ -186,7 +186,7 @@ module Mongo
       def near_servers(candidates = [])
         return candidates if candidates.empty?
         nearest_server = candidates.min_by(&:average_round_trip_time)
-        threshold = nearest_server.average_round_trip_time + (local_threshold * 1000)
+        threshold = nearest_server.average_round_trip_time + local_threshold
         candidates.select { |server| server.average_round_trip_time <= threshold }.shuffle!
       end
 


### PR DESCRIPTION
## The problem 

The local_threshold's default time is 0.015 second ([see the code here](https://github.com/mongodb/mongo-ruby-driver/blob/8b442d8ff30083ef8dca3bc8dac78d4b924d9ff8/lib/mongo/server_selector.rb#L34))

But when it is used, it is multiplied by 1000 and behaves as 0.015 * 1000 = 15 seconds.
So it does not work as developer is expected.
(if developer use 'nearest' option with default settings, it means almost 'random'!)

## Solution

The `average_round_trip_time` is given in seconds (not ms) so we should not multiply the `local_threshold`.

## Discussions

It seems like this bug has been added in [this commit](
https://github.com/mongodb/mongo-ruby-driver/commit/0b5255e116f150b322342adbb62584fd5063fb22#diff-ea2082a78a5d9b36b80ce79b7705943dR170)
and at that time, `local_threshold` may be expected to specified as milliseconds. 
I am not sure but the default value of local_threshold was '5' so I guess this was 5 milliseconds - 
related pull request: https://github.com/mongodb/mongoid/pull/4377


