### PR TITLE
Memoize a variable that could change by a separate thread.

### DIFF
--- a/lib/mongo/session/session_pool.rb
+++ b/lib/mongo/session/session_pool.rb
@@ -123,9 +123,11 @@ module Mongo
       private
 
       def about_to_expire?(session)
-        if @cluster.logical_session_timeout
+        logical_session_timeout = @cluster.logical_session_timeout
+
+        if logical_session_timeout
           idle_time_minutes = (Time.now - session.last_use) / 60
-          (idle_time_minutes + 1) >= @cluster.logical_session_timeout
+          (idle_time_minutes + 1) >= logical_session_timeout
         end
       end
 


### PR DESCRIPTION
I assume that what happened here was that `@cluster.logical_session_timeout` changed in the middle of the execution, since it comes from an isMaster command. I believe we had a server failure at or around this time.

![image](https://user-images.githubusercontent.com/832655/46838198-cdabe200-cd7d-11e8-9fdf-96038533bacd.png)
