### PR TITLE
Request 16k chunks from socket to prevent excessive memory allocation

### DIFF
--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -173,7 +173,9 @@ module Mongo
       deadline = (Time.now + timeout) if timeout
       begin
         while (data.length < length)
-          data << @socket.read_nonblock(length - data.length)
+          bytes_to_read = length - data.length
+          bytes_to_read = 16384 if bytes_to_read > 16384
+         data << @socket.read_nonblock(bytes_to_read)
         end
       rescue IO::WaitReadable
         select_timeout = (deadline - Time.now) if deadline


### PR DESCRIPTION
At the recommendation of the CRuby team, read in 16k chunks:

https://bugs.ruby-lang.org/issues/13597

Replaces https://github.com/mongodb/mongo-ruby-driver/pull/864