### PR TITLE
Speed up Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,43 +8,37 @@ before_install:
 
 install: ruby -S bundle install --without release development
 
-rvm:
-  - 1.9.3
-  - 2.4.2
-  - 2.5
-  - ruby-head
-  - jruby-9.1.16.0
-
 branches:
   only:
     - master
     - 2.5-stable
 
 matrix:
+  include:
+    - rvm: 1.9.3
+      env: MONGODB_VERSIONS="2.6.12 3.0.15 3.2.20 3.4.14 3.6.5"
+    - rvm: 2.4.2
+      env: MONGODB_VERSIONS="2.6.12 3.0.15 3.2.20 3.4.14 3.6.5"
+    - rvm: 2.5
+      env: MONGODB_VERSIONS="2.6.12 3.0.15 3.2.20 3.4.14 3.6.5"
+    - rvm: ruby-head
+      env: MONGODB_VERSIONS="2.6.12 3.0.15 3.2.20 3.4.14 3.6.5"
+    - rvm: jruby-9.1.16.0
+      env: MONGODB_VERSIONS="3.6.5"
   allow_failures:
     - rvm: ruby-head
-  exclude:
-    - rvm: jruby-9.1.16.0
-      env: MONGODB=2.6.12
-    - rvm: jruby-9.1.16.0
-      env: MONGODB=3.0.12
-    - rvm: jruby-9.1.16.0
-      env: MONGODB=3.2.11
-    - rvm: jruby-9.1.16.0
-      env: MONGODB=3.4.1
 
 env:
   global:
     - CI="travis"
     - JRUBY_OPTS="--server -J-Xms512m -J-Xmx1024m"
-  matrix:
-    - MONGODB_VERSION=2.6.12
-    - MONGODB_VERSION=3.0.15
-    - MONGODB_VERSION=3.2.20
-    - MONGODB_VERSION=3.4.14
-    - MONGODB_VERSION=3.6.5
 
-script: bundle exec rake spec:ci
+script:
+  - |
+    for MONGODB_VERSION in ${MONGODB_VERSIONS}; do
+      echo "CI test on MONGODB_VERSION: ${MONGODB_VERSION}"
+      MONGODB_VERSION="${MONGODB_VERSION}" bundle exec rake spec:ci
+    done
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,6 @@ before_install:
 
 install: ruby -S bundle install --without release development
 
-before_script:
-  - wget http://fastdl.mongodb.org/linux/mongodb-linux-x86_64-${MONGODB_VERSION}.tgz -O /tmp/mongodb.tgz
-  - tar -xvf /tmp/mongodb.tgz
-  - mkdir /tmp/data
-  - ${PWD}/mongodb-linux-x86_64-${MONGODB_VERSION}/bin/mongod --dbpath /tmp/data --bind_ip 127.0.0.1 --auth &> /dev/null &
-  - export MONGODB_VERSION=${MONGODB_VERSION}
-
 rvm:
   - 1.9.3
   - 2.4.2


### PR DESCRIPTION
Related to https://github.com/mongodb/mongo-ruby-driver/pull/986

In my experience, I knew that a number of virtual machine (VM) instance in Travis was related to the total running time. I did it on `sass` project https://github.com/sass/sass/issues/2293 .

I think we can reduce the number of VM instance, unifying same a Ruby's test cases to 1 test case.

## Current master situation

- Total VM number: 25
- Total running time (Ran for): 24 min 44 sec
- Travis build log
  https://travis-ci.org/mongodb/mongo-ruby-driver/builds/407289058

## Suggestion in this PR

- MRI 4 Rubies x (2.6.12, 3.0.15, 3.2.20, 3.4.14, 3.6.5) = 4 VMs
- JRuby x latest 1 version. = 1 VM
- Total VM number: 5

Let's look at the result.

Using this technique. https://github.com/mongodb/mongo-ruby-driver/pull/991

Below are other experiments as a reference.

## Experiment 1

- 5 Rubies x (2.6.12, 3.0.15, 3.2.20, 3.4.14, 3.6.5) = 5 VMs
- Total VM number: 5
- Total running time (Ran for): 23 min 29 sec
  => JRuby is bottle neck.
- Travis build log
  https://travis-ci.org/junaruga/mongo-ruby-driver/builds/407302537
- How to edit .travis.yml
  https://github.com/junaruga/mongo-ruby-driver/blob/feaure/speed-up-travis/.travis.yml


## Experiment 2

- Customize running MongoDB versions for Rubies
- 4 MRI Rubies x (2.6.12, 3.0.15, 3.2.20, 3.4.14, 3.6.5) = 4 VMs
- JRuby x 2 versions. = 1 VM
- Total VM number: 5
- Total running time (Ran for): 12 min 49 sec
  => JRuby is still bottle neck.
- Travis build log
  https://travis-ci.org/junaruga/mongo-ruby-driver/builds/407313553
- How to edit .travis.yml
  https://github.com/junaruga/mongo-ruby-driver/blob/feaure/speed-up-travis-2/.travis.yml

## Experiment 3

This PR.

## Experiment 4

- Customize running MongoDB versions for Rubies
- 4 MRI Rubies x (2.6.12, 3.0.15, 3.2.20, 3.4.14, 3.6.5) = 4 VMs
- JRuby x 5 versions = 5 VMs (1 version, 1 VM)
- Total VM number: 9
- Total running time (Ran for): 18 min 00 sec
- Travis build log
  https://travis-ci.org/junaruga/mongo-ruby-driver/builds/407332797
- How to edit .travis.yml
  https://github.com/junaruga/mongo-ruby-driver/blob/feaure/speed-up-travis-4/.travis.yml