### PR TITLE
RUBY-1347 Do not use sessions by default in parallel scan.

### DIFF
--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -564,19 +564,19 @@ module Mongo
                 }.merge!(options))
           cmd.execute(server).cursor_ids.map do |cursor_id|
             result = if server.features.find_command_enabled?
-                       Operation::GetMore.new({
-                          :selector => {:getMore => cursor_id,
-                                       :collection => collection.name},
-                          :db_name => database.name,
-                          :session => session,
-                       }).execute(server)
-                     else
-                       Operation::GetMore.new({
-                         :to_return => 0,
-                         :cursor_id => cursor_id,
-                         :db_name => database.name,
-                         :coll_name => collection.name
-                     }).execute(server)
+              Operation::GetMore.new({
+                :selector => {:getMore => cursor_id,
+                             :collection => collection.name},
+                :db_name => database.name,
+                :session => session,
+              }).execute(server)
+             else
+              Operation::GetMore.new({
+                :to_return => 0,
+                :cursor_id => cursor_id,
+                :db_name => database.name,
+                :coll_name => collection.name
+              }).execute(server)
             end
             Cursor.new(self, result, server, session: session)
           end

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -578,7 +578,7 @@ module Mongo
                          :coll_name => collection.name
                      }).execute(server)
             end
-            Cursor.new(self, result, server)
+            Cursor.new(self, result, server, session: session)
           end
         end
 

--- a/spec/support/constraints.rb
+++ b/spec/support/constraints.rb
@@ -14,6 +14,14 @@ module Constraints
     end
   end
 
+  def require_sessions
+    before do
+      unless sessions_enabled?
+        skip 'Sessions are not enabled'
+      end
+    end
+  end
+
   def require_topology(*topologies)
     topologies = topologies.map { |t| t.to_s }
     invalid_topologies = topologies - %w(single replica_set sharded)

--- a/spec/support/shared/session.rb
+++ b/spec/support/shared/session.rb
@@ -758,6 +758,7 @@ shared_examples 'an operation updating cluster time' do
 end
 
 shared_examples 'an operation not using a session' do
+  require_sessions
 
   describe 'operation execution' do
 
@@ -805,7 +806,6 @@ shared_examples 'an operation not using a session' do
     end
 
     context 'when the session is ended before it is used' do
-
       let(:session) do
         client.start_session
       end
@@ -828,8 +828,9 @@ shared_examples 'an operation not using a session' do
 end
 
 shared_examples 'a failed operation not using a session' do
+  require_sessions
 
-  context 'when the operation fails', if: test_sessions? do
+  context 'when the operation fails' do
 
     let!(:before_last_use) do
       session.instance_variable_get(:@server_session).last_use


### PR DESCRIPTION
A user is able to explicitly provide a session still,
but the driver will execute the parallel scan outside of a session
by default.

https://jira.mongodb.org/browse/RUBY-1347