### PR TITLE
Memoize Mongo::Operation::PolymorphicResult#result_class to speedup driver

### DIFF
--- a/lib/mongo/operation/shared/polymorphic_result.rb
+++ b/lib/mongo/operation/shared/polymorphic_result.rb
@@ -27,8 +27,16 @@ module Mongo
 
       private
 
+      def self.included(base)
+        base.extend ClassMethods
+      end
+
+      module ClassMethods
+        attr_accessor :result_class
+      end
+
       def result_class
-        begin
+        self.class.result_class ||= begin
           polymorphic_class(self.class.name, :Result)
         rescue NameError
           polymorphic_class(self.class.name.sub(/::[^:]*$/, ''), :Result)


### PR DESCRIPTION
This change alone speeds up our test suit by 10%. It seems that the `PolymorphicResult` was doing a symbol lookup unnecessarily too often.