### PR TITLE
Add rake tasks to start and stop mongod.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ before_install:
 
 install: ruby -S bundle install --without release development
 
-before_script:
-  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB_VERSION}.tgz -O /tmp/mongodb.tgz
-  - tar -xvf /tmp/mongodb.tgz
-  - mkdir /tmp/data
-  - ${PWD}/mongodb-linux-x86_64-${MONGODB_VERSION}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --auth &> /dev/null &
-  - export MONGODB_VERSION=${MONGODB_VERSION}
-
 rvm:
   - 1.9.3
   - 2.4.2


### PR DESCRIPTION
It is hard for me to start mongod manually, when I want to run unit tests.
So, I added rake tasks to start and stop `mongod` daemon.

Start `mongod`.

```
$ bundle exec rake spec:start_mongod
```

Stop `mongod`.

```
$ bundle exec rake spec:stop_mongod
```

Run unit test starting and stopping `mongod`.
When `MONGODB_VERSION` is not set, current installed `mongod` command is used, without downloading MongoDB archive from server.
This is the case I want to use on development.

```
$ bundle exec rake spec:ci
```

When `MONGODB_VERSION` is set, download the MongoDB archive, and run the downloaded `mongod` command. and run unit tests. The behavior is basically same with current CI's one.

```
$ MONGODB_VERSION=3.4.1 bundle exec rake spec:ci
```

Task list.

```
$ bundle exec rake -T
[mongo] Warning: No private key present, creating unsigned gem.
I, [2018-07-20T19:34:49.115691 #23416]  INFO -- : Celluloid 0.17.3 is running in BACKPORTED mode. [ http://git.io/vJf3J ]
rake benchmark:micro:deep:encode    # Benchmarking for deep bson documents
rake benchmark:micro:flat:encode    # Benchmarking for flat bson documents
rake benchmark:micro:full:encode    # Benchmarking for full bson documents
rake benchmark:multi_doc:find_many  # Run the common driver multi-document benchmarking tests
rake benchmark:parallel:import      # Run the common driver paralell ETL benchmarking tests
rake benchmark:single_doc:command   # Run the common driver single-document benchmarking tests
rake build                          # Build mongo-2.6.1.gem into the pkg directory
rake clean                          # Remove any temporary products
rake clobber                        # Remove any generated files
rake docs                           # Generate all documentation
rake docs:yard                      # Generate yard documention
rake install                        # Build and install mongo-2.6.1.gem into system gems
rake install:local                  # Build and install mongo-2.6.1.gem into system gems without net...
rake release[remote]                # Create tag v2.6.1 and build and push mongo-2.6.1.gem to rubyge...
rake spec                           # Run RSpec code examples
rake spec:ci                        # Run RSpec code examples for CI
rake spec:start_mongod              # Start mongod
rake spec:stop_mongod               # Stop mongod
```

I can recommend to use the `rake`'s library `sh`, `mkdir_p` and `rm_rf` instead of `system`. It is good to show the command string as a output.

How do you think?
