### PR TITLE
RUBY-1332 Sync SDAM spec tests (not monitoring)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,11 @@ group :development, :testing do
   gem 'yajl-ruby', require: 'yajl', platforms: :mri
   gem 'celluloid', platforms: :mri
   gem 'fuubar'
+  platforms :mri do
+    if RUBY_VERSION >= '2.0.0'
+      gem 'byebug'
+    end
+  end
 end
 
 group :development do

--- a/lib/mongo/server/description/features.rb
+++ b/lib/mongo/server/description/features.rb
@@ -91,14 +91,14 @@ module Mongo
           @address = address
         end
 
-        # Check that there is an overlap between the driver supported wire version range
-        #   and the server wire version range.
+        # Check that there is an overlap between the driver supported wire
+        #   version range and the server wire version range.
         #
         # @example Verify the wire version overlap.
         #   features.check_driver_support!
         #
-        # @raise [ Error::UnsupportedFeatures ] If the wire version range is not covered
-        #   by the driver.
+        # @raise [ Error::UnsupportedFeatures ] If the wire version range is
+        #   not covered by the driver.
         #
         # @since 2.5.1
         def check_driver_support!

--- a/lib/mongo/server_selector/selectable.rb
+++ b/lib/mongo/server_selector/selectable.rb
@@ -102,7 +102,12 @@ module Mongo
           servers = candidates(cluster)
           if servers && !servers.compact.empty?
             server = servers.first
-            server.check_driver_support!
+            # HACK: all servers in a topology must satisfy wire protocol
+            # constraints. There is probably a better implementation than
+            # checking all servers here
+            cluster.servers.each do |a_server|
+              a_server.check_driver_support!
+            end
             return server
           end
           cluster.scan!

--- a/spec/spec_tests/sdam_spec.rb
+++ b/spec/spec_tests/sdam_spec.rb
@@ -94,8 +94,9 @@ describe 'Server Discovery and Monitoring' do
 
             it 'raises an UnsupportedFeatures error' do
               expect {
-                Mongo::ServerSelector.get(mode: :primary).select_server(@client.cluster)
-                Mongo::ServerSelector.get(mode: :secondary).select_server(@client.cluster)
+                p = Mongo::ServerSelector.get(mode: :primary).select_server(@client.cluster)
+                s = Mongo::ServerSelector.get(mode: :secondary).select_server(@client.cluster)
+                raise "UnsupportedFeatures not raised but we got #{p.inspect} as primary and #{s.inspect} as secondary"
               }.to raise_exception(Mongo::Error::UnsupportedFeatures)
             end
           end

--- a/spec/spec_tests/sdam_spec.rb
+++ b/spec/spec_tests/sdam_spec.rb
@@ -7,7 +7,7 @@ describe 'Server Discovery and Monitoring' do
 
     spec = Mongo::SDAM::Spec.new(file)
 
-    context(spec.description) do
+    context("#{spec.description} (#{file.sub(%r'.*support/sdam/', '')})") do
 
       before(:all) do
         @client = Mongo::Client.new([])

--- a/spec/support/sdam/rs/normalize_case_me.yml
+++ b/spec/support/sdam/rs/normalize_case_me.yml
@@ -1,0 +1,100 @@
+description: "Replica set mixed case normalization"
+
+uri: "mongodb://A/?replicaSet=rs"
+
+phases: [
+
+    {
+        responses: [
+
+                ["a:27017", {
+
+                    ok: 1,
+                    ismaster: true,
+                    setName: "rs",
+                    me: "A:27017",
+                    hosts: ["A:27017"],
+                    passives: ["B:27017"],
+                    arbiters: ["C:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "Unknown",
+                    setName:
+                },
+
+                "c:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+
+            },
+
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    },
+    {
+        responses: [
+
+                ["b:27017", {
+
+                    ok: 1,
+                    ismaster: false,
+                    secondary: true,
+                    setName: "rs",
+                    me: "B:27017",
+                    hosts: ["A:27017"],
+                    passives: ["B:27017"],
+                    arbiters: ["C:27017"],
+                    minWireVersion: 0,
+                    maxWireVersion: 6
+                }]
+        ],
+
+        outcome: {
+
+            servers: {
+
+                "a:27017": {
+
+                    type: "RSPrimary",
+                    setName: "rs"
+                },
+
+                "b:27017": {
+
+                    type: "RSSecondary",
+                    setName: "rs"
+                },
+
+                "c:27017": {
+
+                    type: "Unknown",
+                    setName:
+                }
+
+            },
+
+            topologyType: "ReplicaSetWithPrimary",
+            logicalSessionTimeoutMinutes: null,
+            setName: "rs"
+        }
+    }
+]

--- a/spec/support/sdam/sharded/compatible.yml
+++ b/spec/support/sdam/sharded/compatible.yml
@@ -1,23 +1,16 @@
-description: "Multiple mongoses"
-
+description: "Multiple mongoses with large maxWireVersion"
 uri: "mongodb://a,b"
-
 phases: [
-
     {
         responses: [
-
                 ["a:27017", {
-
                     ok: 1,
                     ismaster: true,
                     msg: "isdbgrid",
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 1000
                 }],
-
                 ["b:27017", {
-
                     ok: 1,
                     ismaster: true,
                     msg: "isdbgrid",
@@ -25,26 +18,21 @@ phases: [
                     maxWireVersion: 6
                 }]
         ],
-
         outcome: {
-
             servers: {
-
                 "a:27017": {
-
                     type: "Mongos",
                     setName:
                 },
-
                 "b:27017": {
-
                     type: "Mongos",
                     setName:
                 }
             },
             topologyType: "Sharded",
             logicalSessionTimeoutMinutes: null,
-            setName:
+            setName: ,
+            compatible: true
         }
     }
 ]

--- a/spec/support/sdam/sharded/mongos_disconnect.yml
+++ b/spec/support/sdam/sharded/mongos_disconnect.yml
@@ -11,14 +11,18 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
 
                 ["b:27017", {
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 
@@ -76,7 +80,9 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
         ],
 

--- a/spec/support/sdam/sharded/non_mongos_removed.yml
+++ b/spec/support/sdam/sharded/non_mongos_removed.yml
@@ -11,7 +11,9 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
 
                 ["b:27017", {
@@ -19,7 +21,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["b:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 

--- a/spec/support/sdam/sharded/too_new.yml
+++ b/spec/support/sdam/sharded/too_new.yml
@@ -1,50 +1,36 @@
-description: "Multiple mongoses"
-
+description: "Multiple mongoses with large minWireVersion"
 uri: "mongodb://a,b"
-
 phases: [
-
     {
         responses: [
-
                 ["a:27017", {
-
                     ok: 1,
                     ismaster: true,
                     msg: "isdbgrid",
-                    minWireVersion: 0,
-                    maxWireVersion: 6
+                    minWireVersion: 999,
+                    maxWireVersion: 1000
                 }],
-
                 ["b:27017", {
-
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid",
-                    minWireVersion: 0,
-                    maxWireVersion: 6
+                    msg: "isdbgrid"
                 }]
         ],
-
         outcome: {
-
             servers: {
-
                 "a:27017": {
-
                     type: "Mongos",
                     setName:
                 },
-
                 "b:27017": {
-
                     type: "Mongos",
                     setName:
                 }
             },
             topologyType: "Sharded",
             logicalSessionTimeoutMinutes: null,
-            setName:
+            setName: ,
+            compatible: false
         }
     }
 ]

--- a/spec/support/sdam/sharded/too_old.yml
+++ b/spec/support/sdam/sharded/too_old.yml
@@ -1,50 +1,36 @@
-description: "Multiple mongoses"
-
+description: "Multiple mongoses with default maxWireVersion of 0"
 uri: "mongodb://a,b"
-
 phases: [
-
     {
         responses: [
-
                 ["a:27017", {
-
                     ok: 1,
                     ismaster: true,
                     msg: "isdbgrid",
-                    minWireVersion: 0,
+                    minWireVersion: 2,
                     maxWireVersion: 6
                 }],
-
                 ["b:27017", {
-
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid",
-                    minWireVersion: 0,
-                    maxWireVersion: 6
+                    msg: "isdbgrid"
                 }]
         ],
-
         outcome: {
-
             servers: {
-
                 "a:27017": {
-
                     type: "Mongos",
                     setName:
                 },
-
                 "b:27017": {
-
                     type: "Mongos",
                     setName:
                 }
             },
             topologyType: "Sharded",
             logicalSessionTimeoutMinutes: null,
-            setName:
+            setName: ,
+            compatible: false
         }
     }
 ]

--- a/spec/support/sdam/single/compatible.yml
+++ b/spec/support/sdam/single/compatible.yml
@@ -1,34 +1,26 @@
-description: "Direct connection to slave"
-
+description: "Standalone with large maxWireVersion"
 uri: "mongodb://a"
-
 phases: [
-
     {
         responses: [
-
                 ["a:27017", {
-
                     ok: 1,
-                    ismaster: false,
+                    ismaster: true,
                     minWireVersion: 0,
                     maxWireVersion: 6
                 }]
         ],
-
         outcome: {
-
             servers: {
-
                 "a:27017": {
-
                     type: "Standalone",
                     setName:
                 }
             },
             topologyType: "Single",
             logicalSessionTimeoutMinutes: null,
-            setName:
+            setName: ,
+            compatible: true
         }
     }
 ]

--- a/spec/support/sdam/single/direct_connection_external_ip.yml
+++ b/spec/support/sdam/single/direct_connection_external_ip.yml
@@ -12,7 +12,9 @@ phases: [
                     ok: 1,
                     ismaster: true,
                     hosts: ["b:27017"],  # Internal IP.
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 

--- a/spec/support/sdam/single/direct_connection_mongos.yml
+++ b/spec/support/sdam/single/direct_connection_mongos.yml
@@ -11,7 +11,9 @@ phases: [
 
                     ok: 1,
                     ismaster: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 

--- a/spec/support/sdam/single/direct_connection_rsarbiter.yml
+++ b/spec/support/sdam/single/direct_connection_rsarbiter.yml
@@ -13,7 +13,9 @@ phases: [
                    ismaster: false,
                    arbiterOnly: true,
                    hosts: ["a:27017", "b:27017"],
-                   setName: "rs"
+                   setName: "rs",
+                   minWireVersion: 0,
+                   maxWireVersion: 6
                 }]
         ],
 

--- a/spec/support/sdam/single/direct_connection_rsprimary.yml
+++ b/spec/support/sdam/single/direct_connection_rsprimary.yml
@@ -12,7 +12,9 @@ phases: [
                    ok: 1,
                    ismaster: true,
                    hosts: ["a:27017", "b:27017"],
-                   setName: "rs"
+                   setName: "rs",
+                   minWireVersion: 0,
+                   maxWireVersion: 6
                 }]
         ],
 

--- a/spec/support/sdam/single/direct_connection_rssecondary.yml
+++ b/spec/support/sdam/single/direct_connection_rssecondary.yml
@@ -13,7 +13,9 @@ phases: [
                     ismaster: false,
                     secondary: true,
                     hosts: ["a:27017", "b:27017"],
-                    setName: "rs"
+                    setName: "rs",
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 

--- a/spec/support/sdam/single/direct_connection_standalone.yml
+++ b/spec/support/sdam/single/direct_connection_standalone.yml
@@ -10,7 +10,9 @@ phases: [
                 ["a:27017", {
 
                     ok: 1,
-                    ismaster: true
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 

--- a/spec/support/sdam/single/not_ok_response.yml
+++ b/spec/support/sdam/single/not_ok_response.yml
@@ -10,13 +10,17 @@ phases: [
                 ["a:27017", {
 
                     ok: 1,
-                    ismaster: true
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }],
 
                 ["a:27017", {
 
                     ok: 0,
-                    ismaster: true
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 

--- a/spec/support/sdam/single/standalone_removed.yml
+++ b/spec/support/sdam/single/standalone_removed.yml
@@ -10,7 +10,9 @@ phases: [
                 ["a:27017", {
 
                     ok: 1,
-                    ismaster: true
+                    ismaster: true,
+                    minWireVersion: 0,
+                    maxWireVersion: 6
                 }]
         ],
 

--- a/spec/support/sdam/single/too_new.yml
+++ b/spec/support/sdam/single/too_new.yml
@@ -1,34 +1,26 @@
-description: "Direct connection to slave"
-
+description: "Standalone with large minWireVersion"
 uri: "mongodb://a"
-
 phases: [
-
     {
         responses: [
-
                 ["a:27017", {
-
                     ok: 1,
-                    ismaster: false,
-                    minWireVersion: 0,
-                    maxWireVersion: 6
+                    ismaster: true,
+                    minWireVersion: 999,
+                    maxWireVersion: 1000
                 }]
         ],
-
         outcome: {
-
             servers: {
-
                 "a:27017": {
-
                     type: "Standalone",
                     setName:
                 }
             },
             topologyType: "Single",
             logicalSessionTimeoutMinutes: null,
-            setName:
+            setName: ,
+            compatible: false
         }
     }
 ]

--- a/spec/support/sdam/single/too_old.yml
+++ b/spec/support/sdam/single/too_old.yml
@@ -1,34 +1,24 @@
-description: "Direct connection to slave"
-
+description: "Standalone with default maxWireVersion of 0"
 uri: "mongodb://a"
-
 phases: [
-
     {
         responses: [
-
                 ["a:27017", {
-
                     ok: 1,
-                    ismaster: false,
-                    minWireVersion: 0,
-                    maxWireVersion: 6
+                    ismaster: true
                 }]
         ],
-
         outcome: {
-
             servers: {
-
                 "a:27017": {
-
                     type: "Standalone",
                     setName:
                 }
             },
             topologyType: "Single",
             logicalSessionTimeoutMinutes: null,
-            setName:
+            setName: ,
+            compatible: false
         }
     }
 ]


### PR DESCRIPTION
This is part of https://jira.mongodb.org/browse/RUBY-1332 which deals with sdam subdirectory. The only code change needed was raising an error when any server in a cluster has an unacceptable wire protocol, whereas before only the server that was selected was subject to wire protocol check.

Verbose cluster/server inspectors were added for debugging.