### PR TITLE
Fix RUBY-1876 Can't disable retryable read/writes via URI options

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -356,13 +356,6 @@ module Mongo
         options = {}
       end
 
-      unless options[:retry_reads] == false
-        options[:retry_reads] = true
-      end
-      unless options[:retry_writes] == false
-        options[:retry_writes] = true
-      end
-
       if addresses_or_uri.is_a?(::String)
         uri = URI.get(addresses_or_uri, options)
         addresses = uri.servers
@@ -377,6 +370,13 @@ module Mongo
         options = uri_options.merge(options)
       else
         addresses = addresses_or_uri
+      end
+
+      unless options[:retry_reads] == false
+        options[:retry_reads] = true
+      end
+      unless options[:retry_writes] == false
+        options[:retry_writes] = true
       end
 
       # Special handling for sdam_proc as it is only used during client

--- a/spec/mongo/client_construction_spec.rb
+++ b/spec/mongo/client_construction_spec.rb
@@ -742,6 +742,52 @@ describe Mongo::Client do
             end
           end
         end
+
+        context 'when retryReads URI option is given' do
+
+          context 'it is false' do
+            let!(:uri) do
+              'mongodb://127.0.0.1:27017/testdb?retryReads=false'
+            end
+
+            it 'sets the option on the client' do
+              expect(client.options[:retry_reads]).to be false
+            end
+          end
+
+          context 'it is true' do
+            let!(:uri) do
+              'mongodb://127.0.0.1:27017/testdb?retryReads=true'
+            end
+
+            it 'sets the option on the client' do
+              expect(client.options[:retry_reads]).to be true
+            end
+          end
+        end
+
+        context 'when retryWrites URI option is given' do
+
+          context 'it is false' do
+            let!(:uri) do
+              'mongodb://127.0.0.1:27017/testdb?retryWrites=false'
+            end
+
+            it 'sets the option on the client' do
+              expect(client.options[:retry_writes]).to be false
+            end
+          end
+
+          context 'it is true' do
+            let!(:uri) do
+              'mongodb://127.0.0.1:27017/testdb?retryWrites=true'
+            end
+
+            it 'sets the option on the client' do
+              expect(client.options[:retry_writes]).to be true
+            end
+          end
+        end
       end
 
       context 'when options are provided not in the string' do


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-1876