### PR TITLE
RUBY-1211 Add Keep-Alive to Mongo::TCPSocket

### DIFF
--- a/lib/mongo/connection/socket/tcp_socket.rb
+++ b/lib/mongo/connection/socket/tcp_socket.rb
@@ -40,6 +40,7 @@ module Mongo
         begin
           sock = Socket.new(info[4], Socket::SOCK_STREAM, 0)
           sock.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, 1)
+          sock.setsockopt(Socket::SOL_SOCKET, Socket::SO_KEEPALIVE, true)
           socket_address = Socket.pack_sockaddr_in(port, info[3])
           connect(sock, socket_address)
           return sock


### PR DESCRIPTION
Back patch of https://github.com/mongodb/mongo-ruby-driver/pull/857 to `1.x-stable`.