### PR TITLE
Disable fail fast when not in CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,6 @@ require 'support/gridfs'
 
 RSpec.configure do |config|
   config.color     = true
-  config.fail_fast = true unless ENV['CI']
   config.formatter = 'documentation'
   config.include(Authorization)
 


### PR DESCRIPTION
Instead run all tests and show all errors.