### PR TITLE
gemspec: Remove relic has_doc attribute

### DIFF
--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
 
   s.executables       = ['mongo_console']
   s.require_paths     = ['lib']
-  s.has_rdoc          = 'yard'
   s.bindir            = 'bin'
 
   s.add_dependency 'bson', '>=4.2.1', '<5.0.0'


### PR DESCRIPTION
`has_doc` is always set to `true` so there's no point in setting it (https://github.com/rubygems/rubygems/blob/d8d235f1eeb6da0fb289ce0415ad049153f9adc9/lib/rubygems/specification.rb#L1411).