### PR TITLE
Spec config expansion

### DIFF
--- a/spec/integration/change_stream_examples_spec.rb
+++ b/spec/integration/change_stream_examples_spec.rb
@@ -47,7 +47,7 @@ describe 'change streams examples in Ruby', if: test_change_streams? do
       expect(change['fullDocument']['_id']).not_to be_nil
       expect(change['fullDocument']['x']).to eq(1)
       expect(change['ns']).not_to be_nil
-      expect(change['ns']['db']).to eq(TEST_DB)
+      expect(change['ns']['db']).to eq(SpecConfig.instance.test_db)
       expect(change['ns']['coll']).to eq(inventory.name)
       expect(change['documentKey']).not_to be_nil
       expect(change['documentKey']['_id']).to eq(change['fullDocument']['_id'])
@@ -86,7 +86,7 @@ describe 'change streams examples in Ruby', if: test_change_streams? do
       expect(change['fullDocument']['_id']).to eq(1)
       expect(change['fullDocument']['x']).to eq(5)
       expect(change['ns']).not_to be_nil
-      expect(change['ns']['db']).to eq(TEST_DB)
+      expect(change['ns']['db']).to eq(SpecConfig.instance.test_db)
       expect(change['ns']['coll']).to eq(inventory.name)
       expect(change['documentKey']).not_to be_nil
       expect(change['documentKey']['_id']).to eq(1)
@@ -113,7 +113,7 @@ describe 'change streams examples in Ruby', if: test_change_streams? do
       expect(next_change['fullDocument']['_id']).not_to be_nil
       expect(next_change['fullDocument']['x']).to eq(1)
       expect(next_change['ns']).not_to be_nil
-      expect(next_change['ns']['db']).to eq(TEST_DB)
+      expect(next_change['ns']['db']).to eq(SpecConfig.instance.test_db)
       expect(next_change['ns']['coll']).to eq(inventory.name)
       expect(next_change['documentKey']).not_to be_nil
       expect(next_change['documentKey']['_id']).to eq(next_change['fullDocument']['_id'])
@@ -129,7 +129,7 @@ describe 'change streams examples in Ruby', if: test_change_streams? do
       expect(next_next_change['fullDocument']['_id']).not_to be_nil
       expect(next_next_change['fullDocument']['x']).to eq(2)
       expect(next_next_change['ns']).not_to be_nil
-      expect(next_next_change['ns']['db']).to eq(TEST_DB)
+      expect(next_next_change['ns']['db']).to eq(SpecConfig.instance.test_db)
       expect(next_next_change['ns']['coll']).to eq(inventory.name)
       expect(next_next_change['documentKey']).not_to be_nil
       expect(next_next_change['documentKey']['_id']).to eq(next_next_change['fullDocument']['_id'])
@@ -180,7 +180,7 @@ describe 'change streams examples in Ruby', if: test_change_streams? do
       expect(change['fullDocument']['_id']).not_to be_nil
       expect(change['fullDocument']['username']).to eq('alice')
       expect(change['ns']).not_to be_nil
-      expect(change['ns']['db']).to eq(TEST_DB)
+      expect(change['ns']['db']).to eq(SpecConfig.instance.test_db)
       expect(change['ns']['coll']).to eq(inventory.name)
       expect(change['documentKey']).not_to be_nil
       expect(change['documentKey']['_id']).to eq(change['fullDocument']['_id'])

--- a/spec/integration/retryable_writes_spec.rb
+++ b/spec/integration/retryable_writes_spec.rb
@@ -271,7 +271,7 @@ describe 'Retryable writes integration tests' do
     end
 
     let!(:collection) do
-      client[TEST_COLL, write: WRITE_CONCERN]
+      client[TEST_COLL, write: SpecConfig.instance.write_concern]
     end
 
     before do
@@ -300,7 +300,7 @@ describe 'Retryable writes integration tests' do
       context 'when the collection has write concern acknowledged' do
 
         let!(:collection) do
-          client[TEST_COLL, write: WRITE_CONCERN]
+          client[TEST_COLL, write: SpecConfig.instance.write_concern]
         end
 
         context 'when the server supports retryable writes' do
@@ -378,7 +378,7 @@ describe 'Retryable writes integration tests' do
       context 'when the collection has write concern acknowledged' do
 
         let!(:collection) do
-          client[TEST_COLL, write: WRITE_CONCERN]
+          client[TEST_COLL, write: SpecConfig.instance.write_concern]
         end
 
         it_behaves_like 'an operation that is not retried'
@@ -412,7 +412,7 @@ describe 'Retryable writes integration tests' do
       context 'when the collection has write concern acknowledged' do
 
         let!(:collection) do
-          client[TEST_COLL, write: WRITE_CONCERN]
+          client[TEST_COLL, write: SpecConfig.instance.write_concern]
         end
 
         it_behaves_like 'an operation that is not retried'

--- a/spec/mongo/address_spec.rb
+++ b/spec/mongo/address_spec.rb
@@ -242,7 +242,7 @@ describe Mongo::Address do
 
       before do
         address.instance_variable_set(:@resolver, nil)
-        address.send(:initialize_resolver!, (SpecConfig.instance.ssl? ? SSL_OPTIONS : {}))
+        address.send(:initialize_resolver!, SpecConfig.instance.ssl_options)
       end
 
       it 'uses the host, not the IP address' do
@@ -251,7 +251,7 @@ describe Mongo::Address do
 
       let(:socket) do
         if SpecConfig.instance.ssl?
-          address.socket(0.0, SSL_OPTIONS).instance_variable_get(:@tcp_socket)
+          address.socket(0.0, SpecConfig.instance.ssl_options).instance_variable_get(:@tcp_socket)
         else
           address.socket(0.0).instance_variable_get(:@socket)
         end

--- a/spec/mongo/auth/cr_spec.rb
+++ b/spec/mongo/auth/cr_spec.rb
@@ -26,11 +26,11 @@ describe Mongo::Auth::CR do
   declare_topology_double
 
   let(:server) do
-    Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+    Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
   end
 
   let(:connection) do
-    Mongo::Server::Connection.new(server, TEST_OPTIONS)
+    Mongo::Server::Connection.new(server, SpecConfig.instance.test_options)
   end
 
   describe '#login' do

--- a/spec/mongo/auth/ldap_spec.rb
+++ b/spec/mongo/auth/ldap_spec.rb
@@ -26,11 +26,11 @@ describe Mongo::Auth::LDAP do
   declare_topology_double
 
   let(:server) do
-    Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+    Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
   end
 
   let(:connection) do
-    Mongo::Server::Connection.new(server, TEST_OPTIONS)
+    Mongo::Server::Connection.new(server, SpecConfig.instance.test_options)
   end
 
   let(:user) do

--- a/spec/mongo/auth/ldap_spec.rb
+++ b/spec/mongo/auth/ldap_spec.rb
@@ -34,7 +34,7 @@ describe Mongo::Auth::LDAP do
   end
 
   let(:user) do
-    Mongo::Auth::User.new(database: TEST_DB, user: 'driver', password: 'password')
+    Mongo::Auth::User.new(database: SpecConfig.instance.test_db, user: 'driver', password: 'password')
   end
 
   describe '#login' do

--- a/spec/mongo/auth/scram/negotiation_spec.rb
+++ b/spec/mongo/auth/scram/negotiation_spec.rb
@@ -333,7 +333,7 @@ describe 'SCRAM-SHA auth mechanism negotiation' do
     end
 
     let(:client) do
-      new_local_client(uri, SSL_OPTIONS)
+      new_local_client(uri, SpecConfig.instance.ssl_options)
     end
 
     context 'when the user exists' do

--- a/spec/mongo/auth/scram/negotiation_spec.rb
+++ b/spec/mongo/auth/scram/negotiation_spec.rb
@@ -42,7 +42,7 @@ describe 'SCRAM-SHA auth mechanism negotiation' do
 
       new_local_client(
         SpecConfig.instance.addresses,
-        TEST_OPTIONS.merge(opts)
+        SpecConfig.instance.test_options.merge(opts)
       )
     end
 

--- a/spec/mongo/auth/scram_spec.rb
+++ b/spec/mongo/auth/scram_spec.rb
@@ -26,11 +26,11 @@ describe Mongo::Auth::SCRAM do
   declare_topology_double
 
   let(:server) do
-    Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+    Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
   end
 
   let(:connection) do
-    Mongo::Server::Connection.new(server, TEST_OPTIONS)
+    Mongo::Server::Connection.new(server, SpecConfig.instance.test_options)
   end
 
   context 'when SCRAM-SHA-1 is used' do

--- a/spec/mongo/auth/x509_spec.rb
+++ b/spec/mongo/auth/x509_spec.rb
@@ -34,7 +34,7 @@ describe Mongo::Auth::X509 do
   end
 
   let(:user) do
-    Mongo::Auth::User.new(database: TEST_DB, user: 'driver', password: 'password')
+    Mongo::Auth::User.new(database: SpecConfig.instance.test_db, user: 'driver', password: 'password')
   end
 
   describe '#login' do

--- a/spec/mongo/auth/x509_spec.rb
+++ b/spec/mongo/auth/x509_spec.rb
@@ -26,11 +26,11 @@ describe Mongo::Auth::X509 do
   declare_topology_double
 
   let(:server) do
-    Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+    Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
   end
 
   let(:connection) do
-    Mongo::Server::Connection.new(server, TEST_OPTIONS)
+    Mongo::Server::Connection.new(server, SpecConfig.instance.test_options)
   end
 
   let(:user) do

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -63,7 +63,7 @@ describe Mongo::Client do
       new_local_client(
         ['127.0.0.1:27017'],
         :read => { :mode => :primary },
-        :database => TEST_DB
+        :database => SpecConfig.instance.test_db
       )
     end
 
@@ -75,7 +75,7 @@ describe Mongo::Client do
           new_local_client(
             ['127.0.0.1:27017'],
             :read => { :mode => :primary },
-            :database => TEST_DB
+            :database => SpecConfig.instance.test_db
           )
         end
 
@@ -90,7 +90,7 @@ describe Mongo::Client do
           new_local_client(
             ['127.0.0.1:27017'],
             :read => { :mode => :secondary },
-            :database => TEST_DB
+            :database => SpecConfig.instance.test_db
           )
         end
 
@@ -105,7 +105,7 @@ describe Mongo::Client do
           new_local_client(
             ['127.0.0.1:27010'],
             :read => { :mode => :primary },
-            :database => TEST_DB
+            :database => SpecConfig.instance.test_db
           )
         end
 
@@ -126,7 +126,7 @@ describe Mongo::Client do
   describe '#[]' do
 
     let(:client) do
-      new_local_client(['127.0.0.1:27017'], :database => TEST_DB)
+      new_local_client(['127.0.0.1:27017'], :database => SpecConfig.instance.test_db)
     end
 
     shared_examples_for 'a collection switching object' do
@@ -165,7 +165,7 @@ describe Mongo::Client do
       new_local_client(
         ['127.0.0.1:27017'],
         :read => { :mode => :primary },
-        :database => TEST_DB
+        :database => SpecConfig.instance.test_db
       )
     end
 
@@ -177,7 +177,7 @@ describe Mongo::Client do
           new_local_client(
             ['127.0.0.1:27017'],
             :read => { :mode => :primary },
-            :database => TEST_DB
+            :database => SpecConfig.instance.test_db
           )
         end
 
@@ -192,7 +192,7 @@ describe Mongo::Client do
           new_local_client(
             ['127.0.0.1:27017'],
             :read => { :mode => :secondary },
-            :database => TEST_DB
+            :database => SpecConfig.instance.test_db
           )
         end
 
@@ -207,7 +207,7 @@ describe Mongo::Client do
           new_local_client(
             ['127.0.0.1:27010'],
             :read => { :mode => :primary },
-            :database => TEST_DB
+            :database => SpecConfig.instance.test_db
           )
         end
 
@@ -223,7 +223,7 @@ describe Mongo::Client do
         new_local_client(
           ['127.0.0.1:27017'],
           :read => { :mode => :primary },
-          :database => TEST_DB
+          :database => SpecConfig.instance.test_db
         )
       end
 
@@ -241,7 +241,7 @@ describe Mongo::Client do
         :read => { :mode => :primary },
         :local_threshold => 0.010,
         :server_selection_timeout => 10000,
-        :database => TEST_DB
+        :database => SpecConfig.instance.test_db
       )
     end
 
@@ -249,7 +249,7 @@ describe Mongo::Client do
       Mongo::Options::Redacted.new(:read => { :mode => :primary },
                                     :local_threshold => 0.010,
                                     :server_selection_timeout => 10000,
-                                    :database => TEST_DB)
+                                    :database => SpecConfig.instance.test_db)
     end
 
     let(:expected) do
@@ -267,7 +267,7 @@ describe Mongo::Client do
       new_local_client(
         ['127.0.0.1:27017'],
         :read => { :mode => :primary },
-        :database => TEST_DB
+        :database => SpecConfig.instance.test_db
       )
     end
 
@@ -281,7 +281,7 @@ describe Mongo::Client do
         new_local_client(
             ['127.0.0.1:27017'],
             :read => { :mode => :primary },
-            :database => TEST_DB,
+            :database => SpecConfig.instance.test_db,
             :password => 'some_password',
             :user => 'emily'
         )
@@ -930,7 +930,7 @@ describe Mongo::Client do
 
       let(:client) do
         new_local_client(['127.0.0.1:27017'],
-                            :database => TEST_DB,
+                            :database => SpecConfig.instance.test_db,
                             :read => mode,
                             :server_selection_timeout => 2)
       end
@@ -1002,7 +1002,7 @@ describe Mongo::Client do
 
         let(:client) do
           new_local_client(['127.0.0.1:27017'],
-                              :database => TEST_DB,
+                              :database => SpecConfig.instance.test_db,
                               :server_selection_timeout => 2)
         end
 
@@ -1044,7 +1044,7 @@ describe Mongo::Client do
 
     let(:client) do
       new_local_client(['127.0.0.1:27017'],
-                          :database => TEST_DB,
+                          :database => SpecConfig.instance.test_db,
                           :read => mode,
                           :server_selection_timeout => 2)
     end
@@ -1112,7 +1112,7 @@ describe Mongo::Client do
 
       let(:client) do
         new_local_client(['127.0.0.1:27017'],
-                            :database => TEST_DB,
+                            :database => SpecConfig.instance.test_db,
                             :server_selection_timeout => 2)
       end
 
@@ -1125,7 +1125,7 @@ describe Mongo::Client do
   describe '#use' do
 
     let(:client) do
-      new_local_client(['127.0.0.1:27017'], :database => TEST_DB)
+      new_local_client(['127.0.0.1:27017'], :database => SpecConfig.instance.test_db)
     end
 
     shared_examples_for 'a database switching object' do
@@ -1170,7 +1170,7 @@ describe Mongo::Client do
   describe '#with' do
 
     let(:client) do
-      new_local_client(['127.0.0.1:27017'], :database => TEST_DB)
+      new_local_client(['127.0.0.1:27017'], :database => SpecConfig.instance.test_db)
     end
 
     context 'when providing nil' do
@@ -1220,7 +1220,7 @@ describe Mongo::Client do
       let(:client) do
         new_local_client(
           ['127.0.0.1:27017'],
-          :read => { :mode => :secondary }, :write => { :w => 1 }, :database => TEST_DB
+          :read => { :mode => :secondary }, :write => { :w => 1 }, :database => SpecConfig.instance.test_db
         )
       end
 
@@ -1231,13 +1231,13 @@ describe Mongo::Client do
       let(:new_options) do
         Mongo::Options::Redacted.new(:read => { :mode => :primary },
                                              :write => { :w => 1 },
-                                             :database => TEST_DB)
+                                             :database => SpecConfig.instance.test_db)
       end
 
       let(:original_options) do
         Mongo::Options::Redacted.new(:read => { :mode => :secondary },
                                              :write => { :w => 1 },
-                                             :database => TEST_DB)
+                                             :database => SpecConfig.instance.test_db)
       end
 
       it 'returns a new client' do
@@ -1260,7 +1260,7 @@ describe Mongo::Client do
     context 'when the write concern is changed' do
 
       let(:client) do
-        new_local_client(['127.0.0.1:27017'], :write => { :w => 1 }, :database => TEST_DB)
+        new_local_client(['127.0.0.1:27017'], :write => { :w => 1 }, :database => SpecConfig.instance.test_db)
       end
 
       context 'when the write concern has not been accessed' do
@@ -1317,7 +1317,7 @@ describe Mongo::Client do
 
     context 'when client is created with ipv6 address' do
       let(:client) do
-        new_local_client(['[::1]:27017'], :database => TEST_DB)
+        new_local_client(['[::1]:27017'], :database => SpecConfig.instance.test_db)
       end
 
       context 'when providing nil' do
@@ -1349,7 +1349,7 @@ describe Mongo::Client do
 
     context 'when no option was provided to the client' do
 
-      let(:client) { new_local_client(['127.0.0.1:27017'], :database => TEST_DB) }
+      let(:client) { new_local_client(['127.0.0.1:27017'], :database => SpecConfig.instance.test_db) }
 
       it 'does not set the write concern' do
         expect(concern).to be_nil
@@ -1361,7 +1361,7 @@ describe Mongo::Client do
       context 'when the option is acknowledged' do
 
         let(:client) do
-          new_local_client(['127.0.0.1:27017'], :write => { :j => true }, :database => TEST_DB)
+          new_local_client(['127.0.0.1:27017'], :write => { :j => true }, :database => SpecConfig.instance.test_db)
         end
 
         it 'returns a acknowledged write concern' do
@@ -1374,7 +1374,7 @@ describe Mongo::Client do
         context 'when the w is 0' do
 
           let(:client) do
-            new_local_client(['127.0.0.1:27017'], :write => { :w => 0 }, :database => TEST_DB)
+            new_local_client(['127.0.0.1:27017'], :write => { :w => 0 }, :database => SpecConfig.instance.test_db)
           end
 
           it 'returns an unacknowledged write concern' do
@@ -1385,7 +1385,7 @@ describe Mongo::Client do
         context 'when the w is -1' do
 
           let(:client) do
-            new_local_client(['127.0.0.1:27017'], :write => { :w => -1 }, :database => TEST_DB)
+            new_local_client(['127.0.0.1:27017'], :write => { :w => -1 }, :database => SpecConfig.instance.test_db)
           end
 
           it 'raises an error' do
@@ -1413,7 +1413,7 @@ describe Mongo::Client do
       end
 
       let(:filter) do
-        { name: TEST_DB }
+        { name: SpecConfig.instance.test_db }
       end
 
       it 'returns a filtered list of database names' do
@@ -1439,7 +1439,7 @@ describe Mongo::Client do
       end
 
       let(:filter) do
-        { name: TEST_DB }
+        { name: SpecConfig.instance.test_db }
       end
 
       it 'returns a filtered list of database info documents' do
@@ -1503,7 +1503,7 @@ describe Mongo::Client do
       end
 
       let(:filter) do
-        { name: TEST_DB }
+        { name: SpecConfig.instance.test_db }
       end
 
       it 'returns a filtered list of Mongo::Database objects' do
@@ -1553,7 +1553,7 @@ describe Mongo::Client do
       new_local_client(
           ['127.0.0.1:27017'],
           :read => { :mode => :primary },
-          :database => TEST_DB
+          :database => SpecConfig.instance.test_db
       )
     end
 

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -413,7 +413,7 @@ describe Mongo::Client do
       context 'when a zlib_compression_level option is provided', if: testing_compression? do
 
         let(:client) do
-          new_local_client([default_address.seed], TEST_OPTIONS.merge(zlib_compression_level: 1))
+          new_local_client([default_address.seed], SpecConfig.instance.test_options.merge(zlib_compression_level: 1))
         end
 
         it 'sets the option on the client' do
@@ -441,7 +441,7 @@ describe Mongo::Client do
         end
 
         let(:client) do
-          new_local_client(['127.0.0.1:27017'], TEST_OPTIONS.merge(options))
+          new_local_client(['127.0.0.1:27017'], SpecConfig.instance.test_options.merge(options))
         end
 
         it 'sets the ssl option' do

--- a/spec/mongo/cluster/topology/replica_set_spec.rb
+++ b/spec/mongo/cluster/topology/replica_set_spec.rb
@@ -24,19 +24,19 @@ describe Mongo::Cluster::Topology::ReplicaSetNoPrimary do
   describe '#servers' do
 
     let(:mongos) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:standalone) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:replica_set) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:replica_set_two) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:mongos_description) do
@@ -325,11 +325,11 @@ describe Mongo::Cluster::Topology::ReplicaSetNoPrimary do
   describe '#add_hosts?' do
 
     let(:primary) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:secondary) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:primary_description) do
@@ -408,7 +408,7 @@ describe Mongo::Cluster::Topology::ReplicaSetNoPrimary do
   describe '#remove_hosts?' do
 
     let(:primary) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:primary_description) do
@@ -489,7 +489,7 @@ describe Mongo::Cluster::Topology::ReplicaSetNoPrimary do
   describe '#remove_server?' do
 
     let(:secondary) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:secondary_description) do

--- a/spec/mongo/cluster/topology/sharded_spec.rb
+++ b/spec/mongo/cluster/topology/sharded_spec.rb
@@ -26,15 +26,15 @@ describe Mongo::Cluster::Topology::Sharded do
   end
 
   let(:mongos) do
-    Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+    Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
   end
 
   let(:standalone) do
-    Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+    Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
   end
 
   let(:replica_set) do
-    Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+    Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
   end
 
   let(:mongos_description) do

--- a/spec/mongo/cluster/topology/single_spec.rb
+++ b/spec/mongo/cluster/topology/single_spec.rb
@@ -28,19 +28,19 @@ describe Mongo::Cluster::Topology::Single do
   describe '.servers' do
 
     let(:mongos) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:standalone) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:standalone_two) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:replica_set) do
-      Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     let(:mongos_description) do

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -7,7 +7,7 @@ describe Mongo::Cluster do
   end
 
   let(:cluster) do
-    described_class.new(SpecConfig.instance.addresses, monitoring, TEST_OPTIONS)
+    described_class.new(SpecConfig.instance.addresses, monitoring, SpecConfig.instance.test_options)
   end
 
   describe '#==' do
@@ -19,7 +19,7 @@ describe Mongo::Cluster do
         context 'when the options are the same' do
 
           let(:other) do
-            described_class.new(SpecConfig.instance.addresses, monitoring, TEST_OPTIONS)
+            described_class.new(SpecConfig.instance.addresses, monitoring, SpecConfig.instance.test_options)
           end
 
           it 'returns true' do
@@ -30,7 +30,7 @@ describe Mongo::Cluster do
         context 'when the options are not the same' do
 
           let(:other) do
-            described_class.new([ '127.0.0.1:27017' ], monitoring, TEST_OPTIONS.merge(:replica_set => 'test'))
+            described_class.new([ '127.0.0.1:27017' ], monitoring, SpecConfig.instance.test_options.merge(:replica_set => 'test'))
           end
 
           it 'returns false' do
@@ -42,7 +42,7 @@ describe Mongo::Cluster do
       context 'when the addresses are not the same' do
 
         let(:other) do
-          described_class.new([ '127.0.0.1:27999' ], monitoring, TEST_OPTIONS)
+          described_class.new([ '127.0.0.1:27999' ], monitoring, SpecConfig.instance.test_options)
         end
 
         it 'returns false' do
@@ -101,7 +101,7 @@ describe Mongo::Cluster do
         described_class.new(
           [ '127.0.0.1:27017' ],
           monitoring,
-          TEST_OPTIONS.merge(:connect => :replica_set, :replica_set => 'testing')
+          SpecConfig.instance.test_options.merge(:connect => :replica_set, :replica_set => 'testing')
         )
       end
 
@@ -113,7 +113,7 @@ describe Mongo::Cluster do
     context 'when the option is not provided' do
 
       let(:cluster) do
-        described_class.new([ '127.0.0.1:27017' ], monitoring, TEST_OPTIONS.merge(connect: :direct).delete_if { |k| k == :replica_set })
+        described_class.new([ '127.0.0.1:27017' ], monitoring, SpecConfig.instance.test_options.merge(connect: :direct).delete_if { |k| k == :replica_set })
       end
 
       it 'returns nil' do
@@ -608,7 +608,7 @@ describe Mongo::Cluster do
   describe '#update_cluster_time' do
 
     let(:cluster) do
-      described_class.new(SpecConfig.instance.addresses, monitoring, TEST_OPTIONS.merge(heartbeat_frequency: 1000))
+      described_class.new(SpecConfig.instance.addresses, monitoring, SpecConfig.instance.test_options.merge(heartbeat_frequency: 1000))
     end
 
     let(:result) do

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -108,7 +108,7 @@ describe Mongo::Collection do
   describe '#with' do
 
     let(:client) do
-      new_local_client(SpecConfig.instance.addresses, TEST_OPTIONS)
+      new_local_client(SpecConfig.instance.addresses, SpecConfig.instance.test_options)
     end
 
     let(:database) do
@@ -140,7 +140,7 @@ describe Mongo::Collection do
       context 'when the client has a server selection timeout setting' do
 
         let(:client) do
-          new_local_client(SpecConfig.instance.addresses, TEST_OPTIONS.merge(server_selection_timeout: 2))
+          new_local_client(SpecConfig.instance.addresses, SpecConfig.instance.test_options.merge(server_selection_timeout: 2))
         end
 
         it 'passes the the server_selection_timeout to the cluster' do
@@ -151,7 +151,7 @@ describe Mongo::Collection do
       context 'when the client has a read preference set' do
 
         let(:client) do
-          new_local_client(SpecConfig.instance.addresses, TEST_OPTIONS.merge(read: { mode: :primary_preferred }))
+          new_local_client(SpecConfig.instance.addresses, SpecConfig.instance.test_options.merge(read: { mode: :primary_preferred }))
         end
 
         it 'sets the new read options on the new collection' do
@@ -163,7 +163,7 @@ describe Mongo::Collection do
       context 'when the client has a read preference and server selection timeout set' do
 
         let(:client) do
-          new_local_client(SpecConfig.instance.addresses, TEST_OPTIONS.merge(read: { mode: :primary_preferred }, server_selection_timeout: 2))
+          new_local_client(SpecConfig.instance.addresses, SpecConfig.instance.test_options.merge(read: { mode: :primary_preferred }, server_selection_timeout: 2))
         end
 
         it 'sets the new read options on the new collection' do
@@ -193,7 +193,7 @@ describe Mongo::Collection do
       context 'when the client has a write concern set' do
 
         let(:client) do
-          new_local_client(SpecConfig.instance.addresses, TEST_OPTIONS.merge(write: INVALID_WRITE_CONCERN))
+          new_local_client(SpecConfig.instance.addresses, SpecConfig.instance.test_options.merge(write: INVALID_WRITE_CONCERN))
         end
 
         it 'sets the new write options on the new collection' do
@@ -226,7 +226,7 @@ describe Mongo::Collection do
       context 'when the client has a server selection timeout setting' do
 
         let(:client) do
-          new_local_client(SpecConfig.instance.addresses, TEST_OPTIONS.merge(server_selection_timeout: 2))
+          new_local_client(SpecConfig.instance.addresses, SpecConfig.instance.test_options.merge(server_selection_timeout: 2))
         end
 
         it 'passes the server_selection_timeout setting to the cluster' do
@@ -237,7 +237,7 @@ describe Mongo::Collection do
       context 'when the client has a read preference set' do
 
         let(:client) do
-          new_local_client(SpecConfig.instance.addresses, TEST_OPTIONS.merge(read: { mode: :primary_preferred }))
+          new_local_client(SpecConfig.instance.addresses, SpecConfig.instance.test_options.merge(read: { mode: :primary_preferred }))
         end
 
         it 'sets the new read options on the new collection' do

--- a/spec/mongo/cursor/builder/get_more_command_spec.rb
+++ b/spec/mongo/cursor/builder/get_more_command_spec.rb
@@ -50,7 +50,7 @@ describe Mongo::Cursor::Builder::GetMoreCommand do
     shared_examples_for 'a getMore command builder' do
 
       it 'includes the database name' do
-        expect(specification[:db_name]).to eq(TEST_DB)
+        expect(specification[:db_name]).to eq(SpecConfig.instance.test_db)
       end
 
       it 'includes getMore with cursor id' do

--- a/spec/mongo/cursor/builder/op_get_more_spec.rb
+++ b/spec/mongo/cursor/builder/op_get_more_spec.rb
@@ -42,7 +42,7 @@ describe Mongo::Cursor::Builder::OpGetMore do
     end
 
     it 'includes the database name' do
-      expect(specification[:db_name]).to eq(TEST_DB)
+      expect(specification[:db_name]).to eq(SpecConfig.instance.test_db)
     end
 
     it 'includes the collection name' do

--- a/spec/mongo/cursor_spec.rb
+++ b/spec/mongo/cursor_spec.rb
@@ -398,7 +398,7 @@ describe Mongo::Cursor do
     end
 
     let(:query_spec) do
-      { :selector => {}, :options => {}, :db_name => TEST_DB, :coll_name => TEST_COLL }
+      { :selector => {}, :options => {}, :db_name => SpecConfig.instance.test_db, :coll_name => TEST_COLL }
     end
 
     let(:reply) do

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -5,13 +5,13 @@ describe Mongo::Database do
   describe '#==' do
 
     let(:database) do
-      described_class.new(authorized_client, TEST_DB)
+      described_class.new(authorized_client, SpecConfig.instance.test_db)
     end
 
     context 'when the names are the same' do
 
       let(:other) do
-        described_class.new(authorized_client, TEST_DB)
+        described_class.new(authorized_client, SpecConfig.instance.test_db)
       end
 
       it 'returns true' do
@@ -41,7 +41,7 @@ describe Mongo::Database do
   describe '#[]' do
 
     let(:database) do
-      described_class.new(authorized_client, TEST_DB)
+      described_class.new(authorized_client, SpecConfig.instance.test_db)
     end
 
     context 'when providing a valid name' do
@@ -88,7 +88,7 @@ describe Mongo::Database do
   describe '#collection_names' do
 
     let(:database) do
-      described_class.new(authorized_client, TEST_DB)
+      described_class.new(authorized_client, SpecConfig.instance.test_db)
     end
 
     before do
@@ -145,7 +145,7 @@ describe Mongo::Database do
   describe '#list_collections' do
 
     let(:database) do
-      described_class.new(authorized_client, TEST_DB)
+      described_class.new(authorized_client, SpecConfig.instance.test_db)
     end
 
     let(:result) do
@@ -164,7 +164,7 @@ describe Mongo::Database do
     end
 
     it 'returns a list of the collections info', unless: list_command_enabled?  do
-      expect(result).to include("#{TEST_DB}.users")
+      expect(result).to include("#{SpecConfig.instance.test_db}.users")
     end
   end
 
@@ -173,7 +173,7 @@ describe Mongo::Database do
     context 'when the database exists' do
 
       let(:database) do
-        described_class.new(authorized_client, TEST_DB)
+        described_class.new(authorized_client, SpecConfig.instance.test_db)
       end
 
       let(:collection) do
@@ -208,7 +208,7 @@ describe Mongo::Database do
     context 'when the user is not authorized', if: auth_enabled? do
 
       let(:database) do
-        described_class.new(unauthorized_client, TEST_DB)
+        described_class.new(unauthorized_client, SpecConfig.instance.test_db)
       end
 
       it 'raises an exception' do
@@ -222,7 +222,7 @@ describe Mongo::Database do
   describe '#command' do
 
     let(:database) do
-      described_class.new(authorized_client, TEST_DB)
+      described_class.new(authorized_client, SpecConfig.instance.test_db)
     end
 
     it 'sends the query command to the cluster' do
@@ -318,7 +318,7 @@ describe Mongo::Database do
       end
 
       let(:database) do
-        described_class.new(client, TEST_DB, client.options)
+        described_class.new(client, SpecConfig.instance.test_db, client.options)
       end
 
       before do
@@ -341,7 +341,7 @@ describe Mongo::Database do
       end
 
       let(:database) do
-        described_class.new(client, TEST_DB, client.options)
+        described_class.new(client, SpecConfig.instance.test_db, client.options)
       end
 
       before do
@@ -362,7 +362,7 @@ describe Mongo::Database do
       end
 
       let(:database) do
-        described_class.new(client, TEST_DB, client.options)
+        described_class.new(client, SpecConfig.instance.test_db, client.options)
       end
 
       it 'uses the client server_selection_timeout' do
@@ -401,7 +401,7 @@ describe Mongo::Database do
       end
 
       let(:database) do
-        described_class.new(authorized_client.with(client_options), TEST_DB)
+        described_class.new(authorized_client.with(client_options), SpecConfig.instance.test_db)
       end
 
       context 'when a write concern is not in the command selector' do
@@ -440,7 +440,7 @@ describe Mongo::Database do
   describe '#drop' do
 
     let(:database) do
-      described_class.new(authorized_client, TEST_DB)
+      described_class.new(authorized_client, SpecConfig.instance.test_db)
     end
 
     it 'drops the database' do
@@ -500,11 +500,11 @@ describe Mongo::Database do
     context 'when provided a valid name' do
 
       let(:database) do
-        described_class.new(authorized_client, TEST_DB)
+        described_class.new(authorized_client, SpecConfig.instance.test_db)
       end
 
       it 'sets the name as a string' do
-        expect(database.name).to eq(TEST_DB)
+        expect(database.name).to eq(SpecConfig.instance.test_db)
       end
 
       it 'sets the client' do
@@ -525,7 +525,7 @@ describe Mongo::Database do
   describe '#inspect' do
 
     let(:database) do
-      described_class.new(authorized_client, TEST_DB)
+      described_class.new(authorized_client, SpecConfig.instance.test_db)
     end
 
     it 'includes the object id' do
@@ -540,7 +540,7 @@ describe Mongo::Database do
   describe '#fs', unless: sharded? do
 
     let(:database) do
-      described_class.new(authorized_client, TEST_DB)
+      described_class.new(authorized_client, SpecConfig.instance.test_db)
     end
 
     shared_context 'a GridFS database' do

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -67,7 +67,7 @@ describe Mongo::Database do
     context 'when the client has options' do
 
       let(:client) do
-        new_local_client([default_address.host], TEST_OPTIONS.merge(read: { mode: :secondary }))
+        new_local_client([default_address.host], SpecConfig.instance.test_options.merge(read: { mode: :secondary }))
       end
 
       let(:database) do

--- a/spec/mongo/operation/aggregate_spec.rb
+++ b/spec/mongo/operation/aggregate_spec.rb
@@ -14,7 +14,7 @@ describe Mongo::Operation::Aggregate do
   let(:spec) do
     { :selector => selector,
       :options => options,
-      :db_name => TEST_DB
+      :db_name => SpecConfig.instance.test_db
     }
   end
   let(:op) { described_class.new(spec) }
@@ -41,7 +41,7 @@ describe Mongo::Operation::Aggregate do
       let(:other_spec) do
         { :selector => other_selector,
           :options => options,
-          :db_name => TEST_DB,
+          :db_name => SpecConfig.instance.test_db,
         }
       end
       let(:other) { described_class.new(other_spec) }

--- a/spec/mongo/operation/collections_info_spec.rb
+++ b/spec/mongo/operation/collections_info_spec.rb
@@ -4,7 +4,7 @@ describe Mongo::Operation::CollectionsInfo do
 
   let(:spec) do
     { selector: { listCollections: 1 },
-      db_name: TEST_DB
+      db_name: SpecConfig.instance.test_db
     }
   end
 
@@ -32,7 +32,7 @@ describe Mongo::Operation::CollectionsInfo do
 
     let(:info) do
       docs = op.execute(authorized_primary).documents
-      docs.collect { |info| info['name'].sub("#{TEST_DB}.", '') }
+      docs.collect { |info| info['name'].sub("#{SpecConfig.instance.test_db}.", '') }
     end
 
     it 'returns the list of collection info' do

--- a/spec/mongo/operation/command_spec.rb
+++ b/spec/mongo/operation/command_spec.rb
@@ -7,7 +7,7 @@ describe Mongo::Operation::Command do
   let(:spec) do
     { :selector => selector,
       :options     => options,
-      :db_name  => TEST_DB
+      :db_name  => SpecConfig.instance.test_db
     }
   end
   let(:op) { described_class.new(spec) }

--- a/spec/mongo/operation/create_index_spec.rb
+++ b/spec/mongo/operation/create_index_spec.rb
@@ -11,7 +11,7 @@ describe Mongo::Operation::CreateIndex do
       end
 
       let(:operation) do
-        described_class.new(indexes: [ spec ], db_name: TEST_DB, coll_name: TEST_COLL)
+        described_class.new(indexes: [ spec ], db_name: SpecConfig.instance.test_db, coll_name: TEST_COLL)
       end
 
       let(:response) do
@@ -34,11 +34,11 @@ describe Mongo::Operation::CreateIndex do
       end
 
       let(:operation) do
-        described_class.new(indexes: [ spec ], db_name: TEST_DB, coll_name: TEST_COLL)
+        described_class.new(indexes: [ spec ], db_name: SpecConfig.instance.test_db, coll_name: TEST_COLL)
       end
 
       let(:second_operation) do
-        described_class.new(indexes: [ spec.merge(unique: false) ], db_name: TEST_DB, coll_name: TEST_COLL)
+        described_class.new(indexes: [ spec.merge(unique: false) ], db_name: SpecConfig.instance.test_db, coll_name: TEST_COLL)
       end
 
       before do

--- a/spec/mongo/operation/create_user_spec.rb
+++ b/spec/mongo/operation/create_user_spec.rb
@@ -13,7 +13,7 @@ describe Mongo::Operation::CreateUser do
     end
 
     let(:operation) do
-      described_class.new(user: user, db_name: TEST_DB)
+      described_class.new(user: user, db_name: SpecConfig.instance.test_db)
     end
 
     after do

--- a/spec/mongo/operation/delete/bulk_spec.rb
+++ b/spec/mongo/operation/delete/bulk_spec.rb
@@ -8,7 +8,7 @@ describe Mongo::Operation::Delete do
 
   let(:spec) do
     { :deletes       => documents,
-      :db_name       => TEST_DB,
+      :db_name       => SpecConfig.instance.test_db,
       :coll_name     => TEST_COLL,
       :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
       :ordered       => true
@@ -46,7 +46,7 @@ describe Mongo::Operation::Delete do
 
         let(:other_spec) do
           { :deletes       => other_docs,
-            :db_name       => TEST_DB,
+            :db_name       => SpecConfig.instance.test_db,
             :coll_name     => TEST_COLL,
             :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
             :ordered       => true
@@ -88,7 +88,7 @@ describe Mongo::Operation::Delete do
       let(:op) do
         described_class.new({
           deletes: documents,
-          db_name: TEST_DB,
+          db_name: SpecConfig.instance.test_db,
           coll_name: TEST_COLL,
           write_concern: Mongo::WriteConcern.get(w: 1)
         })
@@ -112,7 +112,7 @@ describe Mongo::Operation::Delete do
       let(:op) do
         described_class.new({
           deletes: documents,
-          db_name: TEST_DB,
+          db_name: SpecConfig.instance.test_db,
           coll_name: TEST_COLL,
           write_concern: Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
         })
@@ -141,7 +141,7 @@ describe Mongo::Operation::Delete do
 
       let(:spec) do
         { :deletes       => documents,
-          :db_name       => TEST_DB,
+          :db_name       => SpecConfig.instance.test_db,
           :coll_name     => TEST_COLL,
           :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
           :ordered       => true
@@ -190,7 +190,7 @@ describe Mongo::Operation::Delete do
 
       let(:spec) do
         { :deletes       => documents,
-          :db_name       => TEST_DB,
+          :db_name       => SpecConfig.instance.test_db,
           :coll_name     => TEST_COLL,
           :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
           :ordered       => false

--- a/spec/mongo/operation/delete/bulk_spec.rb
+++ b/spec/mongo/operation/delete/bulk_spec.rb
@@ -10,7 +10,7 @@ describe Mongo::Operation::Delete do
     { :deletes       => documents,
       :db_name       => TEST_DB,
       :coll_name     => TEST_COLL,
-      :write_concern => Mongo::WriteConcern.get(WRITE_CONCERN),
+      :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
       :ordered       => true
     }
   end
@@ -48,7 +48,7 @@ describe Mongo::Operation::Delete do
           { :deletes       => other_docs,
             :db_name       => TEST_DB,
             :coll_name     => TEST_COLL,
-            :write_concern => Mongo::WriteConcern.get(WRITE_CONCERN),
+            :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
             :ordered       => true
           }
         end
@@ -114,7 +114,7 @@ describe Mongo::Operation::Delete do
           deletes: documents,
           db_name: TEST_DB,
           coll_name: TEST_COLL,
-          write_concern: Mongo::WriteConcern.get(WRITE_CONCERN)
+          write_concern: Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
         })
       end
 
@@ -143,7 +143,7 @@ describe Mongo::Operation::Delete do
         { :deletes       => documents,
           :db_name       => TEST_DB,
           :coll_name     => TEST_COLL,
-          :write_concern => Mongo::WriteConcern.get(WRITE_CONCERN),
+          :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
           :ordered       => true
         }
       end
@@ -157,7 +157,7 @@ describe Mongo::Operation::Delete do
         context 'when write concern is acknowledged' do
 
           let(:write_concern) do
-            Mongo::WriteConcern.get(WRITE_CONCERN)
+            Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
           end
 
           it 'aborts after first error' do
@@ -192,7 +192,7 @@ describe Mongo::Operation::Delete do
         { :deletes       => documents,
           :db_name       => TEST_DB,
           :coll_name     => TEST_COLL,
-          :write_concern => Mongo::WriteConcern.get(WRITE_CONCERN),
+          :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
           :ordered       => false
         }
       end

--- a/spec/mongo/operation/delete/command_spec.rb
+++ b/spec/mongo/operation/delete/command_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Mongo::Operation::Delete::Command do
 
   let(:write_concern) do
-    Mongo::WriteConcern.get(WRITE_CONCERN)
+    Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
   end
 
   let(:session) { nil }

--- a/spec/mongo/operation/delete/op_msg_spec.rb
+++ b/spec/mongo/operation/delete/op_msg_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Mongo::Operation::Delete::OpMsg do
 
   let(:write_concern) do
-    Mongo::WriteConcern.get(WRITE_CONCERN)
+    Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
   end
 
   let(:session) { nil }

--- a/spec/mongo/operation/delete/op_msg_spec.rb
+++ b/spec/mongo/operation/delete/op_msg_spec.rb
@@ -95,7 +95,7 @@ describe Mongo::Operation::Delete::OpMsg do
             delete: TEST_COLL,
             ordered: true,
             writeConcern: write_concern.options,
-            '$db' => TEST_DB,
+            '$db' => SpecConfig.instance.test_db,
             lsid: session.session_id
         }
       end

--- a/spec/mongo/operation/delete_spec.rb
+++ b/spec/mongo/operation/delete_spec.rb
@@ -23,7 +23,7 @@ describe Mongo::Operation::Delete do
     { :deletes        => [ document ],
       :db_name       => TEST_DB,
       :coll_name     => TEST_COLL,
-      :write_concern => Mongo::WriteConcern.get(WRITE_CONCERN),
+      :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
       :ordered       => true
     }
   end
@@ -59,7 +59,7 @@ describe Mongo::Operation::Delete do
           { :deletes        => [ other_doc ],
             :db_name       => TEST_DB,
             :coll_name     => TEST_COLL,
-            :write_concern => Mongo::WriteConcern.get(WRITE_CONCERN),
+            :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
             :ordered       => true
           }
         end
@@ -92,7 +92,7 @@ describe Mongo::Operation::Delete do
           deletes: [ document ],
           db_name: TEST_DB,
           coll_name: TEST_COLL,
-          write_concern: Mongo::WriteConcern.get(WRITE_CONCERN)
+          write_concern: Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
         })
       end
 
@@ -136,7 +136,7 @@ describe Mongo::Operation::Delete do
           deletes: [ document ],
           db_name: TEST_DB,
           coll_name: TEST_COLL,
-          write_concern: Mongo::WriteConcern.get(WRITE_CONCERN)
+          write_concern: Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
         })
       end
 

--- a/spec/mongo/operation/delete_spec.rb
+++ b/spec/mongo/operation/delete_spec.rb
@@ -21,7 +21,7 @@ describe Mongo::Operation::Delete do
 
   let(:spec) do
     { :deletes        => [ document ],
-      :db_name       => TEST_DB,
+      :db_name       => SpecConfig.instance.test_db,
       :coll_name     => TEST_COLL,
       :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
       :ordered       => true
@@ -57,7 +57,7 @@ describe Mongo::Operation::Delete do
 
         let(:other_spec) do
           { :deletes        => [ other_doc ],
-            :db_name       => TEST_DB,
+            :db_name       => SpecConfig.instance.test_db,
             :coll_name     => TEST_COLL,
             :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
             :ordered       => true
@@ -90,7 +90,7 @@ describe Mongo::Operation::Delete do
       let(:delete) do
         described_class.new({
           deletes: [ document ],
-          db_name: TEST_DB,
+          db_name: SpecConfig.instance.test_db,
           coll_name: TEST_COLL,
           write_concern: Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
         })
@@ -134,7 +134,7 @@ describe Mongo::Operation::Delete do
       let(:delete) do
         described_class.new({
           deletes: [ document ],
-          db_name: TEST_DB,
+          db_name: SpecConfig.instance.test_db,
           coll_name: TEST_COLL,
           write_concern: Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
         })
@@ -198,7 +198,7 @@ describe Mongo::Operation::Delete do
       let(:delete) do
         described_class.new({
                               deletes: [ document ],
-                              db_name: TEST_DB,
+                              db_name: SpecConfig.instance.test_db,
                               coll_name: TEST_COLL,
                               write_concern: Mongo::WriteConcern.get(:w => 0)
                             })

--- a/spec/mongo/operation/drop_index_spec.rb
+++ b/spec/mongo/operation/drop_index_spec.rb
@@ -19,7 +19,7 @@ describe Mongo::Operation::DropIndex do
 
       let(:operation) do
         described_class.new(
-          db_name: TEST_DB,
+          db_name: SpecConfig.instance.test_db,
           coll_name: TEST_COLL,
           index_name: 'another_-1'
         )
@@ -38,7 +38,7 @@ describe Mongo::Operation::DropIndex do
 
       let(:operation) do
         described_class.new(
-          db_name: TEST_DB,
+          db_name: SpecConfig.instance.test_db,
           coll_name: TEST_COLL,
           index_name: 'another_blah'
         )

--- a/spec/mongo/operation/get_more_spec.rb
+++ b/spec/mongo/operation/get_more_spec.rb
@@ -11,7 +11,7 @@ describe Mongo::Operation::GetMore::Legacy do
   end
 
   let(:spec) do
-    { :db_name   => TEST_DB,
+    { :db_name   => SpecConfig.instance.test_db,
       :coll_name => TEST_COLL,
       :to_return => to_return,
       :cursor_id => cursor_id }
@@ -46,7 +46,7 @@ describe Mongo::Operation::GetMore::Legacy do
   describe '#message' do
 
     it 'creates a get more wire protocol message with correct specs' do
-      expect(Mongo::Protocol::GetMore).to receive(:new).with(TEST_DB, TEST_COLL, to_return, cursor_id).and_call_original
+      expect(Mongo::Protocol::GetMore).to receive(:new).with(SpecConfig.instance.test_db, TEST_COLL, to_return, cursor_id).and_call_original
       begin; op.execute(authorized_primary); rescue; end
     end
   end

--- a/spec/mongo/operation/indexes_spec.rb
+++ b/spec/mongo/operation/indexes_spec.rb
@@ -29,7 +29,7 @@ describe Mongo::Operation::Indexes do
     let(:operation) do
       described_class.new({ selector: { listIndexes: TEST_COLL },
                             coll_name: TEST_COLL,
-                            db_name: TEST_DB })
+                            db_name: SpecConfig.instance.test_db })
     end
 
     let(:indexes) do

--- a/spec/mongo/operation/insert/bulk_spec.rb
+++ b/spec/mongo/operation/insert/bulk_spec.rb
@@ -17,7 +17,7 @@ describe Mongo::Operation::Insert do
   end
 
   let(:write_concern) do
-    Mongo::WriteConcern.get(WRITE_CONCERN)
+    Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
   end
 
   let(:spec) do

--- a/spec/mongo/operation/insert/command_spec.rb
+++ b/spec/mongo/operation/insert/command_spec.rb
@@ -15,7 +15,7 @@ describe Mongo::Operation::Insert::Command do
   end
 
   let(:write_concern) do
-    Mongo::WriteConcern.get(WRITE_CONCERN)
+    Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
   end
 
   let(:op) { described_class.new(spec) }

--- a/spec/mongo/operation/insert/op_msg_spec.rb
+++ b/spec/mongo/operation/insert/op_msg_spec.rb
@@ -15,7 +15,7 @@ describe Mongo::Operation::Insert::OpMsg do
   end
 
   let(:write_concern) do
-    Mongo::WriteConcern.get(WRITE_CONCERN)
+    Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
   end
 
   let(:op) { described_class.new(spec) }

--- a/spec/mongo/operation/insert/op_msg_spec.rb
+++ b/spec/mongo/operation/insert/op_msg_spec.rb
@@ -99,7 +99,7 @@ describe Mongo::Operation::Insert::OpMsg do
             insert: TEST_COLL,
             ordered: true,
             writeConcern: write_concern.options,
-            '$db' => TEST_DB,
+            '$db' => SpecConfig.instance.test_db,
             lsid: session.session_id
         }
       end

--- a/spec/mongo/operation/insert_spec.rb
+++ b/spec/mongo/operation/insert_spec.rb
@@ -9,7 +9,7 @@ describe Mongo::Operation::Insert do
 
   let(:spec) do
     { :documents     => documents,
-      :db_name       => TEST_DB,
+      :db_name       => SpecConfig.instance.test_db,
       :coll_name     => TEST_COLL,
       :write_concern => Mongo::WriteConcern.get(:w => 1)
     }
@@ -132,7 +132,7 @@ describe Mongo::Operation::Insert do
 
         let(:spec) do
           { :documents     => documents,
-            :db_name       => TEST_DB,
+            :db_name       => SpecConfig.instance.test_db,
             :coll_name     => TEST_COLL,
             :write_concern => Mongo::WriteConcern.get(:w => 1)
           }
@@ -183,7 +183,7 @@ describe Mongo::Operation::Insert do
 
         let(:spec) do
           { :documents     => documents,
-            :db_name       => TEST_DB,
+            :db_name       => SpecConfig.instance.test_db,
             :coll_name     => TEST_COLL,
             :write_concern => Mongo::WriteConcern.get(:w => 1)
           }
@@ -209,7 +209,7 @@ describe Mongo::Operation::Insert do
 
         let(:spec) do
           { :documents     => documents,
-            :db_name       => TEST_DB,
+            :db_name       => SpecConfig.instance.test_db,
             :coll_name     => TEST_COLL,
             :write_concern => Mongo::WriteConcern.get(:w => 1)
           }
@@ -253,7 +253,7 @@ describe Mongo::Operation::Insert do
 
       let(:spec) do
         { :documents     => documents,
-          :db_name       => TEST_DB,
+          :db_name       => SpecConfig.instance.test_db,
           :coll_name     => TEST_COLL,
           :write_concern => Mongo::WriteConcern.get(:w => 0)
         }

--- a/spec/mongo/operation/kill_cursors_spec.rb
+++ b/spec/mongo/operation/kill_cursors_spec.rb
@@ -4,7 +4,7 @@ describe Mongo::Operation::KillCursors::Legacy do
 
   let(:spec) do
     { coll_name: TEST_COLL,
-      db_name: TEST_DB,
+      db_name: SpecConfig.instance.test_db,
       :cursor_ids => [1,2]
     }
   end
@@ -34,7 +34,7 @@ describe Mongo::Operation::KillCursors::Legacy do
   describe '#message' do
 
     it 'creates a kill cursors wire protocol message with correct specs' do
-      expect(Mongo::Protocol::KillCursors).to receive(:new).with(TEST_COLL, TEST_DB, spec[:cursor_ids])
+      expect(Mongo::Protocol::KillCursors).to receive(:new).with(TEST_COLL, SpecConfig.instance.test_db, spec[:cursor_ids])
       op.send(:message, double('server'))
     end
   end

--- a/spec/mongo/operation/map_reduce_spec.rb
+++ b/spec/mongo/operation/map_reduce_spec.rb
@@ -36,7 +36,7 @@ describe Mongo::Operation::MapReduce do
   let(:spec) do
     { :selector => selector,
       :options  => options,
-      :db_name  => TEST_DB
+      :db_name  => SpecConfig.instance.test_db
     }
   end
 
@@ -66,7 +66,7 @@ describe Mongo::Operation::MapReduce do
       let(:other_spec) do
         { :selector => other_selector,
           :options => {},
-          :db_name => TEST_DB,
+          :db_name => SpecConfig.instance.test_db,
         }
       end
       let(:other) { described_class.new(other_spec) }

--- a/spec/mongo/operation/remove_user_spec.rb
+++ b/spec/mongo/operation/remove_user_spec.rb
@@ -12,7 +12,7 @@ describe Mongo::Operation::RemoveUser do
     end
 
     let(:operation) do
-      described_class.new(user_name: 'durran', db_name: TEST_DB)
+      described_class.new(user_name: 'durran', db_name: SpecConfig.instance.test_db)
     end
 
     context 'when user removal was successful' do

--- a/spec/mongo/operation/result_spec.rb
+++ b/spec/mongo/operation/result_spec.rb
@@ -290,7 +290,7 @@ describe Mongo::Operation::Result do
 
   context 'when there is a top-level Result class defined' do
     let(:client) do
-      new_local_client(SpecConfig.instance.addresses, TEST_OPTIONS)
+      new_local_client(SpecConfig.instance.addresses, SpecConfig.instance.test_options)
     end
 
     before do

--- a/spec/mongo/operation/update/bulk_spec.rb
+++ b/spec/mongo/operation/update/bulk_spec.rb
@@ -19,7 +19,7 @@ describe Mongo::Operation::Update do
   end
 
   let(:write_concern) do
-    Mongo::WriteConcern.get(WRITE_CONCERN)
+    Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
   end
 
   let(:op) do

--- a/spec/mongo/operation/update/command_spec.rb
+++ b/spec/mongo/operation/update/command_spec.rb
@@ -13,7 +13,7 @@ describe Mongo::Operation::Update::Command do
   let(:session) { nil }
   let(:spec) do
     { :updates       => updates,
-      :db_name       => TEST_DB,
+      :db_name       => SpecConfig.instance.test_db,
       :coll_name     => TEST_COLL,
       :write_concern => write_concern,
       :ordered       => true,
@@ -52,7 +52,7 @@ describe Mongo::Operation::Update::Command do
                                 :upsert => false }] }
         let(:other_spec) do
           { :updates       => other_updates,
-            :db_name       => TEST_DB,
+            :db_name       => SpecConfig.instance.test_db,
             :coll_name     => TEST_COLL,
             :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
             :ordered       => true
@@ -73,7 +73,7 @@ describe Mongo::Operation::Update::Command do
 
       let(:spec) do
         { :updates       => updates,
-          :db_name       => TEST_DB,
+          :db_name       => SpecConfig.instance.test_db,
           :coll_name     => TEST_COLL,
           :ordered       => true
         }
@@ -106,7 +106,7 @@ describe Mongo::Operation::Update::Command do
       end
 
       it 'creates the correct Command message', unless: op_msg_enabled? do
-        expect(Mongo::Protocol::Query).to receive(:new).with(TEST_DB, '$cmd', expected_selector, { limit: -1 })
+        expect(Mongo::Protocol::Query).to receive(:new).with(SpecConfig.instance.test_db, '$cmd', expected_selector, { limit: -1 })
         op.send(:message, authorized_primary)
       end
     end

--- a/spec/mongo/operation/update/command_spec.rb
+++ b/spec/mongo/operation/update/command_spec.rb
@@ -8,7 +8,7 @@ describe Mongo::Operation::Update::Command do
                     :upsert => false }] }
 
   let(:write_concern) do
-    Mongo::WriteConcern.get(WRITE_CONCERN)
+    Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
   end
   let(:session) { nil }
   let(:spec) do
@@ -54,7 +54,7 @@ describe Mongo::Operation::Update::Command do
           { :updates       => other_updates,
             :db_name       => TEST_DB,
             :coll_name     => TEST_COLL,
-            :write_concern => Mongo::WriteConcern.get(WRITE_CONCERN),
+            :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
             :ordered       => true
           }
         end

--- a/spec/mongo/operation/update/op_msg_spec.rb
+++ b/spec/mongo/operation/update/op_msg_spec.rb
@@ -8,7 +8,7 @@ describe Mongo::Operation::Update::OpMsg do
                     :upsert => false }] }
 
   let(:write_concern) do
-    Mongo::WriteConcern.get(WRITE_CONCERN)
+    Mongo::WriteConcern.get(SpecConfig.instance.write_concern)
   end
   let(:session) { nil }
   let(:spec) do
@@ -54,7 +54,7 @@ describe Mongo::Operation::Update::OpMsg do
           { :updates       => other_updates,
             :db_name       => TEST_DB,
             :coll_name     => TEST_COLL,
-            :write_concern => Mongo::WriteConcern.get(WRITE_CONCERN),
+            :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
             :ordered       => true
           }
         end

--- a/spec/mongo/operation/update/op_msg_spec.rb
+++ b/spec/mongo/operation/update/op_msg_spec.rb
@@ -13,7 +13,7 @@ describe Mongo::Operation::Update::OpMsg do
   let(:session) { nil }
   let(:spec) do
     { :updates       => updates,
-      :db_name       => TEST_DB,
+      :db_name       => SpecConfig.instance.test_db,
       :coll_name     => TEST_COLL,
       :write_concern => write_concern,
       :ordered       => true,
@@ -52,7 +52,7 @@ describe Mongo::Operation::Update::OpMsg do
                                 :upsert => false }] }
         let(:other_spec) do
           { :updates       => other_updates,
-            :db_name       => TEST_DB,
+            :db_name       => SpecConfig.instance.test_db,
             :coll_name     => TEST_COLL,
             :write_concern => Mongo::WriteConcern.get(SpecConfig.instance.write_concern),
             :ordered       => true
@@ -73,7 +73,7 @@ describe Mongo::Operation::Update::OpMsg do
 
       let(:spec) do
         { :updates       => updates,
-          :db_name       => TEST_DB,
+          :db_name       => SpecConfig.instance.test_db,
           :coll_name     => TEST_COLL,
           :ordered       => true
         }
@@ -101,7 +101,7 @@ describe Mongo::Operation::Update::OpMsg do
             update: TEST_COLL,
             ordered: true,
             writeConcern: write_concern.options,
-            '$db' => TEST_DB,
+            '$db' => SpecConfig.instance.test_db,
             lsid: session.session_id
         }
       end

--- a/spec/mongo/operation/update_spec.rb
+++ b/spec/mongo/operation/update_spec.rb
@@ -11,7 +11,7 @@ describe Mongo::Operation::Update do
 
   let(:spec) do
     { :updates        => [ document ],
-      :db_name       => TEST_DB,
+      :db_name       => SpecConfig.instance.test_db,
       :coll_name     => TEST_COLL,
       :write_concern => Mongo::WriteConcern.get(:w => 1),
       :ordered       => true
@@ -52,7 +52,7 @@ describe Mongo::Operation::Update do
                            :upsert => true } }
         let(:other_spec) do
           { :update        => other_doc,
-            :db_name       => TEST_DB,
+            :db_name       => SpecConfig.instance.test_db,
             :coll_name     => TEST_COLL,
             :write_concern => Mongo::WriteConcern.get(:w => 1),
             :ordered       => true
@@ -87,7 +87,7 @@ describe Mongo::Operation::Update do
       let(:update) do
         described_class.new({
           updates: [ document ],
-          db_name: TEST_DB,
+          db_name: SpecConfig.instance.test_db,
           coll_name: TEST_COLL,
           write_concern: Mongo::WriteConcern.get(:w => 1)
         })
@@ -139,7 +139,7 @@ describe Mongo::Operation::Update do
       let(:update) do
         described_class.new({
           updates: [ document ],
-          db_name: TEST_DB,
+          db_name: SpecConfig.instance.test_db,
           coll_name: TEST_COLL,
           write_concern: Mongo::WriteConcern.get(:w => 1)
         })
@@ -231,7 +231,7 @@ describe Mongo::Operation::Update do
       let(:update) do
         described_class.new({
                                 updates: [ document ],
-                                db_name: TEST_DB,
+                                db_name: SpecConfig.instance.test_db,
                                 coll_name: TEST_COLL,
                                 write_concern: Mongo::WriteConcern.get(:w => 0)
                             })

--- a/spec/mongo/operation/update_user_spec.rb
+++ b/spec/mongo/operation/update_user_spec.rb
@@ -21,7 +21,7 @@ describe Mongo::Operation::UpdateUser do
     end
 
     let(:operation) do
-      described_class.new(user: user_updated, db_name: TEST_DB)
+      described_class.new(user: user_updated, db_name: SpecConfig.instance.test_db)
     end
 
     before do

--- a/spec/mongo/protocol/compressed_spec.rb
+++ b/spec/mongo/protocol/compressed_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Mongo::Protocol::Compressed do
 
-  let(:original_message) { Mongo::Protocol::Query.new(TEST_DB, TEST_COLL, { ping: 1 }) }
+  let(:original_message) { Mongo::Protocol::Query.new(SpecConfig.instance.test_db, TEST_COLL, { ping: 1 }) }
   let(:compressor) { 'zlib' }
   let(:level)      { nil }
 

--- a/spec/mongo/protocol/delete_spec.rb
+++ b/spec/mongo/protocol/delete_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Mongo::Protocol::Delete do
 
   let(:opcode)   { 2006 }
-  let(:db)       { TEST_DB }
+  let(:db)       { SpecConfig.instance.test_db }
   let(:coll)     { TEST_COLL }
   let(:ns)       { "#{db}.#{coll}" }
   let(:selector) { { :name => 'Tyler' } }

--- a/spec/mongo/protocol/get_more_spec.rb
+++ b/spec/mongo/protocol/get_more_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Mongo::Protocol::GetMore do
 
   let(:opcode)    { 2005 }
-  let(:db)        { TEST_DB }
+  let(:db)        { SpecConfig.instance.test_db }
   let(:coll)      { TEST_COLL }
   let(:ns)        { "#{db}.#{coll}" }
   let(:limit)     { 25 }

--- a/spec/mongo/protocol/insert_spec.rb
+++ b/spec/mongo/protocol/insert_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Mongo::Protocol::Insert do
 
   let(:opcode) { 2002 }
-  let(:db)     { TEST_DB }
+  let(:db)     { SpecConfig.instance.test_db }
   let(:coll)   { TEST_COLL }
   let(:ns)     { "#{db}.#{coll}" }
   let(:doc1)   { { :name => 'Tyler' } }

--- a/spec/mongo/protocol/kill_cursors_spec.rb
+++ b/spec/mongo/protocol/kill_cursors_spec.rb
@@ -6,7 +6,7 @@ describe Mongo::Protocol::KillCursors do
   let(:cursor_ids) { [123, 456, 789] }
   let(:id_count)   { cursor_ids.size }
   let(:collection) { TEST_COLL }
-  let(:database)   { TEST_DB }
+  let(:database)   { SpecConfig.instance.test_db }
   let(:message) do
     described_class.new(collection, database, cursor_ids)
   end

--- a/spec/mongo/protocol/msg_spec.rb
+++ b/spec/mongo/protocol/msg_spec.rb
@@ -5,7 +5,7 @@ describe Mongo::Protocol::Msg do
   let(:opcode) { 2013 }
   let(:flags)     { [:none] }
   let(:options)   { {} }
-  let(:global_args)     { { '$db' => TEST_DB, ping: 1 } }
+  let(:global_args)     { { '$db' => SpecConfig.instance.test_db, ping: 1 } }
   let(:sections)   { [ ] }
 
   let(:message) do
@@ -88,7 +88,7 @@ describe Mongo::Protocol::Msg do
       context 'when the global_args are not equal' do
 
         let(:other) do
-          described_class.new(flags, nil, { '$db'=> TEST_DB, ismaster: 1 })
+          described_class.new(flags, nil, { '$db'=> SpecConfig.instance.test_db, ismaster: 1 })
         end
 
         it 'returns false' do
@@ -441,7 +441,7 @@ describe Mongo::Protocol::Msg do
 
       it 'creates a payload with the command' do
         expect(message.payload[:command_name]).to eq(:ping)
-        expect(message.payload[:database_name]).to eq(TEST_DB)
+        expect(message.payload[:database_name]).to eq(SpecConfig.instance.test_db)
         expect(message.payload[:command]).to eq('ping' => 1)
         expect(message.payload[:request_id]).to eq(message.request_id)
       end
@@ -456,7 +456,7 @@ describe Mongo::Protocol::Msg do
       end
 
       let(:global_args) do
-        { '$db' => TEST_DB,
+        { '$db' => SpecConfig.instance.test_db,
           'insert' => TEST_COLL,
           'ordered' => true
         }
@@ -476,7 +476,7 @@ describe Mongo::Protocol::Msg do
 
       it 'creates a payload with the command' do
         expect(message.payload[:command_name]).to eq('insert')
-        expect(message.payload[:database_name]).to eq(TEST_DB)
+        expect(message.payload[:database_name]).to eq(SpecConfig.instance.test_db)
         expect(message.payload[:command]).to eq(expected_command_doc)
         expect(message.payload[:request_id]).to eq(message.request_id)
       end

--- a/spec/mongo/protocol/query_spec.rb
+++ b/spec/mongo/protocol/query_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe Mongo::Protocol::Query do
 
   let(:opcode)   { 2004 }
-  let(:db)       { TEST_DB }
+  let(:db)       { SpecConfig.instance.test_db }
   let(:coll)     { TEST_COLL }
   let(:ns)       { "#{db}.#{coll}" }
   let(:selector) { { :name => 'Tyler' } }

--- a/spec/mongo/protocol/update_spec.rb
+++ b/spec/mongo/protocol/update_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Mongo::Protocol::Update do
 
   let(:opcode)   { 2001 }
-  let(:db)       { TEST_DB }
+  let(:db)       { SpecConfig.instance.test_db }
   let(:coll)     { TEST_COLL }
   let(:ns)       { "#{db}.#{coll}" }
   let(:selector) { { :name => 'Tyler' } }

--- a/spec/mongo/server/connection_pool_spec.rb
+++ b/spec/mongo/server/connection_pool_spec.rb
@@ -220,7 +220,7 @@ describe Mongo::Server::ConnectionPool do
     end
 
     let(:options) do
-      { user: ROOT_USER.name, password: ROOT_USER.password }.merge(SpecConfig.instance.test_options).merge(max_pool_size: 1)
+      { user: SpecConfig.instance.root_user.name, password: SpecConfig.instance.root_user.password }.merge(SpecConfig.instance.test_options).merge(max_pool_size: 1)
     end
 
     before do

--- a/spec/mongo/server/connection_pool_spec.rb
+++ b/spec/mongo/server/connection_pool_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Mongo::Server::ConnectionPool do
 
   let(:options) do
-    TEST_OPTIONS.merge(max_pool_size: 2)
+    SpecConfig.instance.test_options.merge(max_pool_size: 2)
   end
 
   let(:address) do
@@ -220,7 +220,7 @@ describe Mongo::Server::ConnectionPool do
     end
 
     let(:options) do
-      { user: ROOT_USER.name, password: ROOT_USER.password }.merge(TEST_OPTIONS).merge(max_pool_size: 1)
+      { user: ROOT_USER.name, password: ROOT_USER.password }.merge(SpecConfig.instance.test_options).merge(max_pool_size: 1)
     end
 
     before do
@@ -254,7 +254,7 @@ describe Mongo::Server::ConnectionPool do
     context 'when there is a max_idle_time specified' do
 
       let(:options) do
-        TEST_OPTIONS.merge(max_pool_size: 2, max_idle_time: 0.5)
+        SpecConfig.instance.test_options.merge(max_pool_size: 2, max_idle_time: 0.5)
       end
 
       context 'when the connections have not been checked out' do
@@ -277,7 +277,7 @@ describe Mongo::Server::ConnectionPool do
         context 'when min size is 0' do
 
           let(:options) do
-            TEST_OPTIONS.merge(max_pool_size: 2, min_pool_size: 0, max_idle_time: 0.5)
+            SpecConfig.instance.test_options.merge(max_pool_size: 2, min_pool_size: 0, max_idle_time: 0.5)
           end
 
           before do
@@ -300,7 +300,7 @@ describe Mongo::Server::ConnectionPool do
           context 'when more than the number of min_size are checked out' do
 
             let(:options) do
-              TEST_OPTIONS.merge(max_pool_size: 5, min_pool_size: 3, max_idle_time: 0.5)
+              SpecConfig.instance.test_options.merge(max_pool_size: 5, min_pool_size: 3, max_idle_time: 0.5)
             end
 
             before do
@@ -328,7 +328,7 @@ describe Mongo::Server::ConnectionPool do
           context 'when between 0 and min_size number of connections are checked out' do
 
             let(:options) do
-              TEST_OPTIONS.merge(max_pool_size: 5, min_pool_size: 3, max_idle_time: 0.5)
+              SpecConfig.instance.test_options.merge(max_pool_size: 5, min_pool_size: 3, max_idle_time: 0.5)
             end
 
             before do
@@ -367,7 +367,7 @@ describe Mongo::Server::ConnectionPool do
           context 'when a stale connection is unsuccessfully reconnected' do
 
             let(:options) do
-              TEST_OPTIONS.merge(max_pool_size: 5, min_pool_size: 3, max_idle_time: 0.5)
+              SpecConfig.instance.test_options.merge(max_pool_size: 5, min_pool_size: 3, max_idle_time: 0.5)
             end
 
             before do
@@ -406,7 +406,7 @@ describe Mongo::Server::ConnectionPool do
           context 'when exactly the min_size number of connections is checked out' do
 
             let(:options) do
-              TEST_OPTIONS.merge(max_pool_size: 5, min_pool_size: 3, max_idle_time: 0.5)
+              SpecConfig.instance.test_options.merge(max_pool_size: 5, min_pool_size: 3, max_idle_time: 0.5)
             end
 
             before do

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -30,7 +30,7 @@ describe Mongo::Server::Connection do
   declare_topology_double
 
   let(:server) do
-    Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+    Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
   end
 
   let(:pool) do
@@ -99,7 +99,7 @@ describe Mongo::Server::Connection do
         let(:connection) do
           described_class.new(
             server,
-            TEST_OPTIONS.merge(
+            SpecConfig.instance.test_options.merge(
               :user => 'notauser',
               :password => 'password',
               :database => TEST_DB,
@@ -129,7 +129,7 @@ describe Mongo::Server::Connection do
         let(:connection) do
           described_class.new(
             server,
-            TEST_OPTIONS.merge(
+            SpecConfig.instance.test_options.merge(
               :user => TEST_USER.name,
               :password => TEST_USER.password,
               :database => TEST_USER.database )
@@ -182,7 +182,7 @@ describe Mongo::Server::Connection do
     let!(:connection) do
       described_class.new(
         server,
-        TEST_OPTIONS.merge(
+        SpecConfig.instance.test_options.merge(
           :user => TEST_USER.name,
           :password => TEST_USER.password,
           :database => TEST_USER.database )
@@ -683,7 +683,7 @@ describe Mongo::Server::Connection do
       context 'when a socket_timeout is in the options' do
 
         let(:options) do
-          TEST_OPTIONS.merge(connect_timeout: 3, socket_timeout: 5)
+          SpecConfig.instance.test_options.merge(connect_timeout: 3, socket_timeout: 5)
         end
 
         before do
@@ -702,7 +702,7 @@ describe Mongo::Server::Connection do
       context 'when a socket_timeout is not in the options' do
 
         let(:options) do
-          TEST_OPTIONS.merge(connect_timeout: 3, socket_timeout: nil)
+          SpecConfig.instance.test_options.merge(connect_timeout: 3, socket_timeout: nil)
         end
 
         before do
@@ -724,7 +724,7 @@ describe Mongo::Server::Connection do
       context 'when a socket_timeout is in the options' do
 
         let(:options) do
-          TEST_OPTIONS.merge(connect_timeout: nil, socket_timeout: 5)
+          SpecConfig.instance.test_options.merge(connect_timeout: nil, socket_timeout: 5)
         end
 
         before do
@@ -743,7 +743,7 @@ describe Mongo::Server::Connection do
       context 'when a socket_timeout is not in the options' do
 
         let(:options) do
-          TEST_OPTIONS.merge(connect_timeout: nil, socket_timeout: nil)
+          SpecConfig.instance.test_options.merge(connect_timeout: nil, socket_timeout: nil)
         end
 
         before do

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -130,9 +130,9 @@ describe Mongo::Server::Connection do
           described_class.new(
             server,
             SpecConfig.instance.test_options.merge(
-              :user => TEST_USER.name,
-              :password => TEST_USER.password,
-              :database => TEST_USER.database )
+              :user => SpecConfig.instance.test_user.name,
+              :password => SpecConfig.instance.test_user.password,
+              :database => SpecConfig.instance.test_user.database )
           )
         end
 
@@ -183,9 +183,9 @@ describe Mongo::Server::Connection do
       described_class.new(
         server,
         SpecConfig.instance.test_options.merge(
-          :user => TEST_USER.name,
-          :password => TEST_USER.password,
-          :database => TEST_USER.database )
+          :user => SpecConfig.instance.test_user.name,
+          :password => SpecConfig.instance.test_user.password,
+          :database => SpecConfig.instance.test_user.database )
       )
     end
 
@@ -568,8 +568,8 @@ describe Mongo::Server::Connection do
       let(:connection) do
         described_class.new(
           server,
-          :user => TEST_USER.name,
-          :password => TEST_USER.password,
+          :user => SpecConfig.instance.test_user.name,
+          :password => SpecConfig.instance.test_user.password,
           :database => SpecConfig.instance.test_db,
           :auth_mech => :mongodb_cr
         )
@@ -578,8 +578,8 @@ describe Mongo::Server::Connection do
       let(:user) do
         Mongo::Auth::User.new(
           database: SpecConfig.instance.test_db,
-          user: TEST_USER.name,
-          password: TEST_USER.password
+          user: SpecConfig.instance.test_user.name,
+          password: SpecConfig.instance.test_user.password
         )
       end
 

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -102,7 +102,7 @@ describe Mongo::Server::Connection do
             SpecConfig.instance.test_options.merge(
               :user => 'notauser',
               :password => 'password',
-              :database => TEST_DB,
+              :database => SpecConfig.instance.test_db,
               :heartbeat_frequency => 30)
           )
         end
@@ -194,11 +194,11 @@ describe Mongo::Server::Connection do
     end
 
     let(:insert) do
-      Mongo::Protocol::Insert.new(TEST_DB, TEST_COLL, documents)
+      Mongo::Protocol::Insert.new(SpecConfig.instance.test_db, TEST_COLL, documents)
     end
 
     let(:query) do
-      Mongo::Protocol::Query.new(TEST_DB, TEST_COLL, { 'name' => 'testing' })
+      Mongo::Protocol::Query.new(SpecConfig.instance.test_db, TEST_COLL, { 'name' => 'testing' })
     end
 
     context 'when providing a single message' do
@@ -223,7 +223,7 @@ describe Mongo::Server::Connection do
       end
 
       let(:command) do
-        Mongo::Protocol::Query.new(TEST_DB, '$cmd', selector, :limit => -1)
+        Mongo::Protocol::Query.new(SpecConfig.instance.test_db, '$cmd', selector, :limit => -1)
       end
 
       let(:reply) do
@@ -246,15 +246,15 @@ describe Mongo::Server::Connection do
       end
 
       let(:insert) do
-        Mongo::Protocol::Insert.new(TEST_DB, TEST_COLL, documents)
+        Mongo::Protocol::Insert.new(SpecConfig.instance.test_db, TEST_COLL, documents)
       end
 
       let(:query_bob) do
-        Mongo::Protocol::Query.new(TEST_DB, TEST_COLL, { name: 'bob' })
+        Mongo::Protocol::Query.new(SpecConfig.instance.test_db, TEST_COLL, { name: 'bob' })
       end
 
       let(:query_alice) do
-        Mongo::Protocol::Query.new(TEST_DB, TEST_COLL, { name: 'alice' })
+        Mongo::Protocol::Query.new(SpecConfig.instance.test_db, TEST_COLL, { name: 'alice' })
       end
 
       after do
@@ -292,15 +292,15 @@ describe Mongo::Server::Connection do
       end
 
       let(:insert) do
-        Mongo::Protocol::Insert.new(TEST_DB, TEST_COLL, documents)
+        Mongo::Protocol::Insert.new(SpecConfig.instance.test_db, TEST_COLL, documents)
       end
 
       let(:query_bob) do
-        Mongo::Protocol::Query.new(TEST_DB, TEST_COLL, { name: 'bob' })
+        Mongo::Protocol::Query.new(SpecConfig.instance.test_db, TEST_COLL, { name: 'bob' })
       end
 
       let(:query_alice) do
-        Mongo::Protocol::Query.new(TEST_DB, TEST_COLL, { name: 'alice' })
+        Mongo::Protocol::Query.new(SpecConfig.instance.test_db, TEST_COLL, { name: 'alice' })
       end
 
       before do
@@ -357,7 +357,7 @@ describe Mongo::Server::Connection do
         end
 
         let(:command) do
-          Mongo::Protocol::Query.new(TEST_DB, '$cmd', selector, :limit => -1)
+          Mongo::Protocol::Query.new(SpecConfig.instance.test_db, '$cmd', selector, :limit => -1)
         end
 
         let(:reply) do
@@ -460,7 +460,7 @@ describe Mongo::Server::Connection do
     context 'when the process is forked' do
 
       let(:insert) do
-        Mongo::Protocol::Insert.new(TEST_DB, TEST_COLL, documents)
+        Mongo::Protocol::Insert.new(SpecConfig.instance.test_db, TEST_COLL, documents)
       end
 
       before do
@@ -570,14 +570,14 @@ describe Mongo::Server::Connection do
           server,
           :user => TEST_USER.name,
           :password => TEST_USER.password,
-          :database => TEST_DB,
+          :database => SpecConfig.instance.test_db,
           :auth_mech => :mongodb_cr
         )
       end
 
       let(:user) do
         Mongo::Auth::User.new(
-          database: TEST_DB,
+          database: SpecConfig.instance.test_db,
           user: TEST_USER.name,
           password: TEST_USER.password
         )

--- a/spec/mongo/server/monitor/connection_spec.rb
+++ b/spec/mongo/server/monitor/connection_spec.rb
@@ -39,7 +39,7 @@ describe Mongo::Server::Monitor::Connection do
     context 'when a socket_timeout is in the options' do
 
       let(:options) do
-        TEST_OPTIONS.merge(connect_timeout: 3, socket_timeout: 5)
+        SpecConfig.instance.test_options.merge(connect_timeout: 3, socket_timeout: 5)
       end
 
       before do
@@ -58,7 +58,7 @@ describe Mongo::Server::Monitor::Connection do
     context 'when a socket_timeout is not in the options' do
 
       let(:options) do
-        TEST_OPTIONS.merge(connect_timeout: 3, socket_timeout: nil)
+        SpecConfig.instance.test_options.merge(connect_timeout: 3, socket_timeout: nil)
       end
 
       before do
@@ -80,7 +80,7 @@ describe Mongo::Server::Monitor::Connection do
     context 'when a socket_timeout is in the options' do
 
       let(:options) do
-        TEST_OPTIONS.merge(connect_timeout: nil, socket_timeout: 5)
+        SpecConfig.instance.test_options.merge(connect_timeout: nil, socket_timeout: 5)
       end
 
       before do
@@ -99,7 +99,7 @@ describe Mongo::Server::Monitor::Connection do
     context 'when a socket_timeout is not in the options' do
 
       let(:options) do
-        TEST_OPTIONS.merge(connect_timeout: nil, socket_timeout: nil)
+        SpecConfig.instance.test_options.merge(connect_timeout: nil, socket_timeout: nil)
       end
 
       before do

--- a/spec/mongo/server/monitor_spec.rb
+++ b/spec/mongo/server/monitor_spec.rb
@@ -15,7 +15,7 @@ describe Mongo::Server::Monitor do
     context 'when calling multiple times in succession' do
 
       let(:monitor) do
-        described_class.new(address, listeners, TEST_OPTIONS)
+        described_class.new(address, listeners, SpecConfig.instance.test_options)
       end
 
       it 'throttles the scans to minimum 500ms' do
@@ -29,7 +29,7 @@ describe Mongo::Server::Monitor do
     context 'when the ismaster fails the first time' do
 
       let(:monitor) do
-        described_class.new(address, listeners, TEST_OPTIONS)
+        described_class.new(address, listeners, SpecConfig.instance.test_options)
       end
 
       let(:socket) do
@@ -59,7 +59,7 @@ describe Mongo::Server::Monitor do
     context 'when the ismaster command succeeds' do
 
       let(:monitor) do
-        described_class.new(address, listeners, TEST_OPTIONS)
+        described_class.new(address, listeners, SpecConfig.instance.test_options)
       end
 
       before do
@@ -175,7 +175,7 @@ describe Mongo::Server::Monitor do
   describe '#restart!' do
 
     let(:monitor) do
-      described_class.new(address, listeners, TEST_OPTIONS)
+      described_class.new(address, listeners, SpecConfig.instance.test_options)
     end
 
     let!(:thread) do
@@ -205,7 +205,7 @@ describe Mongo::Server::Monitor do
   describe '#stop' do
 
     let(:monitor) do
-      described_class.new(address, listeners, TEST_OPTIONS)
+      described_class.new(address, listeners, SpecConfig.instance.test_options)
     end
 
     let!(:thread) do
@@ -232,7 +232,7 @@ describe Mongo::Server::Monitor do
       end
 
       let(:monitor) do
-        described_class.new(address, listeners, TEST_OPTIONS.merge(connect_timeout: connect_timeout))
+        described_class.new(address, listeners, SpecConfig.instance.test_options.merge(connect_timeout: connect_timeout))
       end
 
       it 'sets the value as the timeout on the connection' do

--- a/spec/mongo/server_spec.rb
+++ b/spec/mongo/server_spec.rb
@@ -30,7 +30,7 @@ describe Mongo::Server do
   describe '#==' do
 
     let(:server) do
-      described_class.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      described_class.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     after do
@@ -54,7 +54,7 @@ describe Mongo::Server do
       context 'when the addresses match' do
 
         let(:other) do
-          described_class.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+          described_class.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
         end
 
         it 'returns true' do
@@ -69,7 +69,7 @@ describe Mongo::Server do
         end
 
         let(:other) do
-          described_class.new(other_address, cluster, monitoring, listeners, TEST_OPTIONS)
+          described_class.new(other_address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
         end
 
         it 'returns false' do
@@ -82,7 +82,7 @@ describe Mongo::Server do
   describe '#disconnect!' do
 
     let(:server) do
-      described_class.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      described_class.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     it 'stops the monitor instance' do
@@ -100,7 +100,7 @@ describe Mongo::Server do
         cluster,
         monitoring,
         listeners,
-        TEST_OPTIONS.merge(:heartbeat_frequency => 5)
+        SpecConfig.instance.test_options.merge(:heartbeat_frequency => 5)
       )
     end
 
@@ -118,14 +118,14 @@ describe Mongo::Server do
     end
 
     it 'sets the options' do
-      expect(server.options).to eq(TEST_OPTIONS.merge(:heartbeat_frequency => 5))
+      expect(server.options).to eq(SpecConfig.instance.test_options.merge(:heartbeat_frequency => 5))
     end
   end
 
   describe '#scan!' do
 
     let(:server) do
-      described_class.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      described_class.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     after do
@@ -141,7 +141,7 @@ describe Mongo::Server do
   describe '#reconnect!' do
 
     let(:server) do
-      described_class.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      described_class.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     before do
@@ -161,7 +161,7 @@ describe Mongo::Server do
   describe 'retry_writes?' do
 
     let(:server) do
-      described_class.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+      described_class.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
     end
 
     before do

--- a/spec/mongo/socket/ssl_spec.rb
+++ b/spec/mongo/socket/ssl_spec.rb
@@ -20,15 +20,15 @@ describe Mongo::Socket::SSL do
   end
 
   let(:options) do
-    SSL_OPTIONS
+    SpecConfig.instance.ssl_options
   end
 
   let (:key_string) do
-    File.read(CLIENT_KEY_PEM)
+    File.read(SpecConfig.instance.client_key_pem)
   end
 
   let (:cert_string) do
-    File.read(CLIENT_CERT_PEM)
+    File.read(SpecConfig.instance.client_cert_pem)
   end
 
   let (:ca_cert_string) do

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -256,7 +256,7 @@ describe Mongo::URI::SRVProtocol do
 
     describe '#client_options' do
 
-      let(:db)          { TEST_DB }
+      let(:db)          { SpecConfig.instance.test_db }
       let(:servers)     { 'test5.test.build.10gen.cc' }
       let(:string)      { "#{scheme}#{credentials}@#{servers}/#{db}" }
       let(:user)        { 'tyler' }
@@ -268,7 +268,7 @@ describe Mongo::URI::SRVProtocol do
       end
 
       it 'includes the database in the options' do
-        expect(options[:database]).to eq(TEST_DB)
+        expect(options[:database]).to eq(SpecConfig.instance.test_db)
       end
 
       it 'includes the user in the options' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -242,7 +242,7 @@ end
 #
 # @since 2.5.0
 def compression_enabled?
-  COMPRESSORS[:compressors]
+  !SpecConfig.instance.compressors.nil?
 end
 
 # Is the test suite testing compression.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -288,7 +288,7 @@ end
 # @since 2.0.0
 def initialize_scanned_client!
   ClientRegistry.instance.new_global_client(
-    SpecConfig.instance.addresses, SpecConfig.instance.test_options.merge(database: TEST_DB))
+    SpecConfig.instance.addresses, SpecConfig.instance.test_options.merge(database: SpecConfig.instance.test_db))
 end
 
 class ScannedClientHasNoServers < StandardError; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -288,7 +288,7 @@ end
 # @since 2.0.0
 def initialize_scanned_client!
   ClientRegistry.instance.new_global_client(
-    SpecConfig.instance.addresses, TEST_OPTIONS.merge(database: TEST_DB))
+    SpecConfig.instance.addresses, SpecConfig.instance.test_options.merge(database: TEST_DB))
 end
 
 class ScannedClientHasNoServers < StandardError; end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,7 +105,7 @@ RSpec.configure do |config|
       # Create the root user administrator as the first user to be added to the
       # database. This user will need to be authenticated in order to add any
       # more users to any other databases.
-      ADMIN_UNAUTHORIZED_CLIENT.database.users.create(ROOT_USER)
+      ADMIN_UNAUTHORIZED_CLIENT.database.users.create(SpecConfig.instance.root_user)
       ADMIN_UNAUTHORIZED_CLIENT.close
     rescue Exception => e
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -112,7 +112,7 @@ RSpec.configure do |config|
     begin
       # Adds the test user to the test database with permissions on all
       # databases that will be used in the test suite.
-      ADMIN_AUTHORIZED_TEST_CLIENT.database.users.create(TEST_USER)
+      ADMIN_AUTHORIZED_TEST_CLIENT.database.users.create(SpecConfig.instance.test_user)
     rescue Exception => e
     end
   end

--- a/spec/spec_tests/max_staleness_spec.rb
+++ b/spec/spec_tests/max_staleness_spec.rb
@@ -24,9 +24,9 @@ describe 'Max Staleness Spec' do
 
       let(:options) do
         if spec.heartbeat_frequency
-          TEST_OPTIONS.merge(heartbeat_frequency: spec.heartbeat_frequency)
+          SpecConfig.instance.test_options.merge(heartbeat_frequency: spec.heartbeat_frequency)
         else
-          TEST_OPTIONS.dup.tap do |opts|
+          SpecConfig.instance.test_options.dup.tap do |opts|
             opts.delete(:heartbeat_frequency)
           end
         end.merge!(server_selection_timeout: 0.2, connect_timeout: 0.1)

--- a/spec/spec_tests/server_selection_rtt_spec.rb
+++ b/spec/spec_tests/server_selection_rtt_spec.rb
@@ -69,7 +69,7 @@ describe 'Server Selection moving average round trip time calculation' do
 
       let(:monitor) do
         Mongo::Server::Monitor.new(address, Mongo::Event::Listeners.new,
-                                   TEST_OPTIONS.merge(avg_rtt_ms: spec.avg_rtt_ms))
+                                   SpecConfig.instance.test_options.merge(avg_rtt_ms: spec.avg_rtt_ms))
       end
 
       before do

--- a/spec/spec_tests/server_selection_spec.rb
+++ b/spec/spec_tests/server_selection_spec.rb
@@ -37,7 +37,7 @@ describe 'Server Selection' do
       let(:candidate_servers) do
         spec.candidate_servers.collect do |server|
           address = Mongo::Address.new(server['address'])
-          Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS).tap do |s|
+          Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options).tap do |s|
             allow(s).to receive(:average_round_trip_time).and_return(server['avg_rtt_ms'] / 1000.0)
             allow(s).to receive(:tags).and_return(server['tags'])
             allow(s).to receive(:secondary?).and_return(server['type'] == 'RSSecondary')
@@ -51,7 +51,7 @@ describe 'Server Selection' do
       let(:in_latency_window) do
         spec.in_latency_window.collect do |server|
           address = Mongo::Address.new(server['address'])
-          Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS).tap do |s|
+          Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options).tap do |s|
             allow(s).to receive(:average_round_trip_time).and_return(server['avg_rtt_ms'] / 1000.0)
             allow(s).to receive(:tags).and_return(server['tags'])
             allow(s).to receive(:connectable?).and_return(true)

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -22,11 +22,6 @@ TEST_DB = 'ruby-driver'.freeze
 # @since 2.0.0
 TEST_COLL = 'test'.freeze
 
-# The write concern to use in the tests.
-#
-# @since 2.0.0
-WRITE_CONCERN = SpecConfig.instance.connect_replica_set? ? { w: 2 } : { w: 1 }
-
 # An invalid write concern.
 #
 # @since 2.4.2
@@ -37,7 +32,7 @@ INVALID_WRITE_CONCERN = { w: 4 }
 # @since 2.1.0
 BASE_OPTIONS = {
                   max_pool_size: 1,
-                  write: WRITE_CONCERN,
+                  write: SpecConfig.instance.write_concern,
                   heartbeat_frequency: 20,
                   max_read_retries: 5,
                   # The test suite seems to perform a number of operations

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -61,8 +61,8 @@ ADMIN_UNAUTHORIZED_CLIENT = ClientRegistry.instance.new_global_client(
 #
 # @since 2.0.0
 ADMIN_AUTHORIZED_TEST_CLIENT = ADMIN_UNAUTHORIZED_CLIENT.with(
-  user: ROOT_USER.name,
-  password: ROOT_USER.password,
+  user: SpecConfig.instance.root_user.name,
+  password: SpecConfig.instance.root_user.password,
   database: SpecConfig.instance.test_db,
   auth_source: SpecConfig.instance.auth_source || Mongo::Database::ADMIN,
   monitoring: false
@@ -93,7 +93,7 @@ module Authorization
     # Gets the root system administrator user.
     #
     # @since 2.0.0
-    context.let(:root_user) { ROOT_USER }
+    context.let(:root_user) { SpecConfig.instance.root_user }
 
     # Get the default test user for the suite.
     #

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -22,41 +22,6 @@ TEST_COLL = 'test'.freeze
 # @since 2.4.2
 INVALID_WRITE_CONCERN = { w: 4 }
 
-# Gets the root system administrator user.
-#
-# @since 2.0.0
-ROOT_USER = Mongo::Auth::User.new(
-  user: SpecConfig.instance.user || 'root-user',
-  password: SpecConfig.instance.password || 'password',
-  roles: [
-    Mongo::Auth::Roles::USER_ADMIN_ANY_DATABASE,
-    Mongo::Auth::Roles::DATABASE_ADMIN_ANY_DATABASE,
-    Mongo::Auth::Roles::READ_WRITE_ANY_DATABASE,
-    Mongo::Auth::Roles::HOST_MANAGER,
-    Mongo::Auth::Roles::CLUSTER_ADMIN
-  ]
-)
-
-# Get the default test user for the suite on versions 2.6 and higher.
-#
-# @since 2.0.0
-TEST_USER = Mongo::Auth::User.new(
-  database: SpecConfig.instance.test_db,
-  user: 'test-user',
-  password: 'password',
-  roles: [
-    { role: Mongo::Auth::Roles::READ_WRITE, db: SpecConfig.instance.test_db },
-    { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: SpecConfig.instance.test_db },
-    { role: Mongo::Auth::Roles::READ_WRITE, db: 'invalid_database' },
-    { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'invalid_database' },
-		{ role: Mongo::Auth::Roles::READ_WRITE, db: 'hr' },           # For transactions examples
-		{ role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'hr' },       # For transactions examples
-		{ role: Mongo::Auth::Roles::READ_WRITE, db: 'reporting' },    # For transactions examples
-		{ role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'reporting' } # For transactions examples
-
-  ]
-)
-
 # Provides an authorized mongo client on the default test database for the
 # default test user.
 #

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The default test database for all specs.
-#
-# @since 2.0.0
-TEST_DB = 'ruby-driver'.freeze
-
 # The default test collection.
 #
 # @since 2.0.0
@@ -46,12 +41,12 @@ ROOT_USER = Mongo::Auth::User.new(
 #
 # @since 2.0.0
 TEST_USER = Mongo::Auth::User.new(
-  database: TEST_DB,
+  database: SpecConfig.instance.test_db,
   user: 'test-user',
   password: 'password',
   roles: [
-    { role: Mongo::Auth::Roles::READ_WRITE, db: TEST_DB },
-    { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: TEST_DB },
+    { role: Mongo::Auth::Roles::READ_WRITE, db: SpecConfig.instance.test_db },
+    { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: SpecConfig.instance.test_db },
     { role: Mongo::Auth::Roles::READ_WRITE, db: 'invalid_database' },
     { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'invalid_database' },
 		{ role: Mongo::Auth::Roles::READ_WRITE, db: 'hr' },           # For transactions examples
@@ -69,7 +64,7 @@ TEST_USER = Mongo::Auth::User.new(
 AUTHORIZED_CLIENT = ClientRegistry.instance.new_global_client(
   SpecConfig.instance.addresses,
   SpecConfig.instance.test_options.merge(
-    database: TEST_DB,
+    database: SpecConfig.instance.test_db,
     user: TEST_USER.name,
     password: TEST_USER.password)
 )
@@ -84,7 +79,7 @@ AUTHROIZED_CLIENT_WITH_RETRY_WRITES = AUTHORIZED_CLIENT.with(retry_writes: true)
 # @since 2.0.0
 UNAUTHORIZED_CLIENT = ClientRegistry.instance.new_global_client(
   SpecConfig.instance.addresses,
-  SpecConfig.instance.test_options.merge(database: TEST_DB, monitoring: false)
+  SpecConfig.instance.test_options.merge(database: SpecConfig.instance.test_db, monitoring: false)
 )
 
 # Provides an unauthorized mongo client on the admin database, for use in
@@ -103,7 +98,7 @@ ADMIN_UNAUTHORIZED_CLIENT = ClientRegistry.instance.new_global_client(
 ADMIN_AUTHORIZED_TEST_CLIENT = ADMIN_UNAUTHORIZED_CLIENT.with(
   user: ROOT_USER.name,
   password: ROOT_USER.password,
-  database: TEST_DB,
+  database: SpecConfig.instance.test_db,
   auth_source: SpecConfig.instance.auth_source || Mongo::Database::ADMIN,
   monitoring: false
 )
@@ -114,7 +109,7 @@ ADMIN_AUTHORIZED_TEST_CLIENT = ADMIN_UNAUTHORIZED_CLIENT.with(
 SUBSCRIBED_CLIENT = ClientRegistry.instance.new_global_client(
     SpecConfig.instance.addresses,
     SpecConfig.instance.test_options.merge(
-      database: TEST_DB,
+      database: SpecConfig.instance.test_db,
       user: TEST_USER.name,
       password: TEST_USER.password)
 )
@@ -152,7 +147,7 @@ module Authorization
       new_local_client(
         SpecConfig.instance.addresses,
         SpecConfig.instance.test_options.merge(
-          database: TEST_DB,
+          database: SpecConfig.instance.test_db,
           user: TEST_USER.name,
           password: TEST_USER.password,
           heartbeat_frequency: 10,

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -30,8 +30,8 @@ AUTHORIZED_CLIENT = ClientRegistry.instance.new_global_client(
   SpecConfig.instance.addresses,
   SpecConfig.instance.test_options.merge(
     database: SpecConfig.instance.test_db,
-    user: TEST_USER.name,
-    password: TEST_USER.password)
+    user: SpecConfig.instance.test_user.name,
+    password: SpecConfig.instance.test_user.password)
 )
 
 # Provides an authorized mongo client that retries writes.
@@ -75,8 +75,8 @@ SUBSCRIBED_CLIENT = ClientRegistry.instance.new_global_client(
     SpecConfig.instance.addresses,
     SpecConfig.instance.test_options.merge(
       database: SpecConfig.instance.test_db,
-      user: TEST_USER.name,
-      password: TEST_USER.password)
+      user: SpecConfig.instance.test_user.name,
+      password: SpecConfig.instance.test_user.password)
 )
 SUBSCRIBED_CLIENT.subscribe(Mongo::Monitoring::COMMAND, EventSubscriber)
 AUTHROIZED_CLIENT_WITH_RETRY_WRITES.subscribe(Mongo::Monitoring::COMMAND, EventSubscriber)
@@ -98,7 +98,7 @@ module Authorization
     # Get the default test user for the suite.
     #
     # @since 2.0.0
-    context.let(:test_user) { TEST_USER }
+    context.let(:test_user) { SpecConfig.instance.test_user }
 
     # Provides an authorized mongo client on the default test database for the
     # default test user.
@@ -113,8 +113,8 @@ module Authorization
         SpecConfig.instance.addresses,
         SpecConfig.instance.test_options.merge(
           database: SpecConfig.instance.test_db,
-          user: TEST_USER.name,
-          password: TEST_USER.password,
+          user: SpecConfig.instance.test_user.name,
+          password: SpecConfig.instance.test_user.password,
           heartbeat_frequency: 10,
         ),
       )

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -37,16 +37,6 @@ INVALID_WRITE_CONCERN = { w: 4 }
 # @since 2.5.0
 COMPRESSORS = ENV['COMPRESSORS'] ? { compressors: ENV['COMPRESSORS'].split(',') } : {}
 
-# SSL options.
-#
-# @since 2.1.0
-SSL_OPTIONS = {
-                  ssl: SpecConfig.instance.ssl?,
-                  ssl_verify: false,
-                  ssl_cert:  CLIENT_CERT_PEM,
-                  ssl_key:  CLIENT_KEY_PEM
-                }
-
 # Base test options.
 #
 # @since 2.1.0
@@ -70,7 +60,8 @@ BASE_OPTIONS = {
 # Options for test suite clients.
 #
 # @since 2.0.3
-TEST_OPTIONS = BASE_OPTIONS.merge(SpecConfig.instance.connect).merge(SSL_OPTIONS).merge(COMPRESSORS)
+TEST_OPTIONS = BASE_OPTIONS.merge(SpecConfig.instance.connect).
+  merge(SpecConfig.instance.ssl_options).merge(COMPRESSORS)
 
 # Gets the root system administrator user.
 #

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -32,11 +32,6 @@ WRITE_CONCERN = SpecConfig.instance.connect_replica_set? ? { w: 2 } : { w: 1 }
 # @since 2.4.2
 INVALID_WRITE_CONCERN = { w: 4 }
 
-# What compressor to use, if any.
-#
-# @since 2.5.0
-COMPRESSORS = ENV['COMPRESSORS'] ? { compressors: ENV['COMPRESSORS'].split(',') } : {}
-
 # Base test options.
 #
 # @since 2.1.0
@@ -61,7 +56,7 @@ BASE_OPTIONS = {
 #
 # @since 2.0.3
 TEST_OPTIONS = BASE_OPTIONS.merge(SpecConfig.instance.connect).
-  merge(SpecConfig.instance.ssl_options).merge(COMPRESSORS)
+  merge(SpecConfig.instance.ssl_options).merge(SpecConfig.instance.compressor_options)
 
 # Gets the root system administrator user.
 #

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -27,32 +27,6 @@ TEST_COLL = 'test'.freeze
 # @since 2.4.2
 INVALID_WRITE_CONCERN = { w: 4 }
 
-# Base test options.
-#
-# @since 2.1.0
-BASE_OPTIONS = {
-                  max_pool_size: 1,
-                  write: SpecConfig.instance.write_concern,
-                  heartbeat_frequency: 20,
-                  max_read_retries: 5,
-                  # The test suite seems to perform a number of operations
-                  # requiring server selection. Hence a timeout of 1 here,
-                  # together with e.g. a misconfigured replica set,
-                  # means the test suite hangs for about 4 seconds before
-                  # failing.
-                  # Server selection timeout of 1 is insufficient for evergreen.
-                  server_selection_timeout: 2,
-                  wait_queue_timeout: 2,
-                  connect_timeout: 3,
-                  max_idle_time: 5
-               }
-
-# Options for test suite clients.
-#
-# @since 2.0.3
-TEST_OPTIONS = BASE_OPTIONS.merge(SpecConfig.instance.connect).
-  merge(SpecConfig.instance.ssl_options).merge(SpecConfig.instance.compressor_options)
-
 # Gets the root system administrator user.
 #
 # @since 2.0.0

--- a/spec/support/authorization.rb
+++ b/spec/support/authorization.rb
@@ -68,7 +68,7 @@ TEST_USER = Mongo::Auth::User.new(
 # @since 2.0.0
 AUTHORIZED_CLIENT = ClientRegistry.instance.new_global_client(
   SpecConfig.instance.addresses,
-  TEST_OPTIONS.merge(
+  SpecConfig.instance.test_options.merge(
     database: TEST_DB,
     user: TEST_USER.name,
     password: TEST_USER.password)
@@ -84,7 +84,7 @@ AUTHROIZED_CLIENT_WITH_RETRY_WRITES = AUTHORIZED_CLIENT.with(retry_writes: true)
 # @since 2.0.0
 UNAUTHORIZED_CLIENT = ClientRegistry.instance.new_global_client(
   SpecConfig.instance.addresses,
-  TEST_OPTIONS.merge(database: TEST_DB, monitoring: false)
+  SpecConfig.instance.test_options.merge(database: TEST_DB, monitoring: false)
 )
 
 # Provides an unauthorized mongo client on the admin database, for use in
@@ -93,7 +93,7 @@ UNAUTHORIZED_CLIENT = ClientRegistry.instance.new_global_client(
 # @since 2.0.0
 ADMIN_UNAUTHORIZED_CLIENT = ClientRegistry.instance.new_global_client(
   SpecConfig.instance.addresses,
-  TEST_OPTIONS.merge(database: Mongo::Database::ADMIN, monitoring: false)
+  SpecConfig.instance.test_options.merge(database: Mongo::Database::ADMIN, monitoring: false)
 )
 
 # Get an authorized client on the test database logged in as the admin
@@ -113,7 +113,7 @@ ADMIN_AUTHORIZED_TEST_CLIENT = ADMIN_UNAUTHORIZED_CLIENT.with(
 # @since 2.5.1
 SUBSCRIBED_CLIENT = ClientRegistry.instance.new_global_client(
     SpecConfig.instance.addresses,
-    TEST_OPTIONS.merge(
+    SpecConfig.instance.test_options.merge(
       database: TEST_DB,
       user: TEST_USER.name,
       password: TEST_USER.password)
@@ -151,7 +151,7 @@ module Authorization
     context.let(:another_authorized_client) do
       new_local_client(
         SpecConfig.instance.addresses,
-        TEST_OPTIONS.merge(
+        SpecConfig.instance.test_options.merge(
           database: TEST_DB,
           user: TEST_USER.name,
           password: TEST_USER.password,

--- a/spec/support/shared/server_selector.rb
+++ b/spec/support/shared/server_selector.rb
@@ -17,7 +17,7 @@ def make_server(mode, options = {})
   cluster = double('cluster')
   allow(cluster).to receive(:topology).and_return(topology)
   allow(cluster).to receive(:app_metadata)
-  server = Mongo::Server.new(address, cluster, monitoring, listeners, TEST_OPTIONS)
+  server = Mongo::Server.new(address, cluster, monitoring, listeners, SpecConfig.instance.test_options)
   description = Mongo::Server::Description.new(address, ismaster, average_round_trip_time)
   server.tap do |s|
     allow(s).to receive(:description).and_return(description)

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -9,13 +9,13 @@ class SpecConfig
       @uri_options = Mongo::Options::Mapper.transform_keys_to_symbols(@mongodb_uri.uri_options)
       if @uri_options[:replica_set]
         @addresses = @mongodb_uri.servers
-        @connect = { connect: :replica_set, replica_set: @uri_options[:replica_set] }
+        @connect_options = { connect: :replica_set, replica_set: @uri_options[:replica_set] }
       elsif ENV['TOPOLOGY'] == 'sharded_cluster'
         @addresses = [ @mongodb_uri.servers.first ] # See SERVER-16836 for why we can only use one host:port
-        @connect = { connect: :sharded }
+        @connect_options = { connect: :sharded }
       else
         @addresses = @mongodb_uri.servers
-        @connect = { connect: :direct }
+        @connect_options = { connect: :direct }
       end
       if @uri_options[:ssl].nil?
         @ssl = (ENV['SSL'] == 'ssl') || (ENV['SSL_ENABLED'] == 'true')
@@ -25,11 +25,11 @@ class SpecConfig
     else
       @addresses = ENV['MONGODB_ADDRESSES'] ? ENV['MONGODB_ADDRESSES'].split(',').freeze : [ '127.0.0.1:27017' ].freeze
       if ENV['RS_ENABLED']
-        @connect = { connect: :replica_set, replica_set: ENV['RS_NAME'] }
+        @connect_options = { connect: :replica_set, replica_set: ENV['RS_NAME'] }
       elsif ENV['SHARDED_ENABLED']
-        @connect = { connect: :sharded }
+        @connect_options = { connect: :sharded }
       else
-        @connect = { connect: :direct }
+        @connect_options = { connect: :direct }
       end
     end
   end
@@ -50,7 +50,7 @@ class SpecConfig
     %w(1 true yes).include?((ENV['CLIENT_DEBUG'] || '').downcase)
   end
 
-  attr_reader :uri_options, :addresses, :connect
+  attr_reader :uri_options, :addresses, :connect_options
 
   def user
     @mongodb_uri && @mongodb_uri.credentials[:user]
@@ -65,7 +65,7 @@ class SpecConfig
   end
 
   def connect_replica_set?
-    connect[:connect] == :replica_set
+    connect_options[:connect] == :replica_set
   end
 
   # The write concern to use in the tests.
@@ -141,6 +141,32 @@ class SpecConfig
     else
       {}
     end
+  end
+
+  # Base test options.
+  def base_test_options
+    {
+      max_pool_size: 1,
+      write: write_concern,
+      heartbeat_frequency: 20,
+      max_read_retries: 5,
+      # The test suite seems to perform a number of operations
+      # requiring server selection. Hence a timeout of 1 here,
+      # together with e.g. a misconfigured replica set,
+      # means the test suite hangs for about 4 seconds before
+      # failing.
+      # Server selection timeout of 1 is insufficient for evergreen.
+      server_selection_timeout: 2,
+      wait_queue_timeout: 2,
+      connect_timeout: 3,
+      max_idle_time: 5
+   }
+  end
+
+  # Options for test suite clients.
+  def test_options
+    base_test_options.merge(connect_options).
+      merge(ssl_options).merge(compressor_options)
   end
 
   def ci?

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -68,6 +68,15 @@ class SpecConfig
     connect[:connect] == :replica_set
   end
 
+  # The write concern to use in the tests.
+  def write_concern
+    if connect_replica_set?
+      {w: 2}
+    else
+      {w: 1}
+    end
+  end
+
   def any_port
     addresses.first.split(':')[1] || '27017'
   end

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -169,6 +169,11 @@ class SpecConfig
       merge(ssl_options).merge(compressor_options)
   end
 
+  # The default test database for all specs.
+  def test_db
+    'ruby-driver'.freeze
+  end
+
   def ci?
     !!ENV['CI']
   end

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -174,6 +174,41 @@ class SpecConfig
     'ruby-driver'.freeze
   end
 
+  # Gets the root system administrator user.
+  def root_user
+    Mongo::Auth::User.new(
+      user: user || 'root-user',
+      password: password || 'password',
+      roles: [
+        Mongo::Auth::Roles::USER_ADMIN_ANY_DATABASE,
+        Mongo::Auth::Roles::DATABASE_ADMIN_ANY_DATABASE,
+        Mongo::Auth::Roles::READ_WRITE_ANY_DATABASE,
+        Mongo::Auth::Roles::HOST_MANAGER,
+        Mongo::Auth::Roles::CLUSTER_ADMIN
+      ]
+    )
+  end
+
+  # Get the default test user for the suite on versions 2.6 and higher.
+  def test_user
+    Mongo::Auth::User.new(
+      database: test_db,
+      user: 'test-user',
+      password: 'password',
+      roles: [
+        { role: Mongo::Auth::Roles::READ_WRITE, db: test_db },
+        { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: test_db },
+        { role: Mongo::Auth::Roles::READ_WRITE, db: 'invalid_database' },
+        { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'invalid_database' },
+                    { role: Mongo::Auth::Roles::READ_WRITE, db: 'hr' },           # For transactions examples
+                    { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'hr' },       # For transactions examples
+                    { role: Mongo::Auth::Roles::READ_WRITE, db: 'reporting' },    # For transactions examples
+                    { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'reporting' } # For transactions examples
+
+      ]
+    )
+  end
+
   def ci?
     !!ENV['CI']
   end

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -117,6 +117,23 @@ class SpecConfig
     end
   end
 
+  # What compressor to use, if any.
+  def compressors
+    if ENV['COMPRESSORS']
+      ENV['COMPRESSORS'].split(',')
+    else
+      nil
+    end
+  end
+
+  def compressor_options
+    if compressors
+      {compressors: compressors}
+    else
+      {}
+    end
+  end
+
   def ci?
     !!ENV['CI']
   end

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -72,8 +72,49 @@ class SpecConfig
     addresses.first.split(':')[1] || '27017'
   end
 
+  def drivers_tools?
+    !!ENV['DRIVERS_TOOLS']
+  end
+
   def ssl?
     @ssl
+  end
+
+  def spec_root
+    File.join(File.dirname(__FILE__), '..')
+  end
+
+  def ssl_certs_dir
+    "#{spec_root}/support/certificates"
+  end
+
+  def client_cert_pem
+    if drivers_tools?
+      ENV['DRIVER_TOOLS_CLIENT_CERT_PEM']
+    else
+      "#{ssl_certs_dir}/client_cert.pem"
+    end
+  end
+
+  def client_key_pem
+    if drivers_tools?
+      ENV['DRIVER_TOOLS_CLIENT_KEY_PEM']
+    else
+      "#{ssl_certs_dir}/client_key.pem"
+    end
+  end
+
+  def ssl_options
+    if ssl?
+      {
+        ssl: true,
+        ssl_verify: false,
+        ssl_cert:  client_cert_pem,
+        ssl_key:  client_key_pem,
+      }
+    else
+      {}
+    end
   end
 
   def ci?


### PR DESCRIPTION
This moves some of the global constants into spec config, for use in the task that will create test users (https://jira.mongodb.org/browse/RUBY-1461).