### PR TITLE
Millisecond precision for duration should be sufficient

### DIFF
--- a/lib/mongo/monitoring/command_log_subscriber.rb
+++ b/lib/mongo/monitoring/command_log_subscriber.rb
@@ -68,7 +68,7 @@ module Mongo
       # @since 2.1.0
       def succeeded(event)
         if logger.debug?
-          log_debug("#{prefix(event)} | SUCCEEDED | #{event.duration}s")
+          log_debug("#{prefix(event)} | SUCCEEDED | #{'%.3f' % event.duration}s")
         end
       end
 


### PR DESCRIPTION
This shortens the log entries a bit.