### PR TITLE
Fix test error on JRuby.

### DIFF
--- a/spec/mongo/socket_spec.rb
+++ b/spec/mongo/socket_spec.rb
@@ -18,9 +18,9 @@ describe Mongo::Socket do
     it 'maps SystemCallError and preserves message' do
       expect do
         socket.send(:handle_errors) do
-          raise SystemCallError.new('Test error', Errno::ENOMEDIUM::Errno)
+          raise SystemCallError.new('Test error', Errno::ENFILE::Errno)
         end
-      end.to raise_error(Mongo::Error::SocketError, 'Errno::ENOMEDIUM: No medium found - Test error')
+      end.to raise_error(Mongo::Error::SocketError, 'Errno::ENFILE: Too many open files in system - Test error')
     end
 
     it 'maps IOError and preserves message' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -72,6 +72,9 @@ require 'lite_spec_helper'
 
 if RUBY_PLATFORM !~ /\bjava\b/
   require 'timeout_interrupt'
+else
+  require 'timeout'
+  TimeoutInterrupt = Timeout
 end
 
 # Replica set name can be overridden via replicaSet parameter in MONGODB_URI


### PR DESCRIPTION
I fixed some tests on JRuby.

* Fix NameRrror for TimeoutInterrupt on JRuby.
  See current master branch's CI https://travis-ci.org/mongodb/mongo-ruby-driver/jobs/403328850

  ```
  uninitialized constant Constraints::TimeoutInterrupt
  ```

* not existing Errno::ENOMEDIUM object.
  I reported a issue to JRuby project.
  https://github.com/jruby/jruby/issues/5257

Here is the result on my repository.
https://travis-ci.org/junaruga/mongo-ruby-driver/builds/406455599
Still one test case is failure.

Feel free to ask me or pick up a part of the source code.