### PR TITLE
Fix RUBY-1749 Two-part hostnames are accepted by the driver for SRV queries with a trailing dot

### DIFF
--- a/lib/mongo/uri/srv_protocol.rb
+++ b/lib/mongo/uri/srv_protocol.rb
@@ -101,8 +101,20 @@ module Mongo
         end
         hostname = @servers.first
         raise_invalid_error!(INVALID_PORT) if hostname.include?(HOST_PORT_DELIM)
-        _, _, domain = hostname.partition(DOT_PARTITION)
-        raise_invalid_error!(INVALID_DOMAIN) unless domain.include?(DOT_PARTITION)
+
+        if hostname.start_with?('.')
+          raise_invalid_error!("Hostname cannot start with a dot: #{hostname}")
+        end
+        if hostname.end_with?('.')
+          raise_invalid_error!("Hostname cannot end with a dot: #{hostname}")
+        end
+        parts = hostname.split('.')
+        if parts.any?(&:empty)
+          raise_invalid_error!("Hostname have consecutive dots: #{hostname}")
+        end
+        if parts.length < 3
+          raise_invalid_error!("Hostname must have a minimum of 3 components (foo.bar.tld): #{hostname}")
+        end
 
         records = get_records(hostname)
         @txt_options = get_txt_opts(hostname) || {}

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -951,84 +951,54 @@ describe Mongo::URI::SRVProtocol do
         end
       end
     end
+  end
 
-    describe '#validate_hostname' do
-      let(:valid_hostname) do
-        'test1.test.build.10gen.cc'
+  describe '#validate_hostname' do
+    let(:valid_hostname) do
+      'test1.test.build.10gen.cc'
+    end
+
+    let(:dummy_uri) do
+      Mongo::URI::SRVProtocol.new("#{scheme}#{valid_hostname}/")
+    end
+
+    let(:validate) do
+      dummy_uri.send(:validate_hostname!, hostname)
+    end
+
+    context 'when the hostname is valid' do
+      let(:hostname) do
+        valid_hostname
       end
 
-      let(:dummy_uri) do
-        Mongo::URI::SRVProtocol.new("#{scheme}#{valid_hostname}/")
-      end
-
-      let(:validate) do
-        dummy_uri.send(:validate_hostname!, hostname)
-      end
-
-      context 'when the hostname is valid' do
-        let(:hostname) do
-          valid_hostname
-        end
-
-        it 'does not raise an error' do
-          expect { validate }.not_to raise_error
-        end
-      end
-
-      context 'when the hostname has a trailing dot' do
-        let(:hostname) do
-          "#{valid_hostname}."
-        end
-
-        it 'does not raise an error' do
-          expect { validate }.not_to raise_error
-        end
-      end
-
-      context 'when the hostname is empty' do
-        let(:hostname) do
-          ''
-        end
-
-        it 'raises an error' do
-          expect { validate }.to raise_error(Mongo::Error::InvalidURI)
-        end
-      end
-
-      context 'when the hostname contains a comma' do
-        let(:hostname) do
-          'host1,host2'
-        end
-
-        it 'raises an error' do
-          expect { validate }.to raise_error(Mongo::Error::InvalidURI)
-        end
-      end
-
-      context 'when the hostname contains a colon' do
-        let(:hostname) do
-          'localhost:27017'
-        end
-
-        it 'raises an error' do
-          expect { validate }.to raise_error(Mongo::Error::InvalidURI)
-        end
-      end
-
-      context 'when the hostname starts with a dot' do
-        let(:hostname) do
-          '.somehost'
-        end
-
-        it 'raises an error' do
-          expect { validate }.to raise_error(Mongo::Error::InvalidURI)
-        end
+      it 'does not raise an error' do
+        expect { validate }.not_to raise_error
       end
     end
 
-    context 'when the hostname ends with consecutive dots' do
+    context 'when the hostname contains no dots' do
       let(:hostname) do
-        'somehost..'
+        'localhost'
+      end
+
+      it 'does not raise an error' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when the hostname has a trailing dot' do
+      let(:hostname) do
+        "#{valid_hostname}."
+      end
+
+      it 'does not raise an error' do
+        expect { validate }.not_to raise_error
+      end
+    end
+
+    context 'when the hostname is empty' do
+      let(:hostname) do
+        ''
       end
 
       it 'raises an error' do
@@ -1036,14 +1006,54 @@ describe Mongo::URI::SRVProtocol do
       end
     end
 
-    context 'when the hostname contains consecutive dots in the middle' do
+    context 'when the hostname contains a comma' do
       let(:hostname) do
-        'prefix..suffix'
+        'host1,host2'
       end
 
       it 'raises an error' do
         expect { validate }.to raise_error(Mongo::Error::InvalidURI)
       end
+    end
+
+    context 'when the hostname contains a colon' do
+      let(:hostname) do
+        'localhost:27017'
+      end
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      end
+    end
+
+    context 'when the hostname starts with a dot' do
+      let(:hostname) do
+        '.somehost'
+      end
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      end
+    end
+  end
+
+  context 'when the hostname ends with consecutive dots' do
+    let(:hostname) do
+      'somehost..'
+    end
+
+    it 'raises an error' do
+      expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+    end
+  end
+
+  context 'when the hostname contains consecutive dots in the middle' do
+    let(:hostname) do
+      'prefix..suffix'
+    end
+
+    it 'raises an error' do
+      expect { validate }.to raise_error(Mongo::Error::InvalidURI)
     end
   end
 end

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -962,7 +962,7 @@ describe Mongo::URI::SRVProtocol do
     end
 
     let(:validate) do
-      dummy_uri.send(:validate_hostname!, hostname)
+      dummy_uri.send(:validate_hostname, hostname)
     end
 
     context 'when the hostname is valid' do
@@ -980,8 +980,8 @@ describe Mongo::URI::SRVProtocol do
         "a.b.c."
       end
 
-      it 'does not raise an error' do
-        expect { validate }.not_to raise_error
+      it 'raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI, /Hostname cannot end with a dot: a\.b\.c\./)
       end
     end
 
@@ -1026,13 +1026,11 @@ describe Mongo::URI::SRVProtocol do
       end
     end
 
-    context 'when the hostname contains a comma' do
-      let(:hostname) do
-        'a.b.c,d.e.f'
-      end
-
+    context 'when multiple hostnames are specified' do
       it 'raises an error' do
-        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+        expect do
+          Mongo::URI::SRVProtocol.new("mongodb+srv://a.b.c,d.e.f/")
+        end.to raise_error(Mongo::Error::InvalidURI, /One and only one host is required/)
       end
     end
 

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -1055,25 +1055,25 @@ describe Mongo::URI::SRVProtocol do
         expect { validate }.to raise_error(Mongo::Error::InvalidURI)
       end
     end
-  end
 
-  context 'when the hostname ends with consecutive dots' do
-    let(:hostname) do
-      'a.b.c..'
+    context 'when the hostname ends with consecutive dots' do
+      let(:hostname) do
+        'a.b.c..'
+      end
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      end
     end
 
-    it 'raises an error' do
-      expect { validate }.to raise_error(Mongo::Error::InvalidURI)
-    end
-  end
+    context 'when the hostname contains consecutive dots in the middle' do
+      let(:hostname) do
+        'a..b.c'
+      end
 
-  context 'when the hostname contains consecutive dots in the middle' do
-    let(:hostname) do
-      'a..b.c'
-    end
-
-    it 'raises an error' do
-      expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      it 'raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      end
     end
   end
 end

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -951,5 +951,99 @@ describe Mongo::URI::SRVProtocol do
         end
       end
     end
+
+    describe '#validate_hostname' do
+      let(:valid_hostname) do
+        'test1.test.build.10gen.cc'
+      end
+
+      let(:dummy_uri) do
+        Mongo::URI::SRVProtocol.new("#{scheme}#{valid_hostname}/")
+      end
+
+      let(:validate) do
+        dummy_uri.send(:validate_hostname!, hostname)
+      end
+
+      context 'when the hostname is valid' do
+        let(:hostname) do
+          valid_hostname
+        end
+
+        it 'does not raise an error' do
+          expect { validate }.not_to raise_error
+        end
+      end
+
+      context 'when the hostname has a trailing dot' do
+        let(:hostname) do
+          "#{valid_hostname}."
+        end
+
+        it 'does not raise an error' do
+          expect { validate }.not_to raise_error
+        end
+      end
+
+      context 'when the hostname is empty' do
+        let(:hostname) do
+          ''
+        end
+
+        it 'raises an error' do
+          expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+        end
+      end
+
+      context 'when the hostname contains a comma' do
+        let(:hostname) do
+          'host1,host2'
+        end
+
+        it 'raises an error' do
+          expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+        end
+      end
+
+      context 'when the hostname contains a colon' do
+        let(:hostname) do
+          'localhost:27017'
+        end
+
+        it 'raises an error' do
+          expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+        end
+      end
+
+      context 'when the hostname starts with a dot' do
+        let(:hostname) do
+          '.somehost'
+        end
+
+        it 'raises an error' do
+          expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+        end
+      end
+    end
+
+    context 'when the hostname ends with consecutive dots' do
+      let(:hostname) do
+        'somehost..'
+      end
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      end
+    end
+
+    context 'when the hostname contains consecutive dots in the middle' do
+      let(:hostname) do
+        'prefix..suffix'
+      end
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      end
+    end
   end
 end

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -955,11 +955,10 @@ describe Mongo::URI::SRVProtocol do
 
   describe '#validate_hostname' do
     let(:valid_hostname) do
-      'test1.test.build.10gen.cc'
     end
 
     let(:dummy_uri) do
-      Mongo::URI::SRVProtocol.new("#{scheme}#{valid_hostname}/")
+      Mongo::URI::SRVProtocol.new("mongodb+srv://test1.test.build.10gen.cc/")
     end
 
     let(:validate) do
@@ -968,17 +967,7 @@ describe Mongo::URI::SRVProtocol do
 
     context 'when the hostname is valid' do
       let(:hostname) do
-        valid_hostname
-      end
-
-      it 'does not raise an error' do
-        expect { validate }.not_to raise_error
-      end
-    end
-
-    context 'when the hostname contains no dots' do
-      let(:hostname) do
-        'localhost'
+        'a.b.c'
       end
 
       it 'does not raise an error' do
@@ -988,7 +977,7 @@ describe Mongo::URI::SRVProtocol do
 
     context 'when the hostname has a trailing dot' do
       let(:hostname) do
-        "#{valid_hostname}."
+        "a.b.c."
       end
 
       it 'does not raise an error' do
@@ -1006,9 +995,40 @@ describe Mongo::URI::SRVProtocol do
       end
     end
 
+    context 'when the hostname has only one part' do
+      let(:hostname) do
+        'a'
+      end
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      end
+    end
+
+
+    context 'when the hostname has only two parts' do
+      let(:hostname) do
+        'a.b'
+      end
+
+      it 'raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      end
+    end
+
+    context 'when the hostname has an empty last part' do
+      let(:hostname) do
+        'a.b.'
+      end
+
+      it 'it raises an error' do
+        expect { validate }.to raise_error(Mongo::Error::InvalidURI)
+      end
+    end
+
     context 'when the hostname contains a comma' do
       let(:hostname) do
-        'host1,host2'
+        'a.b.c,d.e.f'
       end
 
       it 'raises an error' do
@@ -1018,7 +1038,7 @@ describe Mongo::URI::SRVProtocol do
 
     context 'when the hostname contains a colon' do
       let(:hostname) do
-        'localhost:27017'
+        'a.b.c:27017'
       end
 
       it 'raises an error' do
@@ -1028,7 +1048,7 @@ describe Mongo::URI::SRVProtocol do
 
     context 'when the hostname starts with a dot' do
       let(:hostname) do
-        '.somehost'
+        '.a.b.c'
       end
 
       it 'raises an error' do
@@ -1039,7 +1059,7 @@ describe Mongo::URI::SRVProtocol do
 
   context 'when the hostname ends with consecutive dots' do
     let(:hostname) do
-      'somehost..'
+      'a.b.c..'
     end
 
     it 'raises an error' do
@@ -1049,7 +1069,7 @@ describe Mongo::URI::SRVProtocol do
 
   context 'when the hostname contains consecutive dots in the middle' do
     let(:hostname) do
-      'prefix..suffix'
+      'a..b.c'
     end
 
     it 'raises an error' do

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -48,6 +48,17 @@ describe Mongo::URI::SRVProtocol do
       end
     end
 
+    context 'when the {tld} is empty' do
+
+      let(:string) { "#{scheme}#{hosts}" }
+      let(:hosts) { '10gen.cc./' }
+
+      it 'raises an error' do
+        expect { uri }.to raise_error(Mongo::Error::InvalidURI)
+      end
+    end
+
+
     context 'string is not uri' do
 
       let(:string) { 'tyler' }


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-1749