### PR TITLE
DOCS-9835 changes for separate mongoid docs site

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -44,7 +44,7 @@ Object Document Mappers (ODM) as opposed to Object Relational Mappers
 The ODM officially supported by MongoDB is Mongoid, originally written
 by Durran Jordan.
 
-For tutorials on Mongoid, see :doc:`/mongoid`.
+For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mongoid/master>`_.
 
 .. COMMENT  For the actual build, see mongodb/docs-ruby repo which pulls the documentation source from:
 ..    mongo-ruby-driver, 
@@ -60,7 +60,6 @@ For tutorials on Mongoid, see :doc:`/mongoid`.
       quick-start
       ruby-driver-tutorials
       bson-tutorials
-      mongoid
       API <http://api.mongodb.com/ruby/current/>
       /reference/driver-compatibility
       /reference/additional-resources

--- a/docs/meta/404.txt
+++ b/docs/meta/404.txt
@@ -1,0 +1,7 @@
+:orphan:
+
+==============
+File not found
+==============
+
+The URL you requested does not exist or has been removed.


### PR DESCRIPTION
To incorporate the move to https://docs.mongodb.com/mongoid/master/