### PR TITLE
Command monitoring improvements and tests

### DIFF
--- a/lib/mongo/monitoring/event/command_failed.rb
+++ b/lib/mongo/monitoring/event/command_failed.rb
@@ -63,6 +63,7 @@ module Mongo
         # @param [ Float ] duration The duration the command took in seconds.
         #
         # @since 2.1.0
+        # @api private
         def initialize(command_name, database_name, address, request_id, operation_id, message, failure, duration)
           @command_name = command_name.to_s
           @database_name = database_name
@@ -89,6 +90,7 @@ module Mongo
         # @return [ CommandFailed ] The event.
         #
         # @since 2.1.0
+        # @api private
         def self.generate(address, operation_id, payload, message, failure, duration)
           new(
             payload[:command_name],

--- a/lib/mongo/monitoring/event/command_failed.rb
+++ b/lib/mongo/monitoring/event/command_failed.rb
@@ -53,24 +53,24 @@ module Mongo
         #
         # @example Create the event.
         #
-        # @param [ BSON::Document ] failure The error document, if any.
         # @param [ String ] command_name The name of the command.
         # @param [ String ] database_name The database_name name.
         # @param [ Server::Address ] address The server address.
         # @param [ Integer ] request_id The request id.
         # @param [ Integer ] operation_id The operation id.
         # @param [ String ] message The error message.
+        # @param [ BSON::Document ] failure The error document, if any.
         # @param [ Float ] duration The duration the command took in seconds.
         #
         # @since 2.1.0
-        def initialize(failure, command_name, database_name, address, request_id, operation_id, message, duration)
-          @failure = failure
+        def initialize(command_name, database_name, address, request_id, operation_id, message, failure, duration)
           @command_name = command_name.to_s
           @database_name = database_name
           @address = address
           @request_id = request_id
           @operation_id = operation_id
           @message = message
+          @failure = failure
           @duration = duration
         end
 
@@ -79,25 +79,25 @@ module Mongo
         # @example Create the event.
         #   CommandFailed.generate(address, 1, payload, duration)
         #
-        # @param [ BSON::Document ] failure The error document, if any.
         # @param [ Server::Address ] address The server address.
         # @param [ Integer ] operation_id The operation id.
         # @param [ Hash ] payload The message payload.
         # @param [ String ] message The error message.
+        # @param [ BSON::Document ] failure The error document, if any.
         # @param [ Float ] duration The duration of the command in seconds.
         #
         # @return [ CommandFailed ] The event.
         #
         # @since 2.1.0
-        def self.generate(failure, address, operation_id, payload, message, duration)
+        def self.generate(address, operation_id, payload, message, failure, duration)
           new(
-            failure,
             payload[:command_name],
             payload[:database_name],
             address,
             payload[:request_id],
             operation_id,
             message,
+            failure,
             duration
           )
         end

--- a/lib/mongo/monitoring/event/command_failed.rb
+++ b/lib/mongo/monitoring/event/command_failed.rb
@@ -69,7 +69,7 @@ module Mongo
         # @since 2.1.0
         def initialize(failure, command_name, command, database_name, address, request_id, operation_id, message, duration)
           @failure = failure
-          @command_name = command_name
+          @command_name = command_name.to_s
           @command = command
           @database_name = database_name
           @address = address

--- a/lib/mongo/monitoring/event/command_failed.rb
+++ b/lib/mongo/monitoring/event/command_failed.rb
@@ -27,9 +27,6 @@ module Mongo
         # @return [ String ] command_name The name of the command.
         attr_reader :command_name
 
-        # @return [ BSON::Document ] command The command arguments.
-        attr_reader :command
-
         # @return [ String ] database_name The name of the database_name.
         attr_reader :database_name
 
@@ -58,7 +55,6 @@ module Mongo
         #
         # @param [ BSON::Document ] failure The error document, if any.
         # @param [ String ] command_name The name of the command.
-        # @param [ BSON::Document ] command The command arguments.
         # @param [ String ] database_name The database_name name.
         # @param [ Server::Address ] address The server address.
         # @param [ Integer ] request_id The request id.
@@ -67,10 +63,9 @@ module Mongo
         # @param [ Float ] duration The duration the command took in seconds.
         #
         # @since 2.1.0
-        def initialize(failure, command_name, command, database_name, address, request_id, operation_id, message, duration)
+        def initialize(failure, command_name, database_name, address, request_id, operation_id, message, duration)
           @failure = failure
           @command_name = command_name.to_s
-          @command = command
           @database_name = database_name
           @address = address
           @request_id = request_id
@@ -98,7 +93,6 @@ module Mongo
           new(
             failure,
             payload[:command_name],
-            payload[:command],
             payload[:database_name],
             address,
             payload[:request_id],

--- a/lib/mongo/monitoring/event/command_failed.rb
+++ b/lib/mongo/monitoring/event/command_failed.rb
@@ -36,7 +36,14 @@ module Mongo
         # @return [ Float ] duration The duration of the command in seconds.
         attr_reader :duration
 
-        # @return [ String ] message The error message.
+        # @return [ BSON::Document ] failure The error document, if present.
+        #   This will only be filled out for errors communicated by a
+        #   MongoDB server. In other situations, for example in case of
+        #   a network error, this attribute may be nil.
+        attr_reader :failure
+
+        # @return [ String ] message The error message. Unlike the error
+        #   document, the error message should always be present.
         attr_reader :message
 
         # @return [ Integer ] operation_id The operation id.
@@ -49,6 +56,7 @@ module Mongo
         #
         # @example Create the event.
         #
+        # @param [ BSON::Document ] failure The error document, if any.
         # @param [ String ] command_name The name of the command.
         # @param [ BSON::Document ] command The command arguments.
         # @param [ String ] database_name The database_name name.
@@ -59,7 +67,8 @@ module Mongo
         # @param [ Float ] duration The duration the command took in seconds.
         #
         # @since 2.1.0
-        def initialize(command_name, command, database_name, address, request_id, operation_id, message, duration)
+        def initialize(failure, command_name, command, database_name, address, request_id, operation_id, message, duration)
+          @failure = failure
           @command_name = command_name
           @command = command
           @database_name = database_name
@@ -75,6 +84,7 @@ module Mongo
         # @example Create the event.
         #   CommandFailed.generate(address, 1, payload, duration)
         #
+        # @param [ BSON::Document ] failure The error document, if any.
         # @param [ Server::Address ] address The server address.
         # @param [ Integer ] operation_id The operation id.
         # @param [ Hash ] payload The message payload.
@@ -84,8 +94,9 @@ module Mongo
         # @return [ CommandFailed ] The event.
         #
         # @since 2.1.0
-        def self.generate(address, operation_id, payload, message, duration)
+        def self.generate(failure, address, operation_id, payload, message, duration)
           new(
+            failure,
             payload[:command_name],
             payload[:command],
             payload[:database_name],

--- a/lib/mongo/monitoring/event/command_failed.rb
+++ b/lib/mongo/monitoring/event/command_failed.rb
@@ -27,6 +27,9 @@ module Mongo
         # @return [ String ] command_name The name of the command.
         attr_reader :command_name
 
+        # @return [ BSON::Document ] command The command arguments.
+        attr_reader :command
+
         # @return [ String ] database_name The name of the database_name.
         attr_reader :database_name
 
@@ -47,6 +50,7 @@ module Mongo
         # @example Create the event.
         #
         # @param [ String ] command_name The name of the command.
+        # @param [ BSON::Document ] command The command arguments.
         # @param [ String ] database_name The database_name name.
         # @param [ Server::Address ] address The server address.
         # @param [ Integer ] request_id The request id.
@@ -55,8 +59,9 @@ module Mongo
         # @param [ Float ] duration The duration the command took in seconds.
         #
         # @since 2.1.0
-        def initialize(command_name, database_name, address, request_id, operation_id, message, duration)
+        def initialize(command_name, command, database_name, address, request_id, operation_id, message, duration)
           @command_name = command_name
+          @command = command
           @database_name = database_name
           @address = address
           @request_id = request_id
@@ -82,6 +87,7 @@ module Mongo
         def self.generate(address, operation_id, payload, message, duration)
           new(
             payload[:command_name],
+            payload[:command],
             payload[:database_name],
             address,
             payload[:request_id],

--- a/lib/mongo/monitoring/event/command_started.rb
+++ b/lib/mongo/monitoring/event/command_started.rb
@@ -52,6 +52,7 @@ module Mongo
         # @param [ BSON::Document ] command The command arguments.
         #
         # @since 2.1.0
+        # @api private
         def initialize(command_name, database_name, address, request_id, operation_id, command)
           @command_name = command_name.to_s
           @database_name = database_name
@@ -73,6 +74,7 @@ module Mongo
         # @return [ CommandStarted ] The event.
         #
         # @since 2.1.0
+        # @api private
         def self.generate(address, operation_id, payload)
           new(
             payload[:command_name],

--- a/lib/mongo/monitoring/event/command_started.rb
+++ b/lib/mongo/monitoring/event/command_started.rb
@@ -83,6 +83,15 @@ module Mongo
             payload[:command]
           )
         end
+
+        # Returns a concise yet useful summary of the event.
+        #
+        # @return [ String ] String summary of the event.
+        #
+        # @since 2.6.0
+        def inspect
+          "#<{#{self.class} command=#{command_name}>"
+        end
       end
     end
   end

--- a/lib/mongo/monitoring/event/command_started.rb
+++ b/lib/mongo/monitoring/event/command_started.rb
@@ -53,7 +53,7 @@ module Mongo
         #
         # @since 2.1.0
         def initialize(command_name, database_name, address, request_id, operation_id, command)
-          @command_name = command_name
+          @command_name = command_name.to_s
           @database_name = database_name
           @address = address
           @request_id = request_id

--- a/lib/mongo/monitoring/event/command_succeeded.rb
+++ b/lib/mongo/monitoring/event/command_succeeded.rb
@@ -28,6 +28,9 @@ module Mongo
         # @return [ String ] command_name The name of the command.
         attr_reader :command_name
 
+        # @return [ BSON::Document ] command The command arguments.
+        attr_reader :command
+
         # @return [ BSON::Document ] reply The command reply.
         attr_reader :reply
 
@@ -48,6 +51,7 @@ module Mongo
         # @example Create the event.
         #
         # @param [ String ] command_name The name of the command.
+        # @param [ BSON::Document ] command The command arguments.
         # @param [ String ] database_name The database name.
         # @param [ Server::Address ] address The server address.
         # @param [ Integer ] request_id The request id.
@@ -56,8 +60,9 @@ module Mongo
         # @param [ Float ] duration The duration the command took in seconds.
         #
         # @since 2.1.0
-        def initialize(command_name, database_name, address, request_id, operation_id, reply, duration)
+        def initialize(command_name, command, database_name, address, request_id, operation_id, reply, duration)
           @command_name = command_name
+          @command = command
           @database_name = database_name
           @address = address
           @request_id = request_id
@@ -83,6 +88,7 @@ module Mongo
         def self.generate(address, operation_id, command_payload, reply_payload, duration)
           new(
             command_payload[:command_name],
+            command_payload[:command],
             command_payload[:database_name],
             address,
             command_payload[:request_id],

--- a/lib/mongo/monitoring/event/command_succeeded.rb
+++ b/lib/mongo/monitoring/event/command_succeeded.rb
@@ -61,7 +61,7 @@ module Mongo
         #
         # @since 2.1.0
         def initialize(command_name, command, database_name, address, request_id, operation_id, reply, duration)
-          @command_name = command_name
+          @command_name = command_name.to_s
           @command = command
           @database_name = database_name
           @address = address

--- a/lib/mongo/monitoring/event/command_succeeded.rb
+++ b/lib/mongo/monitoring/event/command_succeeded.rb
@@ -56,6 +56,7 @@ module Mongo
         # @param [ Float ] duration The duration the command took in seconds.
         #
         # @since 2.1.0
+        # @api private
         def initialize(command_name, database_name, address, request_id, operation_id, reply, duration)
           @command_name = command_name.to_s
           @database_name = database_name
@@ -80,6 +81,7 @@ module Mongo
         # @return [ CommandCompleted ] The event.
         #
         # @since 2.1.0
+        # @api private
         def self.generate(address, operation_id, command_payload, reply_payload, duration)
           new(
             command_payload[:command_name],

--- a/lib/mongo/monitoring/event/command_succeeded.rb
+++ b/lib/mongo/monitoring/event/command_succeeded.rb
@@ -28,9 +28,6 @@ module Mongo
         # @return [ String ] command_name The name of the command.
         attr_reader :command_name
 
-        # @return [ BSON::Document ] command The command arguments.
-        attr_reader :command
-
         # @return [ BSON::Document ] reply The command reply.
         attr_reader :reply
 
@@ -51,7 +48,6 @@ module Mongo
         # @example Create the event.
         #
         # @param [ String ] command_name The name of the command.
-        # @param [ BSON::Document ] command The command arguments.
         # @param [ String ] database_name The database name.
         # @param [ Server::Address ] address The server address.
         # @param [ Integer ] request_id The request id.
@@ -60,9 +56,8 @@ module Mongo
         # @param [ Float ] duration The duration the command took in seconds.
         #
         # @since 2.1.0
-        def initialize(command_name, command, database_name, address, request_id, operation_id, reply, duration)
+        def initialize(command_name, database_name, address, request_id, operation_id, reply, duration)
           @command_name = command_name.to_s
-          @command = command
           @database_name = database_name
           @address = address
           @request_id = request_id
@@ -88,7 +83,6 @@ module Mongo
         def self.generate(address, operation_id, command_payload, reply_payload, duration)
           new(
             command_payload[:command_name],
-            command_payload[:command],
             command_payload[:database_name],
             address,
             command_payload[:request_id],

--- a/lib/mongo/monitoring/publishable.rb
+++ b/lib/mongo/monitoring/publishable.rb
@@ -51,7 +51,7 @@ module Mongo
           result
         rescue Exception => e
           total_duration = duration(receive_start) + send_duration
-          command_failed(address, operation_id, payload, e.message, total_duration)
+          command_failed(nil, address, operation_id, payload, e.message, total_duration)
           raise e
         end
       end
@@ -80,7 +80,7 @@ module Mongo
         document = result ? (result.documents || []).first : nil
         if error?(document)
           parser = Error::Parser.new(document)
-          command_failed(address, operation_id, payload, parser.message, duration)
+          command_failed(document, address, operation_id, payload, parser.message, duration)
         else
           command_succeeded(result, address, operation_id, payload, duration)
         end
@@ -99,10 +99,10 @@ module Mongo
         )
       end
 
-      def command_failed(address, operation_id, payload, message, duration)
+      def command_failed(failure, address, operation_id, payload, message, duration)
         monitoring.failed(
           Monitoring::COMMAND,
-          Event::CommandFailed.generate(address, operation_id, payload, message, duration)
+          Event::CommandFailed.generate(failure, address, operation_id, payload, message, duration)
         )
       end
 

--- a/lib/mongo/monitoring/publishable.rb
+++ b/lib/mongo/monitoring/publishable.rb
@@ -102,7 +102,7 @@ module Mongo
       def command_failed(failure, address, operation_id, payload, message, duration)
         monitoring.failed(
           Monitoring::COMMAND,
-          Event::CommandFailed.generate(failure, address, operation_id, payload, message, duration)
+          Event::CommandFailed.generate(address, operation_id, payload, message, failure, duration)
         )
       end
 

--- a/spec/integration/command_monitoring_spec.rb
+++ b/spec/integration/command_monitoring_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper'
+
+class TestCommandMonitoringSubscriber
+  def initialize
+    @started_events = []
+    @succeeded_events = []
+    @failed_events = []
+  end
+
+  attr_reader :started_events, :succeeded_events, :failed_events
+
+  def started(event)
+    @started_events << event
+  end
+
+  def succeeded(event)
+    @succeeded_events << event
+  end
+
+  def failed(event)
+    @failed_events << event
+  end
+end
+
+describe 'Command monitoring' do
+  let(:subscriber) { TestCommandMonitoringSubscriber.new }
+
+  before do
+    Mongo::Monitoring::Global.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+  end
+
+  after do
+    Mongo::Monitoring::Global.unsubscribe(Mongo::Monitoring::COMMAND, subscriber)
+  end
+
+  let(:client) { Mongo::Client.new(authorized_client.cluster.addresses.map(&:to_s)) }
+
+  it 'notifies on successful commands' do
+    result = client.database.command(:ismaster => 1)
+    expect(result.documents.first['ismaster']).to be true
+
+    expect(subscriber.started_events.length).to eql(1)
+    started_event = subscriber.started_events.first
+    expect(started_event.command_name).to eql(:ismaster)
+    expect(started_event.command.slice('ismaster')).to eql('ismaster' => 1)
+    expect(started_event.address).to be_a(Mongo::Address)
+
+    expect(subscriber.succeeded_events.length).to eql(1)
+    succeeded_event = subscriber.succeeded_events.first
+    expect(succeeded_event.command_name).to eql(:ismaster)
+    expect(succeeded_event.reply.slice('ismaster')).to eql('ismaster' => true)
+    expect(succeeded_event.address).to be_a(Mongo::Address)
+    expect(succeeded_event.duration).to be_a(Float)
+
+    expect(subscriber.failed_events.length).to eql(0)
+  end
+
+  it 'notifies on failed commands' do
+    expect do
+      result = client.database.command(:bogus => 1)
+    end.to raise_error(Mongo::Error::OperationFailure, /no such command/)
+
+    expect(subscriber.started_events.length).to eql(1)
+    started_event = subscriber.started_events.first
+    expect(started_event.command_name).to eql(:bogus)
+    expect(started_event.address).to be_a(Mongo::Address)
+
+    expect(subscriber.succeeded_events.length).to eql(0)
+
+    expect(subscriber.failed_events.length).to eql(1)
+    failed_event = subscriber.failed_events.first
+    expect(failed_event.command_name).to eql(:bogus)
+    expect(failed_event.message).to match(/no such command/)
+    expect(failed_event.address).to be_a(Mongo::Address)
+    expect(failed_event.duration).to be_a(Float)
+  end
+end

--- a/spec/integration/command_monitoring_spec.rb
+++ b/spec/integration/command_monitoring_spec.rb
@@ -33,7 +33,7 @@ describe 'Command monitoring' do
     Mongo::Monitoring::Global.unsubscribe(Mongo::Monitoring::COMMAND, subscriber)
   end
 
-  let(:client) { Mongo::Client.new(authorized_client.cluster.addresses.map(&:to_s)) }
+  let(:client) { Mongo::Client.new(authorized_client.cluster.addresses.map(&:to_s), authorized_client.options) }
 
   it 'notifies on successful commands' do
     result = client.database.command(:ismaster => 1)

--- a/spec/integration/command_monitoring_spec.rb
+++ b/spec/integration/command_monitoring_spec.rb
@@ -48,6 +48,7 @@ describe 'Command monitoring' do
     expect(subscriber.succeeded_events.length).to eql(1)
     succeeded_event = subscriber.succeeded_events.first
     expect(succeeded_event.command_name).to eql(:ismaster)
+    expect(succeeded_event.command.to_hash.slice('ismaster')).to eql('ismaster' => 1)
     expect(succeeded_event.reply.to_hash.slice('ismaster')).to eql('ismaster' => true)
     expect(succeeded_event.address).to be_a(Mongo::Address)
     expect(succeeded_event.duration).to be_a(Float)
@@ -70,6 +71,7 @@ describe 'Command monitoring' do
     expect(subscriber.failed_events.length).to eql(1)
     failed_event = subscriber.failed_events.first
     expect(failed_event.command_name).to eql(:bogus)
+    expect(failed_event.command.to_hash.slice('bogus')).to eql('bogus' => 1)
     expect(failed_event.message).to match(/no such command/)
     expect(failed_event.address).to be_a(Mongo::Address)
     expect(failed_event.duration).to be_a(Float)

--- a/spec/integration/command_monitoring_spec.rb
+++ b/spec/integration/command_monitoring_spec.rb
@@ -72,7 +72,7 @@ describe 'Command monitoring' do
     failed_event = subscriber.failed_events.first
     expect(failed_event.command_name).to eql(:bogus)
     expect(failed_event.command.to_hash.slice('bogus')).to eql('bogus' => 1)
-    expect(failed_event.message).to match(/no such command/)
+    expect(failed_event.message).to match(/no such c(om)?m(an)?d/)
     expect(failed_event.address).to be_a(Mongo::Address)
     expect(failed_event.duration).to be_a(Float)
   end

--- a/spec/integration/command_monitoring_spec.rb
+++ b/spec/integration/command_monitoring_spec.rb
@@ -45,8 +45,6 @@ describe 'Command monitoring' do
     expect(started_events.length).to eql(1)
     started_event = started_events.first
     expect(started_event.command_name).to eql('ismaster')
-    expect(started_event.command).to be_a(BSON::Document)
-    expect(started_event.command['ismaster']).to eql(1)
     expect(started_event.address).to be_a(Mongo::Address)
 
     succeeded_events = subscriber.succeeded_events.select do |event|
@@ -55,8 +53,6 @@ describe 'Command monitoring' do
     expect(succeeded_events.length).to eql(1)
     succeeded_event = succeeded_events.first
     expect(succeeded_event.command_name).to eql('ismaster')
-    expect(succeeded_event.command).to be_a(BSON::Document)
-    expect(succeeded_event.command['ismaster']).to eql(1)
     expect(succeeded_event.reply).to be_a(BSON::Document)
     expect(succeeded_event.reply['ismaster']).to eql(true)
     expect(succeeded_event.address).to be_a(Mongo::Address)
@@ -89,8 +85,6 @@ describe 'Command monitoring' do
     expect(failed_events.length).to eql(1)
     failed_event = failed_events.first
     expect(failed_event.command_name).to eql('bogus')
-    expect(failed_event.command).to be_a(BSON::Document)
-    expect(failed_event.command['bogus']).to eql(1)
     expect(failed_event.message).to match(/no such c(om)?m(an)?d/)
     expect(failed_event.address).to be_a(Mongo::Address)
     expect(failed_event.duration).to be_a(Float)

--- a/spec/integration/command_monitoring_spec.rb
+++ b/spec/integration/command_monitoring_spec.rb
@@ -40,21 +40,21 @@ describe 'Command monitoring' do
     expect(result.documents.first['ismaster']).to be true
 
     started_events = subscriber.started_events.select do |event|
-      event.command_name == :ismaster
+      event.command_name == 'ismaster'
     end
     expect(started_events.length).to eql(1)
     started_event = started_events.first
-    expect(started_event.command_name).to eql(:ismaster)
+    expect(started_event.command_name).to eql('ismaster')
     expect(started_event.command).to be_a(BSON::Document)
     expect(started_event.command['ismaster']).to eql(1)
     expect(started_event.address).to be_a(Mongo::Address)
 
     succeeded_events = subscriber.succeeded_events.select do |event|
-      event.command_name == :ismaster
+      event.command_name == 'ismaster'
     end
     expect(succeeded_events.length).to eql(1)
     succeeded_event = succeeded_events.first
-    expect(succeeded_event.command_name).to eql(:ismaster)
+    expect(succeeded_event.command_name).to eql('ismaster')
     expect(succeeded_event.command).to be_a(BSON::Document)
     expect(succeeded_event.command['ismaster']).to eql(1)
     expect(succeeded_event.reply).to be_a(BSON::Document)
@@ -71,24 +71,24 @@ describe 'Command monitoring' do
     end.to raise_error(Mongo::Error::OperationFailure, /no such c(om)?m(an)?d/)
 
     started_events = subscriber.started_events.select do |event|
-      event.command_name == :bogus
+      event.command_name == 'bogus'
     end
     expect(started_events.length).to eql(1)
     started_event = started_events.first
-    expect(started_event.command_name).to eql(:bogus)
+    expect(started_event.command_name).to eql('bogus')
     expect(started_event.address).to be_a(Mongo::Address)
 
     succeeded_events = subscriber.succeeded_events.select do |event|
-      event.command_name == :ismaster
+      event.command_name == 'ismaster'
     end
     expect(succeeded_events.length).to eql(0)
 
     failed_events = subscriber.failed_events.select do |event|
-      event.command_name == :bogus
+      event.command_name == 'bogus'
     end
     expect(failed_events.length).to eql(1)
     failed_event = failed_events.first
-    expect(failed_event.command_name).to eql(:bogus)
+    expect(failed_event.command_name).to eql('bogus')
     expect(failed_event.command).to be_a(BSON::Document)
     expect(failed_event.command['bogus']).to eql(1)
     expect(failed_event.message).to match(/no such c(om)?m(an)?d/)

--- a/spec/integration/command_monitoring_spec.rb
+++ b/spec/integration/command_monitoring_spec.rb
@@ -42,14 +42,17 @@ describe 'Command monitoring' do
     expect(subscriber.started_events.length).to eql(1)
     started_event = subscriber.started_events.first
     expect(started_event.command_name).to eql(:ismaster)
-    expect(started_event.command.to_hash.slice('ismaster')).to eql('ismaster' => 1)
+    expect(started_event.command).to be_a(BSON::Document)
+    expect(started_event.command['ismaster']).to eql(1)
     expect(started_event.address).to be_a(Mongo::Address)
 
     expect(subscriber.succeeded_events.length).to eql(1)
     succeeded_event = subscriber.succeeded_events.first
     expect(succeeded_event.command_name).to eql(:ismaster)
-    expect(succeeded_event.command.to_hash.slice('ismaster')).to eql('ismaster' => 1)
-    expect(succeeded_event.reply.to_hash.slice('ismaster')).to eql('ismaster' => true)
+    expect(succeeded_event.command).to be_a(BSON::Document)
+    expect(succeeded_event.command['ismaster']).to eql(1)
+    expect(succeeded_event.reply).to be_a(BSON::Document)
+    expect(succeeded_event.reply['ismaster']).to eql(true)
     expect(succeeded_event.address).to be_a(Mongo::Address)
     expect(succeeded_event.duration).to be_a(Float)
 
@@ -71,7 +74,8 @@ describe 'Command monitoring' do
     expect(subscriber.failed_events.length).to eql(1)
     failed_event = subscriber.failed_events.first
     expect(failed_event.command_name).to eql(:bogus)
-    expect(failed_event.command.to_hash.slice('bogus')).to eql('bogus' => 1)
+    expect(failed_event.command).to be_a(BSON::Document)
+    expect(failed_event.command['bogus']).to eql(1)
     expect(failed_event.message).to match(/no such c(om)?m(an)?d/)
     expect(failed_event.address).to be_a(Mongo::Address)
     expect(failed_event.duration).to be_a(Float)

--- a/spec/integration/command_monitoring_spec.rb
+++ b/spec/integration/command_monitoring_spec.rb
@@ -42,13 +42,13 @@ describe 'Command monitoring' do
     expect(subscriber.started_events.length).to eql(1)
     started_event = subscriber.started_events.first
     expect(started_event.command_name).to eql(:ismaster)
-    expect(started_event.command.slice('ismaster')).to eql('ismaster' => 1)
+    expect(started_event.command.to_hash.slice('ismaster')).to eql('ismaster' => 1)
     expect(started_event.address).to be_a(Mongo::Address)
 
     expect(subscriber.succeeded_events.length).to eql(1)
     succeeded_event = subscriber.succeeded_events.first
     expect(succeeded_event.command_name).to eql(:ismaster)
-    expect(succeeded_event.reply.slice('ismaster')).to eql('ismaster' => true)
+    expect(succeeded_event.reply.to_hash.slice('ismaster')).to eql('ismaster' => true)
     expect(succeeded_event.address).to be_a(Mongo::Address)
     expect(succeeded_event.duration).to be_a(Float)
 
@@ -58,7 +58,7 @@ describe 'Command monitoring' do
   it 'notifies on failed commands' do
     expect do
       result = client.database.command(:bogus => 1)
-    end.to raise_error(Mongo::Error::OperationFailure, /no such command/)
+    end.to raise_error(Mongo::Error::OperationFailure, /no such c(om)?m(an)?d/)
 
     expect(subscriber.started_events.length).to eql(1)
     started_event = subscriber.started_events.first

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -1474,7 +1474,7 @@ describe Mongo::Client do
       end
 
       let(:command) do
-        EventSubscriber.started_events.find { |c| c.command_name == :listDatabases }.command
+        EventSubscriber.started_events.find { |c| c.command_name == 'listDatabases' }.command
       end
 
       before do

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -917,7 +917,7 @@ describe Mongo::Collection do
 
         let(:command) do
           client[TEST_COLL].find({}, session: session).explain
-          EventSubscriber.started_events.find { |c| c.command_name == :explain }.command
+          EventSubscriber.started_events.find { |c| c.command_name == 'explain' }.command
         end
 
         it 'sends the session id' do
@@ -1232,7 +1232,7 @@ describe Mongo::Collection do
       end
 
       let(:insert_events) do
-        EventSubscriber.started_events.select { |e| e.command_name == :insert }
+        EventSubscriber.started_events.select { |e| e.command_name == 'insert' }
       end
 
       it 'sends the documents in one OP_MSG' do
@@ -1756,7 +1756,7 @@ describe Mongo::Collection do
 
         let(:command) do
           operation
-          EventSubscriber.started_events.find { |cmd| cmd.command_name == :count }.command
+          EventSubscriber.started_events.find { |cmd| cmd.command_name == 'count' }.command
         end
 
         it_behaves_like 'an operation supporting causally consistent reads'
@@ -1870,7 +1870,7 @@ describe Mongo::Collection do
 
       let(:command) do
         operation
-        EventSubscriber.started_events.find { |cmd| cmd.command_name == :distinct }.command
+        EventSubscriber.started_events.find { |cmd| cmd.command_name == 'distinct' }.command
       end
 
       it_behaves_like 'an operation supporting causally consistent reads'
@@ -2388,7 +2388,7 @@ describe Mongo::Collection do
 
       let(:command) do
         operation
-        EventSubscriber.started_events.find { |cmd| cmd.command_name == :parallelCollectionScan }.command
+        EventSubscriber.started_events.find { |cmd| cmd.command_name == 'parallelCollectionScan' }.command
       end
 
       it_behaves_like 'an operation supporting causally consistent reads'
@@ -3573,7 +3573,7 @@ describe Mongo::Collection do
       end
 
       let(:update_events) do
-        EventSubscriber.started_events.select { |e| e.command_name == :update }
+        EventSubscriber.started_events.select { |e| e.command_name == 'update' }
       end
 
       it 'sends the documents in one OP_MSG' do

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -268,7 +268,7 @@ describe Mongo::Database do
 
 
       let(:full_command) do
-        EventSubscriber.started_events.find { |cmd| cmd.command_name == :ismaster }.command
+        EventSubscriber.started_events.find { |cmd| cmd.command_name == 'ismaster' }.command
       end
 
       it 'does not add a afterClusterTime field' do

--- a/spec/mongo/monitoring/event/command_failed_spec.rb
+++ b/spec/mongo/monitoring/event/command_failed_spec.rb
@@ -13,7 +13,7 @@ describe Mongo::Monitoring::Event::CommandFailed do
   describe '#command_name' do
     context 'when command_name is given as a string' do
       let(:event) do
-        described_class.new(nil, 'find', {}, 'admin', address, 1, 2, reply, 0.5)
+        described_class.new(nil, 'find', 'admin', address, 1, 2, reply, 0.5)
       end
 
       it 'is a string' do
@@ -23,7 +23,7 @@ describe Mongo::Monitoring::Event::CommandFailed do
 
     context 'when command_name is given as a symbol' do
       let(:event) do
-        described_class.new(nil, :find, {}, 'admin', address, 1, 2, reply, 0.5)
+        described_class.new(nil, :find, 'admin', address, 1, 2, reply, 0.5)
       end
 
       it 'is a string' do

--- a/spec/mongo/monitoring/event/command_failed_spec.rb
+++ b/spec/mongo/monitoring/event/command_failed_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mongo::Monitoring::Event::CommandSucceeded do
+describe Mongo::Monitoring::Event::CommandFailed do
 
   let(:address) do
     Mongo::Address.new('127.0.0.1:27017')
@@ -10,24 +10,10 @@ describe Mongo::Monitoring::Event::CommandSucceeded do
     BSON::Document.new(test: 'value')
   end
 
-  describe '#initialize' do
-
-    context 'when the reply should be redacted' do
-
-      let(:event) do
-        described_class.new('copydb', {}, 'admin', address, 1, 2, reply, 0.5)
-      end
-
-      it 'sets the reply to an empty document' do
-        expect(event.reply).to be_empty
-      end
-    end
-  end
-
   describe '#command_name' do
     context 'when command_name is given as a string' do
       let(:event) do
-        described_class.new('find', {}, 'admin', address, 1, 2, reply, 0.5)
+        described_class.new(nil, 'find', {}, 'admin', address, 1, 2, reply, 0.5)
       end
 
       it 'is a string' do
@@ -37,7 +23,7 @@ describe Mongo::Monitoring::Event::CommandSucceeded do
 
     context 'when command_name is given as a symbol' do
       let(:event) do
-        described_class.new(:find, {}, 'admin', address, 1, 2, reply, 0.5)
+        described_class.new(nil, :find, {}, 'admin', address, 1, 2, reply, 0.5)
       end
 
       it 'is a string' do

--- a/spec/mongo/monitoring/event/command_failed_spec.rb
+++ b/spec/mongo/monitoring/event/command_failed_spec.rb
@@ -6,14 +6,10 @@ describe Mongo::Monitoring::Event::CommandFailed do
     Mongo::Address.new('127.0.0.1:27017')
   end
 
-  let(:reply) do
-    BSON::Document.new(test: 'value')
-  end
-
   describe '#command_name' do
     context 'when command_name is given as a string' do
       let(:event) do
-        described_class.new(nil, 'find', 'admin', address, 1, 2, reply, 0.5)
+        described_class.new('find', 'admin', address, 1, 2, 'Uh oh', nil, 0.5)
       end
 
       it 'is a string' do
@@ -23,7 +19,7 @@ describe Mongo::Monitoring::Event::CommandFailed do
 
     context 'when command_name is given as a symbol' do
       let(:event) do
-        described_class.new(nil, :find, 'admin', address, 1, 2, reply, 0.5)
+        described_class.new(:find, 'admin', address, 1, 2, 'Uh oh', nil, 0.5)
       end
 
       it 'is a string' do

--- a/spec/mongo/monitoring/event/command_started_spec.rb
+++ b/spec/mongo/monitoring/event/command_started_spec.rb
@@ -2,11 +2,11 @@ require 'spec_helper'
 
 describe Mongo::Monitoring::Event::CommandStarted do
 
-  describe '#initialize' do
+  let(:address) do
+    Mongo::Address.new('127.0.0.1:27017')
+  end
 
-    let(:address) do
-      Mongo::Address.new('127.0.0.1:27017')
-    end
+  describe '#initialize' do
 
     let(:command) do
       BSON::Document.new(test: 'value')
@@ -20,6 +20,28 @@ describe Mongo::Monitoring::Event::CommandStarted do
 
       it 'sets the command to an empty document' do
         expect(event.command).to be_empty
+      end
+    end
+  end
+
+  describe '#command_name' do
+    context 'when command_name is given as a string' do
+      let(:event) do
+        described_class.new('find', 'admin', address, 1, 2, {})
+      end
+
+      it 'is a string' do
+        expect(event.command_name).to eql('find')
+      end
+    end
+
+    context 'when command_name is given as a symbol' do
+      let(:event) do
+        described_class.new(:find, 'admin', address, 1, 2, {})
+      end
+
+      it 'is a string' do
+        expect(event.command_name).to eql('find')
       end
     end
   end

--- a/spec/mongo/monitoring/event/command_succeeded_spec.rb
+++ b/spec/mongo/monitoring/event/command_succeeded_spec.rb
@@ -15,7 +15,7 @@ describe Mongo::Monitoring::Event::CommandSucceeded do
     context 'when the reply should be redacted' do
 
       let(:event) do
-        described_class.new('copydb', 'admin', address, 1, 2, reply, 0.5)
+        described_class.new('copydb', {}, 'admin', address, 1, 2, reply, 0.5)
       end
 
       it 'sets the reply to an empty document' do

--- a/spec/mongo/monitoring/event/command_succeeded_spec.rb
+++ b/spec/mongo/monitoring/event/command_succeeded_spec.rb
@@ -15,7 +15,7 @@ describe Mongo::Monitoring::Event::CommandSucceeded do
     context 'when the reply should be redacted' do
 
       let(:event) do
-        described_class.new('copydb', {}, 'admin', address, 1, 2, reply, 0.5)
+        described_class.new('copydb', 'admin', address, 1, 2, reply, 0.5)
       end
 
       it 'sets the reply to an empty document' do
@@ -27,7 +27,7 @@ describe Mongo::Monitoring::Event::CommandSucceeded do
   describe '#command_name' do
     context 'when command_name is given as a string' do
       let(:event) do
-        described_class.new('find', {}, 'admin', address, 1, 2, reply, 0.5)
+        described_class.new('find', 'admin', address, 1, 2, reply, 0.5)
       end
 
       it 'is a string' do
@@ -37,7 +37,7 @@ describe Mongo::Monitoring::Event::CommandSucceeded do
 
     context 'when command_name is given as a symbol' do
       let(:event) do
-        described_class.new(:find, {}, 'admin', address, 1, 2, reply, 0.5)
+        described_class.new(:find, 'admin', address, 1, 2, reply, 0.5)
       end
 
       it 'is a string' do

--- a/spec/mongo/monitoring_spec.rb
+++ b/spec/mongo/monitoring_spec.rb
@@ -85,12 +85,37 @@ describe Mongo::Monitoring do
       double('subscriber')
     end
 
-    before do
+    it 'subscribes to the topic' do
       monitoring.subscribe('topic', subscriber)
+      expect(monitoring.subscribers['topic']).to eq([ subscriber ])
     end
 
-    it 'subscribes to the topic' do
-      expect(monitoring.subscribers['topic']).to eq([ subscriber ])
+    it 'subscribes to the topic twice' do
+      monitoring.subscribe('topic', subscriber)
+      monitoring.subscribe('topic', subscriber)
+      expect(monitoring.subscribers['topic']).to eq([ subscriber, subscriber ])
+    end
+  end
+
+  describe '#unsubscribe' do
+
+    let(:monitoring) do
+      described_class.new(monitoring: false)
+    end
+
+    let(:subscriber) do
+      double('subscriber')
+    end
+
+    it 'unsubscribes from the topic' do
+      monitoring.subscribe('topic', subscriber)
+      monitoring.unsubscribe('topic', subscriber)
+      expect(monitoring.subscribers['topic']).to eq([ ])
+    end
+
+    it 'unsubscribes from the topic when not subscribed' do
+      monitoring.unsubscribe('topic', subscriber)
+      expect(monitoring.subscribers['topic']).to eq([ ])
     end
   end
 

--- a/spec/mongo/session/session_pool_spec.rb
+++ b/spec/mongo/session/session_pool_spec.rb
@@ -171,7 +171,7 @@ describe Mongo::Session::SessionPool, if: test_sessions? do
 
       let(:end_sessions_command) do
         pool.end_sessions
-        EventSubscriber.started_events.find { |c| c.command_name == :endSessions}
+        EventSubscriber.started_events.find { |c| c.command_name == 'endSessions'}
       end
 
       it 'sends the endSessions command with all the session ids' do
@@ -210,7 +210,7 @@ describe Mongo::Session::SessionPool, if: test_sessions? do
       end
 
       let(:end_sessions_commands) do
-        EventSubscriber.started_events.select { |c| c.command_name == :endSessions}
+        EventSubscriber.started_events.select { |c| c.command_name == 'endSessions'}
       end
 
       it 'sends the command more than once' do


### PR DESCRIPTION
Added an integration test to verify command monitoring functionality per the spec. Spec needed to be fixed - https://github.com/mongodb/specifications/pull/359.

Changes made to monitoring code itself:
- DRY the code - extract Subscribable module with common methods for per-client and global subscribers
- Add unsubscribe method so that the testing can be done
- Document how multiple subscriptions of the same listener are handled
- ~~Expose command arguments in started and failure events since the events have them~~
- Expose failure document in failure events per specification
- `command_name` on command monitoring events is now always a string, as was documented