### PR TITLE
don't use @flag_bits given that it's never initializated

### DIFF
--- a/lib/mongo/protocol/serializers.rb
+++ b/lib/mongo/protocol/serializers.rb
@@ -187,7 +187,7 @@ module Mongo
         #
         # @since 2.5.0
         def self.deserialize(buffer)
-          end_length = (@flag_bits & Msg::FLAGS.index(:checksum_present)) == 1 ? 32 : 0
+          end_length = 0
           sections = []
           until buffer.length == end_length
             case byte = buffer.get_byte


### PR DESCRIPTION
Given that @flag_bits is never initializated.

(@flag_bits·&·Msg::FLAGS.index(:checksum_present)) will always equal to false
also
(@flag_bits·&·Msg::FLAGS.index(:checksum_present)) == 1 will always equal to false
and finally 
(@flag_bits·&·Msg::FLAGS.index(:checksum_present)) == 1 ? 32 : 0 will always equal to 0

So it's safe to assume that end_length will always be equal to 0