### PR TITLE
 Deprecate MONGODB-CR authentication mechanism

### DIFF
--- a/docs/tutorials/ruby-driver-admin-tasks.txt
+++ b/docs/tutorials/ruby-driver-admin-tasks.txt
@@ -158,6 +158,9 @@ Alternatively, setting the current database and credentials can be done in one s
 MONGODB-CR Mechanism
 ````````````````````
 
+*Deprecated:* MONGODB-CR mechanism is deprecated as of MongoDB version 3.6.
+Please use SCRAM authentication instead.
+
 MONGODB-CR was the default authentication mechanism for MongoDB up through version 2.6.
 
 The mechanism can be explicitly set with the credentials:

--- a/lib/mongo/auth/cr.rb
+++ b/lib/mongo/auth/cr.rb
@@ -20,6 +20,9 @@ module Mongo
     # Defines behaviour for MongoDB-CR authentication.
     #
     # @since 2.0.0
+    # @deprecated MONGODB-CR authentication mechanism is deprecated
+    #   as of MongoDB 3.6. Support for it in the Ruby driver will be
+    #   removed in driver version 3.0. Please use SCRAM instead.
     class CR
 
       # The authentication mechinism string.

--- a/lib/mongo/auth/cr/conversation.rb
+++ b/lib/mongo/auth/cr/conversation.rb
@@ -20,6 +20,9 @@ module Mongo
       # client and server.
       #
       # @since 2.0.0
+      # @deprecated MONGODB-CR authentication mechanism is deprecated
+      #   as of MongoDB 3.6. Support for it in the Ruby driver will be
+      #   removed in driver version 3.0. Please use SCRAM instead.
       class Conversation
 
         # The login message base.

--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -175,7 +175,7 @@ module Mongo
     # @since 2.1.0
     INVALID_PORT = "Invalid port. Port must be an integer greater than 0 and less than 65536".freeze
 
-    # Map of URI read preference modes to ruby driver read preference modes
+    # Map of URI read preference modes to Ruby driver read preference modes
     #
     # @since 2.0.0
     READ_MODE_MAP = {
@@ -186,11 +186,12 @@ module Mongo
       'nearest'            => :nearest
     }.freeze
 
-    # Map of URI authentication mechanisms to ruby driver mechanisms
+    # Map of URI authentication mechanisms to Ruby driver mechanisms
     #
     # @since 2.0.0
     AUTH_MECH_MAP = {
       'PLAIN'        => :plain,
+      # MONGODB-CR is deprecated and will be removed in driver version 3.0
       'MONGODB-CR'   => :mongodb_cr,
       'GSSAPI'       => :gssapi,
       'MONGODB-X509' => :mongodb_x509,


### PR DESCRIPTION
I could not find any warnings in the code for deprecated functionality, hence just added `@deprecated` tags.

https://jira.mongodb.org/browse/RUBY-1288