### PR TITLE
RUBY-1211 Add Keep-Alive to Mongo::Socket::TCP.

### DIFF
--- a/lib/mongo/socket/tcp.rb
+++ b/lib/mongo/socket/tcp.rb
@@ -43,6 +43,7 @@ module Mongo
       def connect!
         Timeout.timeout(timeout, Error::SocketTimeoutError) do
           socket.setsockopt(IPPROTO_TCP, TCP_NODELAY, 1)
+          socket.setsockopt(SOL_SOCKET, SO_KEEPALIVE, true)
           handle_errors { socket.connect(::Socket.pack_sockaddr_in(port, host)) }
           self
         end


### PR DESCRIPTION
https://jira.mongodb.org/browse/RUBY-1211

I wanted to get some eyes on this to get some feedback - would consumers expect this to be enabled by default or should this be configured? If the answer is the later, should it be an explicit connection option that is passed through or via something like `ENV['MONGO_TCP_KEEPALIVE']`?