### PR TITLE
Fix NoMethodError: undefined method `[]' for nil:NilClass for tests.

### DIFF
--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -4,6 +4,7 @@ class SpecConfig
   include Singleton
 
   def initialize
+    @uri_options = {}
     if ENV['MONGODB_URI']
       @mongodb_uri = Mongo::URI.new(ENV['MONGODB_URI'])
       @uri_options = Mongo::Options::Mapper.transform_keys_to_symbols(@mongodb_uri.uri_options)


### PR DESCRIPTION
Right now the CI tests are not started correctly because of below issue.

https://travis-ci.org/mongodb/mongo-ruby-driver/builds/536965194

```
NoMethodError: undefined method `[]' for nil:NilClass
/home/travis/build/mongodb/mongo-ruby-driver/spec/support/spec_config.rb:123:in `uri_option_or_env_var'
```

After this PR, you still see below test failures.
But it's better than current situation.

Here is my repository's result.
https://travis-ci.org/junaruga/mongo-ruby-driver/builds/538259907

### Ruby 1.9.3, MongoDB 2.6.2

https://api.travis-ci.org/v3/job/538259909/log.txt

```
11282 examples, 3 failures, 5300 pending

Failed examples:

rspec ./spec/mongo/server/connection_spec.rb[1:1:1:6:1:1] # Mongo::Server::Connection#connect! when no socket exists when #authenticate! raises an exception behaves like failing connection raises an exception
rspec ./spec/mongo/server/connection_spec.rb[1:1:1:6:1:2] # Mongo::Server::Connection#connect! when no socket exists when #authenticate! raises an exception behaves like failing connection clears socket
rspec ./spec/mongo/server/connection_spec.rb[1:1:1:6:2:1] # Mongo::Server::Connection#connect! when no socket exists when #authenticate! raises an exception behaves like logs a warning logs a warning
```

### Ruby 2.6, MongoDB 4.0.5

https://api.travis-ci.org/v3/job/538259911/log.txt

```
11282 examples, 4 failures, 3962 pending

Failed examples:

rspec ./spec/integration/auth_spec.rb:127 # Auth Unauthorized exception message attempting to connect to a non-tls server with tls reports host, port and tls status
rspec ./spec/mongo/server/connection_spec.rb[1:1:1:6:1:1] # Mongo::Server::Connection#connect! when no socket exists when #authenticate! raises an exception behaves like failing connection raises an exception
rspec ./spec/mongo/server/connection_spec.rb[1:1:1:6:1:2] # Mongo::Server::Connection#connect! when no socket exists when #authenticate! raises an exception behaves like failing connection clears socket
rspec ./spec/mongo/server/connection_spec.rb[1:1:1:6:2:1] # Mongo::Server::Connection#connect! when no socket exists when #authenticate! raises an exception behaves like logs a warning logs a warning
```
