### PR TITLE
DOCS-12711 Fit compatibility tables in view by removing padding

### DIFF
--- a/docs/reference/driver-compatibility.txt
+++ b/docs/reference/driver-compatibility.txt
@@ -16,7 +16,7 @@ MongoDB Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :class: compatibility
+   :class: compatibility-large no-padding
 
    * - Ruby Driver
      - MongoDB 4.0
@@ -165,7 +165,7 @@ Ruby Compatibility
 .. list-table::
    :header-rows: 1
    :stub-columns: 1
-   :class: compatibility
+   :class: compatibility-large no-padding
 
    * - Ruby Driver
      - Ruby 2.6


### PR DESCRIPTION
This uses the new no-padding class added to docs-tools
in https://github.com/mongodb/docs-tools/pull/300 .

The padding on the compatibility tables is interfering with
the ability of the table to stretch to fit.

### JIRA 
https://jira.mongodb.org/browse/DOCS-12771

### Staged
https://docs-mongodbcom-staging.corp.mongodb.com/ruby-driver/bush/master/reference/driver-compatibility.html

### Screenshots
#### Before
![image](https://user-images.githubusercontent.com/20050130/58989517-12273a80-87b2-11e9-905a-a8a7763567f4.png)
![image](https://user-images.githubusercontent.com/20050130/58989538-1ce1cf80-87b2-11e9-8f4c-534288d86e08.png)

#### After
![image](https://user-images.githubusercontent.com/20050130/58989580-2ec37280-87b2-11e9-8b90-e8865d136ca2.png)
![image](https://user-images.githubusercontent.com/20050130/58989591-3420bd00-87b2-11e9-83f4-8da56fa605fd.png)
