### PR TITLE
Always check for a null session.

### DIFF
--- a/lib/mongo/operation/aggregate/op_msg.rb
+++ b/lib/mongo/operation/aggregate/op_msg.rb
@@ -42,7 +42,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/create/op_msg.rb
+++ b/lib/mongo/operation/create/op_msg.rb
@@ -31,7 +31,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/create_index/op_msg.rb
+++ b/lib/mongo/operation/create_index/op_msg.rb
@@ -31,7 +31,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/create_user/op_msg.rb
+++ b/lib/mongo/operation/create_user/op_msg.rb
@@ -31,7 +31,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/delete/op_msg.rb
+++ b/lib/mongo/operation/delete/op_msg.rb
@@ -41,7 +41,7 @@ module Mongo
           result = Result.new(dispatch_message(server))
           process_result(result, server)
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/distinct/op_msg.rb
+++ b/lib/mongo/operation/distinct/op_msg.rb
@@ -32,7 +32,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/drop/op_msg.rb
+++ b/lib/mongo/operation/drop/op_msg.rb
@@ -31,7 +31,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/drop_database/op_msg.rb
+++ b/lib/mongo/operation/drop_database/op_msg.rb
@@ -31,7 +31,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/drop_index/op_msg.rb
+++ b/lib/mongo/operation/drop_index/op_msg.rb
@@ -31,7 +31,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/explain/op_msg.rb
+++ b/lib/mongo/operation/explain/op_msg.rb
@@ -42,7 +42,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/find/op_msg.rb
+++ b/lib/mongo/operation/find/op_msg.rb
@@ -47,7 +47,7 @@ module Mongo
           process_result(result, server)
           result.validate!
          rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/get_more/op_msg.rb
+++ b/lib/mongo/operation/get_more/op_msg.rb
@@ -46,7 +46,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/indexes/op_msg.rb
+++ b/lib/mongo/operation/indexes/op_msg.rb
@@ -42,7 +42,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/insert/op_msg.rb
+++ b/lib/mongo/operation/insert/op_msg.rb
@@ -42,7 +42,7 @@ module Mongo
           result = Result.new(dispatch_message(server), @ids)
           process_result(result, server)
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/kill_cursors/op_msg.rb
+++ b/lib/mongo/operation/kill_cursors/op_msg.rb
@@ -31,7 +31,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/list_collections/op_msg.rb
+++ b/lib/mongo/operation/list_collections/op_msg.rb
@@ -41,7 +41,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/map_reduce/op_msg.rb
+++ b/lib/mongo/operation/map_reduce/op_msg.rb
@@ -42,7 +42,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/parallel_scan/op_msg.rb
+++ b/lib/mongo/operation/parallel_scan/op_msg.rb
@@ -42,7 +42,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/remove_user/op_msg.rb
+++ b/lib/mongo/operation/remove_user/op_msg.rb
@@ -31,7 +31,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/update/op_msg.rb
+++ b/lib/mongo/operation/update/op_msg.rb
@@ -41,7 +41,7 @@ module Mongo
           result = Result.new(dispatch_message(server))
           process_result(result, server)
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/update_user/op_msg.rb
+++ b/lib/mongo/operation/update_user/op_msg.rb
@@ -31,7 +31,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/operation/users_info/op_msg.rb
+++ b/lib/mongo/operation/users_info/op_msg.rb
@@ -41,7 +41,7 @@ module Mongo
           process_result(result, server)
           result.validate!
         rescue Mongo::Error::SocketError => e
-          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session.in_transaction?
+          e.send(:add_label, Mongo::Error::TRANSIENT_TRANSACTION_ERROR_LABEL) if session && session.in_transaction?
           raise e
         end
 

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -116,10 +116,10 @@ module Mongo
         txn_num = session.in_transaction? ? session.txn_num : session.next_txn_num
         yield(server, txn_num)
       rescue Error::SocketError, Error::SocketTimeoutError => e
-        raise e if session.in_transaction? && !ending_transaction
+        raise e if session && session.in_transaction? && !ending_transaction
         retry_write(e, txn_num, &block)
       rescue Error::OperationFailure => e
-        raise e if (session.in_transaction? && !ending_transaction) || !e.write_retryable?
+        raise e if (session && session.in_transaction? && !ending_transaction) || !e.write_retryable?
         retry_write(e, txn_num, &block)
       end
     end


### PR DESCRIPTION
While upgrading a server from MongoDB 3.4 to MongoDB 3.6, we got a few thousand application errors for `undefined method `in_transaction?' for nil:NilClass` which persisted until application restart.

The labeling needs to be more defensive that a session could be null.

![image](https://user-images.githubusercontent.com/832655/46214984-49cc1180-c30a-11e8-9a6c-b9f2db1da1bd.png)
