### PR TITLE
Fix RUBY-1944 Background threads such as the Monitor cannot restart once stopped

### DIFF
--- a/lib/mongo/background_thread.rb
+++ b/lib/mongo/background_thread.rb
@@ -114,6 +114,7 @@ module Mongo
 
     # @return [ Thread ] The created Thread instance.
     def start!
+      @stop_requested = nil
       @thread = Thread.new do
         catch(:done) do
           until @stop_requested

--- a/lib/mongo/background_thread.rb
+++ b/lib/mongo/background_thread.rb
@@ -30,6 +30,14 @@ module Mongo
     #
     # @api public for backwards compatibility only
     def run!
+      if @stop_requested && @thread
+        wait_for_stop
+        if @thread.alive?
+          log_warn("Starting a new background thread in #{self}, but the previous background thread is still running")
+          @thread = nil
+        end
+        @stop_requested = false
+      end
       if running?
         @thread
       else
@@ -81,6 +89,25 @@ module Mongo
       # the middle of an operation.
       @thread.kill
 
+      wait_for_stop
+    end
+
+    private
+
+    def start!
+      @thread = Thread.new do
+        catch(:done) do
+          until @stop_requested
+            do_work
+          end
+        end
+      end
+    end
+
+    # Waits for the thread to die, with a timeout.
+    #
+    # Returns true if the thread died, false otherwise.
+    def wait_for_stop
       # Wait for the thread to die. This is important in order to reliably
       # clean up resources like connections knowing that no background
       # thread will reconnect because it is still working.
@@ -106,21 +133,8 @@ module Mongo
         false
       else
         @thread = nil
+        @stop_requested = false
         true
-      end
-    end
-
-    private
-
-    # @return [ Thread ] The created Thread instance.
-    def start!
-      @stop_requested = nil
-      @thread = Thread.new do
-        catch(:done) do
-          until @stop_requested
-            do_work
-          end
-        end
       end
     end
 

--- a/spec/mongo/server/monitor_spec.rb
+++ b/spec/mongo/server/monitor_spec.rb
@@ -158,7 +158,7 @@ describe Mongo::Server::Monitor do
   end
 =end
 
-  describe '#restart!' do
+  describe '#run!' do
 
     let!(:thread) do
       monitor.run!
@@ -182,6 +182,24 @@ describe Mongo::Server::Monitor do
         expect(monitor.restart!).not_to be(thread)
       end
     end
+
+    context 'when running after a stop' do
+      it 'starts the thread' do
+        ClientRegistry.instance.close_all_clients
+        thread
+        sleep 0.5
+
+        RSpec::Mocks.with_temporary_scope do
+          expect(monitor.connection).to receive(:disconnect!).and_call_original
+          monitor.stop!
+          sleep 0.5
+          expect(thread.alive?).to be false
+          new_thread = monitor.run!
+          sleep 0.5
+          expect(new_thread.alive?).to be(true)
+        end
+      end
+    end
   end
 
   describe '#stop' do
@@ -199,22 +217,6 @@ describe Mongo::Server::Monitor do
         expect(monitor.connection).to receive(:disconnect!).and_call_original
         monitor.stop!
         expect(thread.alive?).to be(false)
-      end
-    end
-
-    context 'when started again' do
-      it 'resumes the thread' do
-        ClientRegistry.instance.close_all_clients
-        thread
-        sleep 0.5
-
-        RSpec::Mocks.with_temporary_scope do
-          expect(monitor.connection).to receive(:disconnect!).and_call_original
-          monitor.stop!
-          monitor.start!
-          sleep 0.5
-          expect(thread.alive?).to be(true)
-        end
       end
     end
   end

--- a/spec/mongo/server/monitor_spec.rb
+++ b/spec/mongo/server/monitor_spec.rb
@@ -201,6 +201,22 @@ describe Mongo::Server::Monitor do
         expect(thread.alive?).to be(false)
       end
     end
+
+    context 'when started again' do
+      it 'resumes the thread' do
+        ClientRegistry.instance.close_all_clients
+        thread
+        sleep 0.5
+
+        RSpec::Mocks.with_temporary_scope do
+          expect(monitor.connection).to receive(:disconnect!).and_call_original
+          monitor.stop!
+          monitor.start!
+          sleep 0.5
+          expect(thread.alive?).to be(true)
+        end
+      end
+    end
   end
 
   describe '#connection' do


### PR DESCRIPTION
Threads that are stopped via a disconnect can't actually be restarted:

```ruby
> server.instance_variable_get(:@monitor).instance_variable_get(:@thread).alive?
=> true
> server.disconnect!
=> true
> server.reconnect!
=> true
> server.instance_variable_get(:@monitor).instance_variable_get(:@thread).alive?
=> false
> server.instance_variable_get(:@monitor).instance_variable_get(:@thread).alive?
=> false
> server.instance_variable_get(:@monitor).instance_variable_get(:@thread).alive?
=> false
```

I can't run tests for some reason, likely due to my config perhaps I don't have some kind of environment variables set up. But I believe this test should pass based on the example code above.

```ruby
     NoMethodError:
       undefined method `map' for true:TrueClass
       Did you mean?  tap
     # ./lib/mongo/cluster.rb:129:in `initialize'
     # ./lib/mongo/client.rb:421:in `new'
     # ./lib/mongo/client.rb:421:in `initialize'
     # ./spec/support/spec_config.rb:70:in `new'
     # ./spec/support/spec_config.rb:70:in `connect_options'
     # ./spec/support/spec_config.rb:359:in `test_options'
     # ./spec/support/client_registry.rb:170:in `new_global_client'
     # ./spec/support/client_registry.rb:83:in `global_client'
     # ./spec/support/cluster_config.rb:124:in `determine_cluster_config'
     # ./spec/support/cluster_config.rb:17:in `server_version'
     # ./spec/support/cluster_config.rb:35:in `fcv_ish'
     # ./spec/spec_helper.rb:22:in `block (2 levels) in <top (required)>'
```