### PR TITLE
Separate concept of user-defined read preference and server selection

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -258,8 +258,12 @@ module Mongo
     #   was provided to the client.
     #
     # @since 2.0.0
+    def server_selector
+      @server_selector ||= ServerSelector.get(read_preference || ServerSelector::PRIMARY)
+    end
+
     def read_preference
-      @read_preference ||= ServerSelector.get(options[:read] || ServerSelector::PRIMARY)
+      @read_preference ||= options[:read]
     end
 
     # Use the database with the provided name. This will switch the current

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -249,19 +249,28 @@ module Mongo
       "#<Mongo::Client:0x#{object_id} cluster=#{cluster.addresses.join(', ')}>"
     end
 
+    # Get the server selector. It either uses the read preference defined in the client options
+    #   or defaults to a Primary server selector.
+    #
+    # @example Get the server selector.
+    #   client.server_selector
+    #
+    # @return [ Mongo::ServerSelector ] The server selector using the user-defined read preference
+    #  or a Primary server selector default.
+    #
+    # @since 2.5.0
+    def server_selector
+      @server_selector ||= ServerSelector.get(read_preference || ServerSelector::PRIMARY)
+    end
+
     # Get the read preference from the options passed to the client.
     #
     # @example Get the read preference.
     #   client.read_preference
     #
-    # @return [ Object ] The appropriate read preference or primary if none
-    #   was provided to the client.
+    # @return [ BSON::Document ] The user-defined read preference.
     #
     # @since 2.0.0
-    def server_selector
-      @server_selector ||= ServerSelector.get(read_preference || ServerSelector::PRIMARY)
-    end
-
     def read_preference
       @read_preference ||= options[:read]
     end

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -100,20 +100,28 @@ module Mongo
       @read_concern ||= options[:read_concern]
     end
 
-    # Get the read preference on this collection.
+    # Get the server selector on this collection.
     #
-    # @example Get the read preference.
-    #   collection.read_preference
+    # @example Get the server selector.
+    #   collection.server_selector
     #
-    # @return [ Mongo::ServerSelector ] The read preference.
+    # @return [ Mongo::ServerSelector ] The server selector.
     #
     # @since 2.0.0
     def server_selector
      @server_selector ||= ServerSelector.get(read_preference || database.server_selector)
     end
 
+    # Get the read preference on this collection.
+    #
+    # @example Get the read preference.
+    #   collection.read_preference
+    #
+    # @return [ Hash ] The read preference.
+    #
+    # @since 2.0.0
     def read_preference
-      @read_preference ||= options[:read]
+      @read_preference ||= options[:read] || database.read_preference
     end
 
     # Get the write concern on this collection.

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -108,8 +108,12 @@ module Mongo
     # @return [ Mongo::ServerSelector ] The read preference.
     #
     # @since 2.0.0
+    def server_selector
+     @server_selector ||= ServerSelector.get(read_preference || database.server_selector)
+    end
+
     def read_preference
-      @read_preference ||= ServerSelector.get(options[:read] || database.read_preference)
+      @read_preference ||= options[:read]
     end
 
     # Get the write concern on this collection.

--- a/lib/mongo/collection/view.rb
+++ b/lib/mongo/collection/view.rb
@@ -59,8 +59,7 @@ module Mongo
       def_delegators :collection,
                      :client,
                      :cluster,
-                     :database,
-                     :read_preference
+                     :database
 
       # Delegate to the cluster for the next primary.
       def_delegators :cluster, :next_primary

--- a/lib/mongo/collection/view/aggregation.rb
+++ b/lib/mongo/collection/view/aggregation.rb
@@ -34,7 +34,7 @@ module Mongo
         attr_reader :pipeline
 
         # Delegate necessary operations to the view.
-        def_delegators :view, :collection, :read, :cluster
+        def_delegators :view, :collection, :read, :cluster, :server_selector
 
         # Delegate necessary operations to the collection.
         def_delegators :collection, :database

--- a/lib/mongo/collection/view/builder/op_query.rb
+++ b/lib/mongo/collection/view/builder/op_query.rb
@@ -68,7 +68,7 @@ module Mongo
           end
 
           def read_pref_formatted
-            @read_formatted ||= read.to_mongos
+            @read_formatted ||= read.to_mongos if read
           end
 
           def special_filter

--- a/lib/mongo/collection/view/builder/op_query.rb
+++ b/lib/mongo/collection/view/builder/op_query.rb
@@ -68,7 +68,7 @@ module Mongo
           end
 
           def read_pref_formatted
-            @read_formatted ||= read.to_mongos if read
+            @read_formatted ||= ServerSelector.get(read).to_mongos if read
           end
 
           def special_filter

--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -37,7 +37,7 @@ module Mongo
         def each
           @cursor = nil
           read_with_retry do
-            server = read.select_server(cluster, false)
+            server = server_selector.select_server(cluster, false)
             result = send_initial_query(server)
             @cursor = Cursor.new(view, result, server)
           end

--- a/lib/mongo/collection/view/map_reduce.rb
+++ b/lib/mongo/collection/view/map_reduce.rb
@@ -47,7 +47,7 @@ module Mongo
         attr_reader :reduce
 
         # Delegate necessary operations to the view.
-        def_delegators :view, :collection, :read, :cluster
+        def_delegators :view, :collection, :read, :cluster, :server_selector
 
         # Delegate necessary operations to the collection.
         def_delegators :collection, :database
@@ -67,7 +67,7 @@ module Mongo
         def each
           @cursor = nil
           write_with_retry do
-            server = read.select_server(cluster, false)
+            server = server_selector.select_server(cluster, false)
             result = send_initial_query(server)
             @cursor = Cursor.new(view, result, server)
           end

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -134,8 +134,9 @@ module Mongo
           cmd[:maxTimeMS] = opts[:max_time_ms] if opts[:max_time_ms]
           cmd[:readConcern] = collection.read_concern if collection.read_concern
           read_pref = opts[:read] || read_preference
+          selector = ServerSelector.get(read_pref || server_selector)
           read_with_retry do
-            server = ServerSelector.get(read_pref || server_selector).select_server(cluster, false)
+            server = selector.select_server(cluster, false)
             apply_collation!(cmd, server, opts)
             Operation::Commands::Command.new({
                                                :selector => cmd,
@@ -170,8 +171,9 @@ module Mongo
           cmd[:maxTimeMS] = opts[:max_time_ms] if opts[:max_time_ms]
           cmd[:readConcern] = collection.read_concern if collection.read_concern
           read_pref = opts[:read] || read_preference
+          selector = ServerSelector.get(read_pref || server_selector)
           read_with_retry do
-            server = ServerSelector.get(read_pref || server_selector).select_server(cluster, false)
+            server = selector.select_server(cluster, false)
             apply_collation!(cmd, server, opts)
             Operation::Commands::Command.new({
                                                :selector => cmd,

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -133,14 +133,15 @@ module Mongo
           cmd[:limit] = opts[:limit] if opts[:limit]
           cmd[:maxTimeMS] = opts[:max_time_ms] if opts[:max_time_ms]
           cmd[:readConcern] = collection.read_concern if collection.read_concern
+          read_pref = opts[:read] || read_preference
           read_with_retry do
-            server = server_selector.select_server(cluster, false)
+            server = ServerSelector.get(read_pref || server_selector).select_server(cluster, false)
             apply_collation!(cmd, server, opts)
             Operation::Commands::Command.new({
                                                :selector => cmd,
                                                :db_name => database.name,
                                                :options => { :limit => -1 },
-                                               :read => read_preference,
+                                               :read => read_pref,
                                              }).execute(server).n.to_i
 
           end
@@ -168,14 +169,15 @@ module Mongo
                   :query => filter }
           cmd[:maxTimeMS] = opts[:max_time_ms] if opts[:max_time_ms]
           cmd[:readConcern] = collection.read_concern if collection.read_concern
+          read_pref = opts[:read] || read_preference
           read_with_retry do
-            server = server_selector.select_server(cluster, false)
+            server = ServerSelector.get(read_pref || server_selector).select_server(cluster, false)
             apply_collation!(cmd, server, opts)
             Operation::Commands::Command.new({
                                                :selector => cmd,
                                                :db_name => database.name,
                                                :options => { :limit => -1 },
-                                               :read => read_preference
+                                               :read => read_pref,
                                              }).execute(server).first['values']
 
           end

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -448,14 +448,14 @@ module Mongo
           configure(:cursor_type, type)
         end
 
-        def read_preference
-          @read_preference ||= (options[:read] || collection.read_preference)
-        end
-
         private
 
         def collation(doc = nil)
           configure(:collation, doc)
+        end
+
+        def read_preference
+          @read_preference ||= (options[:read] || collection.read_preference)
         end
 
         def server_selector

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -66,6 +66,7 @@ module Mongo
     def_delegators :@client,
                    :cluster,
                    :read_preference,
+                   :server_selector,
                    :write_concern
 
     # @return [ Mongo::Server ] Get the primary server from the cluster.

--- a/lib/mongo/grid/fs_bucket.rb
+++ b/lib/mongo/grid/fs_bucket.rb
@@ -84,7 +84,8 @@ module Mongo
       #
       # @since 2.1.0
       def find(selector = nil, options = {})
-        files_collection.find(selector, options.merge(read: read_preference))
+        opts = options.merge(read: read_preference) if read_preference
+        files_collection.find(selector, opts || options)
       end
 
       # Find a file in the GridFS.
@@ -409,7 +410,7 @@ module Mongo
       #
       # @since 2.1.0
       def read_preference
-        @read_preference ||= ServerSelector.get(@options[:read] || database.read_preference)
+        @read_preference ||= options[:read] || database.read_preference
       end
 
       # Get the write concern.

--- a/lib/mongo/grid/stream/read.rb
+++ b/lib/mongo/grid/stream/read.rb
@@ -133,7 +133,7 @@ module Mongo
           #
           # @since 2.1.0
           def read_preference
-            @read_preference ||= ServerSelector.get(@options[:read] || fs.read_preference)
+            @read_preference ||= options[:read] || fs.read_preference
           end
 
           # Get the files collection file information document for the file being read.
@@ -167,7 +167,8 @@ module Mongo
           end
 
           def view
-            @view ||= fs.chunks_collection.find({ :files_id => file_id }, options).read(read_preference).sort(:n => 1)
+            @view ||= (opts = options.merge(read: read_preference) if read_preference
+                         fs.chunks_collection.find({ :files_id => file_id }, opts || options).sort(:n => 1))
           end
 
           def validate!(index, num_chunks, chunk, length_read)

--- a/lib/mongo/operation/read_preference.rb
+++ b/lib/mongo/operation/read_preference.rb
@@ -29,7 +29,7 @@ module Mongo
       private
 
       def update_selector_for_read_pref(sel, server)
-        if server.mongos? && read_pref = read.to_mongos
+        if read && server.mongos? && read_pref = read.to_mongos
           sel = sel[:$query] ? sel : { :$query => sel }
           sel.merge(:$readPreference => read_pref)
         else
@@ -38,7 +38,7 @@ module Mongo
       end
 
       def slave_ok?(server)
-        (server.cluster.single? && !server.mongos?) || read.slave_ok?
+        (server.cluster.single? && !server.mongos?) || (read && read.slave_ok?)
       end
 
       def update_options_for_slave_ok(opts, server)

--- a/lib/mongo/operation/specifiable.rb
+++ b/lib/mongo/operation/specifiable.rb
@@ -476,7 +476,7 @@ module Mongo
       #
       # @since 2.0.0
       def read
-        @read ||= ServerSelector.get(@spec[READ] || ServerSelector::PRIMARY)
+        @read ||= ServerSelector.get(spec[READ]) if spec[READ]
       end
 
       # Whether the operation is ordered.

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -710,7 +710,7 @@ describe Mongo::Client do
       end
 
       it 'returns a primary read preference' do
-        expect(preference).to be_a(Mongo::ServerSelector::Primary)
+        expect(preference).to eq(BSON::Document.new(mode))
       end
 
       it 'passes the options to the cluster' do
@@ -725,7 +725,11 @@ describe Mongo::Client do
       end
 
       it 'returns a primary preferred read preference' do
-        expect(preference).to be_a(Mongo::ServerSelector::PrimaryPreferred)
+        expect(preference).to eq(BSON::Document.new(mode))
+      end
+
+      it 'uses a PrimaryPreferred server selector' do
+        expect(client.server_selector).to be_a(Mongo::ServerSelector::PrimaryPreferred)
       end
     end
 
@@ -736,7 +740,11 @@ describe Mongo::Client do
       end
 
       it 'returns a secondary read preference' do
-        expect(preference).to be_a(Mongo::ServerSelector::Secondary)
+        expect(preference).to eq(BSON::Document.new(mode))
+      end
+
+      it 'uses a Secondary server selector' do
+        expect(client.server_selector).to be_a(Mongo::ServerSelector::Secondary)
       end
     end
 
@@ -747,7 +755,11 @@ describe Mongo::Client do
       end
 
       it 'returns a secondary preferred read preference' do
-        expect(preference).to be_a(Mongo::ServerSelector::SecondaryPreferred)
+        expect(preference).to eq(BSON::Document.new(mode))
+      end
+
+      it 'uses a SecondaryPreferred server selector' do
+        expect(client.server_selector).to be_a(Mongo::ServerSelector::SecondaryPreferred)
       end
     end
 
@@ -758,7 +770,11 @@ describe Mongo::Client do
       end
 
       it 'returns a nearest read preference' do
-        expect(preference).to be_a(Mongo::ServerSelector::Nearest)
+        expect(preference).to eq(BSON::Document.new(mode))
+      end
+
+      it 'uses a Nearest server selector' do
+        expect(client.server_selector).to be_a(Mongo::ServerSelector::Nearest)
       end
     end
 
@@ -769,7 +785,11 @@ describe Mongo::Client do
       end
 
       it 'returns a primary read preference' do
-        expect(preference).to be_a(Mongo::ServerSelector::Primary)
+        expect(preference).to eq(BSON::Document.new(mode))
+      end
+
+      it 'uses a Primary server selector' do
+        expect(client.server_selector).to be_a(Mongo::ServerSelector::Primary)
       end
     end
 

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -1134,28 +1134,19 @@ describe Mongo::Collection::View::Readable do
 
   describe '#read' do
 
-    context 'when providing a hash' do
-
-      it 'converts to a read preference' do
-        expect(view.read(:mode => :primary_preferred).read).to be_a(
-          Mongo::ServerSelector::PrimaryPreferred
-        )
-      end
-    end
-
     context 'when a read pref is specified' do
 
       let(:options) do
-        { :read => Mongo::ServerSelector.get(:mode => :secondary) }
+        { :read => { :mode => :secondary } }
       end
 
       let(:new_read) do
-        Mongo::ServerSelector.get(:mode => :secondary_preferred)
+        { :mode => :secondary_preferred }
       end
 
       it 'sets the read preference' do
         new_view = view.read(new_read)
-        expect(new_view.read).to eq(new_read)
+        expect(new_view.read).to eq(BSON::Document.new(new_read))
       end
 
       it 'returns a new View' do

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -205,7 +205,7 @@ describe Mongo::Collection do
       end
 
       it 'sets the new read options on the new collection' do
-        expect(new_collection.read_preference).to eq(Mongo::ServerSelector.get(new_options[:read]))
+        expect(new_collection.read_preference).to eq(new_options[:read])
       end
 
       it 'sets the new write options on the new collection' do
@@ -230,7 +230,7 @@ describe Mongo::Collection do
         end
 
         it 'sets the new read options on the new collection' do
-          expect(new_collection.read_preference).to eq(Mongo::ServerSelector.get(new_options[:read]))
+          expect(new_collection.read_preference).to eq(new_options[:read])
           expect(new_collection.read_preference).not_to be(client.read_preference)
         end
       end

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -123,7 +123,7 @@ describe Mongo::Collection do
       end
 
       it 'sets the new read options on the new collection' do
-        expect(new_collection.read_preference).to eq(Mongo::ServerSelector.get(new_options[:read]))
+        expect(new_collection.read_preference).to eq(new_options[:read])
       end
 
       context 'when the client has a server selection timeout setting' do
@@ -144,7 +144,7 @@ describe Mongo::Collection do
         end
 
         it 'sets the new read options on the new collection' do
-          expect(new_collection.read_preference).to eq(Mongo::ServerSelector.get(new_options[:read]))
+          expect(new_collection.read_preference).to eq(new_options[:read])
           expect(new_collection.read_preference).not_to eq(client.read_preference)
         end
       end
@@ -156,7 +156,7 @@ describe Mongo::Collection do
         end
 
         it 'sets the new read options on the new collection' do
-          expect(new_collection.read_preference).to eq(Mongo::ServerSelector.get(new_options[:read]))
+          expect(new_collection.read_preference).to eq(new_options[:read])
         end
 
         it 'passes the server_selection_timeout setting to the cluster' do

--- a/spec/mongo/cursor_spec.rb
+++ b/spec/mongo/cursor_spec.rb
@@ -5,7 +5,7 @@ describe Mongo::Cursor do
   describe '#each' do
 
     let(:server) do
-      view.read.select_server(authorized_client.cluster)
+      view.send(:server_selector).select_server(authorized_client.cluster)
     end
 
     let(:reply) do

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -79,7 +79,8 @@ describe Mongo::Database do
       end
 
       it 'applies the options to the collection' do
-        expect(collection.read_preference).to eq(Mongo::ServerSelector.get(mode: :secondary))
+        expect(collection.server_selector).to eq(Mongo::ServerSelector.get(mode: :secondary))
+        expect(collection.read_preference).to eq(BSON::Document.new(mode: :secondary))
       end
     end
   end

--- a/spec/mongo/grid/fs_bucket_spec.rb
+++ b/spec/mongo/grid/fs_bucket_spec.rb
@@ -54,12 +54,8 @@ describe Mongo::Grid::FSBucket do
           { read: { mode: :secondary } }
         end
 
-        let(:read_pref) do
-          Mongo::ServerSelector.get(Mongo::Options::Redacted.new(options[:read].merge(authorized_client.options)))
-        end
-
         it 'sets the read preference' do
-          expect(fs.send(:read_preference)).to eq(read_pref)
+          expect(fs.send(:read_preference)).to eq(options[:read])
         end
       end
 
@@ -678,7 +674,7 @@ describe Mongo::Grid::FSBucket do
       end
 
       it 'sets the read preference on the Stream::Read object' do
-        expect(stream.read_preference).to eq(Mongo::ServerSelector.get(options[:read]))
+        expect(stream.read_preference).to eq(options[:read])
       end
     end
 

--- a/spec/mongo/grid/stream/read_spec.rb
+++ b/spec/mongo/grid/stream/read_spec.rb
@@ -68,11 +68,11 @@ describe Mongo::Grid::FSBucket::Stream::Read do
         end
 
         it 'sets the read preference' do
-          expect(stream.read_preference).to eq(Mongo::ServerSelector.get(options[:read]))
+          expect(stream.read_preference).to eq(options[:read])
         end
 
         it 'sets the read preference on the view' do
-          expect(stream.send(:view).read).to eq(Mongo::ServerSelector.get(options[:read]))
+          expect(stream.send(:view).read).to eq(BSON::Document.new(options[:read]))
         end
       end
 

--- a/spec/mongo/operation/specifiable_spec.rb
+++ b/spec/mongo/operation/specifiable_spec.rb
@@ -76,8 +76,8 @@ describe Mongo::Operation::Specifiable do
 
     context 'when read is not specified' do
 
-      it 'returns a Primary ServerSelector object' do
-        expect(specifiable.read).to eq(Mongo::ServerSelector.get(Mongo::ServerSelector::PRIMARY))
+      it 'returns nil' do
+        expect(specifiable.read).to be_nil
       end
     end
   end

--- a/spec/mongo/uri_spec.rb
+++ b/spec/mongo/uri_spec.rb
@@ -566,7 +566,7 @@ describe Mongo::URI do
 
           it 'raises an exception when read preference is accessed on the client' do
             expect {
-              Mongo::Client.new(string).read_preference
+              Mongo::Client.new(string).server_selector
             }.to raise_exception(Mongo::Error::InvalidServerPreference)
           end
         end
@@ -578,7 +578,7 @@ describe Mongo::URI do
           end
 
           it 'does not raise an exception until the read preference is used' do
-            expect(Mongo::Client.new(string).read_preference).to be_a(Mongo::ServerSelector::Secondary)
+            expect(Mongo::Client.new(string).read_preference).to eq(BSON::Document.new(mode: :secondary, max_staleness: 89))
           end
         end
       end


### PR DESCRIPTION
The driver made no distinction between a read preference set in options and a server selector. A server selector must use the user-defined read preference or default to a primary. The read preference is either set in options or is nil.

These changes are necessary when implementing OP_MSG so that we aren't sending a read preference to the server if the user hasn't defined one. In the case that the user hasn't defined one on the client or collection, we must not send the read preference so that the default server-side can be used.