### PR TITLE
Add Ruby 2.5 on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 rvm:
   - 1.9.3
   - 2.4.2
+  - 2.5
   - ruby-head
   - jruby-19mode
   - jruby-9.1.12.0


### PR DESCRIPTION
Let's add Ruby 2.5, as the preview version is available.
https://www.ruby-lang.org/en/news/2017/10/10/ruby-2-5-0-preview1-released/