### PR TITLE
Allow bulk upsert to be executed with write_concern of { w: 0 }.

### DIFF
--- a/lib/mongo/operation/write/bulk/update/result.rb
+++ b/lib/mongo/operation/write/bulk/update/result.rb
@@ -108,7 +108,11 @@ module Mongo
             #
             # @since 2.1.0
             def upserted
-              reply.documents.first[UPSERTED] || []
+              if acknowledged?
+                reply.documents.first[UPSERTED] || []
+              else
+                []
+              end
             end
 
             private


### PR DESCRIPTION
As per the contribution guidelines I checked to see if there was an open issue (there was none I found) and submitted a new support ticket but JIRA swallowed it and redirected me to https://jira.mongodb.org/servicedesk/customer/portal/17.

The less detailed version of the support ticket I submitted is

THe error as thrown for the bulk upsert was `#<NoMethodError: undefined method 'documents' for nil:NilClass>` with a backtrace of:

```bash
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/operation/write/bulk/update/result.rb:111:in `upserted'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/bulk_write/result_combiner.rb:93:in `combine_ids!'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/bulk_write/result_combiner.rb:57:in `combine!'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/bulk_write.rb:178:in `execute_operation'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/bulk_write.rb:73:in `block (3 levels) in execute'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/retryable.rb:150:in `legacy_write_with_retry'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/bulk_write.rb:72:in `block (2 levels) in execute'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/bulk_write.rb:59:in `each'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/bulk_write.rb:59:in `block in execute'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/cluster.rb:515:in `with_session'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/client.rb:449:in `with_session'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/bulk_write.rb:58:in `execute'
/app/vendor/bundle/ruby/2.4.0/gems/mongo-2.5.1/lib/mongo/collection.rb:476:in `bulk_write'
```

The offending line of code is `model_class..collection.bulk_write(ops, { ordered: false, write_concern: { w: 0 } })` where at least one of the `ops` is `update_one: { ..., upsert: true }`.