### PR TITLE
minor: fix travis with ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: ruby
 sudo: false
 
 before_install:
-  - gem update --system -q
-  - gem update bundler -q
+  - if [[ (-z "$NO_BUNDLER_UPGRADE") ]]; then gem update --system -q; fi
+  - if [[ (-z "$NO_BUNDLER_UPGRADE") ]]; then gem update bundler -q; fi
 
 install: ruby -S bundle install --without release development
 
@@ -27,16 +27,16 @@ branches:
 matrix:
   exclude:
     - rvm: 1.9.3
-      env: MONGODB_VERSION=4.0.1
-    - rvm: 2.5
-      env: MONGODB_VERSION=2.6.12
+      env: MONGODB_VERSION=4.0.5
+    - rvm: 2.6
+      env: MONGODB_VERSION=2.6.12 NO_BUNDLER_UPGRADE=true
 
 env:
   global:
     - CI="travis"
   matrix:
-    - MONGODB_VERSION=2.6.12
-    - MONGODB_VERSION=4.0.1
+    - MONGODB_VERSION=2.6.12 NO_BUNDLER_UPGRADE=true
+    - MONGODB_VERSION=4.0.5
 
 script: bundle exec rake spec:ci
 


### PR DESCRIPTION
The Travis build was failing on Ruby 1.9.3 due to trying to update bundler to a newer version than supports 1.9.3. Given that the commands doing to update appear to be copied from the [Travis documentation](https://docs.travis-ci.com/user/languages/ruby/#bundler-20) describing how to update to bundler 2.0 (which does not support 1.9.3), I disabled them from running in the job that uses 1.9.3.