### PR TITLE
RUBY-1562 spec preparation

### DIFF
--- a/spec/spec_tests/crud_spec.rb
+++ b/spec/spec_tests/crud_spec.rb
@@ -1,11 +1,15 @@
 require 'spec_helper'
 
-define_crud_spec_tests('CRUD spec tests', CRUD_TESTS.sort) do |spec, test|
-  let(:client) { authorized_client }
-  let(:collection) { client['crud_spec_test'] }
+describe do
+  define_crud_spec_tests('CRUD spec tests', CRUD_TESTS.sort) do |spec, req, test|
+    let(:client) { authorized_client }
+    let(:collection) { client['crud_spec_test'] }
 
-  before do
-    collection.delete_many
-    test.setup_test(collection)
+    before do
+      if req.nil? || req.satisfied?
+        collection.delete_many
+        test.setup_test(collection)
+      end
+    end
   end
 end

--- a/spec/spec_tests/crud_spec.rb
+++ b/spec/spec_tests/crud_spec.rb
@@ -1,59 +1,11 @@
 require 'spec_helper'
 
-describe 'CRUD' do
+define_crud_spec_tests('CRUD spec tests', CRUD_TESTS.sort) do |spec, test|
+  let(:client) { authorized_client }
+  let(:collection) { client['crud_spec_test'] }
 
-  CRUD_TESTS.each do |file|
-
-    spec = Mongo::CRUD::Spec.new(file)
-
-    context(spec.description) do
-
-      spec.tests.each do |test|
-
-        context(test.description) do
-
-          before(:each) do
-            unless spec.server_version_satisfied?(authorized_client)
-              skip 'Version requirement not satisfied'
-            end
-
-            test.setup_test(authorized_collection)
-          end
-
-          after(:each) do
-            authorized_collection.delete_many
-          end
-
-          let(:verifier) { Mongo::CRUD::Verifier.new(test) }
-
-          test.operations.each_with_index do |operation, index|
-            context "operation #{index+1}" do
-
-              let!(:result) do
-                test.run(authorized_collection, index+1)
-              end
-
-              let(:actual_collection) do
-                if operation.outcome && operation.outcome.collection_name
-                  authorized_client[operation.outcome.collection_name]
-                else
-                  authorized_collection
-                end
-              end
-
-              it 'returns the correct result' do
-                verifier.verify_operation_result(operation.outcome.result, result)
-              end
-
-              it 'has the correct data in the collection', if: operation.outcome.collection_data? do
-                verifier.verify_collection_data(
-                  operation.outcome.collection_data,
-                  actual_collection.find.to_a)
-              end
-            end
-          end
-        end
-      end
-    end
+  before do
+    collection.delete_many
+    test.setup_test(collection)
   end
 end

--- a/spec/spec_tests/data/retryable_writes/bulkWrite-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/bulkWrite-serverErrors.yml
@@ -2,8 +2,7 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
+minServerVersion: '4.0'
 
 tests:
     -

--- a/spec/spec_tests/data/retryable_writes/deleteOne-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/deleteOne-serverErrors.yml
@@ -2,8 +2,7 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
+minServerVersion: '4.0'
 
 tests:
     -

--- a/spec/spec_tests/data/retryable_writes/findOneAndDelete-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/findOneAndDelete-serverErrors.yml
@@ -2,8 +2,7 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
+minServerVersion: '4.0'
 
 tests:
     -

--- a/spec/spec_tests/data/retryable_writes/findOneAndReplace-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/findOneAndReplace-serverErrors.yml
@@ -2,8 +2,7 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
+minServerVersion: '4.0'
 
 tests:
     -

--- a/spec/spec_tests/data/retryable_writes/findOneAndUpdate-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/findOneAndUpdate-serverErrors.yml
@@ -2,8 +2,7 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
+minServerVersion: '4.0'
 
 tests:
     -

--- a/spec/spec_tests/data/retryable_writes/insertMany-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/insertMany-serverErrors.yml
@@ -1,8 +1,7 @@
 data:
     - { _id: 1, x: 11 }
 
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
+minServerVersion: '4.0'
 
 tests:
     -

--- a/spec/spec_tests/data/retryable_writes/insertOne-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/insertOne-serverErrors.yml
@@ -2,8 +2,7 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
+minServerVersion: '4.0'
 
 tests:
     -

--- a/spec/spec_tests/data/retryable_writes/replaceOne-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/replaceOne-serverErrors.yml
@@ -2,8 +2,7 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
+minServerVersion: '4.0'
 
 tests:
     -

--- a/spec/spec_tests/data/retryable_writes/updateOne-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/updateOne-serverErrors.yml
@@ -2,8 +2,7 @@ data:
     - { _id: 1, x: 11 }
     - { _id: 2, x: 22 }
 
-# TODO: this should change to 4.0 once 4.0.0 is released.
-minServerVersion: '3.99'
+minServerVersion: '4.0'
 
 tests:
     -

--- a/spec/spec_tests/retryable_writes_spec.rb
+++ b/spec/spec_tests/retryable_writes_spec.rb
@@ -29,12 +29,16 @@ describe 'Retryable writes spec tests' do
           end
 
           before do
-            test.setup_test(collection)
+            if spec.server_version_satisfied?(client)
+              test.setup_test(collection)
+            end
           end
 
           after do
-            test.clear_fail_point(collection.client)
-            collection.delete_many
+            if spec.server_version_satisfied?(client)
+              test.clear_fail_point(collection.client)
+              collection.delete_many
+            end
           end
 
           let(:verifier) { Mongo::CRUD::Verifier.new(test) }

--- a/spec/spec_tests/retryable_writes_spec.rb
+++ b/spec/spec_tests/retryable_writes_spec.rb
@@ -33,7 +33,7 @@ describe 'Retryable writes spec tests' do
           end
 
           after do
-            test.clear_fail_point(collection)
+            test.clear_fail_point(collection.client)
             collection.delete_many
           end
 

--- a/spec/spec_tests/retryable_writes_spec.rb
+++ b/spec/spec_tests/retryable_writes_spec.rb
@@ -11,7 +11,9 @@ describe 'Retryable writes spec tests' do
       spec.tests.each do |test|
 
         context(test.description) do
-          min_server_fcv '3.6'
+          # Retryable writes work on 3.6 servers but fail points only
+          # exist in 4.0 and higher
+          min_server_fcv '4.0'
           require_topology :replica_set
 
           let(:collection) do

--- a/spec/support/crud.rb
+++ b/spec/support/crud.rb
@@ -12,231 +12,113 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require_relative './gridfs'
+require 'support/gridfs'
+require 'support/crud/spec'
+require 'support/crud/test'
+require 'support/crud/outcome'
+require 'support/crud/operation'
+require 'support/crud/read'
+require 'support/crud/write'
+require 'support/crud/verifier'
 
-module Mongo
-  module CRUD
+def define_crud_spec_test_examples(spec, &block)
+  spec.tests.each do |test|
 
-    # Represents a CRUD specification test.
-    #
-    # @since 2.0.0
-    class Spec
+    context(test.description) do
 
-      # @return [ String ] description The spec description.
-      #
-      # @since 2.0.0
-      attr_reader :description
+      before(:each) do
+        unless spec.server_version_satisfied?(client)
+          skip 'Version requirement not satisfied'
+        end
+      end
 
-      # Instantiate the new spec.
-      #
-      # @example Create the spec.
-      #   Spec.new(file)
-      #
-      # @param [ String ] file The name of the file.
-      #
-      # @since 2.0.0
-      def initialize(file)
-        file = File.new(file)
-        @spec = YAML.load(ERB.new(file.read).result)
-        file.close
-        @description = File.basename(file)
-        @data = @spec['data']
-        @crud_tests = @spec['tests']
-        @min_server_version = @spec['minServerVersion']
-        @max_server_version = @spec['maxServerVersion']
-        @topologies = if topologies = @spec['topology']
-          topologies.map do |topology|
-            {'replicaset' => :replica_set, 'single' => :single, 'sharded' => :sharded}[topology]
+      let(:verifier) { Mongo::CRUD::Verifier.new(test) }
+
+      instance_exec(spec, test, &block)
+
+      test.operations.each_with_index do |operation, index|
+        context "operation #{index+1}" do
+
+          let(:result) do
+            if operation.outcome.error?
+              error = nil
+              begin
+                test.run(collection, index+1)
+              rescue => e
+                error = e
+              end
+              error
+            else
+              test.run(collection, index+1)
+            end
           end
-        else
-          nil
-        end
-      end
 
-      attr_reader :min_server_version
-      attr_reader :topologies
-
-      # Whether the test can be run on a given server version.
-      #
-      # @example Can the test run on this server version?
-      #   spec.server_version_satisfied?(client)
-      #
-      # @param [ Mongo::Client ] client The client to check.
-      #
-      # @return [ true, false ] Whether the test can be run on the given
-      #   server version.
-      #
-      # @since 2.4.0
-      def server_version_satisfied?(client)
-        lower_bound_satisfied?(client) && upper_bound_satisfied?(client)
-      end
-
-      # Get a list of CRUDTests for each test definition.
-      #
-      # @example Get the list of CRUDTests.
-      #   spec.tests
-      #
-      # @return [ Array<CRUDTest> ] The list of CRUDTests.
-      #
-      # @since 2.0.0
-      def tests
-        @crud_tests.collect do |test|
-          Mongo::CRUD::CRUDTest.new(@data, test)
-        end
-      end
-
-      private
-
-      def upper_bound_satisfied?(client)
-        return true unless @max_server_version
-        client.database.command(buildInfo: 1).first['version'] <= @max_server_version
-      end
-
-      def lower_bound_satisfied?(client)
-        return true unless @min_server_version
-        #@min_server_version <= client.database.command(buildInfo: 1).first['version']
-        @min_server_version <= ClusterConfig.instance.fcv_ish
-      end
-    end
-
-    # Represents a single CRUD test.
-    #
-    # @since 2.0.0
-    class CRUDTest
-
-      # The test description.
-      #
-      # @return [ String ] description The test description.
-      #
-      # @since 2.0.0
-      attr_reader :description
-
-      # Spec tests have configureFailPoint as a string, make it a string here too
-      FAIL_POINT_BASE_COMMAND = {
-        'configureFailPoint' => "onPrimaryTransactionalWrite",
-      }.freeze
-
-      # Instantiate the new CRUDTest.
-      #
-      # data can be an array of hashes, with each hash corresponding to a
-      # document to be inserted into the collection whose name is given in
-      # collection_name as configured in the YAML file. Alternatively data
-      # can be a map of collection names to arrays of hashes.
-      #
-      # @param [ Hash | Array<Hash> ] data The documents the collection
-      #   must have before the test runs.
-      # @param [ Hash ] test The test specification.
-      #
-      # @since 2.0.0
-      def initialize(data, test)
-        @data = data
-        if test['failPoint']
-          @fail_point_command = FAIL_POINT_BASE_COMMAND.merge(test['failPoint'])
-        end
-        @description = test['description']
-        @client_options = Utils.convert_client_options(test['clientOptions'] || {})
-        if test['operations']
-          @operations = test['operations'].map do |op_spec|
-            Operation.get(op_spec)
+          let(:verify_collection_name) do
+            if operation.outcome && operation.outcome.collection_name
+              operation.outcome.collection_name
+            else
+              'crud_spec_test'
+            end
           end
-        else
-          @operations = [Operation.get(test['operation'], test['outcome'])]
-        end
-      end
 
-      attr_reader :client_options
+          let(:verify_collection) { client[verify_collection_name] }
 
-      # Operations to be performed by the test.
-      #
-      # For CRUD tests, there is one operation for test. For retryable writes,
-      # there are multiple operations for each test. In either case we build
-      # an array of operations.
-      attr_reader :operations
-
-      # Run the test.
-      #
-      # The specified number of operations are executed, so that the
-      # test can assert on the outcome of each specified operation in turn.
-      #
-      # @param [ Collection ] collection The collection the test
-      #   should be run on.
-      # @param [ Integer ] num_ops Number of operations to run.
-      #
-      # @return [ Result, Array<Hash> ] The result(s) of running the test.
-      #
-      # @since 2.0.0
-      def run(collection, num_ops)
-        result = nil
-        1.upto(num_ops) do |i|
-          operation = @operations[i-1]
-          target = case operation.object
-          when 'collection'
-            collection
-          when 'database'
-            collection.database
-          when 'client'
-            collection.client
-          when 'gridfsbucket'
-            collection.database.fs
+          if operation.outcome.error?
+            it 'raises an error' do
+              expect(result).to be_a(Mongo::Error)
+            end
           else
-            raise "Unknown target #{operation.object}"
+            tested = false
+
+            if operation.outcome.result
+              tested = true
+              it 'returns the correct result' do
+                result
+                verifier.verify_operation_result(operation.outcome.result, result)
+              end
+            end
+
+            if operation.outcome.collection_data?
+              tested = true
+              it 'has the correct data in the collection' do
+                result
+                verifier.verify_collection_data(
+                  operation.outcome.collection_data,
+                  verify_collection.find.to_a)
+              end
+            end
+
+            unless tested
+              it 'succeeds' do
+                expect do
+                  result
+                end.not_to raise_error
+              end
+            end
           end
-          result = operation.execute(target)
-        end
-        result
-      end
-
-      class DataConverter
-        include Mongo::GridFS::Convertible
-      end
-
-      def setup_test(collection)
-        client = collection.client
-        clear_fail_point(client)
-        if @data.is_a?(Array)
-          @collection = collection
-          collection.delete_many
-          collection.insert_many(@data)
-        elsif @data.is_a?(Hash)
-          converter = DataConverter.new
-          @data.each do |collection_name, data|
-            collection = client[collection_name]
-            collection.delete_many
-            data = converter.transform_docs(data)
-            collection.insert_many(data)
-          end
-        else
-          raise "Unknown type of data: #{@data}"
-        end
-        set_up_fail_point(client)
-      end
-
-      def set_up_fail_point(client)
-        if @fail_point_command
-          client.use(:admin).command(@fail_point_command)
-        end
-      end
-
-      def clear_fail_point(client)
-        if @fail_point_command
-          client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(mode: "off"))
-        end
-      end
-
-      private
-
-      def actual_collection_data
-        if expected_outcome.collection_data?
-          collection_name = expected_outcome.collection_name || @collection.name
-          @collection.database[collection_name].find.to_a
         end
       end
     end
   end
 end
 
-require 'support/crud/outcome'
-require 'support/crud/operation'
-require 'support/crud/read'
-require 'support/crud/write'
-require 'support/crud/verifier'
+def define_crud_spec_tests(description, test_paths, &block)
+  describe(description) do
+
+    test_paths.each do |path|
+
+      spec = Mongo::CRUD::Spec.new(path)
+
+      context(spec.description) do
+        if spec.min_server_version
+          min_server_fcv spec.min_server_version.split('.')[0..1].join('.')
+        end
+        if spec.topologies
+          require_topology *spec.topologies
+        end
+
+        define_crud_spec_test_examples(spec, &block)
+      end
+    end
+  end
+end

--- a/spec/support/crud/requirement.rb
+++ b/spec/support/crud/requirement.rb
@@ -1,0 +1,64 @@
+module Mongo
+  module CRUD
+    class Requirement
+      YAML_KEYS = %w(minServerVersion maxServerVersion topology).freeze
+
+      def initialize(spec)
+        @min_server_version = spec['minServerVersion']
+        @max_server_version = spec['maxServerVersion']
+        @topologies = if topologies = spec['topology']
+          topologies.map do |topology|
+            {'replicaset' => :replica_set, 'single' => :single, 'sharded' => :sharded}[topology]
+          end
+        else
+          nil
+        end
+      end
+
+      attr_reader :min_server_version
+      attr_reader :max_server_version
+      attr_reader :topologies
+
+      def short_min_server_version
+        if min_server_version
+          min_server_version.split('.')[0..1].join('.')
+        else
+          nil
+        end
+      end
+
+      def short_max_server_version
+        if max_server_version
+          max_server_version.split('.')[0..1].join('.')
+        else
+          nil
+        end
+      end
+
+      def satisfied?
+        cc = ClusterConfig.instance
+        ok = true
+        if short_min_server_version
+          ok &&= cc.fcv_ish >= short_min_server_version
+        end
+        if max_server_version
+          ok &&= cc.server_version <= max_server_version
+        end
+        if topologies
+          ok &&= topologies.include?(cc.topology)
+        end
+        ok
+      end
+
+      def description
+        versions = [min_server_version, max_server_version].compact.join('-')
+        topologies = if self.topologies
+          self.topologies.map(&:to_s).join(',')
+        else
+          nil
+        end
+        [versions, topologies].compact.join('/')
+      end
+    end
+  end
+end

--- a/spec/support/crud/spec.rb
+++ b/spec/support/crud/spec.rb
@@ -25,19 +25,19 @@ module Mongo
         @description = File.basename(file)
         @data = @spec['data']
         @crud_tests = @spec['tests']
-        @min_server_version = @spec['minServerVersion']
-        @max_server_version = @spec['maxServerVersion']
-        @topologies = if topologies = @spec['topology']
-          topologies.map do |topology|
-            {'replicaset' => :replica_set, 'single' => :single, 'sharded' => :sharded}[topology]
+        @requirements = Requirement.new(@spec)
+        @requirements = if run_on = @spec['runOn']
+          run_on.map do |spec|
+            Requirement.new(spec)
           end
+        elsif Requirement::YAML_KEYS.any? { |key| @spec.key?(key) }
+          [Requirement.new(@spec)]
         else
           nil
         end
       end
 
-      attr_reader :min_server_version
-      attr_reader :topologies
+      attr_reader :requirements
 
       # Whether the test can be run on a given server version.
       #

--- a/spec/support/crud/spec.rb
+++ b/spec/support/crud/spec.rb
@@ -1,0 +1,85 @@
+module Mongo
+  module CRUD
+    # Represents a CRUD specification test.
+    #
+    # @since 2.0.0
+    class Spec
+
+      # @return [ String ] description The spec description.
+      #
+      # @since 2.0.0
+      attr_reader :description
+
+      # Instantiate the new spec.
+      #
+      # @example Create the spec.
+      #   Spec.new(file)
+      #
+      # @param [ String ] file The name of the file.
+      #
+      # @since 2.0.0
+      def initialize(file)
+        file = File.new(file)
+        @spec = YAML.load(ERB.new(file.read).result)
+        file.close
+        @description = File.basename(file)
+        @data = @spec['data']
+        @crud_tests = @spec['tests']
+        @min_server_version = @spec['minServerVersion']
+        @max_server_version = @spec['maxServerVersion']
+        @topologies = if topologies = @spec['topology']
+          topologies.map do |topology|
+            {'replicaset' => :replica_set, 'single' => :single, 'sharded' => :sharded}[topology]
+          end
+        else
+          nil
+        end
+      end
+
+      attr_reader :min_server_version
+      attr_reader :topologies
+
+      # Whether the test can be run on a given server version.
+      #
+      # @example Can the test run on this server version?
+      #   spec.server_version_satisfied?(client)
+      #
+      # @param [ Mongo::Client ] client The client to check.
+      #
+      # @return [ true, false ] Whether the test can be run on the given
+      #   server version.
+      #
+      # @since 2.4.0
+      def server_version_satisfied?(client)
+        lower_bound_satisfied?(client) && upper_bound_satisfied?(client)
+      end
+
+      # Get a list of CRUDTests for each test definition.
+      #
+      # @example Get the list of CRUDTests.
+      #   spec.tests
+      #
+      # @return [ Array<CRUDTest> ] The list of CRUDTests.
+      #
+      # @since 2.0.0
+      def tests
+        @crud_tests.collect do |test|
+          Mongo::CRUD::CRUDTest.new(@data, test)
+        end
+      end
+
+      private
+
+      def upper_bound_satisfied?(client)
+        return true unless @max_server_version
+        client.database.command(buildInfo: 1).first['version'] <= @max_server_version
+      end
+
+      def lower_bound_satisfied?(client)
+        return true unless @min_server_version
+        #@min_server_version <= client.database.command(buildInfo: 1).first['version']
+        @min_server_version <= ClusterConfig.instance.fcv_ish
+      end
+    end
+  end
+end

--- a/spec/support/crud/test.rb
+++ b/spec/support/crud/test.rb
@@ -1,0 +1,138 @@
+module Mongo
+  module CRUD
+
+    # Represents a single CRUD test.
+    #
+    # @since 2.0.0
+    class CRUDTest
+
+      # The test description.
+      #
+      # @return [ String ] description The test description.
+      #
+      # @since 2.0.0
+      attr_reader :description
+
+      # Spec tests have configureFailPoint as a string, make it a string here too
+      FAIL_POINT_BASE_COMMAND = {
+        'configureFailPoint' => "onPrimaryTransactionalWrite",
+      }.freeze
+
+      # Instantiate the new CRUDTest.
+      #
+      # data can be an array of hashes, with each hash corresponding to a
+      # document to be inserted into the collection whose name is given in
+      # collection_name as configured in the YAML file. Alternatively data
+      # can be a map of collection names to arrays of hashes.
+      #
+      # @param [ Hash | Array<Hash> ] data The documents the collection
+      #   must have before the test runs.
+      # @param [ Hash ] test The test specification.
+      #
+      # @since 2.0.0
+      def initialize(data, test)
+        @data = data
+        if test['failPoint']
+          @fail_point_command = FAIL_POINT_BASE_COMMAND.merge(test['failPoint'])
+        end
+        @description = test['description']
+        @client_options = Utils.convert_client_options(test['clientOptions'] || {})
+        if test['operations']
+          @operations = test['operations'].map do |op_spec|
+            Operation.get(op_spec)
+          end
+        else
+          @operations = [Operation.get(test['operation'], test['outcome'])]
+        end
+      end
+
+      attr_reader :client_options
+
+      # Operations to be performed by the test.
+      #
+      # For CRUD tests, there is one operation for test. For retryable writes,
+      # there are multiple operations for each test. In either case we build
+      # an array of operations.
+      attr_reader :operations
+
+      # Run the test.
+      #
+      # The specified number of operations are executed, so that the
+      # test can assert on the outcome of each specified operation in turn.
+      #
+      # @param [ Collection ] collection The collection the test
+      #   should be run on.
+      # @param [ Integer ] num_ops Number of operations to run.
+      #
+      # @return [ Result, Array<Hash> ] The result(s) of running the test.
+      #
+      # @since 2.0.0
+      def run(collection, num_ops)
+        result = nil
+        1.upto(num_ops) do |i|
+          operation = @operations[i-1]
+          target = case operation.object
+          when 'collection'
+            collection
+          when 'database'
+            collection.database
+          when 'client'
+            collection.client
+          when 'gridfsbucket'
+            collection.database.fs
+          else
+            raise "Unknown target #{operation.object}"
+          end
+          result = operation.execute(target)
+        end
+        result
+      end
+
+      class DataConverter
+        include Mongo::GridFS::Convertible
+      end
+
+      def setup_test(collection)
+        client = collection.client
+        clear_fail_point(client)
+        if @data.is_a?(Array)
+          @collection = collection
+          collection.delete_many
+          collection.insert_many(@data)
+        elsif @data.is_a?(Hash)
+          converter = DataConverter.new
+          @data.each do |collection_name, data|
+            collection = client[collection_name]
+            collection.delete_many
+            data = converter.transform_docs(data)
+            collection.insert_many(data)
+          end
+        else
+          raise "Unknown type of data: #{@data}"
+        end
+        set_up_fail_point(client)
+      end
+
+      def set_up_fail_point(client)
+        if @fail_point_command
+          client.use(:admin).command(@fail_point_command)
+        end
+      end
+
+      def clear_fail_point(client)
+        if @fail_point_command
+          client.use(:admin).command(FAIL_POINT_BASE_COMMAND.merge(mode: "off"))
+        end
+      end
+
+      private
+
+      def actual_collection_data
+        if expected_outcome.collection_data?
+          collection_name = expected_outcome.collection_name || @collection.name
+          @collection.database[collection_name].find.to_a
+        end
+      end
+    end
+  end
+end

--- a/spec/support/crud/write.rb
+++ b/spec/support/crud/write.rb
@@ -74,6 +74,10 @@ module Mongo
 
         attr_reader :outcome
 
+        def object
+          'collection'
+        end
+
         # Whether the operation is expected to have results.
         #
         # @example Whether the operation is expected to have results.


### PR DESCRIPTION
This PR contains changes to the crud spec runner needed to support retryable reads, specifically:

- Adding additional read operations not previously implemented by the runner
- Supporting additional operation targets (database & client in addition to collection, for change stream tests)
- Supporting runOn server version/topology requirements
