### PR TITLE
Add debug logging for topology events

### DIFF
--- a/lib/mongo/event.rb
+++ b/lib/mongo/event.rb
@@ -36,15 +36,10 @@ module Mongo
     #
     # @since 2.0.6
     DESCRIPTION_CHANGED = 'description_changed'.freeze
-
-    class Base
-      def inspect
-        "#<{#{self.class}>"
-      end
-    end
   end
 end
 
+require 'mongo/event/base'
 require 'mongo/event/listeners'
 require 'mongo/event/publisher'
 require 'mongo/event/subscriber'

--- a/lib/mongo/event.rb
+++ b/lib/mongo/event.rb
@@ -12,14 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'mongo/event/listeners'
-require 'mongo/event/publisher'
-require 'mongo/event/subscriber'
-require 'mongo/event/primary_elected'
-require 'mongo/event/member_discovered'
-require 'mongo/event/description_changed'
-require 'mongo/event/standalone_discovered'
-
 module Mongo
   module Event
 
@@ -44,5 +36,19 @@ module Mongo
     #
     # @since 2.0.6
     DESCRIPTION_CHANGED = 'description_changed'.freeze
+
+    class Base
+      def inspect
+        "#<{#{self.class}>"
+      end
+    end
   end
 end
+
+require 'mongo/event/listeners'
+require 'mongo/event/publisher'
+require 'mongo/event/subscriber'
+require 'mongo/event/primary_elected'
+require 'mongo/event/member_discovered'
+require 'mongo/event/description_changed'
+require 'mongo/event/standalone_discovered'

--- a/lib/mongo/event/base.rb
+++ b/lib/mongo/event/base.rb
@@ -1,0 +1,33 @@
+# Copyright (C) 2018 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the 'License');
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an 'AS IS' BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  module Event
+
+    # Base class for all events.
+    #
+    # @since 2.6.0
+    class Base
+      # Returns a concise yet useful summary of the event.
+      # Meant to be overridden in derived classes.
+      #
+      # @return [ String ] String summary of the event.
+      #
+      # @since 2.6.0
+      def inspect
+        "#<{#{self.class}>"
+      end
+    end
+  end
+end

--- a/lib/mongo/event/description_changed.rb
+++ b/lib/mongo/event/description_changed.rb
@@ -19,7 +19,7 @@ module Mongo
     # This handles a change in description.
     #
     # @since 2.0.6
-    class DescriptionChanged
+    class DescriptionChanged < Base
       include Monitoring::Publishable
 
       # @return [ Mongo::Cluster ] cluster The cluster.

--- a/lib/mongo/event/member_discovered.rb
+++ b/lib/mongo/event/member_discovered.rb
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'mongo/monitoring/publishable'
+
 module Mongo
   module Event
 
     # This handles member discovered events for server descriptions.
     #
     # @since 2.4.0
-    class MemberDiscovered
+    class MemberDiscovered < Base
       include Monitoring::Publishable
 
       # @return [ Mongo::Cluster ] cluster The cluster.

--- a/lib/mongo/event/primary_elected.rb
+++ b/lib/mongo/event/primary_elected.rb
@@ -20,7 +20,7 @@ module Mongo
     # @since 2.0.0
     #
     # @deprecated. Will be removed in 3.0
-    class PrimaryElected
+    class PrimaryElected < Base
 
       # @return [ Mongo::Cluster ] cluster The cluster.
       attr_reader :cluster

--- a/lib/mongo/event/standalone_discovered.rb
+++ b/lib/mongo/event/standalone_discovered.rb
@@ -18,7 +18,7 @@ module Mongo
     # This handles when a standalone is discovered.
     #
     # @since 2.0.6
-    class StandaloneDiscovered
+    class StandaloneDiscovered < Base
 
       # @return [ Mongo::Cluster ] cluster The cluster.
       attr_reader :cluster

--- a/lib/mongo/monitoring.rb
+++ b/lib/mongo/monitoring.rb
@@ -12,16 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'mongo/monitoring/event'
-require 'mongo/monitoring/publishable'
-require 'mongo/monitoring/command_log_subscriber'
-require 'mongo/monitoring/sdam_log_subscriber'
-require 'mongo/monitoring/server_description_changed_log_subscriber'
-require 'mongo/monitoring/server_closed_log_subscriber'
-require 'mongo/monitoring/server_opening_log_subscriber'
-require 'mongo/monitoring/topology_changed_log_subscriber'
-require 'mongo/monitoring/topology_opening_log_subscriber'
-
 module Mongo
 
   # The class defines behaviour for the performance monitoring API.
@@ -236,3 +226,13 @@ module Mongo
     end
   end
 end
+
+require 'mongo/monitoring/event'
+require 'mongo/monitoring/publishable'
+require 'mongo/monitoring/command_log_subscriber'
+require 'mongo/monitoring/sdam_log_subscriber'
+require 'mongo/monitoring/server_description_changed_log_subscriber'
+require 'mongo/monitoring/server_closed_log_subscriber'
+require 'mongo/monitoring/server_opening_log_subscriber'
+require 'mongo/monitoring/topology_changed_log_subscriber'
+require 'mongo/monitoring/topology_opening_log_subscriber'

--- a/lib/mongo/monitoring/event.rb
+++ b/lib/mongo/monitoring/event.rb
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'mongo/event'
 require 'mongo/monitoring/event/secure'
 require 'mongo/monitoring/event/command_started'
 require 'mongo/monitoring/event/command_succeeded'

--- a/lib/mongo/monitoring/event/command_failed.rb
+++ b/lib/mongo/monitoring/event/command_failed.rb
@@ -19,7 +19,7 @@ module Mongo
       # Event that is fired when a command operation fails.
       #
       # @since 2.1.0
-      class CommandFailed
+      class CommandFailed < Mongo::Event::Base
 
         # @return [ Server::Address ] address The server address.
         attr_reader :address

--- a/lib/mongo/monitoring/event/command_started.rb
+++ b/lib/mongo/monitoring/event/command_started.rb
@@ -19,7 +19,7 @@ module Mongo
       # Event that is fired when a command operation starts.
       #
       # @since 2.1.0
-      class CommandStarted
+      class CommandStarted < Mongo::Event::Base
         include Secure
 
         # @return [ Server::Address ] address The server address.

--- a/lib/mongo/monitoring/event/command_succeeded.rb
+++ b/lib/mongo/monitoring/event/command_succeeded.rb
@@ -19,7 +19,7 @@ module Mongo
       # Event that is fired when a command operation succeeds.
       #
       # @since 2.1.0
-      class CommandSucceeded
+      class CommandSucceeded < Mongo::Event::Base
         include Secure
 
         # @return [ Server::Address ] address The server address.

--- a/lib/mongo/monitoring/event/server_closed.rb
+++ b/lib/mongo/monitoring/event/server_closed.rb
@@ -19,7 +19,7 @@ module Mongo
       # Event fired when the server is closed.
       #
       # @since 2.4.0
-      class ServerClosed
+      class ServerClosed < Mongo::Event::Base
 
         # @return [ Address ] address The server address.
         attr_reader :address

--- a/lib/mongo/monitoring/event/server_description_changed.rb
+++ b/lib/mongo/monitoring/event/server_description_changed.rb
@@ -19,7 +19,7 @@ module Mongo
       # Event fired when a server's description changes.
       #
       # @since 2.4.0
-      class ServerDescriptionChanged
+      class ServerDescriptionChanged < Mongo::Event::Base
 
         # @return [ Address ] address The server address.
         attr_reader :address

--- a/lib/mongo/monitoring/event/server_opening.rb
+++ b/lib/mongo/monitoring/event/server_opening.rb
@@ -19,7 +19,7 @@ module Mongo
       # Event fired when the server is opening.
       #
       # @since 2.4.0
-      class ServerOpening
+      class ServerOpening < Mongo::Event::Base
 
         # @return [ Address ] address The server address.
         attr_reader :address
@@ -39,6 +39,10 @@ module Mongo
         def initialize(address, topology)
           @address = address
           @topology = topology
+        end
+
+        def inspect
+          "#<#{self.class} address=#{address} topology=#{topology.class.name.sub(/.*::/, '')}>"
         end
       end
     end

--- a/lib/mongo/monitoring/event/server_opening.rb
+++ b/lib/mongo/monitoring/event/server_opening.rb
@@ -41,6 +41,11 @@ module Mongo
           @topology = topology
         end
 
+        # Returns a concise yet useful summary of the event.
+        #
+        # @return [ String ] String summary of the event.
+        #
+        # @since 2.6.0
         def inspect
           "#<#{self.class} address=#{address} topology=#{topology.class.name.sub(/.*::/, '')}>"
         end

--- a/lib/mongo/monitoring/event/topology_changed.rb
+++ b/lib/mongo/monitoring/event/topology_changed.rb
@@ -19,7 +19,7 @@ module Mongo
       # Event fired when the topology changes.
       #
       # @since 2.4.0
-      class TopologyChanged
+      class TopologyChanged < Mongo::Event::Base
 
         # @return [ Cluster::Topology ] previous_topology The previous topology.
         attr_reader :previous_topology
@@ -39,6 +39,12 @@ module Mongo
         def initialize(previous_topology, new_topology)
           @previous_topology = previous_topology
           @new_topology = new_topology
+        end
+
+        def inspect
+          "#<Mongo::Monitoring::Event::TopologyChanged" +
+          " prev=#{previous_topology.class.name.sub(/.*::/, '')}" +
+          " new=#{new_topology.class.name.sub(/.*::/, '')}>"
         end
       end
     end

--- a/lib/mongo/monitoring/event/topology_changed.rb
+++ b/lib/mongo/monitoring/event/topology_changed.rb
@@ -41,6 +41,11 @@ module Mongo
           @new_topology = new_topology
         end
 
+        # Returns a concise yet useful summary of the event.
+        #
+        # @return [ String ] String summary of the event.
+        #
+        # @since 2.6.0
         def inspect
           "#<Mongo::Monitoring::Event::TopologyChanged" +
           " prev=#{previous_topology.class.name.sub(/.*::/, '')}" +

--- a/lib/mongo/monitoring/event/topology_closed.rb
+++ b/lib/mongo/monitoring/event/topology_closed.rb
@@ -19,7 +19,7 @@ module Mongo
       # Event fired when the topology closes.
       #
       # @since 2.4.0
-      class TopologyClosed
+      class TopologyClosed < Mongo::Event::Base
 
         # @return [ Topology ] topology The topology.
         attr_reader :topology

--- a/lib/mongo/monitoring/event/topology_opening.rb
+++ b/lib/mongo/monitoring/event/topology_opening.rb
@@ -36,6 +36,11 @@ module Mongo
           @topology = topology
         end
 
+        # Returns a concise yet useful summary of the event.
+        #
+        # @return [ String ] String summary of the event.
+        #
+        # @since 2.6.0
         def inspect
           "#<#{self.class} topology=#{topology.class.name.sub(/.*::/, '')}>"
         end

--- a/lib/mongo/monitoring/event/topology_opening.rb
+++ b/lib/mongo/monitoring/event/topology_opening.rb
@@ -19,7 +19,7 @@ module Mongo
       # Event fired when the topology is opening.
       #
       # @since 2.4.0
-      class TopologyOpening
+      class TopologyOpening < Mongo::Event::Base
 
         # @return [ Topology ] topology The topology.
         attr_reader :topology
@@ -34,6 +34,10 @@ module Mongo
         # @since 2.4.0
         def initialize(topology)
           @topology = topology
+        end
+
+        def inspect
+          "#<#{self.class} topology=#{topology.class.name.sub(/.*::/, '')}>"
         end
       end
     end

--- a/lib/mongo/monitoring/publishable.rb
+++ b/lib/mongo/monitoring/publishable.rb
@@ -19,6 +19,7 @@ module Mongo
     #
     # @since 2.1.0
     module Publishable
+      include Loggable
 
       # @return [ Monitoring ] monitoring The monitoring.
       attr_reader :monitoring
@@ -60,7 +61,10 @@ module Mongo
       end
 
       def publish_sdam_event(topic, event)
-        monitoring.succeeded(topic, event) if monitoring?
+        return unless monitoring?
+
+        log_debug("EVENT: #{event.inspect}")
+        monitoring.succeeded(topic, event)
       end
 
       private

--- a/spec/spec_tests/sdam_monitoring_spec.rb
+++ b/spec/spec_tests/sdam_monitoring_spec.rb
@@ -7,7 +7,7 @@ describe 'SDAM Monitoring' do
 
     spec = Mongo::SDAM::Spec.new(file)
 
-    context(spec.description) do
+    context("#{spec.description} (#{file.sub(%r'.*support/sdam_monitoring/', '')})") do
 
       before(:all) do
         @client = Mongo::Client.new([], heartbeat_frequency: 100, connect_timeout: 0.1)


### PR DESCRIPTION
This is to assist in understanding SDAM state transitions, ultimately for https://jira.mongodb.org/browse/RUBY-1332

Eventually the various debug events should be organized, and support being turned on and off, by a subsystem as otherwise they would be too noisy.