### PR TITLE
RUBY-1559 Update URI option spec tests and fix comparisons

### DIFF
--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -181,13 +181,13 @@ URI Options Conversions
    * - tlsCAFile=String
      - ``:ssl_ca_cert => String``
 
-   * - tlsClientCertFile=String
+   * - tlsCertificateKeyFile=String
      - ``:ssl_cert => String``
 
    * - tlsClientKeyFile=String
      - ``:ssl_key => String``
 
-   * - tlsClientKeyPassword=String
+   * - tlsCertificateKeyFilePassword=String
      - ``:ssl_key_pass_phrase => String``
 
    * - tlsInsecure=Boolean

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -330,6 +330,7 @@ module Mongo
       @cluster = Cluster.new(addresses, @monitoring, cluster_options)
       # Unset monitoring, it will be taken out of cluster from now on
       remove_instance_variable('@monitoring')
+
       yield(self) if block_given?
     end
 

--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -445,8 +445,8 @@ module Mongo
     uri_option 'maxstalenessseconds', :max_staleness, :group => :read, :type => :max_staleness
 
     # Pool options
-    uri_option 'minpoolsize', :min_pool_size
-    uri_option 'maxpoolsize', :max_pool_size
+    uri_option 'minpoolsize', :min_pool_size, :type => :min_pool_size
+    uri_option 'maxpoolsize', :max_pool_size, :type => :max_pool_size
     uri_option 'waitqueuetimeoutms', :wait_queue_timeout, :type => :wait_queue_timeout
 
     # Security Options
@@ -643,6 +643,37 @@ module Mongo
       end
 
       log_warn("#{value} is not a valid zlibCompressionLevel")
+      nil
+    end
+
+    # Parses the max pool size.
+    #
+    # @param value [ String ] The max pool size string.
+    #
+    # @return [ Integer | nil ] The min pool size if it is valid, otherwise nil (and a warning will)
+    #   be logged.
+    def max_pool_size(value)
+      if /\A\d+\z/ =~ value
+        return value.to_i
+      end
+
+      log_warn("#{value} is not a valid maxPoolSize")
+      nil
+    end
+
+
+    # Parses the min pool size.
+    #
+    # @param value [ String ] The min pool size string.
+    #
+    # @return [ Integer | nil ] The min pool size if it is valid, otherwise nil (and a warning will)
+    #   be logged.
+    def min_pool_size(value)
+      if /\A\d+\z/ =~ value
+        return value.to_i
+      end
+
+      log_warn("#{value} is not a valid minPoolSize")
       nil
     end
 

--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -666,8 +666,8 @@ module Mongo
     #
     # @param value [ String ] The min pool size string.
     #
-    # @return [ Integer | nil ] The min pool size if it is valid, otherwise nil (and a warning will)
-    #   be logged.
+    # @return [ Integer | nil ] The min pool size if it is valid, otherwise nil (and a warning will
+    #   be logged).
     def min_pool_size(value)
       if /\A\d+\z/ =~ value
         return value.to_i

--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -455,8 +455,7 @@ module Mongo
     uri_option 'tlsallowinvalidcertificates', :ssl_verify, :type => :ssl_verify
     uri_option 'tlscafile', :ssl_ca_cert
     uri_option 'tlscertificatekeyfile', :ssl_cert
-    uri_option 'tlsclientkeyfile', :ssl_key
-    uri_option 'tlscertificatekeypassword', :ssl_key_pass_phrase
+    uri_option 'tlscertificatekeyfilepassword', :ssl_key_pass_phrase
     uri_option 'tlsinsecure', :ssl_verify, :type => :ssl_verify
 
     # Topology options
@@ -485,7 +484,7 @@ module Mongo
         true
       elsif value == 'false'
         false
-      elsif value =~ /[\d]/
+      elsif value =~ /\A[\d]\z/
         value.to_i
       else
         decode(value).to_sym

--- a/spec/spec_tests/data/uri_options/auth-options.yml
+++ b/spec/spec_tests/data/uri_options/auth-options.yml
@@ -1,14 +1,14 @@
 tests:
     -
         description: "Valid auth options are parsed correctly"
-        uri: "mongodb://example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external"
+        uri: "mongodb://foo:bar@example.com/?authMechanism=GSSAPI&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true&authSource=$external"
         valid: true
         warning: false
         hosts: ~
         auth: ~
         options:
-            authmechanism: "GSSAPI"
+            authMechanism: "GSSAPI"
             authMechanismProperties:
                 SERVICE_NAME: "other"
-                CANONICALIZE_HOST_NAME: "true"
+                CANONICALIZE_HOST_NAME: true
             authSource: "$external"

--- a/spec/spec_tests/data/uri_options/compression-options.yml
+++ b/spec/spec_tests/data/uri_options/compression-options.yml
@@ -7,16 +7,20 @@ tests:
         hosts: ~
         auth: ~
         options:
-            compressors: "zlib"
+            compressors: 
+              - "zlib"
             zlibCompressionLevel: 9
     -
-        description: "Invalid compressors cause a warning"
-        uri: "mongodb://example.com/?compressors=jpeg"
+        description: "Multiple compressors are parsed correctly"
+        uri: "mongodb://example.com/?compressors=snappy,zlib"
         valid: true
         warning: true
         hosts: ~
         auth: ~
-        options: {}
+        options:
+            compressors:
+              - "snappy"
+              - "zlib"
     -
         description: "Non-numeric zlibCompressionLevel causes a warning"
         uri: "mongodb://example.com/?compressors=zlib&zlibCompressionLevel=invalid"

--- a/spec/spec_tests/data/uri_options/connection-options.yml
+++ b/spec/spec_tests/data/uri_options/connection-options.yml
@@ -1,7 +1,7 @@
 tests:
     -
         description: "Valid connection and timeout options are parsed correctly"
-        uri: "mongodb://example.com/?appname=URI-OPTIONS-SPEC-TEST&connectTimeoutMS=20000&heartbeatFrequencyMS=5000&localThresholdMS=3000&replicaSet=uri-options-spec&retryWrites=true&serverSelectionTimeoutMS=15000&socketTimeoutMS=7500"
+        uri: "mongodb://example.com/?appname=URI-OPTIONS-SPEC-TEST&connectTimeoutMS=20000&heartbeatFrequencyMS=5000&localThresholdMS=3000&maxIdleTimeMS=50000&replicaSet=uri-options-spec&retryWrites=true&serverSelectionTimeoutMS=15000&socketTimeoutMS=7500"
         valid: true
         warning: false
         hosts: ~
@@ -103,3 +103,4 @@ tests:
         warning: true
         hosts: ~
         auth: ~
+        options: {}

--- a/spec/spec_tests/data/uri_options/read-preference-options.yml
+++ b/spec/spec_tests/data/uri_options/read-preference-options.yml
@@ -9,8 +9,11 @@ tests:
         options:
             readPreference: "primaryPreferred"
             readPreferenceTags:
-                - "dc:ny,rack"
-                - "dc:ny"
+                - 
+                    dc: "ny"
+                    rack: "1"
+                -
+                    dc: "ny"
             maxStalenessSeconds: 120
     -
         description: "Invalid readPreferenceTags causes a warning"

--- a/spec/spec_tests/data/uri_options/tls-options.yml
+++ b/spec/spec_tests/data/uri_options/tls-options.yml
@@ -1,7 +1,7 @@
 tests:
     -
         description: "Valid required tls options are parsed correctly"
-        uri: "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem&tlsCertificateKeyPassword=hunter2"
+        uri: "mongodb://example.com/?tls=true&tlsCAFile=ca.pem&tlsCertificateKeyFile=cert.pem&tlsCertificateKeyFilePassword=hunter2"
         valid: true
         warning: false
         hosts: ~
@@ -10,7 +10,7 @@ tests:
             tls: true
             tlsCAFile: "ca.pem"
             tlsCertificateKeyFile: "cert.pem"
-            tlsCertificateKeyPassword: "hunter2"
+            tlsCertificateKeyFilePassword: "hunter2"
     -  
         description: "Invalid tlsAllowInvalidCertificates causes a warning"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=invalid"
@@ -18,7 +18,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: ~
+        options: {}
     -
         description: "tlsAllowInvalidCertificates is parsed correctly"
         uri: "mongodb://example.com/?tlsAllowInvalidCertificates=true"
@@ -35,7 +35,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: ~
+        options: {}
     -
         description: "tlsAllowInvalidHostnames is parsed correctly"
         uri: "mongodb://example.com/?tlsAllowInvalidHostnames=true"
@@ -52,7 +52,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: ~
+        options: {}
     -
         description: "tlsInsecure is parsed correctly"
         uri: "mongodb://example.com/?tlsInsecure=true"
@@ -69,7 +69,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: ~
+        options: {}
     -
         description: "tlsInsecure=true and tlsAllowInvalidCertificates=false warns"
         uri: "mongodb://example.com/?tlsInsecure=true&tlsAllowInvalidCertificates=false"
@@ -77,7 +77,7 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: ~
+        options: {}
     -
         description: "tlsInsecure=true and tlsAllowInvalidHostnames=false warns"
         uri: "mongodb://example.com/?tlsInsecure=true&tlsAllowInvalidHostnames=false"
@@ -85,5 +85,5 @@ tests:
         warning: true
         hosts: ~
         auth: ~
-        options: ~
+        options: {}
   

--- a/spec/support/connection_string.rb
+++ b/spec/support/connection_string.rb
@@ -214,6 +214,9 @@ module Mongo
         # Replica Set Options
         'replicaset' => :replica_set,
 
+        # Auth Source
+        'authsource' => :auth_source,
+
         # Timeout Options
         'connecttimeoutms' => :connect_timeout,
         'sockettimeoutms' => :socket_timeout,
@@ -271,7 +274,7 @@ module Mongo
             when 'authmechanism'
               Mongo::URI::AUTH_MECH_MAP[v].downcase.to_s
             when 'authsource'
-              v == '$external' ? 'external' : v
+              v == '$external' ? 'external' : v.downcase
             when 'authmechanismproperties'
               v.reduce({}) do |new_v, prop|
                 prop_key = prop.first.downcase
@@ -311,6 +314,7 @@ module Mongo
 
           actual = actual.to_s if actual.is_a?(Symbol)
           actual.downcase! if actual.is_a?(String)
+
 
           expected == actual
         end

--- a/spec/support/connection_string.rb
+++ b/spec/support/connection_string.rb
@@ -211,8 +211,49 @@ module Mongo
     class Options
 
       MAPPINGS = {
-          'replicaset' => :replica_set,
-          'authmechanism' => :auth_mech
+        # Replica Set Options
+        'replicaset' => :replica_set,
+
+        # Timeout Options
+        'connecttimeoutms' => :connect_timeout,
+        'sockettimeoutms' => :socket_timeout,
+        'serverselectiontimeoutms' => :server_selection_timeout,
+        'localthresholdms' => :local_threshold,
+        'heartbeatfrequencyms' => :heartbeat_frequency,
+        'maxidletimems' => :max_idle_time,
+
+         # Write  Options
+        'journal' => [:write, 'j'],
+        'w' => [:write, 'w'],
+        'wtimeoutms' => [:write, 'timeout'],
+
+        # Read Options
+        'readpreference' => ['read', 'mode'],
+        'readpreferencetags' => ['read', 'tag_sets'],
+        'maxstalenessseconds' => ['read', 'max_staleness'],
+
+        # Pool Options
+        'minpoolsize' => :min_pool_size,
+        'maxpoolsize' => :max_pool_size,
+
+        # Security Options
+        'tls' => :ssl,
+        'tlsallowinvalidcertificates' => :ssl_verify,
+        'tlscafile' => :ssl_ca_cert,
+        'tlscertificatekeyfile' => :ssl_cert,
+        'tlscertificatekeyfilepassword' => :ssl_key_pass_phrase,
+        'tlsinsecure' => :ssl_verify,
+
+        # Auth Options
+        'authsource' => :auth_source,
+        'authmechanism' => :auth_mech,
+        'authmechanismproperties' => :auth_mech_properties,
+
+        # Client Options
+        'appname' => :app_name,
+        'readconcernlevel' => :read_concern,
+        'retrywrites' => :retry_writes,
+        'zlibcompressionlevel' => :zlib_compression_level,
       }
 
       attr_reader :options
@@ -223,8 +264,55 @@ module Mongo
 
       def match?(opts)
         @options.all? do |k, v|
-          opts[MAPPINGS[k.downcase]] == v ||
-              opts[MAPPINGS[k.downcase]] == Mongo::URI::AUTH_MECH_MAP[v]
+          k = k.downcase
+
+          expected =
+            case k
+            when 'authmechanism'
+              Mongo::URI::AUTH_MECH_MAP[v].downcase.to_s
+            when 'authsource'
+              v == '$external' ? 'external' : v
+            when 'authmechanismproperties'
+              v.reduce({}) do |new_v, prop|
+                prop_key = prop.first.downcase
+                prop_val = prop.last == 'true' ? true : prop.last
+                new_v[prop_key] = prop_val
+
+                new_v
+              end
+            when 'compressors'
+              v.dup.tap do |compressors|
+                # The Ruby driver doesn't support snappy
+                compressors.delete('snappy')
+              end
+            when 'readpreference'
+              Mongo::URI::READ_MODE_MAP[v.downcase].to_s
+            when 'tlsallowinvalidcertificates', 'tlsinsecure'
+              !v
+            else
+              if k.end_with?('ms') && k != 'wtimeoutms'
+                v / 1000.0
+              elsif v.is_a?(String)
+                v.downcase
+              else
+                v
+              end
+            end
+
+          actual =
+            case MAPPINGS[k]
+            when nil
+              opts[k]
+            when Array
+              opts[MAPPINGS[k].first][MAPPINGS[k].last]
+            else
+              opts[MAPPINGS[k]]
+            end
+
+          actual = actual.to_s if actual.is_a?(Symbol)
+          actual.downcase! if actual.is_a?(String)
+
+          expected == actual
         end
       end
     end


### PR DESCRIPTION
The URI options have been merged, so this PR includes the changes that have been made since the initial commit for them.

Additionally, it appears that the test runner wasn't properly comparing the expected URI options to their parsed options of different names, so I've fixed that as well.