### PR TITLE
RUBY-1871 Associate connections with pools

### DIFF
--- a/lib/mongo/server/connection.rb
+++ b/lib/mongo/server/connection.rb
@@ -123,6 +123,14 @@ module Mongo
         options[:generation]
       end
 
+      # ID of the connection pool from which this connection was created.
+      # May be nil.
+      #
+      # @api private
+      def pool_object_id
+        options[:pool_object_id]
+      end
+
       # Whether the connection was closed.
       #
       # Closed connections should no longer be used. Instead obtain a new

--- a/lib/mongo/server/connection.rb
+++ b/lib/mongo/server/connection.rb
@@ -127,8 +127,8 @@ module Mongo
       # May be nil.
       #
       # @api private
-      def pool_object_id
-        options[:pool_object_id]
+      def pool
+        options[:pool]
       end
 
       # Whether the connection was closed.
@@ -159,7 +159,7 @@ module Mongo
       def connect!
         if closed?
           if Lint.enabled?
-            raise Error::LintError, "Reconnecting closed connections is no longer supported"
+            raise Error::LintError, "Reconnecting closed connections is no longer supported (for #{address})"
           else
             log_warn("Reconnecting closed connections is deprecated (for #{address})")
           end
@@ -298,7 +298,7 @@ module Mongo
 
       def handshake!(socket)
         unless socket
-          raise Error::HandshakeError, "Cannot handshake because there is no usable socket"
+          raise Error::HandshakeError, "Cannot handshake because there is no usable socket (for #{address})"
         end
 
         response = average_rtt = nil

--- a/lib/mongo/server/connection.rb
+++ b/lib/mongo/server/connection.rb
@@ -123,12 +123,12 @@ module Mongo
         options[:generation]
       end
 
-      # ID of the connection pool from which this connection was created.
+      # The connection pool from which this connection was created.
       # May be nil.
       #
       # @api private
-      def pool
-        options[:pool]
+      def connection_pool
+        options[:connection_pool]
       end
 
       # Whether the connection was closed.

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -348,8 +348,8 @@ module Mongo
       # @since 2.9.0
       def check_in(connection)
         @lock.synchronize do
-          unless connection.pool_object_id == object_id
-            raise ArgumentError, "Trying to check in a connection which was not checked out by this pool: #{connection}"
+          unless connection.pool == self
+            raise ArgumentError, "Trying to check in a connection which was not checked out by this pool: #{connection} checked out from pool #{connection.pool} (for #{self})"
           end
 
           # Note: if an event handler raises, resource will not be signaled.
@@ -625,7 +625,7 @@ module Mongo
 
       def create_connection
         connection = Connection.new(@server, options.merge(generation: generation,
-          pool_object_id: object_id))
+          pool: self))
       end
 
       # Create a connection, connect it, and add it to the pool.

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -348,8 +348,8 @@ module Mongo
       # @since 2.9.0
       def check_in(connection)
         @lock.synchronize do
-          unless connection.pool == self
-            raise ArgumentError, "Trying to check in a connection which was not checked out by this pool: #{connection} checked out from pool #{connection.pool} (for #{self})"
+          unless connection.connection_pool == self
+            raise ArgumentError, "Trying to check in a connection which was not checked out by this pool: #{connection} checked out from pool #{connection.connection_pool} (for #{self})"
           end
 
           unless @checked_out_connections.include?(connection)
@@ -625,7 +625,7 @@ module Mongo
 
       def create_connection
         connection = Connection.new(@server, options.merge(generation: generation,
-          pool: self))
+          connection_pool: self))
       end
 
       # Create a connection, connect it, and add it to the pool.

--- a/spec/mongo/server/connection_pool_spec.rb
+++ b/spec/mongo/server/connection_pool_spec.rb
@@ -402,7 +402,7 @@ describe Mongo::Server::ConnectionPool do
 
         expect do
           pool_other.check_in(connection)
-        end.to raise_error(ArgumentError)
+        end.to raise_error(ArgumentError, /Trying to check in a connection which was not checked out by this pool.*/)
       end
     end
   end

--- a/spec/mongo/server/connection_pool_spec.rb
+++ b/spec/mongo/server/connection_pool_spec.rb
@@ -396,7 +396,7 @@ describe Mongo::Server::ConnectionPool do
 
     context 'when connection is checked in to a different pool' do
       it 'raises an ArgumentError and does not change the state of either pool' do
-        pool_other = described_class.new(server)
+        pool_other = register_pool(described_class.new(server))
 
         expect do
           pool_other.check_in(connection)

--- a/spec/mongo/server/connection_pool_spec.rb
+++ b/spec/mongo/server/connection_pool_spec.rb
@@ -384,25 +384,25 @@ describe Mongo::Server::ConnectionPool do
     end
 
     context 'when connection is checked in twice' do
-      before do
+      it 'raises an ArgumentError and does not change pool state' do
         pool.check_in(connection)
-      end
-
-      it 'is a no-op' do
-        expect(pool.size).to eq(1)
-        pool.check_in(connection)
+        expect do
+          pool.check_in(connection)
+        end.to raise_error(ArgumentError, /Trying to check in a connection which is not currently checked out by this pool.*/)
         expect(pool.size).to eq(1)
         expect(pool.check_out).to eq(connection)
       end
     end
 
     context 'when connection is checked in to a different pool' do
-      it 'raises an ArgumentError' do
+      it 'raises an ArgumentError and does not change the state of either pool' do
         pool_other = described_class.new(server)
 
         expect do
           pool_other.check_in(connection)
         end.to raise_error(ArgumentError, /Trying to check in a connection which was not checked out by this pool.*/)
+        expect(pool.size).to eq(1)
+        expect(pool_other.size).to eq(0)
       end
     end
   end

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -561,7 +561,7 @@ describe Mongo::Server::Connection, retry: 3 do
 
           expect do
             connection.dispatch([ query_alice ]).documents
-          end.to raise_error(Mongo::Error::LintError, 'Reconnecting closed connections is no longer supported')
+          end.to raise_error(Mongo::Error::LintError, /Reconnecting closed connections is no longer supported.*/)
         end
       end
 


### PR DESCRIPTION
First part of 1871 followup work: Distinguish between connection being checked into the correct pool, but out of sequence vs connection being checked into a foreign pool