### PR TITLE
RUBY-1887 add AuthError and rescue it with Mongo::Error (wip)

### DIFF
--- a/lib/mongo/auth.rb
+++ b/lib/mongo/auth.rb
@@ -73,7 +73,7 @@ module Mongo
     # Raised when trying to get an invalid authorization mechanism.
     #
     # @since 2.0.0
-    class InvalidMechanism < RuntimeError
+    class InvalidMechanism < Mongo::Error::AuthError
 
       # Instantiate the new error.
       #
@@ -94,7 +94,7 @@ module Mongo
     # Raised when a user is not authorized on a database.
     #
     # @since 2.0.0
-    class Unauthorized < RuntimeError
+    class Unauthorized < Mongo::Error::AuthError
 
       # Instantiate the new error.
       #

--- a/lib/mongo/error.rb
+++ b/lib/mongo/error.rb
@@ -141,6 +141,7 @@ module Mongo
   end
 end
 
+require 'mongo/error/auth_error'
 require 'mongo/error/sdam_error_detection'
 require 'mongo/error/parser'
 require 'mongo/error/write_retryable'

--- a/lib/mongo/error/auth_error.rb
+++ b/lib/mongo/error/auth_error.rb
@@ -17,7 +17,11 @@ module Mongo
 
     # Raised when authentication fails.
     #
-    # @since 2.7.0
+    # Note: This class is derived from RuntimeError for
+    # backwards compatibility reasons. It is subject to
+    # change in future major versions of the driver.
+    #
+    # @since 2.11.0
     class AuthError < RuntimeError
     end
   end

--- a/lib/mongo/error/auth_error.rb
+++ b/lib/mongo/error/auth_error.rb
@@ -1,0 +1,24 @@
+# Copyright (C) 2018-2019 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  class Error
+
+    # Raised when authentication fails.
+    #
+    # @since 2.7.0
+    class AuthError < RuntimeError
+    end
+  end
+end

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -574,14 +574,15 @@ module Mongo
       end
 
       # Creates and adds a connection to the pool, if the pool's size is below
-      # min_size. Retries once if an error is encountered during this process
-      # and raises if a second error occurs.
+      # min_size. Retries once if a socket-related error is encountered during
+      # this process and raises if a second error or a non socket-related error occurs.
       #
       # Used by the pool populator background thread.
       #
       # @return [ true | false ] Whether this method should be called again
       #   to create more connections.
-      # @raise [ Mongo::Error ] The second error raised if a retry occured
+      # @raise [ Exception ] The second socket-related error raised if a retry
+      # occured, or the non socket-related error
       #
       # @api private
       def populate

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -581,7 +581,7 @@ module Mongo
       #
       # @return [ true | false ] Whether this method should be called again
       #   to create more connections.
-      # @raise [ Exception ] The second socket-related error raised if a retry
+      # @raise [ Error::AuthError, Error ] The second socket-related error raised if a retry
       # occured, or the non socket-related error
       #
       # @api private
@@ -597,7 +597,7 @@ module Mongo
         end
 
         return create_and_add_connection
-      rescue Exception
+      rescue Error::AuthError, Error
         # wake up one thread waiting for connections, since one could not
         # be created here, and can instead be created in flow
         @available_semaphore.signal

--- a/lib/mongo/server/connection_pool/connection_pool_populator.rb
+++ b/lib/mongo/server/connection_pool/connection_pool_populator.rb
@@ -43,7 +43,7 @@ module Mongo
           unless @pool.populate
             @pool.populate_semaphore.wait
           end
-        rescue Error => e
+        rescue Error::AuthError, Error => e
           # Errors encountered when trying to add connections to
           # pool; try again later
           log_warn("Populator failed to connect a connection: #{e.class}: #{e}.")


### PR DESCRIPTION
This does not include an entire audit of the driver; that will be in a future PR. 