### PR TITLE
RUBY-1676 Add missing client option documentation

### DIFF
--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -124,9 +124,6 @@ URI Options Conversions
    * - connect=String
      - ``:connect => Symbol``
 
-   * - ssl=Boolean
-     - ``:ssl => true|false``
-
    * - connectTimeoutMS=Integer
      - ``:connect_timeout => Float``
 
@@ -145,11 +142,17 @@ URI Options Conversions
    * - maxIdleTimeMS=Integer
      - ``:max_idle_time => Float``
 
+   * - maxStalenessSeconds=Integer
+     - ``:max_staleness => Float``
+
    * - maxPoolSize=Integer
      - ``:max_pool_size => Integer``
 
    * - minPoolSize=Integer
      - ``:min_pool_size => Integer``
+
+   * - readConcernLevel=String
+     - ``:read_concern => Hash``
 
    * - readPreference=String
      - ``{ :read => { :mode => Symbol }}``
@@ -162,11 +165,17 @@ URI Options Conversions
    * - replicaSet=String
      - ``:replica_set => String``
 
+   * - retryWrites=Boolean
+     - ``:retry_writes => boolean``
+
    * - serverSelectionTimeoutMS=Integer
      - ``:server_selection_timeout => Float``
 
    * - socketTimeoutMS=Integer
      - ``:socket_timeout => Float``
+
+   * - ssl=Boolean
+     - ``:ssl => true|false``
 
    * - tls=Boolean
      - ``:ssl => boolean``
@@ -193,7 +202,7 @@ URI Options Conversions
    * - tlsCertificateKeyFile=String
      - ``:ssl_cert => String``
 
-   * - tlsClientKeyFile=String
+   * - tlsCertificateKeyFile=String
      - ``:ssl_key => String``
 
    * - tlsCertificateKeyFilePassword=String
@@ -231,97 +240,43 @@ Ruby Options
      - Type
      - Default
 
-   * - ``:replica_set``
-     - When connecting to a replica set, this is the name of the set to
-       filter servers by.
+   * - ``:app_name``
+     - Application name that is printed to the mongod logs upon establishing a connection
+       in server versions >= 3.4.
      - ``String``
      - none
 
-   * - ``:ssl``
-     - Tell the client to connect to the servers via SSL.
-     - ``Boolean``
-     - false
+   * - ``:auth_mech``
+     - Specifies the authenticaion mechanism to use. Can be one of:
+       ``:mongodb_cr``, ``:mongodb_x509``, ``:plain``, ``:scram``.
+     - ``Symbol``
+     - MongoDB 3.0 and later: ``:scram`` if user credentials
+       are supplied but an ``:auth_mech`` is not. 2.6 and earlier:
+       ``:mongodb_cr``
 
-   * - ``:ssl_cert``
-     - The certificate file path used to identify the connection against MongoDB. This option, if present,
-       takes precedence over the values of :ssl_cert_string and :ssl_cert_object.
+   * - ``:auth_mech_properties``
+     - Provides additional authentication mechanism properties.
+     - ``Hash``
+     - none
+
+   * - ``:auth_source``
+     - Specifies the authentication source.
      - ``String``
+     - For MongoDB 2.6 and later: **admin** if credentials are
+       supplied, otherwise the current database
+
+   * - ``:compressors``
+     - A list of potential compressors to use, in order of preference. The driver chooses the first
+       compressor that is also supported by the server. Currently the driver only supports 'zlib'.
+     - ``Array<String>``
      - none
 
-   * - ``:ssl_cert_string``
-     - A string containing the PEM-encoded certificate used to identify the connection against MongoDB.
-       This option, if present, takes precedence over the value of :ssl_cert_object.
-     - ``String``
+   * - ``:connect``
+     - Overrides the auto-discovery feature of the driver and forces the cluster
+       topology to a specific type. Choices: ``:direct``,
+       ``:replica_set`` or ``:sharded``.
+     - ``Symbol``
      - none
-
-   * - ``:ssl_cert_object``
-     - The OpenSSL::X509::Certificate used to identify the connection against MongoDB.
-     - ``OpenSSL::X509::Certificate``
-     - none
-
-   * - ``:ssl_key``
-     - The private keyfile used to identify the connection against MongoDB. Note that even if the key is stored in
-       the same file as the certificate, both need to be explicitly specified. This option, if present, takes
-       precedence over the values of :ssl_key_string and :ssl_key_object.
-     - ``String``
-     - none
-
-   * - ``:ssl_key_string``
-     - A string containing the PEM-encoded private key used to identify the connection against MongoDB.
-       This parameter, if present, takes precedence over the value of option :ssl_key_object.
-     - ``String``
-     - none
-
-   * - ``:ssl_key_object``
-     - The private key used to identify the connection against MongoDB.
-     - ``OpenSSL::PKey``
-     - none
-
-   * - ``:ssl_key_pass_phrase``
-     - A passphrase for the private key.
-     - ``String``
-     - none
-
-   * - ``:ssl_ca_cert``
-     - The file path containing concatenated certificate authority certificates used to validate certs
-       passed from the other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or :ssl_ca_cert_object
-       (in order of priority) is required for :ssl_verify.
-     - ``String``
-     - none
-
-   * - ``:ssl_ca_cert_string``
-     - A string containing concatenated certificate authority certificates used to validate certs
-       passed from the other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or :ssl_ca_cert_object
-       (in order of priority) is required for :ssl_verify.
-     - ``String``
-     - none
-
-   * - ``:ssl_ca_cert_object``
-     - An array of OpenSSL::X509::Certificate representing the certificate authority certificates used to
-       validate certs passed from the other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or
-       :ssl_ca_cert_object (in order of priority) is required for :ssl_verify.
-     - ``Array<OpenSSL::X509::Certificate>``
-     - none
-
-   * - ``:ssl_verify``
-     - Whether to perform peer certificate validation and hostname verification. Note that
-       the decision of whether to validate certificates will be overriden if :ssl_verify_certificate
-       is set, and the decision of whether to validate hostnames will be overridden if
-       :ssl_verify_hostname is set.
-     - ``Boolean``
-     - true
-
-   * - ``:ssl_verify_certificate``
-     - Whether to perform peer certificate validation. This setting overrides :ssl_verify with
-       respect to whether certificate validition is performed.
-     - ``Boolean``
-     - true
-
-   * - ``:ssl_verify_hostname``
-     - Whether to perform peer hostname validation. This setting overrides :ssl_verify with
-       respect to whether hostname validition is performed.
-     - ``Boolean``
-     - true
 
    * - ``:connect_timeout``
      - The number of seconds to wait to establish a socket connection
@@ -329,16 +284,47 @@ Ruby Options
      - ``Float``
      - 10 seconds
 
-   * - ``:socket_timeout``
-     - The number of seconds to wait for an operation to execute on a
-       socket before raising an exception.
+   * - ``:database``
+     - The name of the database to connect to.
+     - ``String``
+     - admin
+
+   * - ``:heartbeat_frequency``
+     - The number of seconds for the server monitors to refresh
+       server states asynchronously.
      - ``Float``
-     - 5 seconds
+     - 10
+
+   * - ``:id_generator``
+     - A custom object to generate ids for documents. Must respond to #generate.
+     - ``Object``
+     - none
+
+   * - ``:local_threshold``
+     - Specifies the maximum latency in seconds between the nearest
+       server and the servers that can be available for selection to operate on.
+     - ``Float``
+     - 0.015
+
+   * - ``:logger``
+     - A custom logger.
+     - ``Object``
+     - ``Logger``
+
+   * - ``:max_idle_time``
+     - The maximum seconds a socket can remain idle since it has been checked in to the pool.
+     - ``Integer``
+     - none
 
    * - ``:max_pool_size``
      - The maximum size of the connection pool for each server.
      - ``Integer``
      - 5
+
+   * - ``:max_read_retries``
+     - The maximum number of read retries on mongos query failures.
+     - ``Integer``
+     - 1
 
    * - ``:min_pool_size``
      - The minimum number of connections in the connection pool for each
@@ -346,21 +332,21 @@ Ruby Options
      - ``Integer``
      - 1
 
-   * - ``:wait_queue_timeout``
-     - The number of seconds to wait for a connection in the connection
-       pool to become available.
-     - ``Float``
-     - 1
+   * - ``:monitoring``
+     - The monitoring object.
+     - ``Object``
+     - none
 
-   * - ``:write``
-     - Specifies write concern options as a ``Hash``.
-       Keys in the hash can be ``:w``, ``:wtimeout``, ``:j``, ``:fsync``.
+   * - ``:password``
+     - The password of the user to authenticate with.
+     - ``String``
+     - none
 
-       .. code-block:: ruby
-
-         { :write => { :w => 2 } }
-     - ``Hash``
-     - ``{ :w => 1 }``
+   * - ``:platform``
+     - Platform information to include in the metadata printed to the mongod logs upon establishing a
+       connection in server versions >= 3.4.
+     - ``String``
+     - none
 
    * - ``:read``
      - Specifies the read preference mode and tag sets for selecting servers as a ``Hash``.
@@ -377,107 +363,10 @@ Ruby Options
      - ``Hash``
      -  ``{ :mode => :primary }``
 
-   * - ``:auth_source``
-     - Specifies the authentication source.
-     - ``String``
-     - For MongoDB 2.6 and later: **admin** if credentials are
-       supplied, otherwise the current database
-
-
-   * - ``:auth_mech``
-     - Specifies the authenticaion mechanism to use. Can be one of:
-       ``:mongodb_cr``, ``:mongodb_x509``, ``:plain``, ``:scram``.
-     - ``Symbol``
-     - MongoDB 3.0 and later: ``:scram`` if user credentials
-       are supplied but an ``:auth_mech`` is not. 2.6 and earlier:
-       ``:mongodb_cr``
-
-   * - ``:auth_mech_properties``
-     - Provides additional authentication mechanism properties.
+   * - ``:read_concern``
+     - Specifies the read concern options. The only valid key is ``level``, for which the valid
+       values are ``:local``, ``:majority``, and ``:snapshot``.
      - ``Hash``
-     - none
-
-   * - ``:user``
-     - The name of the user to authenticate with.
-     - ``String``
-     - none
-
-   * - ``:password``
-     - The password of the user to authenticate with.
-     - ``String``
-     - none
-
-   * - ``:connect``
-     - Overrides the auto-discovery feature of the driver and forces the cluster
-       topology to a specific type. Choices: ``:direct``,
-       ``:replica_set`` or ``:sharded``.
-     - ``Symbol``
-     - none
-
-   * - ``:heartbeat_frequency``
-     - The number of seconds for the server monitors to refresh
-       server states asynchronously.
-     - ``Float``
-     - 10
-
-   * - ``:database``
-     - The name of the database to connect to.
-     - ``String``
-     - admin
-
-   * - ``:server_selection_timeout``
-     - The number of seconds to wait for an appropriate server to
-       be selected for an operation to be executed before raising an exception.
-     - ``Float``
-     - 30
-
-   * - ``:local_threshold``
-     - Specifies the maximum latency in seconds between the nearest
-       server and the servers that can be available for selection to operate on.
-     - ``Float``
-     - 0.015
-
-   * - ``:app_name``
-     - Application name that is printed to the mongod logs upon establishing a connection
-       in server versions >= 3.4.
-     - ``String``
-     - none
-
-   * - ``:compressors``
-     - A list of potential compressors to use, in order of preference. The driver chooses the first
-       compressor that is also supported by the server. Currently the driver only supports 'zlib'.
-     - ``Array<String>``
-     - none
-
-   * - ``:id_generator``
-     - A custom object to generate ids for documents. Must respond to #generate.
-     - ``Object``
-     - none
-
-   * - ``:logger``
-     - A custom logger.
-     - ``Object``
-     - ``Logger``
-
-   * - ``:max_idle_time``
-     - The maximum seconds a socket can remain idle since it has been checked in to the pool.
-     - ``Integer``
-     - none
-
-   * - ``:max_read_retries``
-     - The maximum number of read retries on mongos query failures.
-     - ``Integer``
-     - 1
-
-   * - ``:monitoring``
-     - The monitoring object.
-     - ``Object``
-     - none
-
-   * - ``:platform``
-     - Platform information to include in the metadata printed to the mongod logs upon establishing a
-       connection in server versions >= 3.4.
-     - ``String``
      - none
 
    * - ``:read_retry_interval``
@@ -485,14 +374,10 @@ Ruby Options
      - ``Integer``
      - 5
 
-   * - ``:truncate_logs``
-     - Whether to truncate the logs at the default 250 characters.
-     - ``Boolean``
-     - true
-
-   * - ``:zlib_compression_level``
-     - The Zlib compression level to use, if using compression. See Ruby's Zlib module for valid levels.
-     - ``Integer``
+   * - ``:replica_set``
+     - When connecting to a replica set, this is the name of the set to
+       filter servers by.
+     - ``String``
      - none
 
    * - ``:retry_writes``
@@ -501,6 +386,135 @@ Ruby Options
      - ``Boolean``
      - false
 
+   * - ``:server_selection_timeout``
+     - The number of seconds to wait for an appropriate server to
+       be selected for an operation to be executed before raising an exception.
+     - ``Float``
+     - 30
+
+   * - ``:socket_timeout``
+     - The number of seconds to wait for an operation to execute on a
+       socket before raising an exception.
+     - ``Float``
+     - 5 seconds
+
+   * - ``:ssl``
+     - Tell the client to connect to the servers via SSL.
+     - ``Boolean``
+     - false
+
+   * - ``:ssl_ca_cert``
+     - The file path containing concatenated certificate authority certificates used to validate certs
+       passed from the other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or :ssl_ca_cert_object
+       (in order of priority) is required for :ssl_verify.
+     - ``String``
+     - none
+
+   * - ``:ssl_ca_cert_object``
+     - An array of OpenSSL::X509::Certificate representing the certificate authority certificates used to
+       validate certs passed from the other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or
+       :ssl_ca_cert_object (in order of priority) is required for :ssl_verify.
+     - ``Array<OpenSSL::X509::Certificate>``
+     - none
+
+   * - ``:ssl_ca_cert_string``
+     - A string containing concatenated certificate authority certificates used to validate certs
+       passed from the other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or :ssl_ca_cert_object
+       (in order of priority) is required for :ssl_verify.
+     - ``String``
+     - none
+
+   * - ``:ssl_cert``
+     - The certificate file path used to identify the connection against MongoDB. This option, if present,
+       takes precedence over the values of :ssl_cert_string and :ssl_cert_object.
+     - ``String``
+     - none
+
+   * - ``:ssl_cert_object``
+     - The OpenSSL::X509::Certificate used to identify the connection against MongoDB.
+     - ``OpenSSL::X509::Certificate``
+     - none
+
+   * - ``:ssl_cert_string``
+     - A string containing the PEM-encoded certificate used to identify the connection against MongoDB.
+       This option, if present, takes precedence over the value of :ssl_cert_object.
+     - ``String``
+     - none
+
+   * - ``:ssl_key``
+     - The private keyfile used to identify the connection against MongoDB. Note that even if the key is stored in
+       the same file as the certificate, both need to be explicitly specified. This option, if present, takes
+       precedence over the values of :ssl_key_string and :ssl_key_object.
+     - ``String``
+     - none
+
+   * - ``:ssl_key_object``
+     - The private key used to identify the connection against MongoDB.
+     - ``OpenSSL::PKey``
+     - none
+
+   * - ``:ssl_key_pass_phrase``
+     - A passphrase for the private key.
+     - ``String``
+     - none
+
+   * - ``:ssl_key_string``
+     - A string containing the PEM-encoded private key used to identify the connection against MongoDB.
+       This parameter, if present, takes precedence over the value of option :ssl_key_object.
+     - ``String``
+     - none
+
+   * - ``:ssl_verify``
+     - Whether to perform peer certificate validation and hostname verification. Note that
+       the decision of whether to validate certificates will be overridden if
+       :ssl_verify_certificate is set, and the decision of whether to validate hostnames will be
+       overridden if :ssl_verify_hostname is set.
+     - ``Boolean``
+     - true
+
+   * - ``:ssl_verify_certificate``
+     - Whether to perform peer certificate validation. This setting overrides :ssl_verify with
+       respect to whether certificate validation is performed.
+     - ``Boolean``
+     - true
+
+   * - ``:ssl_verify_hostname``
+     - Whether to perform peer hostname validation. This setting overrides :ssl_verify with
+       respect to whether hostname validation is performed.
+     - ``Boolean``
+     - true
+
+   * - ``:truncate_logs``
+     - Whether to truncate the logs at the default 250 characters.
+     - ``Boolean``
+     - true
+
+   * - ``:user``
+     - The name of the user to authenticate with.
+     - ``String``
+     - none
+
+   * - ``:wait_queue_timeout``
+     - The number of seconds to wait for a connection in the connection
+       pool to become available.
+     - ``Float``
+     - 1
+
+   * - ``:write``
+     - Specifies write concern options as a ``Hash``.
+       Keys in the hash can be ``:w``, ``:wtimeout``, ``:j``, ``:fsync``.
+
+       .. code-block:: ruby
+
+         { :write => { :w => 2 } }
+
+     - ``Hash``
+     - ``{ :w => 1 }``
+
+   * - ``:zlib_compression_level``
+     - The Zlib compression level to use, if using compression. See Ruby's Zlib module for valid levels.
+     - ``Integer``
+     - none
 
 Details on Timeout Options
 --------------------------

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -36,9 +36,9 @@ module Mongo
       :auth_mech,
       :auth_mech_properties,
       :auth_source,
+      :compressors,
       :connect,
       :connect_timeout,
-      :compressors,
       :database,
       :heartbeat_frequency,
       :id_generator,
@@ -49,6 +49,7 @@ module Mongo
       :max_read_retries,
       :min_pool_size,
       :monitoring,
+      :monitoring_io,
       :password,
       :platform,
       :read,
@@ -57,19 +58,20 @@ module Mongo
       :replica_set,
       :retry_writes,
       :scan,
+      :sdam_proc,
       :server_selection_timeout,
       :socket_timeout,
       :ssl,
       :ssl_ca_cert,
-      :ssl_ca_cert_string,
       :ssl_ca_cert_object,
+      :ssl_ca_cert_string,
       :ssl_cert,
-      :ssl_cert_string,
       :ssl_cert_object,
+      :ssl_cert_string,
       :ssl_key,
-      :ssl_key_string,
       :ssl_key_object,
       :ssl_key_pass_phrase,
+      :ssl_key_string,
       :ssl_verify,
       :ssl_verify_certificate,
       :ssl_verify_hostname,
@@ -78,7 +80,6 @@ module Mongo
       :wait_queue_timeout,
       :write,
       :zlib_compression_level,
-      :monitoring_io,
     ].freeze
 
     # The compression algorithms supported by the driver.
@@ -173,83 +174,39 @@ module Mongo
     #   form of host:port or a MongoDB URI connection string.
     # @param [ Hash ] options The options to be used by the client.
     #
+    #
+    # @option options [ String, Symbol ] :app_name Application name that is
+    #   printed to the mongod logs upon establishing a connection in server
+    #   versions >= 3.4.
     # @option options [ Symbol ] :auth_mech The authentication mechanism to
     #   use. One of :mongodb_cr, :mongodb_x509, :plain, :scram, :scram256
-    # @option options [ String ] :auth_source The source to authenticate from.
-    # @option options [ Symbol ] :connect The connection method to use. This
-    #   forces the cluster to behave in the specified way instead of
-    #   auto-discovering. One of :direct, :replica_set, :sharded
-    # @option options [ String ] :database The database to connect to.
     # @option options [ Hash ] :auth_mech_properties
-    # @option options [ Float ] :heartbeat_frequency The number of seconds for
-    #   the server monitor to refresh it's description via ismaster.
-    # @option options [ Integer ] :local_threshold The local threshold boundary
-    #   in seconds for selecting a near server for an operation.
-    # @option options [ Integer ] :server_selection_timeout The timeout in seconds
-    #   for selecting a server for an operation.
-    # @option options [ String ] :password The user's password.
-    # @option options [ Integer ] :max_idle_time The maximum seconds a socket can remain idle
-    #   since it has been checked in to the pool.
-    # @option options [ Integer ] :max_pool_size The maximum size of the
-    #   connection pool.
-    # @option options [ Integer ] :min_pool_size The minimum size of the
-    #   connection pool.
-    # @option options [ Float ] :wait_queue_timeout The time to wait, in
-    #   seconds, in the connection pool for a connection to be checked in.
-    # @option options [ Float ] :connect_timeout The timeout, in seconds, to
-    #   attempt a connection.
+    # @option options [ String ] :auth_source The source to authenticate from.
     # @option options [ Array<String> ] :compressors A list of potential
     #   compressors to use, in order of preference. The driver chooses the
     #   first compressor that is also supported by the server. Currently the
     #   driver only supports 'zlib'.
-    # @option options [ Hash ] :read The read preference options. The hash
-    #   may have the following items:
-    #   - *:mode* -- read preference specified as a symbol; valid values are
-    #     *:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
-    #     and *:nearest*.
-    #   - *:tag_sets* -- an array of hashes.
-    #   - *:local_threshold*.
-    # @option options [ Symbol ] :replica_set The name of the replica set to
-    #   connect to. Servers not in this replica set will be ignored.
-    # @option options [ true, false ] :ssl Whether to use SSL.
-    # @option options [ String ] :ssl_cert The certificate file used to identify
-    #   the connection against MongoDB. This option, if present, takes precedence
-    #   over the values of :ssl_cert_string and :ssl_cert_object
-    # @option options [ String ] :ssl_cert_string A string containing the PEM-encoded
-    #   certificate used to identify the connection against MongoDB. This option, if present,
-    #   takes precedence over the value of :ssl_cert_object
-    # @option options [ OpenSSL::X509::Certificate ] :ssl_cert_object The OpenSSL::X509::Certificate
-    #   used to identify the connection against MongoDB
-    # @option options [ String ] :ssl_key The private keyfile used to identify the
-    #   connection against MongoDB. Note that even if the key is stored in the same
-    #   file as the certificate, both need to be explicitly specified. This option,
-    #   if present, takes precedence over the values of :ssl_key_string and :ssl_key_object
-    # @option options [ String ] :ssl_key_string A string containing the PEM-encoded private key
-    #   used to identify the connection against MongoDB. This parameter, if present,
-    #   takes precedence over the value of option :ssl_key_object
-    # @option options [ OpenSSL::PKey ] :ssl_key_object The private key used to identify the
-    #   connection against MongoDB
-    # @option options [ String ] :ssl_key_pass_phrase A passphrase for the private key.
-    # @option options [ true, false ] :ssl_verify Whether to do peer certificate
-    #   validation.
-    # @option options [ String ] :ssl_ca_cert The file containing concatenated
-    #   certificate authority certificates used to validate certs passed from the
-    #   other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or
-    #   :ssl_ca_cert_object (in order of priority) is required for :ssl_verify.
-    # @option options [ String ] :ssl_ca_cert_string A string containing concatenated
-    #   certificate authority certificates used to validate certs passed from the
-    #   other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or
-    #   :ssl_ca_cert_object (in order of priority) is required for :ssl_verify.
-    # @option options [ Array<OpenSSL::X509::Certificate> ] :ssl_ca_cert_object An array of
-    #   OpenSSL::X509::Certificate representing the certificate authority certificates used
-    #   to validate certs passed from the other end of the connection. One of :ssl_ca_cert,
-    #   :ssl_ca_cert_string or :ssl_ca_cert_object (in order of priority) is required for :ssl_verify.
-    # @option options [ Float ] :socket_timeout The timeout, in seconds, to
-    #   execute operations on a socket.
-    # @option options [ String ] :user The user name.
-    # @option options [ Hash ] :write The write concern options. Can be :w =>
-    #   Integer|String, :fsync => Boolean, :j => Boolean.
-    # @option options [ Hash ] :read_concern The read concern option.
+    # @option options [ Symbol ] :connect The connection method to use. This
+    #   forces the cluster to behave in the specified way instead of
+    #   auto-discovering. One of :direct, :replica_set, :sharded
+    # @option options [ Float ] :connect_timeout The timeout, in seconds, to
+    #   attempt a connection.
+    # @option options [ String ] :database The database to connect to.
+    # @option options [ Float ] :heartbeat_frequency The number of seconds for
+    #   the server monitor to refresh it's description via ismaster.
+    # @option options [ Object ] :id_generator A custom object to generate ids
+    #   for documents. Must respond to #generate.
+    # @option options [ Integer ] :local_threshold The local threshold boundary
+    #   in seconds for selecting a near server for an operation.
+    # @option options [ Logger ] :logger A custom logger if desired.
+    # @option options [ Integer ] :max_idle_time The maximum seconds a socket can remain idle
+    #   since it has been checked in to the pool.
+    # @option options [ Integer ] :max_pool_size The maximum size of the
+    #   connection pool.
+    # @option options [ Integer ] :max_read_retries The maximum number of read
+    #   retries on mongos query failures.
+    # @option options [ Integer ] :min_pool_size The minimum size of the
+    #   connection pool.
     # @option options [ true, false ] :monitoring If false is given, the
     #   client is initialized without global SDAM event subscribers and
     #   will not publish SDAM events. Command monitoring and legacy events
@@ -260,29 +217,29 @@ module Mongo
     #   succeed for all event types, but subscribers to SDAM events will
     #   not be invoked. Values other than false result in default behavior
     #   which is to perform normal SDAM event publication.
-    # @option options [ Logger ] :logger A custom logger if desired.
-    # @option options [ true, false ] :truncate_logs Whether to truncate the
-    #   logs at the default 250 characters.
-    # @option options [ Integer ] :max_read_retries The maximum number of read
-    #   retries on mongos query failures.
-    # @option options [ Float ] :read_retry_interval The interval, in seconds,
-    #   in which reads on a mongos are retried.
-    # @option options [ Object ] :id_generator A custom object to generate ids
-    #   for documents. Must respond to #generate.
-    # @option options [ String, Symbol ] :app_name Application name that is
-    #   printed to the mongod logs upon establishing a connection in server
-    #   versions >= 3.4.
+    # @option options [ true, false ] :monitoring_io For internal driver
+    #   use only. Set to false to prevent SDAM-related I/O from being
+    #   done by this client or servers under it. Note: setting this option
+    #   to false will make the client non-functional. It is intended for
+    #   use in tests which manually invoke SDAM state transitions.
+    # @option options [ String ] :password The user's password.
     # @option options [ String ] :platform Platform information to include in
     #   the metadata printed to the mongod logs upon establishing a connection
     #   in server versions >= 3.4.
-    # @option options [ Integer ] :zlib_compression_level The Zlib compression level to use, if using compression.
-    #   See Ruby's Zlib module for valid levels.
+    # @option options [ Hash ] :read The read preference options. The hash
+    #   may have the following items:
+    #   - *:mode* -- read preference specified as a symbol; valid values are
+    #     *:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
+    #     and *:nearest*.
+    #   - *:tag_sets* -- an array of hashes.
+    #   - *:local_threshold*.
+    # @option options [ Hash ] :read_concern The read concern option.
+    # @option options [ Float ] :read_retry_interval The interval, in seconds,
+    #   in which reads on a mongos are retried.
+    # @option options [ Symbol ] :replica_set The name of the replica set to
+    #   connect to. Servers not in this replica set will be ignored.
     # @option options [ true, false ] :retry_writes Retry writes once when
     #   connected to a replica set or sharded cluster versions 3.6 and up.
-    # @option options [ Proc ] :sdam_proc A Proc to invoke with the client
-    #   as the argument prior to performing server discovery and monitoring.
-    #   Use this to set up SDAM event listeners to receive events dispatched
-    #   during client construction.
     # @option options [ true, false ] :scan Whether to scan all seeds
     #   in constructor. The default in driver version 2.x is to do so;
     #   driver version 3.x will not scan seeds in constructor. Opt in to the
@@ -290,16 +247,69 @@ module Mongo
     #   this option to nil enables scanning seeds in constructor in driver
     #   version 2.x. Driver version 3.x will recognize this option but
     #   will ignore it and will never scan seeds in the constructor.
+    # @option options [ Proc ] :sdam_proc A Proc to invoke with the client
+    #   as the argument prior to performing server discovery and monitoring.
+    #   Use this to set up SDAM event listeners to receive events dispatched
+    #   during client construction.
     #
     #   Note: the client is not fully constructed when sdam_proc is invoked,
     #   in particular the cluster is nil at this time. sdam_proc should
     #   limit itself to calling #subscribe and #unsubscribe methods on the
     #   client only.
-    # @option options [ true, false ] :monitoring_io For internal driver
-    #   use only. Set to false to prevent SDAM-related I/O from being
-    #   done by this client or servers under it. Note: setting this option
-    #   to false will make the client non-functional. It is intended for
-    #   use in tests which manually invoke SDAM state transitions.
+    # @option options [ Integer ] :server_selection_timeout The timeout in seconds
+    #   for selecting a server for an operation.
+    # @option options [ Float ] :socket_timeout The timeout, in seconds, to
+    #   execute operations on a socket.
+    # @option options [ true, false ] :ssl Whether to use SSL.
+    # @option options [ String ] :ssl_ca_cert The file containing concatenated
+    #   certificate authority certificates used to validate certs passed from the
+    #   other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or
+    #   :ssl_ca_cert_object (in order of priority) is required for :ssl_verify.
+    # @option options [ Array<OpenSSL::X509::Certificate> ] :ssl_ca_cert_object An array of
+    #   OpenSSL::X509::Certificate representing the certificate authority certificates used
+    #   to validate certs passed from the other end of the connection. One of :ssl_ca_cert,
+    #   :ssl_ca_cert_string or :ssl_ca_cert_object (in order of priority) is required for :ssl_verify.
+    # @option options [ String ] :ssl_ca_cert_string A string containing concatenated
+    #   certificate authority certificates used to validate certs passed from the
+    #   other end of the connection. One of :ssl_ca_cert, :ssl_ca_cert_string or
+    #   :ssl_ca_cert_object (in order of priority) is required for :ssl_verify.
+    # @option options [ String ] :ssl_cert The certificate file used to identify
+    #   the connection against MongoDB. This option, if present, takes precedence
+    #   over the values of :ssl_cert_string and :ssl_cert_object
+    # @option options [ OpenSSL::X509::Certificate ] :ssl_cert_object The OpenSSL::X509::Certificate
+    #   used to identify the connection against MongoDB
+    # @option options [ String ] :ssl_cert_string A string containing the PEM-encoded
+    #   certificate used to identify the connection against MongoDB. This option, if present,
+    #   takes precedence over the value of :ssl_cert_object
+    # @option options [ String ] :ssl_key The private keyfile used to identify the
+    #   connection against MongoDB. Note that even if the key is stored in the same
+    #   file as the certificate, both need to be explicitly specified. This option,
+    #   if present, takes precedence over the values of :ssl_key_string and :ssl_key_object
+    # @option options [ OpenSSL::PKey ] :ssl_key_object The private key used to identify the
+    #   connection against MongoDB
+    # @option options [ String ] :ssl_key_pass_phrase A passphrase for the private key.
+    # @option options [ String ] :ssl_key_string A string containing the PEM-encoded private key
+    #   used to identify the connection against MongoDB. This parameter, if present,
+    #   takes precedence over the value of option :ssl_key_object
+    # @option options [ true, false ] :ssl_verify Whether to perform peer certificate validation and
+    #   hostname verification. Note that the decision of whether to validate certificates will be
+    #   overridden if :ssl_verify_certificate is set, and the decision of whether to validate
+    #   hostnames will be overridden if :ssl_verify_hostname is set.
+    # @option options [ true, false ] :ssl_verify_certificate Whether to perform peer certificate
+    #   validation. This setting overrides :ssl_verify with respect to whether certificate
+    #   validation is performed.
+    # @option options [ true, false ] :ssl_verify_hostname Whether to perform peer hostname
+    #   validation. This setting overrides :ssl_verify with respect to whether hostname validation
+    #   is performed.
+    # @option options [ true, false ] :truncate_logs Whether to truncate the
+    #   logs at the default 250 characters.
+    # @option options [ String ] :user The user name.
+    # @option options [ Float ] :wait_queue_timeout The time to wait, in
+    #   seconds, in the connection pool for a connection to be checked in.
+    # @option options [ Hash ] :write The write concern options. Can be :w =>
+    #   Integer|String, :fsync => Boolean, :j => Boolean.
+    # @option options [ Integer ] :zlib_compression_level The Zlib compression level to use, if using compression.
+    #   See Ruby's Zlib module for valid levels.
     #
     # @since 2.0.0
     def initialize(addresses_or_uri, options = nil)


### PR DESCRIPTION
The diff is a little weird since I reordered everything to be in alphabetical order. It might be easier to just look at the final state of the files rather than the diff.