### PR TITLE
IPv6 fallback issue

### DIFF
--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -173,7 +173,7 @@ module Mongo
           res = FAMILY_MAP[info[4]].new(info[3], port, host)
           res.socket(timeout, ssl_options).connect!.close
           return res
-        rescue IOError, SystemCallError, Error::SocketError, Mongo::Error::SocketTimeoutError => e
+        rescue IOError, SystemCallError, Error::SocketError, Error::SocketTimeoutError => e
           error = e
         end
       end

--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -173,7 +173,7 @@ module Mongo
           res = FAMILY_MAP[info[4]].new(info[3], port, host)
           res.socket(timeout, ssl_options).connect!.close
           return res
-        rescue IOError, SystemCallError, Error::SocketError => e
+        rescue IOError, SystemCallError, Error::SocketError, Mongo::Error::SocketTimeoutError => e
           error = e
         end
       end

--- a/spec/mongo/address_spec.rb
+++ b/spec/mongo/address_spec.rb
@@ -209,7 +209,7 @@ describe Mongo::Address do
     context 'when providing a DNS entry that resolves to both IPv6 and IPv4' do
 
       let(:address) do
-        default_address
+        described_class.new('localhost')
       end
 
       let(:host) do
@@ -218,13 +218,13 @@ describe Mongo::Address do
 
       before do
         allow(::Socket).to receive(:getaddrinfo).and_return(
-          [ ["AF_INET6", 0, '::1', '::1', ::Socket::AF_INET6, 1, 6],
+          [ ["AF_INET6", 0, '2607:5300:60:4c2f::', '2607:5300:60:4c2f::', ::Socket::AF_INET6, 1, 6],
             ["AF_INET", 0, host, host, ::Socket::AF_INET, 1, 6]]
         )
       end
 
       it "attempts to use IPv6 and fallbacks to IPv4" do
-        expect(address.socket(0.0)).not_to be_nil
+        expect(address.socket(1)).not_to be_nil
       end
     end
   end


### PR DESCRIPTION
Hello, this MR is not mergeable, it's only to demonstrate the issue:
Basically when IPv6 is down but IPv4 is ok, mongo ruby driver doesn't work.
I got the issue in production and was quite surprised as the mongo server and CLI were still working perfectly (fallbacking to IPv4) but the ruby mongo driver was dead so there's something wrong in the IPv6 failover.

I had a look at the code and the issue seems to be:
- It seems you're using the `socket_timeout` to try the connexion, which by default is undefined (infinite) so the fallback can't really work, I guess you should use the `connect_timeout ` which is more appropriate and defaults to 10s.
- Even if the connexion times out, the error is not catched to go to the next IP, because it's a `Error::SocketTimeoutError` and you're only catching `Error::SocketError` (and it's not an ancestor)
- Finally, there was a test for that but it wasn't doing anything because using an `Address` instance which already have a `@resolver` initialized, it was just a dead test.

In this MR I added the exception and fixed the spec to show you the issue (it's one of my server IPs, packets are filtered which leads to timeout instead of connexion closed). With the timeout set to 1 the fallback seems to be working ok, but with your current value of 0 it waits indefinitely.

Of course you don't want to keep that and you need to fix the default timeout because otherwise it'll only work in specs ;) And I'm not sure how to simulate a timeout locally to leave this test without my IPs.