### PR TITLE
Update change stream examples test

### DIFF
--- a/spec/mongo/change_stream_examples_spec.rb
+++ b/spec/mongo/change_stream_examples_spec.rb
@@ -2,8 +2,12 @@ require 'spec_helper'
 
 describe 'change streams examples in Ruby', if: test_change_streams? do
 
-  let(:inventory) do
-    authorized_client[:inventory]
+  let!(:inventory) do
+    client[:inventory]
+  end
+
+  let(:client) do
+    authorized_client.with(heartbeat_frequency: 20)
   end
 
   before do
@@ -11,6 +15,7 @@ describe 'change streams examples in Ruby', if: test_change_streams? do
   end
 
   after do
+    client.close
     inventory.drop
   end
 
@@ -18,67 +23,78 @@ describe 'change streams examples in Ruby', if: test_change_streams? do
 
     it 'returns a change after an insertion' do
 
-      Thread.new do
-        sleep 1
+      insert_thread = Thread.new do
+        sleep 2
         inventory.insert_one(x: 1)
       end
 
-      # Start Changestream Example 1
+      stream_thread = Thread.new do
 
-      cursor = inventory.watch.to_enum
-      next_change = cursor.next
+        # Start Changestream Example 1
 
-      # End Changestream Example 1
+        cursor = inventory.watch.to_enum
+        next_change = cursor.next
 
-      expect(next_change['_id']).not_to be_nil
-      expect(next_change['_id']['_data']).not_to be_nil
-      expect(next_change['operationType']).to eq('insert')
-      expect(next_change['fullDocument']).not_to be_nil
-      expect(next_change['fullDocument']['_id']).not_to be_nil
-      expect(next_change['fullDocument']['x']).to eq(1)
-      expect(next_change['ns']).not_to be_nil
-      expect(next_change['ns']['db']).to eq(TEST_DB)
-      expect(next_change['ns']['coll']).to eq(inventory.name)
-      expect(next_change['documentKey']).not_to be_nil
-      expect(next_change['documentKey']['_id']).to eq(next_change['fullDocument']['_id'])
+        # End Changestream Example 1
+      end
+
+      insert_thread.value
+      change = stream_thread.value
+
+      expect(change['_id']).not_to be_nil
+      expect(change['_id']['_data']).not_to be_nil
+      expect(change['operationType']).to eq('insert')
+      expect(change['fullDocument']).not_to be_nil
+      expect(change['fullDocument']['_id']).not_to be_nil
+      expect(change['fullDocument']['x']).to eq(1)
+      expect(change['ns']).not_to be_nil
+      expect(change['ns']['db']).to eq(TEST_DB)
+      expect(change['ns']['coll']).to eq(inventory.name)
+      expect(change['documentKey']).not_to be_nil
+      expect(change['documentKey']['_id']).to eq(change['fullDocument']['_id'])
     end
   end
 
   context 'example 2 - full document update lookup specified' do
 
-    before do
-      inventory.insert_one(_id: 1, x: 2)
-    end
-
     it 'returns a change and the delta after an insertion' do
 
-      Thread.new do
-        sleep 1
+      inventory.insert_one(_id: 1, x: 2)
+
+      update_thread = Thread.new do
+        sleep 2
         inventory.update_one({ _id: 1}, { '$set' => { x: 5 }})
       end
 
-      # Start Changestream Example 2
+      stream_thread = Thread.new do
 
-      cursor = inventory.watch([], full_document: 'updateLookup').to_enum
-      next_change = cursor.next
+        # Start Changestream Example 2
 
-      # End Changestream Example 2
+        cursor = inventory.watch([], full_document: 'updateLookup').to_enum
+        next_change = cursor.next
 
-      expect(next_change['_id']).not_to be_nil
-      expect(next_change['_id']['_data']).not_to be_nil
-      expect(next_change['operationType']).to eq('update')
-      expect(next_change['fullDocument']).not_to be_nil
-      expect(next_change['fullDocument']['_id']).to eq(1)
-      expect(next_change['fullDocument']['x']).to eq(5)
-      expect(next_change['ns']).not_to be_nil
-      expect(next_change['ns']['db']).to eq(TEST_DB)
-      expect(next_change['ns']['coll']).to eq(inventory.name)
-      expect(next_change['documentKey']).not_to be_nil
-      expect(next_change['documentKey']['_id']).to eq(1)
-      expect(next_change['updateDescription']).not_to be_nil
-      expect(next_change['updateDescription']['updatedFields']).not_to be_nil
-      expect(next_change['updateDescription']['updatedFields']['x']).to eq(5)
-      expect(next_change['updateDescription']['removedFields']).to eq([])
+        # End Changestream Example 2
+      end
+
+
+      update_thread.value
+      change = stream_thread.value
+
+      expect(change['_id']).not_to be_nil
+      expect(change['_id']['_data']).not_to be_nil
+      expect(change['operationType']).to eq('update')
+      expect(change['fullDocument']).not_to be_nil
+      expect(change['fullDocument']['_id']).to eq(1)
+      expect(change['fullDocument']['x']).to eq(5)
+      expect(change['ns']).not_to be_nil
+      expect(change['ns']['db']).to eq(TEST_DB)
+      expect(change['ns']['coll']).to eq(inventory.name)
+      expect(change['documentKey']).not_to be_nil
+      expect(change['documentKey']['_id']).to eq(1)
+      expect(change['updateDescription']).not_to be_nil
+      expect(change['updateDescription']['updatedFields']).not_to be_nil
+      expect(change['updateDescription']['updatedFields']['x']).to eq(5)
+      expect(change['updateDescription']['removedFields']).to eq([])
     end
   end
 
@@ -86,12 +102,9 @@ describe 'change streams examples in Ruby', if: test_change_streams? do
 
     it 'returns the correct change when resuming' do
 
-      Thread.new do
-        sleep 1
-        inventory.insert_one(x: 1)
-      end
-
-      cursor = inventory.watch.to_enum
+      stream = inventory.watch
+      cursor = stream.to_enum
+      inventory.insert_one(x: 1)
       next_change = cursor.next
 
       expect(next_change['_id']).not_to be_nil
@@ -108,6 +121,7 @@ describe 'change streams examples in Ruby', if: test_change_streams? do
 
       inventory.insert_one(x: 2)
       next_next_change = cursor.next
+      stream.close
 
       expect(next_next_change['_id']).not_to be_nil
       expect(next_next_change['_id']['_data']).not_to be_nil


### PR DESCRIPTION
These tests were previously failing frequently on Evergreen because the operations launched in the thread didn't seem to always execute. I've changed the test to create two threads and force the main thread to wait until each completes in succession.