### PR TITLE
Make bundle install work in ruby 1.9.3

### DIFF
--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -4,7 +4,10 @@ require 'mongo/version'
 
 Gem::Specification.new do |s|
   s.name              = 'mongo'
-  s.version           = Mongo::VERSION
+  # The dup call makes `bundle install` work on ruby 1.9.3.
+  # Without it rubygems tries to modify version which fails because
+  # Mongo::VERSION is frozen.
+  s.version           = Mongo::VERSION.dup
   s.platform          = Gem::Platform::RUBY
 
   s.authors           = ['Tyler Brock', 'Emily Stolfo', 'Durran Jordan']


### PR DESCRIPTION
The dup call makes `bundle install` work on ruby 1.9.3. Without it rubygems tries to modify version which fails because Mongo::VERSION is frozen.

I am not sure how e.g. Travis is succeeding on 1.9.3 without this patch - perhaps it does not use vanilla 1.9.3.