### PR TITLE
Lite specs

### DIFF
--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -37,10 +37,8 @@ unless %w(1 true yes).include?((ENV['CLIENT_DEBUG'] || '').downcase)
 end
 Encoding.default_external = Encoding::UTF_8
 
-require 'support/travis'
 require 'support/matchers'
 require 'support/event_subscriber'
-require 'support/authorization'
 require 'support/server_discovery_and_monitoring'
 require 'support/server_selection_rtt'
 require 'support/server_selection'

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -1,0 +1,57 @@
+COVERAGE_MIN = 90
+CURRENT_PATH = File.expand_path(File.dirname(__FILE__))
+SERVER_DISCOVERY_TESTS = Dir.glob("#{CURRENT_PATH}/support/sdam/**/*.yml")
+SDAM_MONITORING_TESTS = Dir.glob("#{CURRENT_PATH}/support/sdam_monitoring/*.yml")
+SERVER_SELECTION_RTT_TESTS = Dir.glob("#{CURRENT_PATH}/support/server_selection/rtt/*.yml")
+SERVER_SELECTION_TESTS = Dir.glob("#{CURRENT_PATH}/support/server_selection/selection/**/*.yml")
+MAX_STALENESS_TESTS = Dir.glob("#{CURRENT_PATH}/support/max_staleness/**/*.yml")
+CRUD_TESTS = Dir.glob("#{CURRENT_PATH}/support/crud_tests/**/*.yml")
+RETRYABLE_WRITES_TESTS = Dir.glob("#{CURRENT_PATH}/support/retryable_writes_tests/**/*.yml")
+COMMAND_MONITORING_TESTS = Dir.glob("#{CURRENT_PATH}/support/command_monitoring/**/*.yml")
+CONNECTION_STRING_TESTS = Dir.glob("#{CURRENT_PATH}/support/connection_string_tests/*.yml")
+DNS_SEEDLIST_DISCOVERY_TESTS = Dir.glob("#{CURRENT_PATH}/support/dns_seedlist_discovery_tests/*.yml")
+GRIDFS_TESTS = Dir.glob("#{CURRENT_PATH}/support/gridfs_tests/*.yml")
+
+if ENV['DRIVERS_TOOLS']
+  CLIENT_CERT_PEM = ENV['DRIVER_TOOLS_CLIENT_CERT_PEM']
+  CLIENT_KEY_PEM = ENV['DRIVER_TOOLS_CLIENT_KEY_PEM']
+  CA_PEM = ENV['DRIVER_TOOLS_CA_PEM']
+  CLIENT_KEY_ENCRYPTED_PEM = ENV['DRIVER_TOOLS_CLIENT_KEY_ENCRYPTED_PEM']
+else
+  SSL_CERTS_DIR = "#{CURRENT_PATH}/support/certificates"
+  CLIENT_PEM = "#{SSL_CERTS_DIR}/client.pem"
+  CLIENT_PASSWORD_PEM = "#{SSL_CERTS_DIR}/password_protected.pem"
+  CA_PEM = "#{SSL_CERTS_DIR}/ca.pem"
+  CRL_PEM = "#{SSL_CERTS_DIR}/crl.pem"
+  CLIENT_KEY_PEM = "#{SSL_CERTS_DIR}/client_key.pem"
+  CLIENT_CERT_PEM = "#{SSL_CERTS_DIR}/client_cert.pem"
+  CLIENT_KEY_ENCRYPTED_PEM = "#{SSL_CERTS_DIR}/client_key_encrypted.pem"
+  CLIENT_KEY_PASSPHRASE = "passphrase"
+end
+
+require 'mongo'
+
+Mongo::Logger.logger = Logger.new($stdout)
+unless %w(1 true yes).include?((ENV['CLIENT_DEBUG'] || '').downcase)
+  Mongo::Logger.logger.level = Logger::INFO
+end
+Encoding.default_external = Encoding::UTF_8
+
+require 'support/travis'
+require 'support/matchers'
+require 'support/event_subscriber'
+require 'support/authorization'
+require 'support/server_discovery_and_monitoring'
+require 'support/server_selection_rtt'
+require 'support/server_selection'
+require 'support/sdam_monitoring'
+require 'support/crud'
+require 'support/command_monitoring'
+require 'support/connection_string'
+require 'support/gridfs'
+
+RSpec.configure do |config|
+  if ENV['CI'] && RUBY_PLATFORM =~ /\bjava\b/
+    config.formatter = 'documentation'
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -43,6 +43,9 @@ require 'lite_spec_helper'
 
 TEST_SET = 'ruby-driver-rs'
 
+require 'support/travis'
+require 'support/authorization'
+
 RSpec.configure do |config|
   config.include(Authorization)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -39,64 +39,11 @@
 # Set MONGODB_URI appropriately as well.
 #   SHARDED_ENABLED=1
 
+require 'lite_spec_helper'
+
 TEST_SET = 'ruby-driver-rs'
-COVERAGE_MIN = 90
-CURRENT_PATH = File.expand_path(File.dirname(__FILE__))
-SERVER_DISCOVERY_TESTS = Dir.glob("#{CURRENT_PATH}/support/sdam/**/*.yml")
-SDAM_MONITORING_TESTS = Dir.glob("#{CURRENT_PATH}/support/sdam_monitoring/*.yml")
-SERVER_SELECTION_RTT_TESTS = Dir.glob("#{CURRENT_PATH}/support/server_selection/rtt/*.yml")
-SERVER_SELECTION_TESTS = Dir.glob("#{CURRENT_PATH}/support/server_selection/selection/**/*.yml")
-MAX_STALENESS_TESTS = Dir.glob("#{CURRENT_PATH}/support/max_staleness/**/*.yml")
-CRUD_TESTS = Dir.glob("#{CURRENT_PATH}/support/crud_tests/**/*.yml")
-RETRYABLE_WRITES_TESTS = Dir.glob("#{CURRENT_PATH}/support/retryable_writes_tests/**/*.yml")
-COMMAND_MONITORING_TESTS = Dir.glob("#{CURRENT_PATH}/support/command_monitoring/**/*.yml")
-CONNECTION_STRING_TESTS = Dir.glob("#{CURRENT_PATH}/support/connection_string_tests/*.yml")
-DNS_SEEDLIST_DISCOVERY_TESTS = Dir.glob("#{CURRENT_PATH}/support/dns_seedlist_discovery_tests/*.yml")
-GRIDFS_TESTS = Dir.glob("#{CURRENT_PATH}/support/gridfs_tests/*.yml")
-
-if ENV['DRIVERS_TOOLS']
-  CLIENT_CERT_PEM = ENV['DRIVER_TOOLS_CLIENT_CERT_PEM']
-  CLIENT_KEY_PEM = ENV['DRIVER_TOOLS_CLIENT_KEY_PEM']
-  CA_PEM = ENV['DRIVER_TOOLS_CA_PEM']
-  CLIENT_KEY_ENCRYPTED_PEM = ENV['DRIVER_TOOLS_CLIENT_KEY_ENCRYPTED_PEM']
-else
-  SSL_CERTS_DIR = "#{CURRENT_PATH}/support/certificates"
-  CLIENT_PEM = "#{SSL_CERTS_DIR}/client.pem"
-  CLIENT_PASSWORD_PEM = "#{SSL_CERTS_DIR}/password_protected.pem"
-  CA_PEM = "#{SSL_CERTS_DIR}/ca.pem"
-  CRL_PEM = "#{SSL_CERTS_DIR}/crl.pem"
-  CLIENT_KEY_PEM = "#{SSL_CERTS_DIR}/client_key.pem"
-  CLIENT_CERT_PEM = "#{SSL_CERTS_DIR}/client_cert.pem"
-  CLIENT_KEY_ENCRYPTED_PEM = "#{SSL_CERTS_DIR}/client_key_encrypted.pem"
-  CLIENT_KEY_PASSPHRASE = "passphrase"
-end
-
-require 'mongo'
-
-Mongo::Logger.logger = Logger.new($stdout)
-unless %w(1 true yes).include?((ENV['CLIENT_DEBUG'] || '').downcase)
-  Mongo::Logger.logger.level = Logger::INFO
-end
-Encoding.default_external = Encoding::UTF_8
-
-require 'support/travis'
-require 'support/matchers'
-require 'support/event_subscriber'
-require 'support/authorization'
-require 'support/server_discovery_and_monitoring'
-require 'support/server_selection_rtt'
-require 'support/server_selection'
-require 'support/sdam_monitoring'
-require 'support/crud'
-require 'support/command_monitoring'
-require 'support/connection_string'
-require 'support/gridfs'
 
 RSpec.configure do |config|
-  if ENV['CI'] && RUBY_PLATFORM =~ /\bjava\b/
-    config.formatter = 'documentation'
-  end
-
   config.include(Authorization)
 
   config.before(:suite) do

--- a/spec/spec_tests/command_monitoring_spec.rb
+++ b/spec/spec_tests/command_monitoring_spec.rb
@@ -41,7 +41,13 @@ describe 'Command Monitoring Events' do
 
         test.expectations.each do |expectation|
 
-          it "generates a #{expectation.event_name} for #{expectation.command_name}", unless: ignore?(test) do
+          before do
+            if ignore?(test)
+              skip 'Preconditions not met'
+            end
+          end
+
+          it "generates a #{expectation.event_name} for #{expectation.command_name}" do
             begin
               test.run(authorized_collection)
               event = subscriber.send(expectation.event_type)[expectation.command_name]

--- a/spec/spec_tests/connection_string_spec.rb
+++ b/spec/spec_tests/connection_string_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'lite_spec_helper'
 
 describe 'ConnectionString' do
   include Mongo::ConnectionString

--- a/spec/spec_tests/crud_spec.rb
+++ b/spec/spec_tests/crud_spec.rb
@@ -6,15 +6,15 @@ describe 'CRUD' do
 
     spec = Mongo::CRUD::Spec.new(file)
 
+    before do
+      unless spec.server_version_satisfied?(authorized_client)
+        skip 'Version requirement not satisfied'
+      end
+    end
+
     context(spec.description) do
 
       spec.tests.each do |test|
-
-        around do |example|
-          if spec.server_version_satisfied?(authorized_client)
-            example.run
-          end
-        end
 
         context(test.description) do
 

--- a/spec/spec_tests/dns_seedlist_discovery_spec.rb
+++ b/spec/spec_tests/dns_seedlist_discovery_spec.rb
@@ -54,7 +54,7 @@ describe 'DNS Seedlist Discovery' do
 
       test = Mongo::ConnectionString::Test.new(spec)
 
-      context(File.basename(file_name), if: test_connecting_externally?) do
+      context(File.basename(file_name)) do
 
         context 'when the uri is invalid', if: test.raise_error? do
 

--- a/spec/spec_tests/sdam_monitoring_spec.rb
+++ b/spec/spec_tests/sdam_monitoring_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'lite_spec_helper'
 
 describe 'SDAM Monitoring' do
   include Mongo::SDAM

--- a/spec/spec_tests/sdam_spec.rb
+++ b/spec/spec_tests/sdam_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+require 'lite_spec_helper'
 
 describe 'Server Discovery and Monitoring' do
   include Mongo::SDAM


### PR DESCRIPTION
- Created a lite spec helper to be used instead of the full spec helper for tests that do not interact with a real mongod. This is meant to accomplish two goals: 1) remove noise from global client init for tests that also deal with client initialization, like topology ones and 2) speed up the tests.
- Changed two more tests to have explicit skips when preconditions are not met.