### PR TITLE
Prevent excessive memory allocation in Mongo::Socket#read_from_socket.

### DIFF
--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -173,7 +173,9 @@ module Mongo
       deadline = (Time.now + timeout) if timeout
       begin
         while (data.length < length)
-          data << @socket.read_nonblock(length - data.length)
+          bytes_to_read = length - data.length
+          bytes_to_read = 4096 if bytes_to_read > 4096
+          data << @socket.read_nonblock(bytes_to_read)
         end
       rescue IO::WaitReadable
         select_timeout = (deadline - Time.now) if deadline


### PR DESCRIPTION
PROBLEM: After upgrading the driver gem to version 2.4.1, I noticed a
large increase in the number of bytes allocated per Rails request.
After a lot of debugging I found the problem in the Mongo::Socket class.
The current code calls @socket.read_nonblock(n), where n is
the number of bytes to read. This leads to read_nonblock allocating
a buffer of at least capacity n, on the heap. For large n, say 1MB,
this will result in a large number of differently sized heap chunks
allocated and immediately discarded, because read_nonblock usually
returns only a few kilobytes of data per call.

SOLUTION: read data from the socket in smaller chunks. I chose 4096
bytes, which brought memory allocation back to what it was before the
upgrade.
