### PR TITLE
Fix unix domain socket connection for mongoid

### DIFF
--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -371,6 +371,7 @@ module Mongo
           validate_port_string!(p)
         elsif host =~ UNIX_SOCKET
           raise_invalid_error!(UNESCAPED_UNIX_SOCKET) if host =~ UNSAFE
+          host = decode host
         end
         servers << host
       end

--- a/spec/mongo/uri_spec.rb
+++ b/spec/mongo/uri_spec.rb
@@ -302,7 +302,7 @@ describe Mongo::URI do
       let(:servers) { '%2Ftmp%2Fmongodb-27017.sock' }
 
       it 'returns an array with the parsed server' do
-        expect(uri.servers).to eq([servers])
+        expect(uri.servers).to eq([URI.unescape(servers)])
       end
     end
 


### PR DESCRIPTION
mongoid 7.0.0.beta
mongo 2.5.0.beta

mongoid.yml
```yml
development:
  clients:
    default:
      uri: mongodb:///tmp/mongodb-27017.sock/database_name
```

When set MongoDB URI string `mongodb:///tmp/mongodb-27017.sock/database_name`, it's fails with error when call `rails s`
``` 
Mongo::Error::InvalidURI (Bad URI: mongodb:///tmp/mongodb-27017.sock/database_name
UNIX domain sockets must be urlencoded.
MongoDB URI must be in the following format: mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][/[database][?options]]
Please see the following URL for more information: http://docs.mongodb.org/manual/reference/connection-string/
):
```

Following the documentation https://docs.mongodb.com/manual/reference/connection-string/#unix-domain-socket we should pass string `mongodb://%2Ftmp%2Fmongodb-27017.sock/database_name`
```yml
development:
  clients:
    default:
      uri: mongodb://%2Ftmp%2Fmongodb-27017.sock/database_name
```
but this fails with other error
```
MONGODB | Topology type 'unknown' initializing.
MONGODB | Server %2ftmp%2fmongodb-27017.sock initializing.
MONGODB | No such file or directory - connect(2) for %2ftmp%2fmongodb-27017.sock
```

With fix
```
MONGODB | Topology type 'unknown' initializing.
MONGODB | Server /tmp/mongodb-27017.sock initializing.
MONGODB | Topology type 'unknown' changed to type 'single'.
```