### PR TITLE
Remove dead code

### DIFF
--- a/lib/mongo/auth.rb
+++ b/lib/mongo/auth.rb
@@ -67,12 +67,7 @@ module Mongo
     def get(user)
       mechanism = user.mechanism
       raise InvalidMechanism.new(mechanism) if !SOURCES.has_key?(mechanism)
-      case SOURCES[mechanism]
-      when SCRAM
-        SOURCES[mechanism].new(user, mechanism)
-      else
-        SOURCES[mechanism].new(user)
-      end
+      SOURCES[mechanism].new(user)
     end
 
     # Raised when trying to get an invalid authorization mechanism.


### PR DESCRIPTION
All mechanisms take a single argument which is the user, hence the
special case for SCRAM does not work. But, it appears that that
code is never run anyways.