### PR TITLE
RUBY-1208 Verify that time remaining is positive or nil when checking if socket connect timed out

### DIFF
--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -177,7 +177,7 @@ module Mongo
         end
       rescue IO::WaitReadable
         select_timeout = (deadline - Time.now) if deadline
-        unless Kernel::select([@socket], nil, [@socket], select_timeout)
+        unless (select_timeout.nil? || select_timeout > 0) && Kernel::select([@socket], nil, [@socket], select_timeout)
           raise Timeout::Error.new("Took more than #{timeout} seconds to receive data.")
         end
         retry

--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -177,7 +177,7 @@ module Mongo
         end
       rescue IO::WaitReadable
         select_timeout = (deadline - Time.now) if deadline
-        unless (select_timeout.nil? || select_timeout > 0) && Kernel::select([@socket], nil, [@socket], select_timeout)
+        if (select_timeout && select_timeout <= 0) || !Kernel::select([@socket], nil, [@socket], select_timeout)
           raise Timeout::Error.new("Took more than #{timeout} seconds to receive data.")
         end
         retry

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -444,6 +444,28 @@ describe Mongo::Server::Connection do
         end_time = Time.now
         expect(end_time - start).to be_within(0.2).of(1.5)
       end
+
+      context 'when the socket_timeout is negative' do
+
+        let(:socket) do
+          connection.connect!
+          connection.send(:socket)
+        end
+
+        before do
+          allow(socket).to receive(:timeout).and_return(-(Time.now.to_i))
+        end
+
+        let(:query) do
+          Mongo::Protocol::Query.new(TEST_DB, TEST_COLL, { 'name' => 'testing' })
+        end
+
+        it 'raises a timeout error' do
+          expect {
+            connection.dispatch([ query ])
+          }.to raise_exception(Timeout::Error)
+        end
+      end
     end
 
     context 'when the process is forked' do

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -447,22 +447,22 @@ describe Mongo::Server::Connection do
 
       context 'when the socket_timeout is negative' do
 
-        let(:socket) do
-          connection.connect!
-          connection.send(:socket)
+        let(:messages) do
+          [ insert ]
         end
 
         before do
-          allow(socket).to receive(:timeout).and_return(-(Time.now.to_i))
+          connection.send(:write, messages)
+          connection.send(:socket).instance_variable_set(:@timeout, -(Time.now.to_i))
         end
 
-        let(:query) do
-          Mongo::Protocol::Query.new(TEST_DB, TEST_COLL, { 'name' => 'testing' })
+        let(:reply) do
+          connection.send(:read, messages.last.request_id)
         end
 
         it 'raises a timeout error' do
           expect {
-            connection.dispatch([ query ])
+            reply
           }.to raise_exception(Timeout::Error)
         end
       end

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -447,6 +447,10 @@ describe Mongo::Server::Connection do
 
       context 'when the socket_timeout is negative' do
 
+        let(:connection) do
+          described_class.new(server, server.options)
+        end
+
         let(:messages) do
           [ insert ]
         end


### PR DESCRIPTION
Ruby's Kernel#select can take a positive value or nil as the last argument (the socket timeout), but not a negative value.