### PR TITLE
Fix the only_mri constraint.

### DIFF
--- a/spec/support/lite_constraints.rb
+++ b/spec/support/lite_constraints.rb
@@ -2,7 +2,7 @@ module LiteConstraints
   # Constrain tests that use TimeoutInterrupt to MRI (and Unix)
   def only_mri
     before do
-      if SpecConfig.instance.mri?
+      unless SpecConfig.instance.mri?
         skip "MRI required, we have #{SpecConfig.instance.platform}"
       end
     end


### PR DESCRIPTION
Testing mongo 2.6.2 with

~~~
$ rpm -q mongodb-server
mongodb-server-4.0.1-1.fc29.x86_64

$ rpm -q ruby
ruby-2.5.1-100.fc30.x86_64
~~~

I see the following test results:

~~~
  11) Change stream integration watch+next no errors next returns changes
     # MRI required, we have x86_64-linux
     # ./spec/integration/change_stream_spec.rb:51
~~~

This appears to be wrong and this PR fixes the issue.