### PR TITLE
Omit monitoring io when creating clients for connection string spec t…

### DIFF
--- a/spec/support/connection_string.rb
+++ b/spec/support/connection_string.rb
@@ -152,7 +152,7 @@ module Mongo
       end
 
       def client
-        @client ||= Mongo::Client.new(@spec['uri'])
+        @client ||= Mongo::Client.new(@spec['uri'], monitoring_io: false)
       end
 
       def uri


### PR DESCRIPTION
…ests.

This speeds up the test suite by about 20 seconds.