### PR TITLE
Reduce travis log size

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --tty
 --colour
+--format progress

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,3 @@
 --tty
 --colour
---format progress
+--format Fuubar

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: ruby
 sudo: false
 
 before_install:
-  - gem update --system
-  - gem update bundler
+  - gem update --system -q
+  - gem update bundler -q
 
 install: ruby -S bundle install --without release development
 

--- a/Gemfile
+++ b/Gemfile
@@ -17,11 +17,11 @@ group :development, :testing do
   end
   gem 'yajl-ruby', require: 'yajl', platforms: :mri
   gem 'celluloid', platforms: :mri
+  gem 'fuubar'
 end
 
 group :development do
   gem 'ruby-prof', :platforms => :mri
   gem 'pry-rescue'
   gem 'pry-nav'
-  gem 'rspec-instafail'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,5 @@ group :development do
   gem 'ruby-prof', :platforms => :mri
   gem 'pry-rescue'
   gem 'pry-nav'
+  gem 'rspec-instafail'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,8 +50,6 @@ require 'support/connection_string'
 require 'support/gridfs'
 
 RSpec.configure do |config|
-  config.color     = true
-  config.formatter = 'documentation'
   config.include(Authorization)
 
   config.before(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,7 @@ require 'support/gridfs'
 
 RSpec.configure do |config|
   if ENV['CI'] && RUBY_PLATFORM =~ /\bjava\b/
-    config.formatter = 'progress'
+    config.formatter = 'documentation'
   end
 
   config.include(Authorization)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,10 @@ require 'support/connection_string'
 require 'support/gridfs'
 
 RSpec.configure do |config|
+  if ENV['CI'] && RUBY_PLATFORM =~ /\bjava\b/
+    config.formatter = 'progress'
+  end
+
   config.include(Authorization)
 
   config.before(:suite) do


### PR DESCRIPTION
This PR reduces Travis log size from ~10,000 lines to ~1,000 lines.

A big change here is replacement of default documentation formatter with Fuubar which provides 1) immediate failure messages for failing tests, 2) progress bar for overall test runtime and 3) compact overall output.