### PR TITLE
RUBY-1562 Remove -1 limit in db view

### DIFF
--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -51,7 +51,6 @@ module Mongo
       def collection_names(options = {})
         @batch_size = options[:batch_size]
         server = next_primary(false)
-        @limit = -1 if server.features.list_collections_enabled?
         session = client.send(:get_session, options)
         collections_info(server, session, name_only: true).collect do |info|
           if server.features.list_collections_enabled?


### PR DESCRIPTION
As far as I can tell the -1 limit is ignored by the driver, just like
a nil limit would be ignored. However the call on server is problematic
with the new retryable reads API since server may change during a
read operation.
