### PR TITLE
Correctly use BulkWriteError in example

### DIFF
--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -27,7 +27,7 @@ module Mongo
       # Instantiate the new exception.
       #
       # @example Instantiate the exception.
-      #   Mongo::Error::BulkWriteFailure.new(response)
+      #   Mongo::Error::BulkWriteError.new(response)
       #
       # @param [ Hash ] result A processed response from the server
       #   reporting results of the operation.


### PR DESCRIPTION
Example referenced BulkWriteFailure whereas the class name is BulkWriteError.