### PR TITLE
fix s3 uploads

### DIFF
--- a/.evergreen/.evg.yml
+++ b/.evergreen/.evg.yml
@@ -240,12 +240,12 @@ functions:
       params:
         script: |
           ${PREPARE_SHELL}
-          find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf ${PROJECT_DIRECTORY}/mongodb-logs.tar.gz
+          find $MONGO_ORCHESTRATION_HOME -name \*.log | xargs tar czf mongodb-logs.tar.gz
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: ${PROJECT_DIRECTORY}/mongodb-logs.tar.gz
+        local_file: mongodb-logs.tar.gz
         remote_file: ${UPLOAD_BUCKET}/${build_variant}/${revision}/${version_id}/${build_id}/logs/${task_id}-${execution}-mongodb-logs.tar.gz
         bucket: mciuploads
         permissions: public-read


### PR DESCRIPTION
Currently, the s3 uploads of the server logs fail on evergreen due to a quirk in how the s3.put command deals with absolute paths (see the line starting with "[2018/04/12 11:45:39.716] Command failed: missing file" in [this log](https://evergreen.mongodb.com/task_log_raw/mongo_ruby_driver_rhel70_all_mongodbs_all_rubies_all_topologies_all_auth_all_ssl__mongodb_version~2.6_topology~replicaset_auth~auth_ssl~nossl_ruby~ruby_1.9_test_fe269bf89f832912e0f2779ba7e47783d785ee24_18_04_12_14_38_42/0?type=T&text=true). To fix this, we can just use save the tarball in the current working directory and upload it from there instead of relying on a proper expansion of $PROJECT_DIRECTORY.

See [here](https://evergreen.mongodb.com/build/mongo_ruby_driver_rhel70_all_mongodbs_all_rubies_all_topologies_all_auth_all_ssl__mongodb_version~3.6_topology~standalone_auth~noauth_ssl~nossl_ruby~ruby_2.5.0_patch_e5fc94189a88008ffe87f7652f6f919a5b7217e2_5acfbf72e3c3314579366095_18_04_12_20_20_39) for an example of the logs being correctly uploaded after this patch is applied.