### PR TITLE
Change stream retry behavior change

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,9 @@ group :development do
   gem 'pry-rescue'
   gem 'pry-nav'
 end
+
+group :testing do
+  platforms :mri do
+    gem 'timeout-interrupt'
+  end
+end

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,10 @@ group :development, :testing do
   end
 end
 
+group :testing do
+  gem 'rspec-retry'
+end
+
 group :development do
   gem 'ruby-prof', :platforms => :mri
   gem 'pry-rescue'

--- a/docs/tutorials/ruby-driver-change-streams.txt
+++ b/docs/tutorials/ruby-driver-change-streams.txt
@@ -77,3 +77,24 @@ You can close a change stream by calling the ``#close`` method:
   doc = stream.to_enum.next
   process(doc)
   stream.close
+
+Resuming a Change Stream
+------------------------
+
+The driver will automatically retry getMore operations on a change stream
+once. Initial aggregation is never retried. In practical terms this means
+that, for example:
+
+- Calling ``collection.watch`` will fail if the cluster does not have
+enough available nodes to satisfy the ``"majority"`` read preference;
+- Once ``collection.watch`` successfully returns, if the cluster subsequently
+experiences an election or loses a node, but heals quickly enough,
+change stream reads via ``next`` or ``each`` methods will continue
+transparently to the application.
+
+If the cluster loses enough nodes to not be able to satisfy the ``"majority"``
+read preference and does not heal quickly enough, ``next`` and ``each``
+will raise an error. In these cases the application must track which
+documents from the change stream it has processed and create a new
+change stream object via the ``watch`` call, passing an appropriate
+``:resume_after`` argument.

--- a/lib/mongo/collection/view/change_stream.rb
+++ b/lib/mongo/collection/view/change_stream.rb
@@ -93,6 +93,8 @@ module Mongo
 
         # Iterate through documents returned by the change stream.
         #
+        # This method retries indefinitely on resumable errors.
+        #
         # @example Iterate through the stream of documents.
         #   stream.each do |document|
         #     p document
@@ -121,6 +123,20 @@ module Mongo
           end
         end
 
+        # Return one document from the change stream, if one is available.
+        #
+        # Retries once on a resumable error.
+        #
+        # Raises StopIteration if the change stream is closed.
+        #
+        # This method will wait up to max_await_time_ms milliseconds
+        # for changes from the server, and if no changes are received
+        # it will return nil.
+        #
+        # @note This method is experimental and subject to change.
+        #
+        # @return [ BSON::Document | nil ] A change stream document.
+        # @api private
         def try_next
           raise StopIteration.new if closed?
           doc = @cursor.try_next

--- a/lib/mongo/collection/view/change_stream.rb
+++ b/lib/mongo/collection/view/change_stream.rb
@@ -93,7 +93,9 @@ module Mongo
 
         # Iterate through documents returned by the change stream.
         #
-        # This method retries indefinitely on resumable errors.
+        # This method retries once per error on resumable errors
+        # (two consecutive errors result in the second error being raised,
+        # an error which is recovered from resets the error count to zero).
         #
         # @example Iterate through the stream of documents.
         #   stream.each do |document|

--- a/lib/mongo/collection/view/change_stream.rb
+++ b/lib/mongo/collection/view/change_stream.rb
@@ -115,22 +115,17 @@ module Mongo
             end if block_given?
             @cursor.to_enum
           rescue Mongo::Error => e
-            unless e.change_stream_resumable?
+            if retried || !e.change_stream_resumable?
               raise
             end
 
-            if retried
-              # Rerun initial aggregation.
-              # Any errors here will stop iteration and break out of this
-              # method
-              close
-              create_cursor!
-              retried = false
-            else
-              # Attempt to retry a getMore once
-              retried = true
-              retry
-            end
+            retried = true
+            # Rerun initial aggregation.
+            # Any errors here will stop iteration and break out of this
+            # method
+            close
+            create_cursor!
+            retry
           end
         end
 

--- a/lib/mongo/collection/view/change_stream.rb
+++ b/lib/mongo/collection/view/change_stream.rb
@@ -121,6 +121,26 @@ module Mongo
           end
         end
 
+        def try_next
+          raise StopIteration.new if closed?
+          doc = @cursor.try_next
+          if doc
+            cache_resume_token(doc)
+          end
+          doc
+        end
+
+        def to_enum
+          enum = super
+          enum.send(:instance_variable_set, '@obj', self)
+          class << enum
+            def try_next
+              @obj.try_next
+            end
+          end
+          enum
+        end
+
         # Close the change stream.
         #
         # @example Close the change stream.

--- a/lib/mongo/collection/view/change_stream/retryable.rb
+++ b/lib/mongo/collection/view/change_stream/retryable.rb
@@ -26,24 +26,12 @@ module Mongo
 
           def read_with_one_retry
             yield
-          rescue => e
-            if retryable?(e)
+          rescue Mongo::Error => e
+            if e.change_stream_resumable?
               yield
             else
               raise(e)
             end
-          end
-
-          def retryable?(error)
-             network_error?(error) || retryable_operation_failure?(error)
-          end
-
-          def network_error?(error)
-            [ Error::SocketError, Error::SocketTimeoutError].include?(error.class)
-          end
-
-          def retryable_operation_failure?(error)
-            error.is_a?(Error::OperationFailure) && error.change_stream_resumable?
           end
         end
       end

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -125,6 +125,30 @@ module Mongo
       end
     end
 
+    def try_next
+      if @documents.nil?
+        @documents = process(@initial_result)
+      elsif @documents.empty?
+        if more?
+          if exhausted?
+            kill_cursors
+            return nil
+          end
+
+          @documents = get_more
+        end
+      else
+        # cursor is closed here
+        # keep documents as an empty array
+      end
+
+      if @documents
+        return @documents.shift
+      end
+
+      nil
+    end
+
     # Get the batch size.
     #
     # @example Get the batch size.

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -125,10 +125,22 @@ module Mongo
       end
     end
 
+    # Return one document from the query, if one is available.
+    #
+    # Retries once on a resumable error.
+    #
+    # This method will wait up to max_await_time_ms milliseconds
+    # for changes from the server, and if no changes are received
+    # it will return nil.
+    #
+    # @note This method is experimental and subject to change.
+    #
+    # @return [ BSON::Document | nil ] A document.
+    # @api private
     def try_next
       if @documents.nil?
         @documents = process(@initial_result)
-        # the docuemnts here can be an empty array, hence
+        # the documents here can be an empty array, hence
         # we may end up issuing a getMore in the first try_next call
       end
 

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -128,7 +128,11 @@ module Mongo
     def try_next
       if @documents.nil?
         @documents = process(@initial_result)
-      elsif @documents.empty?
+        # the docuemnts here can be an empty array, hence
+        # we may end up issuing a getMore in the first try_next call
+      end
+
+      if @documents.empty?
         if more?
           if exhausted?
             kill_cursors

--- a/lib/mongo/error.rb
+++ b/lib/mongo/error.rb
@@ -69,11 +69,16 @@ module Mongo
     #
     # @since 2.2.3
     CURSOR_NOT_FOUND = 'Cursor not found.'
+
+    def change_stream_resumable?
+      false
+    end
   end
 end
 
 require 'mongo/error/parser'
 require 'mongo/error/write_retryable'
+require 'mongo/error/change_stream_resumable'
 require 'mongo/error/bulk_write_error'
 require 'mongo/error/closed_stream'
 require 'mongo/error/extra_file_chunk'

--- a/lib/mongo/error.rb
+++ b/lib/mongo/error.rb
@@ -70,6 +70,15 @@ module Mongo
     # @since 2.2.3
     CURSOR_NOT_FOUND = 'Cursor not found.'
 
+    # Can the change stream on which this error occurred be resumed,
+    # provided the operation that triggered this error was a getMore?
+    #
+    # @example Is the error resumable for the change stream?
+    #   error.change_stream_resumable?
+    #
+    # @return [ true, false ] Whether the error is resumable.
+    #
+    # @since 2.6.0
     def change_stream_resumable?
       false
     end

--- a/lib/mongo/error/change_stream_resumable.rb
+++ b/lib/mongo/error/change_stream_resumable.rb
@@ -1,4 +1,4 @@
-# Copyright (C) 2015-2017 MongoDB, Inc.
+# Copyright (C) 2018 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,12 +15,14 @@
 module Mongo
   class Error
 
-    # Raised when a socket connection times out.
+    # A module signifying the error will always cause change stream to
+    # resume once.
     #
-    # @since 2.0.0
-    class SocketTimeoutError < Error
-      include WriteRetryable
-      include ChangeStreamResumable
+    # @since 2.6.0
+    module ChangeStreamResumable
+      def change_stream_resumable?
+        true
+      end
     end
   end
 end

--- a/lib/mongo/error/change_stream_resumable.rb
+++ b/lib/mongo/error/change_stream_resumable.rb
@@ -20,6 +20,15 @@ module Mongo
     #
     # @since 2.6.0
     module ChangeStreamResumable
+      # Can the change stream on which this error occurred be resumed,
+      # provided the operation that triggered this error was a getMore?
+      #
+      # @example Is the error resumable for the change stream?
+      #   error.change_stream_resumable?
+      #
+      # @return [ true, false ] Whether the error is resumable.
+      #
+      # @since 2.6.0
       def change_stream_resumable?
         true
       end

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -129,9 +129,8 @@ module Mongo
       # @api private
       CHANGE_STREAM_RESUME_MESSAGES = WRITE_RETRY_MESSAGES
 
-      # Can the change stream on which this error occurred be resumed?
-      #
-      # Note: only errors from getMore commands are resumable.
+      # Can the change stream on which this error occurred be resumed,
+      # provided the operation that triggered this error was a getMore?
       #
       # @example Is the error resumable for the change stream?
       #   error.change_stream_resumable?

--- a/lib/mongo/error/socket_error.rb
+++ b/lib/mongo/error/socket_error.rb
@@ -20,6 +20,7 @@ module Mongo
     # @since 2.0.0
     class SocketError < Error
       include WriteRetryable
+      include ChangeStreamResumable
 
       # Instantiate the new exception.
       #

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -1,25 +1,103 @@
 require 'spec_helper'
 
 describe 'Change stream integration' do
+  FAIL_POINT_BASE_COMMAND = { 'configureFailPoint' => "failCommand" }
+
   before do
     unless test_change_streams?
       skip 'Not testing change streams'
     end
   end
 
-  describe 'next' do
-    it 'returns changes' do
-      cs = authorized_collection.watch
+  describe 'watch+next' do
+    shared_context 'returns a change document' do
+      it 'returns a change document' do
+        cs = authorized_collection.watch
 
-      authorized_collection.insert_one(:a => 1)
+        authorized_collection.insert_one(:a => 1)
+        sleep 0.5
 
-      change = cs.to_enum.next
-      expect(change).to be_a(BSON::Document)
-      expect(change['operationType']).to eql('insert')
-      doc = change['fullDocument']
-      expect(doc['_id']).to be_a(BSON::ObjectId)
-      doc.delete('_id')
-      expect(doc).to eql('a' => 1)
+        change = cs.to_enum.next
+        expect(change).to be_a(BSON::Document)
+        expect(change['operationType']).to eql('insert')
+        doc = change['fullDocument']
+        expect(doc['_id']).to be_a(BSON::ObjectId)
+        doc.delete('_id')
+        expect(doc).to eql('a' => 1)
+      end
+    end
+
+    context 'no errors' do
+      it 'next returns changes' do
+        cs = authorized_collection.watch
+
+        authorized_collection.insert_one(:a => 1)
+
+        change = cs.to_enum.next
+        expect(change).to be_a(BSON::Document)
+        expect(change['operationType']).to eql('insert')
+        doc = change['fullDocument']
+        expect(doc['_id']).to be_a(BSON::ObjectId)
+        doc.delete('_id')
+        expect(doc).to eql('a' => 1)
+      end
+    end
+
+    context 'error on initial aggregation' do
+      before do
+        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+          :mode => {:times => 1},
+          :data => {:failCommands => ['aggregate'], errorCode: 100}))
+      end
+
+      it 'watch raises error' do
+        expect do
+          authorized_collection.watch
+        end.to raise_error(Mongo::Error::OperationFailure, "Failing command due to 'failCommand' failpoint (100)")
+      end
+    end
+
+    context 'one error on getMore' do
+      before do
+        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+          :mode => {:times => 1},
+          :data => {:failCommands => ['getMore'], errorCode: 100}))
+      end
+
+      it_behaves_like 'returns a change document'
+    end
+
+    context 'two errors on getMore' do
+      before do
+        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+          :mode => {:times => 2},
+          :data => {:failCommands => ['getMore'], errorCode: 100}))
+      end
+
+      # this retries twice because aggregation resets retry count,
+      # and ultimately succeeds and returns data
+      it_behaves_like 'returns a change document'
+    end
+
+    context 'two errors on getMore followed by an error on aggregation' do
+      it 'next raises error' do
+        cs = authorized_collection.watch
+
+        authorized_collection.insert_one(:a => 1)
+        sleep 0.5
+
+        enum = cs.to_enum
+
+        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+          :mode => {:times => 3},
+          :data => {:failCommands => ['getMore', 'aggregate'], errorCode: 101}))
+
+        sleep 0.5
+
+        expect do
+          enum.next
+        end.to raise_error(Mongo::Error::OperationFailure, "Failing command due to 'failCommand' failpoint (101)")
+      end
     end
   end
 
@@ -29,6 +107,7 @@ describe 'Change stream integration' do
         cs = authorized_collection.watch
 
         authorized_collection.insert_one(:a => 1)
+        sleep 0.5
 
         change = cs.to_enum.try_next
         expect(change).to be_a(BSON::Document)

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -44,6 +44,8 @@ describe 'Change stream integration' do
     end
 
     context 'error on initial aggregation' do
+      min_server_version '4.0'
+
       before do
         authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
           :mode => {:times => 1},
@@ -58,6 +60,8 @@ describe 'Change stream integration' do
     end
 
     context 'one error on getMore' do
+      min_server_version '4.0'
+
       before do
         authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
           :mode => {:times => 1},
@@ -68,6 +72,8 @@ describe 'Change stream integration' do
     end
 
     context 'two errors on getMore' do
+      min_server_version '4.0'
+
       before do
         authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
           :mode => {:times => 2},
@@ -80,6 +86,8 @@ describe 'Change stream integration' do
     end
 
     context 'two errors on getMore followed by an error on aggregation' do
+      min_server_version '4.0'
+
       it 'next raises error' do
         cs = authorized_collection.watch
 
@@ -133,6 +141,8 @@ describe 'Change stream integration' do
     end
 
     context 'one error on getMore' do
+      min_server_version '4.0'
+
       before do
         authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
           :mode => {:times => 1},
@@ -143,6 +153,8 @@ describe 'Change stream integration' do
     end
 
     context 'two errors on getMore' do
+      min_server_version '4.0'
+
       before do
         authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
           :mode => {:times => 2},
@@ -155,6 +167,8 @@ describe 'Change stream integration' do
     end
 
     context 'two errors on getMore followed by an error on aggregation' do
+      min_server_version '4.0'
+
       it 'next raises error' do
         cs = authorized_collection.watch
 

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -6,21 +6,31 @@ describe 'Change stream integration' do
 
   FAIL_POINT_BASE_COMMAND = { 'configureFailPoint' => "failCommand" }
 
+  # There is value in not clearing fail points between tests because
+  # their triggering will distinguish fail points not being set vs
+  # them not being triggered
+  def clear_fail_point(collection)
+    collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(mode: "off"))
+  end
+
   before do
     unless test_change_streams?
       skip 'Not testing change streams'
     end
+    clear_fail_point(authorized_collection)
   end
 
   describe 'watch+next' do
+    let(:change_stream) { authorized_collection.watch }
+
     shared_context 'returns a change document' do
       it 'returns a change document' do
-        cs = authorized_collection.watch
+        change_stream
 
         authorized_collection.insert_one(:a => 1)
         sleep 0.5
 
-        change = cs.to_enum.next
+        change = change_stream.to_enum.next
         expect(change).to be_a(BSON::Document)
         expect(change['operationType']).to eql('insert')
         doc = change['fullDocument']
@@ -32,11 +42,11 @@ describe 'Change stream integration' do
 
     context 'no errors' do
       it 'next returns changes' do
-        cs = authorized_collection.watch
+        change_stream
 
         authorized_collection.insert_one(:a => 1)
 
-        change = cs.to_enum.next
+        change = change_stream.to_enum.next
         expect(change).to be_a(BSON::Document)
         expect(change['operationType']).to eql('insert')
         doc = change['fullDocument']
@@ -65,39 +75,91 @@ describe 'Change stream integration' do
     context 'one error on getMore' do
       min_server_version '4.0'
 
-      before do
-        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
-          :mode => {:times => 1},
-          :data => {:failCommands => ['getMore'], errorCode: 100}))
+      xcontext 'error on first getMore' do
+        before do
+          pending 'Requires startAtOperationTime support'
+        end
+
+        before do
+          authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+            :mode => {:times => 1},
+            :data => {:failCommands => ['getMore'], errorCode: 100}))
+        end
+
+        it_behaves_like 'returns a change document'
       end
 
-      it_behaves_like 'returns a change document'
+      context 'error on a getMore other than first' do
+        before do
+          # Need to retrieve a change stream document successfully prior to
+          # failing to have the resume token, otherwise the change stream
+          # ignores documents inserted after the first aggregation
+          # and the test gets stuck
+          change_stream
+          authorized_collection.insert_one(:a => 1)
+          change_stream.to_enum.next
+          authorized_collection.insert_one(:a => 1)
+
+          authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+            :mode => {:times => 1},
+            :data => {:failCommands => ['getMore'], errorCode: 100}))
+        end
+
+        it_behaves_like 'returns a change document'
+      end
     end
 
     context 'two errors on getMore' do
       min_server_version '4.0'
 
-      before do
-        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
-          :mode => {:times => 2},
-          :data => {:failCommands => ['getMore'], errorCode: 100}))
+      xcontext 'error of first getMores' do
+        before do
+          pending 'Requires startAtOperationTime support'
+        end
+
+        before do
+          authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+            :mode => {:times => 2},
+            :data => {:failCommands => ['getMore'], errorCode: 100}))
+        end
+
+        # this retries twice because aggregation resets retry count,
+        # and ultimately succeeds and returns data
+        it_behaves_like 'returns a change document'
       end
 
-      # this retries twice because aggregation resets retry count,
-      # and ultimately succeeds and returns data
-      it_behaves_like 'returns a change document'
+      context 'error on a getMore other than first' do
+        before do
+          # Need to retrieve a change stream document successfully prior to
+          # failing to have the resume token, otherwise the change stream
+          # ignores documents inserted after the first aggregation
+          # and the test gets stuck
+          change_stream
+          authorized_collection.insert_one(:a => 1)
+          change_stream.to_enum.next
+          authorized_collection.insert_one(:a => 1)
+
+          authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+            :mode => {:times => 2},
+            :data => {:failCommands => ['getMore'], errorCode: 100}))
+        end
+
+        # this retries twice because aggregation resets retry count,
+        # and ultimately succeeds and returns data
+        it_behaves_like 'returns a change document'
+      end
     end
 
     context 'two errors on getMore followed by an error on aggregation' do
       min_server_version '4.0'
 
       it 'next raises error' do
-        cs = authorized_collection.watch
+        change_stream
 
         authorized_collection.insert_one(:a => 1)
         sleep 0.5
 
-        enum = cs.to_enum
+        enum = change_stream.to_enum
 
         authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
           :mode => {:times => 2},
@@ -113,14 +175,16 @@ describe 'Change stream integration' do
   end
 
   describe 'try_next' do
+    let(:change_stream) { authorized_collection.watch }
+
     shared_context 'returns a change document' do
       it 'returns a change document' do
-        cs = authorized_collection.watch
+        change_stream
 
         authorized_collection.insert_one(:a => 1)
         sleep 0.5
 
-        change = cs.to_enum.try_next
+        change = change_stream.to_enum.try_next
         expect(change).to be_a(BSON::Document)
         expect(change['operationType']).to eql('insert')
         doc = change['fullDocument']
@@ -136,9 +200,9 @@ describe 'Change stream integration' do
 
     context 'there are no changes' do
       it 'returns nil' do
-        cs = authorized_collection.watch
+        change_stream
 
-        change = cs.to_enum.try_next
+        change = change_stream.to_enum.try_next
         expect(change).to be nil
       end
     end
@@ -146,13 +210,30 @@ describe 'Change stream integration' do
     context 'one error on getMore' do
       min_server_version '4.0'
 
-      before do
-        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
-          :mode => {:times => 1},
-          :data => {:failCommands => ['getMore'], errorCode: 100}))
+      xcontext 'error on first getMore' do
+        before do
+          authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+            :mode => {:times => 1},
+            :data => {:failCommands => ['getMore'], errorCode: 100}))
+        end
+
+        it_behaves_like 'returns a change document'
       end
 
-      it_behaves_like 'returns a change document'
+      context 'error on a getMore other than first' do
+        before do
+          change_stream
+          authorized_collection.insert_one(:a => 1)
+          change_stream.to_enum.next
+          authorized_collection.insert_one(:a => 1)
+
+          authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+            :mode => {:times => 1},
+            :data => {:failCommands => ['getMore'], errorCode: 100}))
+        end
+
+        it_behaves_like 'returns a change document'
+      end
     end
 
     context 'two errors on getMore' do
@@ -172,23 +253,48 @@ describe 'Change stream integration' do
     context 'two errors on getMore followed by an error on aggregation' do
       min_server_version '4.0'
 
-      it 'next raises error' do
-        cs = authorized_collection.watch
+      xcontext 'error on first getMore' do
+        it 'next raises error' do
+          change_stream
 
-        authorized_collection.insert_one(:a => 1)
-        sleep 0.5
+          authorized_collection.insert_one(:a => 1)
+          sleep 0.5
 
-        enum = cs.to_enum
+          enum = change_stream.to_enum
 
-        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
-          :mode => {:times => 3},
-          :data => {:failCommands => ['getMore', 'aggregate'], errorCode: 101}))
+          authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+            :mode => {:times => 3},
+            :data => {:failCommands => ['getMore', 'aggregate'], errorCode: 101}))
 
-        sleep 0.5
+          sleep 0.5
 
-        expect do
-          enum.try_next
-        end.to raise_error(Mongo::Error::OperationFailure, "Failing command due to 'failCommand' failpoint (101)")
+          expect do
+            enum.try_next
+          end.to raise_error(Mongo::Error::OperationFailure, "Failing command due to 'failCommand' failpoint (101)")
+        end
+      end
+
+      context 'error on a getMore other than first' do
+        it 'next raises error' do
+          change_stream
+
+          authorized_collection.insert_one(:a => 1)
+          change_stream.to_enum.next
+          authorized_collection.insert_one(:a => 1)
+          sleep 0.5
+
+          enum = change_stream.to_enum
+
+          authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+            :mode => {:times => 3},
+            :data => {:failCommands => ['getMore', 'aggregate'], errorCode: 101}))
+
+          sleep 0.5
+
+          expect do
+            enum.try_next
+          end.to raise_error(Mongo::Error::OperationFailure, "Failing command due to 'failCommand' failpoint (101)")
+        end
       end
     end
   end

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -97,7 +97,7 @@ describe 'Change stream integration' do
         enum = cs.to_enum
 
         authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
-          :mode => {:times => 3},
+          :mode => {:times => 2},
           :data => {:failCommands => ['getMore', 'aggregate'], errorCode: 101}))
 
         sleep 0.5

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -13,11 +13,18 @@ describe 'Change stream integration' do
     collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(mode: "off"))
   end
 
+  class << self
+    def clear_fail_point_before
+      before do
+        clear_fail_point(authorized_collection)
+      end
+    end
+  end
+
   before do
     unless test_change_streams?
       skip 'Not testing change streams'
     end
-    clear_fail_point(authorized_collection)
   end
 
   describe 'watch+next' do
@@ -58,6 +65,7 @@ describe 'Change stream integration' do
 
     context 'error on initial aggregation' do
       min_server_version '4.0'
+      clear_fail_point_before
 
       before do
         authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
@@ -74,6 +82,7 @@ describe 'Change stream integration' do
 
     context 'one error on getMore' do
       min_server_version '4.0'
+      clear_fail_point_before
 
       xcontext 'error on first getMore' do
         before do
@@ -111,6 +120,7 @@ describe 'Change stream integration' do
 
     context 'two errors on getMore' do
       min_server_version '4.0'
+      clear_fail_point_before
 
       xcontext 'error of first getMores' do
         before do
@@ -152,6 +162,7 @@ describe 'Change stream integration' do
 
     context 'two errors on getMore followed by an error on aggregation' do
       min_server_version '4.0'
+      clear_fail_point_before
 
       it 'next raises error' do
         change_stream
@@ -209,6 +220,7 @@ describe 'Change stream integration' do
 
     context 'one error on getMore' do
       min_server_version '4.0'
+      clear_fail_point_before
 
       xcontext 'error on first getMore' do
         before do
@@ -238,6 +250,7 @@ describe 'Change stream integration' do
 
     context 'two errors on getMore' do
       min_server_version '4.0'
+      clear_fail_point_before
 
       before do
         authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
@@ -252,6 +265,7 @@ describe 'Change stream integration' do
 
     context 'two errors on getMore followed by an error on aggregation' do
       min_server_version '4.0'
+      clear_fail_point_before
 
       xcontext 'error on first getMore' do
         it 'next raises error' do

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
 describe 'Change stream integration' do
+  only_mri
+  max_example_run_time 7
+
   FAIL_POINT_BASE_COMMAND = { 'configureFailPoint' => "failCommand" }
 
   before do

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -39,5 +39,14 @@ describe 'Change stream integration' do
         expect(doc).to eql('a' => 1)
       end
     end
+
+    context 'there are no changes' do
+      it 'returns nil' do
+        cs = authorized_collection.watch
+
+        change = cs.to_enum.try_next
+        expect(change).to be nil
+      end
+    end
   end
 end

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -102,8 +102,8 @@ describe 'Change stream integration' do
   end
 
   describe 'try_next' do
-    context 'there are changes' do
-      it 'returns changes' do
+    shared_context 'returns a change document' do
+      it 'returns a change document' do
         cs = authorized_collection.watch
 
         authorized_collection.insert_one(:a => 1)
@@ -119,12 +119,59 @@ describe 'Change stream integration' do
       end
     end
 
+    context 'there are changes' do
+      it_behaves_like 'returns a change document'
+    end
+
     context 'there are no changes' do
       it 'returns nil' do
         cs = authorized_collection.watch
 
         change = cs.to_enum.try_next
         expect(change).to be nil
+      end
+    end
+
+    context 'one error on getMore' do
+      before do
+        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+          :mode => {:times => 1},
+          :data => {:failCommands => ['getMore'], errorCode: 100}))
+      end
+
+      it_behaves_like 'returns a change document'
+    end
+
+    context 'two errors on getMore' do
+      before do
+        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+          :mode => {:times => 2},
+          :data => {:failCommands => ['getMore'], errorCode: 100}))
+      end
+
+      # this retries twice because aggregation resets retry count,
+      # and ultimately succeeds and returns data
+      it_behaves_like 'returns a change document'
+    end
+
+    context 'two errors on getMore followed by an error on aggregation' do
+      it 'next raises error' do
+        cs = authorized_collection.watch
+
+        authorized_collection.insert_one(:a => 1)
+        sleep 0.5
+
+        enum = cs.to_enum
+
+        authorized_collection.client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(
+          :mode => {:times => 3},
+          :data => {:failCommands => ['getMore', 'aggregate'], errorCode: 101}))
+
+        sleep 0.5
+
+        expect do
+          enum.try_next
+        end.to raise_error(Mongo::Error::OperationFailure, "Failing command due to 'failCommand' failpoint (101)")
       end
     end
   end

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Mongo::Collection::View::ChangeStream do
+describe 'Change stream integration' do
   before do
     unless test_change_streams?
       skip 'Not testing change streams'

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -7,16 +7,37 @@ describe 'Change stream integration' do
     end
   end
 
-  it 'returns data' do
-    cs = authorized_collection.watch
+  describe 'next' do
+    it 'returns changes' do
+      cs = authorized_collection.watch
 
-    authorized_collection.insert_one(:a => 1)
+      authorized_collection.insert_one(:a => 1)
 
-    change = cs.to_enum.next
-    expect(change['operationType']).to eql('insert')
-    doc = change['fullDocument']
-    expect(doc['_id']).to be_a(BSON::ObjectId)
-    doc.delete('_id')
-    expect(doc).to eql('a' => 1)
+      change = cs.to_enum.next
+      expect(change).to be_a(BSON::Document)
+      expect(change['operationType']).to eql('insert')
+      doc = change['fullDocument']
+      expect(doc['_id']).to be_a(BSON::ObjectId)
+      doc.delete('_id')
+      expect(doc).to eql('a' => 1)
+    end
+  end
+
+  describe 'try_next' do
+    context 'there are changes' do
+      it 'returns changes' do
+        cs = authorized_collection.watch
+
+        authorized_collection.insert_one(:a => 1)
+
+        change = cs.to_enum.try_next
+        expect(change).to be_a(BSON::Document)
+        expect(change['operationType']).to eql('insert')
+        doc = change['fullDocument']
+        expect(doc['_id']).to be_a(BSON::ObjectId)
+        doc.delete('_id')
+        expect(doc).to eql('a' => 1)
+      end
+    end
   end
 end

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -1604,8 +1604,8 @@ describe Mongo::Client do
         expect(session).to be_a(Mongo::Session)
       end
 
-      it 'sets the last use field to the current time' do
-        expect(session.instance_variable_get(:@server_session).last_use).to be_within(2).of(Time.now)
+      it 'sets the last use field to the current time', retry: 4 do
+        expect(session.instance_variable_get(:@server_session).last_use).to be_within(1).of(Time.now)
       end
 
       context 'when options are provided' do

--- a/spec/mongo/collection/view/change_stream_integration_spec.rb
+++ b/spec/mongo/collection/view/change_stream_integration_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe Mongo::Collection::View::ChangeStream do
+  before do
+    unless test_change_streams?
+      skip 'Not testing change streams'
+    end
+  end
+
+  it 'returns data' do
+    cs = authorized_collection.watch
+
+    authorized_collection.insert_one(:a => 1)
+
+    change = cs.to_enum.next
+    expect(change['operationType']).to eql('insert')
+    doc = change['fullDocument']
+    expect(doc['_id']).to be_a(BSON::ObjectId)
+    doc.delete('_id')
+    expect(doc).to eql('a' => 1)
+  end
+end

--- a/spec/mongo/collection/view/change_stream_spec.rb
+++ b/spec/mongo/collection/view/change_stream_spec.rb
@@ -495,7 +495,7 @@ describe Mongo::Collection::View::ChangeStream, if: test_change_streams? do
           Mongo::Error::SocketError
         end
 
-        it_behaves_like 'a resumable change stream'
+        it_behaves_like 'a non-resumed change stream'
       end
 
       context 'when the error is a SocketTimeoutError' do
@@ -504,7 +504,7 @@ describe Mongo::Collection::View::ChangeStream, if: test_change_streams? do
           Mongo::Error::SocketTimeoutError
         end
 
-        it_behaves_like 'a resumable change stream'
+        it_behaves_like 'a non-resumed change stream'
       end
 
       context "when the error is a 'not master' error" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,6 +70,10 @@
 
 require 'lite_spec_helper'
 
+if RUBY_PLATFORM !~ /\bjava\b/
+  require 'timeout_interrupt'
+end
+
 # Replica set name can be overridden via replicaSet parameter in MONGODB_URI
 # environment variable or by specifying RS_NAME environment variable when
 # not using MONGODB_URI.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -83,6 +83,7 @@ require 'support/travis'
 require 'support/authorization'
 require 'support/primary_socket'
 require 'support/constraints'
+require 'rspec/retry'
 
 RSpec.configure do |config|
   config.include(Authorization)

--- a/spec/support/constraints.rb
+++ b/spec/support/constraints.rb
@@ -28,4 +28,21 @@ module Constraints
       end
     end
   end
+
+  # Constrain tests that use TimeoutInterrupt to MRI (and Unix)
+  def only_mri
+    before do
+      if RUBY_PLATFORM =~ /\bjava\b/
+        skip "MRI required, we have #{RUBY_PLATFORM}"
+      end
+    end
+  end
+
+  def max_example_run_time(timeout)
+    around do |example|
+      TimeoutInterrupt.timeout(timeout) do
+        example.run
+      end
+    end
+  end
 end


### PR DESCRIPTION
- Retry/resume change streams once on getMore and no times on initial aggregation
- Add try_next method (experimental)
- Add integration tests to demonstrate new behavior

https://jira.mongodb.org/browse/RUBY-1369
(and https://jira.mongodb.org/browse/RUBY-1327)