### PR TITLE
RUBY-1223 Ignore lastWrite when comparing server descriptions

### DIFF
--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -157,7 +157,7 @@ module Mongo
       # Fields to exclude when comparing two descriptions.
       #
       # @since 2.0.6
-      EXCLUDE_FOR_COMPARISON = [ LOCAL_TIME ].freeze
+      EXCLUDE_FOR_COMPARISON = [ LOCAL_TIME, LAST_WRITE ].freeze
 
       # @return [ Address ] address The server's address.
       attr_reader :address

--- a/spec/mongo/server/description_spec.rb
+++ b/spec/mongo/server/description_spec.rb
@@ -23,6 +23,7 @@ describe Mongo::Server::Description do
       'maxWireVersion' => 2,
       'minWireVersion' => 0,
       'localTime' => Time.now,
+      'lastWrite' => { 'lastWriteDate' => Time.now },
       'ok' => 1
     }
   end
@@ -838,7 +839,10 @@ describe Mongo::Server::Description do
     end
 
     let(:other) do
-      described_class.new(address, replica.merge('localTime' => 1))
+      described_class.new(address, replica.merge(
+        'localTime' => 1,
+        'lastWrite' => { 'lastWriteDate' => 1 }
+      ))
     end
 
     it 'excludes certain fields' do


### PR DESCRIPTION
This pull request solves the problem discussed at the following URL.

https://groups.google.com/forum/#!msg/mongodb-user/moEu4STgzUg/HMnZhj2mDQAJ

Since lastWrite changes like localTime, I think it is correct to ignore them when comparing config.