### PR TITLE
RUBY-1913 Do not convert auth source from $external to :external because server does not recognize symbol database names

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -914,7 +914,7 @@ module Mongo
         raise Mongo::Auth::InvalidConfiguration.new('password is not supported for mongodb_x509')
       end
 
-      if ![:external, nil].include?(auth_source) && [:gssapi, :mongodb_x509].include?(auth_mech)
+      if !['$external', nil].include?(auth_source) && [:gssapi, :mongodb_x509].include?(auth_mech)
         raise Mongo::Auth::InvalidConfiguration.new("#{auth_source} is an invalid auth source for #{auth_mech}; valid options are $external and nil")
       end
 

--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -463,9 +463,9 @@ module Mongo
     def default_auth_source
       case @uri_options[:auth_mech]
       when :gssapi, :mongodb_x509
-        :external
+        '$external'
       when :plain
-        @database || :external
+        @database || '$external'
       else
         @database || Database::ADMIN
       end

--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -466,7 +466,7 @@ module Mongo
         :external
       when :plain
         @database || :external
-      else 
+      else
         @database || Database::ADMIN
       end
     end
@@ -544,7 +544,7 @@ module Mongo
     uri_option 'connect', :connect, type: :symbol
 
     # Auth Options
-    uri_option 'authsource', :auth_source, :type => :auth_source
+    uri_option 'authsource', :auth_source
     uri_option 'authmechanism', :auth_mech, :type => :auth_mech
     uri_option 'authmechanismproperties', :auth_mech_properties, :type => :auth_mech_props
 
@@ -630,16 +630,6 @@ module Mongo
       target = select_target(uri_options, strategy[:group])
       value = apply_transform(key, value, strategy[:type])
       merge_uri_option(target, value, strategy[:name])
-    end
-
-    # Auth source transformation, either db string or :external.
-    #
-    # @param value [String] Authentication source.
-    #
-    # @return [String] If auth source is database name.
-    # @return [:external] If auth source is external authentication.
-    def auth_source(value)
-      value == '$external' ? :external : value
     end
 
     # Authentication mechanism transformation.

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -716,9 +716,9 @@ describe Mongo::URI::SRVProtocol do
 
         context '$external' do
           let(:source) { '$external' }
-          let(:expected) { :external }
+          let(:expected) { '$external' }
 
-          it 'sets the auth source to :external' do
+          it 'sets the auth source to '$external'' do
             expect(uri.uri_options[:auth_source]).to eq(expected)
           end
 

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -713,19 +713,6 @@ describe Mongo::URI::SRVProtocol do
             expect(client.options[:auth_source]).to eq(source)
           end
         end
-
-        context '$external' do
-          let(:source) { '$external' }
-          let(:expected) { '$external' }
-
-          it 'sets the auth source to '$external'' do
-            expect(uri.uri_options[:auth_source]).to eq(expected)
-          end
-
-          it 'sets the options on a client created with the uri' do
-            expect(client.options[:auth_source]).to eq(expected)
-          end
-        end
       end
 
       context 'auth mechanism properties provided' do

--- a/spec/mongo/uri_option_parsing_spec.rb
+++ b/spec/mongo/uri_option_parsing_spec.rb
@@ -242,14 +242,6 @@ describe Mongo::URI do
 
     it_behaves_like 'a string option'
 
-    context '$external' do
-      let(:string) { "mongodb://example.com/?#{uri_option}=$external" }
-
-      it 'is converted to ;external' do
-        expect(uri.uri_options[ruby_option]).to eq('$external')
-      end
-    end
-
     context 'empty' do
       let(:string) { "mongodb://example.com/?#{uri_option}=" }
 

--- a/spec/mongo/uri_option_parsing_spec.rb
+++ b/spec/mongo/uri_option_parsing_spec.rb
@@ -246,7 +246,7 @@ describe Mongo::URI do
       let(:string) { "mongodb://example.com/?#{uri_option}=$external" }
 
       it 'is converted to ;external' do
-        expect(uri.uri_options[ruby_option]).to eq(:external)
+        expect(uri.uri_options[ruby_option]).to eq('$external')
       end
     end
 

--- a/spec/mongo/uri_spec.rb
+++ b/spec/mongo/uri_spec.rb
@@ -729,7 +729,7 @@ describe Mongo::URI do
 
         context 'when mechanism_properties are provided' do
           let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=CANONICALIZE_HOST_NAME:true" }
-          
+
           it 'does not allow a client to be created' do
             expect {
               new_local_client_nmio(string)
@@ -758,7 +758,7 @@ describe Mongo::URI do
 
         context 'when mechanism_properties are provided' do
           let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=CANONICALIZE_HOST_NAME:true" }
-          
+
           it 'does not allow a client to be created' do
             expect {
               new_local_client_nmio(string)
@@ -799,7 +799,7 @@ describe Mongo::URI do
 
         context 'when mechanism_properties are provided' do
           let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=SERVICE_NAME:other,CANONICALIZE_HOST_NAME:true" }
-          
+
           it 'sets the options on a client created with the uri' do
             client = new_local_client_nmio(string)
             expect(client.options[:auth_mech_properties]).to eq({ 'canonicalize_host_name' => true, 'service_name' => 'other' })
@@ -827,7 +827,7 @@ describe Mongo::URI do
 
         context 'when mechanism_properties are provided' do
           let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=CANONICALIZE_HOST_NAME:true" }
-          
+
           it 'does not allow a client to be created' do
             expect {
               new_local_client_nmio(string)
@@ -878,7 +878,7 @@ describe Mongo::URI do
         context 'when a password is provided' do
           let(:credentials) { "#{user}:#{password}"}
           let(:password) { 's3kr4t' }
-          
+
           it 'does not allow a client to be created' do
             expect {
               new_local_client_nmio(string)
@@ -888,7 +888,7 @@ describe Mongo::URI do
 
         context 'when mechanism_properties are provided' do
           let(:options) { "authMechanism=#{mechanism}&authMechanismProperties=CANONICALIZE_HOST_NAME:true" }
-          
+
           it 'does not allow a client to be created' do
             expect {
               new_local_client_nmio(string)
@@ -950,9 +950,9 @@ describe Mongo::URI do
 
       context '$external' do
         let(:source) { '$external' }
-        let(:expected) { :external }
+        let(:expected) { '$external' }
 
-        it 'sets the auth source to :external' do
+        it 'sets the auth source to '$external'' do
           expect(uri.uri_options[:auth_source]).to eq(expected)
         end
 

--- a/spec/mongo/uri_spec.rb
+++ b/spec/mongo/uri_spec.rb
@@ -947,20 +947,6 @@ describe Mongo::URI do
           expect(client.options[:auth_source]).to eq(source)
         end
       end
-
-      context '$external' do
-        let(:source) { '$external' }
-        let(:expected) { '$external' }
-
-        it 'sets the auth source to '$external'' do
-          expect(uri.uri_options[:auth_source]).to eq(expected)
-        end
-
-        it 'sets the options on a client created with the uri' do
-          client = new_local_client_nmio(string)
-          expect(client.options[:auth_source]).to eq(expected)
-        end
-      end
     end
 
     context 'auth mechanism properties provided' do

--- a/spec/support/auth.rb
+++ b/spec/support/auth.rb
@@ -68,9 +68,7 @@ module Mongo
       end
 
       def expected_credential
-        expected_credential = {
-          'auth_source' => expected_auth_source,
-        }
+        expected_credential = { 'auth_source' => credential['source'] }
 
         if credential['username']
           expected_credential['user'] = credential['username']
@@ -102,11 +100,6 @@ module Mongo
 
       def expected_auth_mech_properties
         credential['mechanism_properties'].keys.map(&:downcase)
-      end
-
-      def expected_auth_source
-        return '$external' if credential['source'] == '$external'
-        credential['source']
       end
     end
   end

--- a/spec/support/auth.rb
+++ b/spec/support/auth.rb
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-RSpec::Matchers.define :have_blank_credentials do 
+RSpec::Matchers.define :have_blank_credentials do
   match do |client|
     %i(auth_mech auth_mech_properties auth_source password user).all? do |key|
       client.options[key].nil?
@@ -105,7 +105,7 @@ module Mongo
       end
 
       def expected_auth_source
-        return :external if credential['source'] == '$external'
+        return '$external' if credential['source'] == '$external'
         credential['source']
       end
     end

--- a/spec/support/connection_string.rb
+++ b/spec/support/connection_string.rb
@@ -277,7 +277,7 @@ module Mongo
             when 'authmechanism'
               Mongo::URI::AUTH_MECH_MAP[v].downcase.to_s
             when 'authsource'
-              v == '$external' ? 'external' : v.downcase
+              v.downcase
             when 'authmechanismproperties'
               v.reduce({}) do |new_v, prop|
                 prop_key = prop.first.downcase


### PR DESCRIPTION
Part one of [RUBY-1913](https://jira.mongodb.org/browse/RUBY-1913)

Any references to the `$external` auth source was being changed into a symbol, which is not a type that the server recognizes. This removes all references to `:external` and deletes related code.