### PR TITLE
amended documentation to add clarity

### DIFF
--- a/lib/mongo/operation/commands/aggregate.rb
+++ b/lib/mongo/operation/commands/aggregate.rb
@@ -18,7 +18,7 @@ module Mongo
 
       # A MongoDB aggregate operation.
       #
-      # @note An aggregate operation can behave like a read and return a 
+      # @note An aggregate operation can behave like a read and return a
       #   result set, or can behave like a write operation and
       #   output results to a user-specified collection.
       #

--- a/lib/mongo/operation/commands/collections_info.rb
+++ b/lib/mongo/operation/commands/collections_info.rb
@@ -18,16 +18,16 @@ module Mongo
   module Operation
     module Commands
 
-      # A MongoDB operation to get a list of collection names in a database.
+      # A MongoDB operation to get a list of collections info in a database.
       #
-      # @example Create the collection names operation.
-      #   Read::CollectionNames.new(:db_name => 'test-db')
+      # @example Create the collections info operation.
+      #   CollectionsInfo.new(:db_name => 'test-db')
       #
       # Initialization:
-      #   param [ Hash ] spec The specifications for the collection names operation.
+      #   param [ Hash ] spec The specifications for the collections info operation.
       #
-      #   option spec :db_name [ String ] The name of the database whose collection
-      #     names is requested.
+      #   option spec :db_name [ String ] The name of the database whose collections
+      #     info is requested.
       #   option spec :options [ Hash ] Options for the operation.
       #
       # @since 2.0.0

--- a/lib/mongo/operation/commands/command.rb
+++ b/lib/mongo/operation/commands/command.rb
@@ -19,7 +19,7 @@ module Mongo
       # A MongoDB command operation.
       #
       # @example Create the command operation.
-      #   Mongo::Operation::Command.new({ :selector => { :isMaster => 1 } })
+      #   Command.new({ :selector => { :isMaster => 1 } })
       #
       # Initialization:
       #   param [ Hash ] spec The specifications for the command.

--- a/lib/mongo/operation/commands/create.rb
+++ b/lib/mongo/operation/commands/create.rb
@@ -19,7 +19,7 @@ module Mongo
       # A MongoDB create collection operation.
       #
       # @example Instantiate the operation.
-      #   Commands::Create.new(selector: { create: 'test' }, :db_name => 'test')
+      #   Create.new(selector: { create: 'test' }, :db_name => 'test')
       #
       # Initialization:
       #   param [ Hash ] spec The specifications for the operation.

--- a/lib/mongo/operation/commands/drop.rb
+++ b/lib/mongo/operation/commands/drop.rb
@@ -19,7 +19,7 @@ module Mongo
       # A MongoDB drop collection operation.
       #
       # @example Instantiate the operation.
-      #   Commands::Drop.new(selector: { drop: 'test' }, :db_name => 'test')
+      #   Drop.new(selector: { drop: 'test' }, :db_name => 'test')
       #
       # Initialization:
       #   param [ Hash ] spec The specifications for the operation.

--- a/lib/mongo/operation/commands/drop_database.rb
+++ b/lib/mongo/operation/commands/drop_database.rb
@@ -19,7 +19,7 @@ module Mongo
       # A MongoDB drop database operation.
       #
       # @example Instantiate the operation.
-      #   Commands::Drop.new(selector: { dropDatabase: 'test' }, :db_name => 'test')
+      #   Drop.new(selector: { dropDatabase: 'test' }, :db_name => 'test')
       #
       # Initialization:
       #   param [ Hash ] spec The specifications for the operation.

--- a/lib/mongo/operation/commands/indexes.rb
+++ b/lib/mongo/operation/commands/indexes.rb
@@ -21,7 +21,7 @@ module Mongo
       # Initialize the get indexes operation.
       #
       # @example Instantiate the operation.
-      #   Read::Indexes.new(:db_name => 'test', :coll_name => 'test_coll')
+      #   Indexes.new(:db_name => 'test', :coll_name => 'test_coll')
       #
       # Initialization:
       #   param [ Hash ] spec The specifications for the insert.

--- a/lib/mongo/operation/commands/list_collections.rb
+++ b/lib/mongo/operation/commands/list_collections.rb
@@ -19,7 +19,7 @@ module Mongo
       # A MongoDB listCollections command operation.
       #
       # @example Create the listCollections command operation.
-      #   Mongo::Operation::Read::ListCollections.new(db_name: 'test')
+      #   ListCollections.new(db_name: 'test')
       #
       # @note A command is actually a query on the virtual '$cmd' collection.
       #

--- a/lib/mongo/operation/commands/list_indexes.rb
+++ b/lib/mongo/operation/commands/list_indexes.rb
@@ -19,7 +19,7 @@ module Mongo
       # A MongoDB listIndexes command operation.
       #
       # @example Create the listIndexes command operation.
-      #   Mongo::Operation::Read::ListIndexes.new({ db_name: 'test', coll_name: 'example' })
+      #   ListIndexes.new({ db_name: 'test', coll_name: 'example' })
       #
       # @note A command is actually a query on the virtual '$cmd' collection.
       #

--- a/lib/mongo/operation/commands/user_query.rb
+++ b/lib/mongo/operation/commands/user_query.rb
@@ -19,7 +19,7 @@ module Mongo
       # A MongoDB operation to get info of a particular user in a database.
       #
       # @example Create the user query operation.
-      #   Read::UserQuery.new(:name => 'emily', :db_name => 'test-db')
+      #   UserQuery.new(:name => 'emily', :db_name => 'test-db')
       #
       # Initialization:
       #   param [ Hash ] spec The specifications for the user query operation.

--- a/lib/mongo/operation/commands/users_info.rb
+++ b/lib/mongo/operation/commands/users_info.rb
@@ -19,7 +19,7 @@ module Mongo
       # A MongoDB operation to get info of a particular user in a database.
       #
       # @example Create the users info operation.
-      #   Read::UsersInfo.new(:name => 'emily', :db_name => 'test-db')
+      #   UsersInfo.new(:name => 'emily', :db_name => 'test-db')
       #
       # Initialization:
       #   param [ Hash ] spec The specifications for the users info operation.


### PR DESCRIPTION
Amended documentation in the `operation/commands` folder to add clarity and consistency to command documentation.

#### Files amended:
- operation/commands/aggregate.rb
- operation/commands/collections_info.rb
- operation/commands/command.rb
- operation/commands/create.rb
- operation/commands/drop_database.rb
- operation/commands/drop.rb
- operation/commands/indexes.rb
- operation/commands/list_collections.rb
- operation/commands/list_indexes.rb
- operation/commands/user_query.rb
- operation/commands/users_info.rb