### PR TITLE
Require that cluster time is updated

### DIFF
--- a/spec/mongo/auth/cr_spec.rb
+++ b/spec/mongo/auth/cr_spec.rb
@@ -20,7 +20,7 @@ describe Mongo::Auth::CR do
       allow(cl).to receive(:app_metadata).and_return(app_metadata)
       allow(cl).to receive(:options).and_return({})
       allow(cl).to receive(:cluster_time).and_return(nil)
-      allow(cl).to receive(:update_cluster_time)
+      expect(cl).to receive(:update_cluster_time)
     end
   end
 

--- a/spec/mongo/auth/ldap_spec.rb
+++ b/spec/mongo/auth/ldap_spec.rb
@@ -20,7 +20,7 @@ describe Mongo::Auth::LDAP do
       allow(cl).to receive(:app_metadata).and_return(app_metadata)
       allow(cl).to receive(:options).and_return({})
       allow(cl).to receive(:cluster_time).and_return(nil)
-      allow(cl).to receive(:update_cluster_time)
+      expect(cl).to receive(:update_cluster_time)
     end
   end
 

--- a/spec/mongo/auth/scram_spec.rb
+++ b/spec/mongo/auth/scram_spec.rb
@@ -20,7 +20,7 @@ describe Mongo::Auth::SCRAM do
       allow(cl).to receive(:app_metadata).and_return(app_metadata)
       allow(cl).to receive(:options).and_return({})
       allow(cl).to receive(:cluster_time).and_return(nil)
-      allow(cl).to receive(:update_cluster_time)
+      expect(cl).to receive(:update_cluster_time).at_least(:once)
     end
   end
 

--- a/spec/mongo/auth/x509_spec.rb
+++ b/spec/mongo/auth/x509_spec.rb
@@ -20,7 +20,7 @@ describe Mongo::Auth::X509 do
       allow(cl).to receive(:app_metadata).and_return(app_metadata)
       allow(cl).to receive(:options).and_return({})
       allow(cl).to receive(:cluster_time).and_return(nil)
-      allow(cl).to receive(:update_cluster_time)
+      expect(cl).to receive(:update_cluster_time)
     end
   end
 

--- a/spec/mongo/server/connection_auth_spec.rb
+++ b/spec/mongo/server/connection_auth_spec.rb
@@ -24,7 +24,7 @@ describe Mongo::Server::Connection, retry: 3 do
       allow(cl).to receive(:app_metadata).and_return(app_metadata)
       allow(cl).to receive(:options).and_return({})
       allow(cl).to receive(:cluster_time).and_return(nil)
-      allow(cl).to receive(:update_cluster_time)
+      expect(cl).to receive(:update_cluster_time)
       pool = double('pool')
       allow(pool).to receive(:disconnect!)
       allow(cl).to receive(:pool).and_return(pool)

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -34,7 +34,7 @@ describe Mongo::Server::Connection, retry: 3 do
       allow(cl).to receive(:app_metadata).and_return(app_metadata)
       allow(cl).to receive(:options).and_return({})
       allow(cl).to receive(:cluster_time).and_return(nil)
-      allow(cl).to receive(:update_cluster_time)
+      expect(cl).to receive(:update_cluster_time)
       pool = double('pool')
       allow(pool).to receive(:disconnect!)
       allow(cl).to receive(:pool).and_return(pool)


### PR DESCRIPTION
Related to updating cluster time with kerberos, we can be enforcing that cluster time is updated for non-kerberos auth methods.