### PR TITLE
minor: fix catching of all errors for pry import

### DIFF
--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -40,7 +40,7 @@ rescue LoadError
     require 'pry'
   # jruby likes to raise random error classes, in this case
   # NameError in addition to LoadError
-  rescue
+  rescue Exception
   end
 end
 


### PR DESCRIPTION
The Travis job testing against server version 2.6 has been failing recently due to the failed import of `pry` not properly being caught. Simply adding `Exception` as the type of error to catch rather than leaving it blank fixes this.