### PR TITLE
RUBY-1222 Use IP address for creating sockets and stop caching hostna…

### DIFF
--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -136,6 +136,12 @@ module Mongo
 
     # Get a socket for the provided address, given the options.
     #
+    # The address the socket connects to is determined by the algorithm described in the
+    # #intialize_resolver! documentation. Each time this method is called, #initialize_resolver!
+    # will be called, meaning that a new hostname lookup will occur. This is done so that any
+    # changes to which addresses the hostname resolves to will be picked up even if a socket has
+    # been connected to it before.
+    #
     # @example Get a socket.
     #   address.socket(5, :ssl => true)
     #
@@ -186,6 +192,10 @@ module Mongo
       @connect_timeout ||= @options[:connect_timeout] || Server::CONNECT_TIMEOUT
     end
 
+    # To determine which address the socket will connect to, the driver will attempt to connect to
+    # each IP address returned by Socket::getaddrinfo in sequence. Once a successful connection is
+    # made, a resolver with that IP address specified is returned. If no successful connection is
+    # made, the error made by the last connection attempt is raised.
     def initialize_resolver!(ssl_options)
       return Unix.new(seed.downcase) if seed.downcase =~ Unix::MATCH
 

--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -146,7 +146,7 @@ module Mongo
     #
     # @since 2.0.0
     def socket(socket_timeout, ssl_options = {})
-      @resolver ||= initialize_resolver!(ssl_options)
+      @resolver = initialize_resolver!(ssl_options)
       @resolver.socket(socket_timeout, ssl_options)
     end
 
@@ -193,8 +193,7 @@ module Mongo
       error = nil
       ::Socket.getaddrinfo(host, nil, family, ::Socket::SOCK_STREAM).each do |info|
         begin
-          _host = (host == LOCALHOST) ? info[3] : host
-          res = FAMILY_MAP[info[4]].new(_host, port, host)
+          res = FAMILY_MAP[info[4]].new(info[3], port, host)
           res.socket(connect_timeout, ssl_options).connect!(connect_timeout).close
           return res
         rescue IOError, SystemCallError, Error::SocketTimeoutError, Error::SocketError => e

--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -152,8 +152,7 @@ module Mongo
     #
     # @since 2.0.0
     def socket(socket_timeout, ssl_options = {})
-      @resolver = create_resolver(ssl_options)
-      @resolver.socket(socket_timeout, ssl_options)
+      create_resolver(ssl_options).socket(socket_timeout, ssl_options)
     end
 
     # Get the address as a string.

--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -152,7 +152,7 @@ module Mongo
     #
     # @since 2.0.0
     def socket(socket_timeout, ssl_options = {})
-      @resolver = initialize_resolver!(ssl_options)
+      @resolver = create_resolver(ssl_options)
       @resolver.socket(socket_timeout, ssl_options)
     end
 
@@ -196,7 +196,7 @@ module Mongo
     # each IP address returned by Socket::getaddrinfo in sequence. Once a successful connection is
     # made, a resolver with that IP address specified is returned. If no successful connection is
     # made, the error made by the last connection attempt is raised.
-    def initialize_resolver!(ssl_options)
+    def create_resolver(ssl_options)
       return Unix.new(seed.downcase) if seed.downcase =~ Unix::MATCH
 
       family = (host == LOCALHOST) ? ::Socket::AF_INET : ::Socket::AF_UNSPEC

--- a/spec/mongo/address_spec.rb
+++ b/spec/mongo/address_spec.rb
@@ -225,15 +225,27 @@ describe Mongo::Address do
 
     context 'when providing a DNS entry that resolves to both IPv6 and IPv4' do
 
+      let(:custom_hostname) do
+        'not_localhost'
+      end
+
+      let(:ip) do
+        '127.0.0.1'
+      end
+
+      let(:address) do
+        Mongo::Address.new(custom_hostname)
+      end
+
       before do
         allow(::Socket).to receive(:getaddrinfo).and_return(
           [ ["AF_INET6", 0, '::1', '::1', ::Socket::AF_INET6, 1, 6],
-            ["AF_INET", 0, socket_address_or_host, socket_address_or_host, ::Socket::AF_INET, 1, 6]]
+            ["AF_INET", 0, custom_hostname, ip, ::Socket::AF_INET, 1, 6]]
         )
       end
 
       it "attempts to use IPv6 and fallbacks to IPv4" do
-        expect(address.socket(0.0)).not_to be_nil
+        expect(address.socket(0.0).host).to eq(ip)
       end
     end
 

--- a/spec/mongo/address_spec.rb
+++ b/spec/mongo/address_spec.rb
@@ -226,7 +226,6 @@ describe Mongo::Address do
     context 'when providing a DNS entry that resolves to both IPv6 and IPv4' do
 
       before do
-        address.instance_variable_set(:@resolver, nil)
         allow(::Socket).to receive(:getaddrinfo).and_return(
           [ ["AF_INET6", 0, '::1', '::1', ::Socket::AF_INET6, 1, 6],
             ["AF_INET", 0, socket_address_or_host, socket_address_or_host, ::Socket::AF_INET, 1, 6]]
@@ -241,7 +240,6 @@ describe Mongo::Address do
     context 'when creating a socket using the resolver' do
 
       before do
-        address.instance_variable_set(:@resolver, nil)
         address.send(:create_resolver, SpecConfig.instance.ssl_options)
       end
 

--- a/spec/mongo/address_spec.rb
+++ b/spec/mongo/address_spec.rb
@@ -242,7 +242,7 @@ describe Mongo::Address do
 
       before do
         address.instance_variable_set(:@resolver, nil)
-        address.send(:initialize_resolver!, SpecConfig.instance.ssl_options)
+        address.send(:create_resolver, SpecConfig.instance.ssl_options)
       end
 
       it 'uses the host, not the IP address' do

--- a/spec/mongo/address_spec.rb
+++ b/spec/mongo/address_spec.rb
@@ -239,7 +239,7 @@ describe Mongo::Address do
 
       before do
         allow(::Socket).to receive(:getaddrinfo).and_return(
-          [ ["AF_INET6", 0, '::1', '::1', ::Socket::AF_INET6, 1, 6],
+          [ ["AF_INET6", 0, '::2', '::2', ::Socket::AF_INET6, 1, 6],
             ["AF_INET", 0, custom_hostname, ip, ::Socket::AF_INET, 1, 6]]
         )
       end

--- a/spec/mongo/socket/ssl_spec.rb
+++ b/spec/mongo/socket/ssl_spec.rb
@@ -8,7 +8,7 @@ describe Mongo::Socket::SSL do
   end
 
   let(:resolver) do
-    address.send(:create_resolver)
+    address.send(:create_resolver, {})
   end
 
   let(:socket_timeout) do

--- a/spec/mongo/socket/ssl_spec.rb
+++ b/spec/mongo/socket/ssl_spec.rb
@@ -8,7 +8,7 @@ describe Mongo::Socket::SSL do
   end
 
   let(:resolver) do
-    address.instance_variable_get(:@resolver)
+    address.send(:create_resolver)
   end
 
   let(:socket_timeout) do

--- a/spec/spec_tests/connection_string_spec.rb
+++ b/spec/spec_tests/connection_string_spec.rb
@@ -16,8 +16,8 @@ describe 'ConnectionString' do
 
             private
 
-            alias :original_initialize_resolver! :initialize_resolver!
-            def initialize_resolver!(timeout, ssl_options)
+            alias :original_create_resolver :create_resolver
+            def create_resolver(timeout, ssl_options)
               family = (host == 'localhost') ? ::Socket::AF_INET : ::Socket::AF_UNSPEC
               info = ::Socket.getaddrinfo(host, nil, family, ::Socket::SOCK_STREAM)
               FAMILY_MAP[info.first[4]].new(info[3], port, host)
@@ -51,8 +51,8 @@ describe 'ConnectionString' do
           # Return the implementations to their originals for the other
           # tests in the suite.
           class Address
-            alias :initialize_resolver! :original_initialize_resolver!
-            remove_method(:original_initialize_resolver!)
+            alias :initialize_resolver! :original_create_resolver
+            remove_method(:original_create_resolver)
           end
 
           class Server

--- a/spec/spec_tests/connection_string_spec.rb
+++ b/spec/spec_tests/connection_string_spec.rb
@@ -51,7 +51,7 @@ describe 'ConnectionString' do
           # Return the implementations to their originals for the other
           # tests in the suite.
           class Address
-            alias :initialize_resolver! :original_create_resolver
+            alias :create_resolver :original_create_resolver
             remove_method(:original_create_resolver)
           end
 


### PR DESCRIPTION
…me resolution

This pull request fixes two bugs in the hostname resolution/socket creation functionality of the driver. The first is that sockets are incorrectly being created with the hostname rather than the IP address that was obtained with `getaddrinfo`. This breaks the ability to fallback to IPv4 in the case that connecting to the IPv6 address fails. The second bug is the caching of the resolver in the address; doing a DNS lookup each time a socket is created ensures that the driver will detect any changes to where the hostname resolves to without requiring the Client to be recreated.