### PR TITLE
Ipv6 address stringification fix

### DIFF
--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -159,7 +159,15 @@ module Mongo
     #
     # @since 2.0.0
     def to_s
-      port ? "#{host}:#{port}" : host
+      if port
+        if host.include?(':')
+          "[#{host}]:#{port}"
+        else
+          "#{host}:#{port}"
+        end
+      else
+        host
+      end
     end
 
     # Connect a socket.

--- a/lib/mongo/address/ipv6.rb
+++ b/lib/mongo/address/ipv6.rb
@@ -61,10 +61,13 @@ module Mongo
           host = address
           port = 27017
         end
-        # Validate host
+        # Validate host.
+        # This will raise IPAddr::InvalidAddressError
+        # on newer rubies which is a subclass of ArgumentError
+        # if host is invalid
         begin
           IPAddr.new(host)
-        rescue IPAddr::InvalidAddressError
+        rescue ArgumentError
           raise ArgumentError, "Invalid IPv6 address: #{address}"
         end
         [ host, port ]

--- a/lib/mongo/address/ipv6.rb
+++ b/lib/mongo/address/ipv6.rb
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'ipaddr'
+
 module Mongo
   class Address
 
@@ -38,7 +40,7 @@ module Mongo
       # Parse an IPv6 address into its host and port.
       #
       # @example Parse the address.
-      #   IPv4.parse("[::1]:28011")
+      #   IPv6.parse("[::1]:28011")
       #
       # @param [ String ] address The address to parse.
       #
@@ -46,9 +48,24 @@ module Mongo
       #
       # @since 2.0.0
       def self.parse(address)
-        parts = address.match(/\[(.+)\]:?(.+)?/)
-        host = parts[1]
-        port = (parts[2] || 27017).to_i
+        # To keep the Ruby driver dependency free, use a basic
+        # parser here rather than using a full IPv6 parser
+        if address =~ /[\[\]]/
+          parts = address.match(/\[(.+)\]:?(.+)?/)
+          if parts.nil?
+            raise ArgumentError, "Invalid IPV6 address: #{address}"
+          end
+          host = parts[1]
+          port = (parts[2] || 27017).to_i
+        else
+          begin
+            IPAddr.new(address)
+          rescue IPAddr::InvalidAddressError
+            raise ArgumentError, "Invalid IPV6 address: #{address}"
+          end
+          host = address
+          port = 27017
+        end
         [ host, port ]
       end
 

--- a/lib/mongo/address/ipv6.rb
+++ b/lib/mongo/address/ipv6.rb
@@ -48,23 +48,24 @@ module Mongo
       #
       # @since 2.0.0
       def self.parse(address)
-        # To keep the Ruby driver dependency free, use a basic
-        # parser here rather than using a full IPv6 parser
+        # IPAddr's parser handles IP address only, not port.
+        # Therefore we need to handle the port ourselves
         if address =~ /[\[\]]/
-          parts = address.match(/\[(.+)\]:?(.+)?/)
+          parts = address.match(/\A\[(.+)\](?::(\d+))?\z/)
           if parts.nil?
-            raise ArgumentError, "Invalid IPV6 address: #{address}"
+            raise ArgumentError, "Invalid IPv6 address: #{address}"
           end
           host = parts[1]
           port = (parts[2] || 27017).to_i
         else
-          begin
-            IPAddr.new(address)
-          rescue IPAddr::InvalidAddressError
-            raise ArgumentError, "Invalid IPV6 address: #{address}"
-          end
           host = address
           port = 27017
+        end
+        # Validate host
+        begin
+          IPAddr.new(host)
+        rescue IPAddr::InvalidAddressError
+          raise ArgumentError, "Invalid IPv6 address: #{address}"
         end
         [ host, port ]
       end

--- a/spec/mongo/address/ipv6_spec.rb
+++ b/spec/mongo/address/ipv6_spec.rb
@@ -15,10 +15,26 @@ describe Mongo::Address::IPv6 do
       end
     end
 
-    context 'when no port is provided' do
+    context 'when no port is provided and host is in brackets' do
 
       it 'returns the host and port' do
         expect(described_class.parse('[::1]')).to eq(['::1', 27017])
+      end
+    end
+
+    context 'when no port is provided and host is not in brackets' do
+
+      it 'returns the host and port' do
+        expect(described_class.parse('::1')).to eq(['::1', 27017])
+      end
+    end
+
+    context 'when invalid address is provided' do
+
+      it 'raises ArgumentError' do
+        expect do
+          described_class.parse('::1:27017')
+        end.to raise_error(ArgumentError, 'Invalid IPV6 address: ::1:27017')
       end
     end
   end

--- a/spec/mongo/address/ipv6_spec.rb
+++ b/spec/mongo/address/ipv6_spec.rb
@@ -34,7 +34,19 @@ describe Mongo::Address::IPv6 do
       it 'raises ArgumentError' do
         expect do
           described_class.parse('::1:27017')
-        end.to raise_error(ArgumentError, 'Invalid IPV6 address: ::1:27017')
+        end.to raise_error(ArgumentError, 'Invalid IPv6 address: ::1:27017')
+      end
+
+      it 'rejects extra data around the address' do
+        expect do
+          described_class.parse('[::1]:27017oh')
+        end.to raise_error(ArgumentError, 'Invalid IPv6 address: [::1]:27017oh')
+      end
+
+      it 'rejects bogus data in brackets' do
+        expect do
+          described_class.parse('[::hello]:27017')
+        end.to raise_error(ArgumentError, 'Invalid IPv6 address: [::hello]:27017')
       end
     end
   end

--- a/spec/mongo/address_spec.rb
+++ b/spec/mongo/address_spec.rb
@@ -276,4 +276,38 @@ describe Mongo::Address do
       end
     end
   end
+  
+  describe '#to_s' do
+    context 'address with ipv4 host only' do
+      let(:address) { Mongo::Address.new('127.0.0.1') }
+      
+      it 'is host with port' do
+        expect(address.to_s).to eql('127.0.0.1:27017')
+      end
+    end
+    
+    context 'address with ipv4 host and port' do
+      let(:address) { Mongo::Address.new('127.0.0.1:27000') }
+      
+      it 'is host with port' do
+        expect(address.to_s).to eql('127.0.0.1:27000')
+      end
+    end
+    
+    context 'address with ipv6 host only' do
+      let(:address) { Mongo::Address.new('::1') }
+      
+      it 'is host with port' do
+        expect(address.to_s).to eql('[::1]:27017')
+      end
+    end
+    
+    context 'address with ipv6 host and port' do
+      let(:address) { Mongo::Address.new('[::1]:27000') }
+      
+      it 'is host with port' do
+        expect(address.to_s).to eql('[::1]:27000')
+      end
+    end
+  end
 end

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -1327,6 +1327,33 @@ describe Mongo::Client do
         expect(new_client.options.keys).not_to include('invalid')
       end
     end
+    
+    context 'when client is created with ipv6 address' do
+      let(:client) do
+        described_class.new(['[::1]:27017'], :database => TEST_DB)
+      end
+      
+      context 'when providing nil' do
+
+        it 'returns the cloned client' do
+          expect(client.with(nil)).to eq(client)
+        end
+      end
+      
+      context 'when changing options' do
+        let(:new_options) do
+          { app_name: 'client_test' }
+        end
+
+        let!(:new_client) do
+          client.with(new_options)
+        end
+
+        it 'returns a new client' do
+          expect(new_client).not_to equal(client)
+        end
+      end
+    end
   end
 
   describe '#write_concern' do


### PR DESCRIPTION
The main change in this PR is in the to_s method to correctly serialize IPv6 addresses with ports as `[::1]:27017` instead of `::1:20017`.

The parser was changed to accept `::1` as a valid address, validate the host part of the address using stdlib's `ipaddr` library, and produce more helpful exceptions when given invalid input. These changes are primarily to improve developer experience.

https://jira.mongodb.org/browse/RUBY-1298