### PR TITLE
Improve User Management Documentation

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -62,7 +62,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mong
       quick-start
       /tutorials/ruby-driver-create-client
       /tutorials/ruby-driver-authentication
-      /tutorials/ruby-driver-user-management
+      /tutorials/user-management
       /tutorials/ruby-driver-crud-operations
       /tutorials/ruby-driver-collection-tasks
       /tutorials/ruby-driver-projections

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -48,8 +48,8 @@ by Durran Jordan.
 For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mongoid/master>`_.
 
 .. COMMENT  For the actual build, see mongodb/docs-ruby repo which pulls the documentation source from:
-..    mongo-ruby-driver, 
-..    bson-ruby, and 
+..    mongo-ruby-driver,
+..    bson-ruby, and
 ..    mongoid repos.
 
 .. class:: hidden
@@ -62,6 +62,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mong
       quick-start
       /tutorials/ruby-driver-create-client
       /tutorials/ruby-driver-authentication
+      /tutorials/ruby-driver-user-management
       /tutorials/ruby-driver-crud-operations
       /tutorials/ruby-driver-collection-tasks
       /tutorials/ruby-driver-projections

--- a/docs/tutorials/ruby-driver-authentication.txt
+++ b/docs/tutorials/ruby-driver-authentication.txt
@@ -10,28 +10,15 @@ Authentication
    :depth: 1
    :class: singlecol
 
-MongoDB supports a variety of 
+MongoDB supports a variety of
 :manual:`authentication mechanisms </core/authentication/>`.
 
 For more information about configuring your MongoDB server for each of
-these authentication mechanisms see MongoDB's 
+these authentication mechanisms see MongoDB's
 :manual:`online documentation </tutorial/enable-authentication>`.
 
-Creating a user
-```````````````
-
-To create a user in specific database, use the ``create`` method with the
-username, password and roles parameters.
-
-.. code-block:: ruby
-
-  client.database.users.create(
-        'durran',
-        password: 'password',
-        roles: [ Mongo::Auth::Roles::READ_WRITE ])
-		
-.. seealso::
-  :manual:`Built-in roles</reference/built-in-roles/>`
+For more information about users and user management, see the
+:ref:`User Management tutorial<user-management>`.
 
 Providing credentials
 `````````````````````
@@ -120,7 +107,7 @@ LDAP (SASL PLAIN) mechanism
 
 MongoDB Enterprise Edition supports the LDAP authentication mechanism
 which allows you to delegate authentication using a Lightweight Directory
-Access Protocol `LDAP <http://en.wikipedia.org/wiki/LDAP>`_ server. 
+Access Protocol `LDAP <http://en.wikipedia.org/wiki/LDAP>`_ server.
 
 .. warning::
 
@@ -166,7 +153,7 @@ installed. Add to your ``Gemfile``:
   require 'mongo_kerberos'
 
 To use Kerberos in the Ruby driver with **MRI**, create a
-ticket-granting ticket using ``kinit``. See 
+ticket-granting ticket using ``kinit``. See
 `this documentation <http://linux.die.net/man/1/kinit>`_ for more
 information.
 

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -10,7 +10,24 @@ User Management
    :depth: 1
    :class: singlecol
 
-[introduction here]
+The Mongo Ruby Driver provides a set of methods for managing users on a MongoDB deployment.
+All of these methods are defined on the ``Mongo::Auth::User::View`` class, which defines the
+behavior for performing user-related operations on a database. You can access a database's
+user view using the ``users`` method on that database:
+
+.. code-block:: ruby
+
+  client.database.users
+
+Note that this will open a view on the database to which the client is already connected.
+To interact with the users defined on a different database, use the client's ``use`` method
+and pass in the name of the database with which you want to connect:
+
+.. code-block:: ruby
+
+  client.use(:users).database.users
+
+In this example, all operations would be performed on the ``users`` database.
 
 Creating a user
 ```````````````

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -1,3 +1,5 @@
+.. _user-management:
+
 ===============
 User Management
 ===============
@@ -28,6 +30,9 @@ and pass in the name of the database with which you want to connect:
   client.use(:users).database.users
 
 In this example, all operations would be performed on the ``users`` database.
+
+For more information about users and user management, see MongoDB's
+:manual:`online documentation </core/security-users>`.
 
 Creating a user
 ```````````````

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -15,14 +15,14 @@ User Management
 The Mongo Ruby Driver provides a set of methods for managing users on a MongoDB deployment.
 All of these methods are defined on the ``Mongo::Auth::User::View`` class, which defines the
 behavior for performing user-related operations on a database. You can access a database's
-user view using the ``users`` method on that database:
+user view by calling the ``users`` method on the correpsonding ``Mongo::Database`` object:
 
 .. code-block:: ruby
 
   client.database.users
 
 Note that this will open a view on the database to which the client is already connected.
-To interact with the users defined on a different database, use the client's ``use`` method
+To interact with the users defined on a different database, call the client's ``use`` method
 and pass in the name of the database with which you want to connect:
 
 .. code-block:: ruby
@@ -50,7 +50,7 @@ password, and roles:
   )
 
 Another way to create a user is to first create a ``Mongo::Auth::User`` object with all the
-user information and then pass that object into the ``create`` method in lieu of a username.
+user information and then pass that object into the ``create`` method instead.
 
 .. code-block:: ruby
 
@@ -63,11 +63,13 @@ user information and then pass that object into the ``create`` method in lieu of
   client.database.users.create(user)
 
 The ``create`` method takes a ``Hash`` of options as an optional second argument.
-The ``:roles`` option allows you to grant your user permissions on your MongoDB instance.
-For example, the Mongo::Auth::Roles::READ_WRITE role grants the user the ability to both
+The ``:roles`` option allows you to grant permissions to the new user.
+For example, the ``Mongo::Auth::Roles::READ_WRITE`` role grants the user the ability to both
 read from and write to the database in which they were created. Each role can be specified
 as a ``String`` or as a ``Hash``. If you would like to grant permissions to a user on a database
-other than the one on which they were created, you can pass that database name in the role hash:
+other than the one on which they were created, you can pass that database name in the role ``Hash``.
+To create a user ``alanturing`` with permission to read and write on the ``machines`` database,
+you could execute the following code:
 
 .. code-block:: ruby
 
@@ -77,24 +79,22 @@ other than the one on which they were created, you can pass that database name i
     roles: [{ role: Mongo::Auth::Roles::READWRITE, db: 'machines' }]
   )
 
-In this example, the user `alanturing` has permission to read and write on the `machines` database. For
-more information about roles in MongoDB, see the  :manual:`Built-in roles</reference/built-in-roles/>`
+For more information about roles in MongoDB, see the :manual:`Built-in roles</reference/built-in-roles/>`
 documentation.
 
 In addition to the ``:roles`` option, the ``create`` method supports a ``:session`` option,
 which allows you to specify a ``Mongo::Session`` object to use for this operation,
-as well as a ``:write_concern`` option, which represents the write concern of this operation
+as well as a ``:write_concern`` option, which specifies the write concern of this operation
 when performed on a replica set.
 
 .. seealso::
+  :manual:`Built-in roles</reference/built-in-roles/>`
   :manual:`Write Concerns</core/replica-set-write-concern/>`,
   :ref:`Sessions<sessions>`,
-  :manual:`Built-in roles</reference/built-in-roles/>`
 
 User Info
 `````````
-To view information about a user that has already been created
-in the database, use the ``info`` method:
+To view information about a user that has already been created in the database, use the ``info`` method:
 
 .. code-block:: ruby
 
@@ -119,13 +119,13 @@ that currently exist on a database.
 
 Updating a user
 ```````````````
-To update a user that already exists in the database, you may use the ``update`` method in
+To update a user that already exists in the database, you can use the ``update`` method in
 one of two ways. The first way is to specify the name of the user you wish to update,
-and a new set of options.
+along with a new set of options.
 
 .. warning::
 
-  You must include all user options in the options ``Hash``, even those options that
+  You must include all user options in the options ``Hash``, even those options whose values
   will remain the same. Omitting an option is the same as setting it to an empty value.
 
 .. code-block:: ruby
@@ -155,8 +155,8 @@ a ``Mongo::Session`` object on which to perform this operation, and ``:write_con
 which sets a write concern if this operation is performed on a replica set.
 
 .. seealso::
-  :manual:`Write Concerns</core/replica-set-write-concern/>`,
   :ref:`Sessions<sessions>`
+  :manual:`Write Concerns</core/replica-set-write-concern/>`,
 
 Removing users
 ``````````````
@@ -172,17 +172,10 @@ options for the ``remove`` method are ``:session`` and ``:write_concern``.
 this operation. ``:write_concern`` specifies the write concern
 of the operation if you are running this command against a replica set.
 
-.. code-block:: ruby
-
-  client.database.users.remove('alanturing', { w: "majority" , wtimeout: 5000 })
-
-This method will return a ``Mongo::Operation::Result`` document
-indicating whether the operation has been performed successfully.
-
 The Ruby Driver does not implement a method for removing all users
 from a database.
 
 .. seealso::
-  :manual:`Write Concerns</core/replica-set-write-concern/>`,
   :ref:`Sessions<sessions>`
+  :manual:`Write Concerns</core/replica-set-write-concern/>`,
 

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -97,6 +97,44 @@ that currently exist on a database.
 
 Updating a user
 ```````````````
+To update a user that already exists in the database, you may use the ``update`` method in
+one of two ways. The first way is to specify the name of the user you wish to update,
+and a new set of options.
+
+.. warning::
+
+  You must include all user options in the options ``Hash``, even those options that
+  will remain the same. Omitting an option is the same as setting it to an empty value.
+
+.. code-block:: ruby
+
+  client.database.users.update(
+    'alanturing',
+    roles: [ Mongo::Auth::Roles::READ_WRITE ]
+    password: 'turing-test'
+  )
+
+The second way to update a user is to pass an updated ``Mongo::Auth::User`` object
+to the ``update`` method in lieu of a username.
+
+.. code-block:: ruby
+
+  user = Mongo::Auth::User.new({
+    user: 'alanturing',
+    roles: [ Mongo::Auth::Roles::READ_WRITE ],
+    password: 'turing-test'
+  })
+
+  client.database.users.update(user)
+
+Optionally, the ``update`` method takes a ``Hash`` of options as a second argument.
+The two possible options for this method are ``:session``, which allows you to specify
+a ``Mongo::Session`` object on which to perform this operation, and ``:write_concern``,
+which sets a write concern if this operation is performed on a replica set.
+
+.. seealso::
+  :manual:`Write Concerns</core/replica-set-write-concern/>`,
+  :ref:`Sessions<sessions>`
 
 Removing users
 ``````````````

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -28,7 +28,7 @@ password, and roles:
   )
 
 Another way to create a user is to first create a ``Mongo::Auth::User`` object with all the
-user information, and then pass that object into the ``create`` method in lieu of a username.
+user information and then pass that object into the ``create`` method in lieu of a username.
 
 .. code-block:: ruby
 
@@ -41,26 +41,33 @@ user information, and then pass that object into the ``create`` method in lieu o
   client.database.users.create(user)
 
 The ``create`` method takes a ``Hash`` of options as an optional second argument.
-In addition to the ``:password`` and ``:roles`` options, which you can see used above,
-this method supports a ``:session`` option, which allows you to specify a ``Mongo::Session``
-object to use for this operation, and a ``:write_concern`` option, which represents the
-write concern of this operation against a replica set.
-
-Note that this method will create a user on the database to which the client is already connected.
-To create a user on a different database, use the ``use`` method and specify the new
-database:
+The ``:roles`` option allows you to grant your user permissions on your MongoDB instance.
+For example, the Mongo::Auth::Roles::READ_WRITE role grants the user the ability to both
+read from and write to the database in which they were created. Each role can be specified
+as a ``String`` or as a ``Hash``. If you would like to grant permissions to a user on a database
+other than the one on which they were created, you can pass that database name in the role hash:
 
 .. code-block:: ruby
 
-  client.use(:users).database.users.create(
+  client.database.users.create(
     'alanturing',
     password: 'enigma',
-    roles: [ Mongo::Auth::Roles::READWRITE ]
+    roles: [{ role: Mongo::Auth::Roles::READWRITE, db: 'machines' }]
   )
+
+In this example, the user `alanturing` has permission to read and write on the `machines` database. For
+more information about roles in MongoDB, see the  :manual:`Built-in roles</reference/built-in-roles/>`
+documentation.
+
+In addition to the ``:roles`` option, the ``create`` method supports a ``:session`` option,
+which allows you to specify a ``Mongo::Session`` object to use for this operation,
+as well as a ``:write_concern`` option, which represents the write concern of this operation
+when performed on a replica set.
 
 .. seealso::
   :manual:`Write Concerns</core/replica-set-write-concern/>`,
-  :ref:`Sessions<sessions>`
+  :ref:`Sessions<sessions>`,
+  :manual:`Built-in roles</reference/built-in-roles/>`
 
 User Info
 `````````

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -15,8 +15,31 @@ User Management
 Creating a user
 ```````````````
 
-Listing users in a database
-```````````````````````````
+User Info
+`````````
+To view the information of a user that has already been created
+in the database, use the ``info`` method:
+
+.. code-block:: ruby
+
+  client.database.users.info('ada')
+
+If the user exists, this method will return an ``Array`` object
+containing a ``Hash`` with information about the user, such as
+their id, username, the database they were created on, and their
+roles. If the user doesn't exist, this method will return an
+empty Array.
+
+The ``info`` method also takes an optional ``Hash`` of options
+as a second argument. Currently, the only supported option is ``:session``,
+which allows you to specify a ``Mongo::Session`` object to use for this
+operation.
+
+.. seealso::
+  :manual:`Sessions`</tutorials/ruby-driver-sessions>`
+
+The Ruby Driver does not have a method that lists all of the users
+that currently exist on a database.
 
 Updating a user
 ```````````````
@@ -29,10 +52,11 @@ To remove a user from the database, use the ``remove`` method:
 
   client.database.users.remove('ada')
 
-Optionally, you may pass a ``Hash`` of options as a second argument.
-The only option currently supported is ``:write_concern``, which specifies
-the write concern of the operation if you are running this command against
-a replica set.
+You may pass a ``Hash`` of options as a second argument. The two supported
+options for the ``remove`` method are ``:session`` and ``:write_concern``.
+``:session`` allows you to specify a ``Mongo::Session`` object to use for
+this operation. `:write_concern`` specifies the write concern
+of the operation if you are running this command against a replica set.
 
 .. code-block:: ruby
 
@@ -40,6 +64,10 @@ a replica set.
 
 .. seealso::
   :manual:`Write Concerns</core/replica-set-write-concern/>`
+  :manual:`Sessions`</tutorials/ruby-driver-sessions>`
+
+This method will return a ``Mongo::Operation::Result`` document
+indicating whether the operation has been performed successfully.
 
 The Ruby Driver does not implement a method for removing all users
 from a database.

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -26,6 +26,7 @@ Removing users
 To remove a user from the database, use the ``remove`` method:
 
 .. code-block:: ruby
+
   client.database.users.remove('ada')
 
 Optimonally, you may pass a ``Hash`` of options as a second argument.
@@ -34,6 +35,7 @@ the write concern of the operation if you are running this command against
 a replica set.
 
 .. code-block:: ruby
+
   client.database.users.remove('ada')
 
 .. seealso::

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -36,8 +36,7 @@ which allows you to specify a ``Mongo::Session`` object to use for this
 operation.
 
 .. seealso::
-  :manual:`Sessions`</tutorials/ruby-driver-sessions>`
-
+  :ref:`Sessions`<ruby-driver-sessions>`
 The Ruby Driver does not have a method that lists all of the users
 that currently exist on a database.
 
@@ -63,9 +62,8 @@ of the operation if you are running this command against a replica set.
   client.database.users.remove('ada', { w: "majority" , wtimeout: 5000 })
 
 .. seealso::
-  :manual:`Write Concerns</core/replica-set-write-concern/>`
-  :manual:`Sessions`</tutorials/ruby-driver-sessions>`
-
+  :manual:`Write Concerns</core/replica-set-write-concern/>`,
+  :ref:`Sessions`<ruby-driver-sessions>`
 This method will return a ``Mongo::Operation::Result`` document
 indicating whether the operation has been performed successfully.
 

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -1,0 +1,11 @@
+===============
+User Management
+===============
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -39,7 +39,7 @@ The Ruby Driver does not have a method that lists all of the users
 that currently exist on a database.
 
 .. seealso::
-
+  :ref:`Connect to a replica set <ruby-driver-connect-replica-set>`,
   :ref:`Sessions <ruby-driver-sessions>`
 
 Updating a user

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -35,10 +35,11 @@ as a second argument. Currently, the only supported option is ``:session``,
 which allows you to specify a ``Mongo::Session`` object to use for this
 operation.
 
-.. seealso::
-  :ref:`Sessions`<ruby-driver-sessions>`
 The Ruby Driver does not have a method that lists all of the users
 that currently exist on a database.
+
+.. seealso::
+  :ref:`Sessions <ruby-driver-sessions>`
 
 Updating a user
 ```````````````
@@ -61,12 +62,13 @@ of the operation if you are running this command against a replica set.
 
   client.database.users.remove('ada', { w: "majority" , wtimeout: 5000 })
 
-.. seealso::
-  :manual:`Write Concerns</core/replica-set-write-concern/>`,
-  :ref:`Sessions`<ruby-driver-sessions>`
 This method will return a ``Mongo::Operation::Result`` document
 indicating whether the operation has been performed successfully.
 
 The Ruby Driver does not implement a method for removing all users
 from a database.
+
+.. seealso::
+  :manual:`Write Concerns</core/replica-set-write-concern/>`,
+  :ref:`Sessions`<ruby-driver-sessions>`
 

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -39,6 +39,7 @@ The Ruby Driver does not have a method that lists all of the users
 that currently exist on a database.
 
 .. seealso::
+
   :ref:`Sessions <ruby-driver-sessions>`
 
 Updating a user
@@ -69,6 +70,7 @@ The Ruby Driver does not implement a method for removing all users
 from a database.
 
 .. seealso::
+
   :manual:`Write Concerns</core/replica-set-write-concern/>`,
   :ref:`Sessions`<ruby-driver-sessions>`
 

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -40,7 +40,7 @@ that currently exist on a database.
 
 .. seealso::
   :ref:`Connect to a replica set <ruby-driver-connect-replica-set>`,
-  :ref:`Sessions <ruby-driver-sessions>`
+  :ref:`Sessions <sessions>`
 
 Updating a user
 ```````````````
@@ -72,5 +72,5 @@ from a database.
 .. seealso::
 
   :manual:`Write Concerns</core/replica-set-write-concern/>`,
-  :ref:`Sessions`<ruby-driver-sessions>`
+  :ref:`Sessions`<sessions>`
 

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -15,21 +15,6 @@ User Management
 Creating a user
 ```````````````
 
-To create a user, use the ``create`` method with the
-username, password and roles parameters.
-
-.. code-block:: ruby
-
-  client.database.users.create(
-        'alan_turing',
-        password: 'enigma',
-        roles: [ Mongo::Auth::Roles::READ_WRITE ])
-
-The user will be created in whichever database the client is
-currently connected to. To create a user in a different database,
-use the `use`
-
-
 Listing users in a database
 ```````````````````````````
 
@@ -38,3 +23,22 @@ Updating a user
 
 Removing users
 ``````````````
+To remove a user from the database, use the ``remove`` method:
+
+.. code-block:: ruby
+  client.database.users.remove('ada')
+
+Optimonally, you may pass a ``Hash`` of options as a second argument.
+The only option currently supported is :write_concern, which specifies
+the write concern of the operation if you are running this command against
+a replica set.
+
+.. code-block:: ruby
+  client.database.users.remove('ada')
+
+.. seealso::
+  :manual:`Write Concern</reference/replica-set-write-concern/>`
+
+The Ruby Driver does not implement a method for removing all users
+from a database.
+

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -29,17 +29,17 @@ To remove a user from the database, use the ``remove`` method:
 
   client.database.users.remove('ada')
 
-Optimonally, you may pass a ``Hash`` of options as a second argument.
-The only option currently supported is :write_concern, which specifies
+Optionally, you may pass a ``Hash`` of options as a second argument.
+The only option currently supported is ``:write_concern``, which specifies
 the write concern of the operation if you are running this command against
 a replica set.
 
 .. code-block:: ruby
 
-  client.database.users.remove('ada')
+  client.database.users.remove('ada', { w: "majority" , wtimeout: 5000 })
 
 .. seealso::
-  :manual:`Write Concern</reference/replica-set-write-concern/>`
+  :manual:`Write Concerns</core/replica-set-write-concern/>`
 
 The Ruby Driver does not implement a method for removing all users
 from a database.

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -9,3 +9,32 @@ User Management
    :backlinks: none
    :depth: 1
    :class: singlecol
+
+[introduction here]
+
+Creating a user
+```````````````
+
+To create a user, use the ``create`` method with the
+username, password and roles parameters.
+
+.. code-block:: ruby
+
+  client.database.users.create(
+        'alan_turing',
+        password: 'enigma',
+        roles: [ Mongo::Auth::Roles::READ_WRITE ])
+
+The user will be created in whichever database the client is
+currently connected to. To create a user in a different database,
+use the `use`
+
+
+Listing users in a database
+```````````````````````````
+
+Updating a user
+```````````````
+
+Removing users
+``````````````

--- a/docs/tutorials/ruby-driver-user-management.txt
+++ b/docs/tutorials/ruby-driver-user-management.txt
@@ -14,15 +14,62 @@ User Management
 
 Creating a user
 ```````````````
+There are two ways to create a new database user with the Ruby Driver.
+
+The simplest way to create a new user is to use the ``create`` method, passing in a username,
+password, and roles:
+
+.. code-block:: ruby
+
+  client.database.users.create(
+    'alanturing',
+    password: 'enigma',
+    roles: [ Mongo::Auth::Roles::READWRITE ]
+  )
+
+Another way to create a user is to first create a ``Mongo::Auth::User`` object with all the
+user information, and then pass that object into the ``create`` method in lieu of a username.
+
+.. code-block:: ruby
+
+  user = Mongo::User.new({
+    user: 'alanturing',
+    password: 'enigma',
+    roles: [ Mongo::Auth::Roles::READWRITE ]
+  })
+
+  client.database.users.create(user)
+
+The ``create`` method takes a ``Hash`` of options as an optional second argument.
+In addition to the ``:password`` and ``:roles`` options, which you can see used above,
+this method supports a ``:session`` option, which allows you to specify a ``Mongo::Session``
+object to use for this operation, and a ``:write_concern`` option, which represents the
+write concern of this operation against a replica set.
+
+Note that this method will create a user on the database to which the client is already connected.
+To create a user on a different database, use the ``use`` method and specify the new
+database:
+
+.. code-block:: ruby
+
+  client.use(:users).database.users.create(
+    'alanturing',
+    password: 'enigma',
+    roles: [ Mongo::Auth::Roles::READWRITE ]
+  )
+
+.. seealso::
+  :manual:`Write Concerns</core/replica-set-write-concern/>`,
+  :ref:`Sessions<sessions>`
 
 User Info
 `````````
-To view the information of a user that has already been created
+To view information about a user that has already been created
 in the database, use the ``info`` method:
 
 .. code-block:: ruby
 
-  client.database.users.info('ada')
+  client.database.users.info('alanturing')
 
 If the user exists, this method will return an ``Array`` object
 containing a ``Hash`` with information about the user, such as
@@ -39,7 +86,6 @@ The Ruby Driver does not have a method that lists all of the users
 that currently exist on a database.
 
 .. seealso::
-  :ref:`Connect to a replica set <ruby-driver-connect-replica-set>`,
   :ref:`Sessions <sessions>`
 
 Updating a user
@@ -51,17 +97,17 @@ To remove a user from the database, use the ``remove`` method:
 
 .. code-block:: ruby
 
-  client.database.users.remove('ada')
+  client.database.users.remove('alanturing')
 
 You may pass a ``Hash`` of options as a second argument. The two supported
 options for the ``remove`` method are ``:session`` and ``:write_concern``.
 ``:session`` allows you to specify a ``Mongo::Session`` object to use for
-this operation. `:write_concern`` specifies the write concern
+this operation. ``:write_concern`` specifies the write concern
 of the operation if you are running this command against a replica set.
 
 .. code-block:: ruby
 
-  client.database.users.remove('ada', { w: "majority" , wtimeout: 5000 })
+  client.database.users.remove('alanturing', { w: "majority" , wtimeout: 5000 })
 
 This method will return a ``Mongo::Operation::Result`` document
 indicating whether the operation has been performed successfully.
@@ -70,7 +116,6 @@ The Ruby Driver does not implement a method for removing all users
 from a database.
 
 .. seealso::
-
   :manual:`Write Concerns</core/replica-set-write-concern/>`,
-  :ref:`Sessions`<sessions>`
+  :ref:`Sessions<sessions>`
 

--- a/docs/tutorials/user-management.txt
+++ b/docs/tutorials/user-management.txt
@@ -12,7 +12,7 @@ User Management
    :depth: 1
    :class: singlecol
 
-The Mongo Ruby Driver provides a set of methods for managing users on a MongoDB deployment.
+The Mongo Ruby Driver provides a set of methods for managing users in a MongoDB deployment.
 All of these methods are defined on the ``Mongo::Auth::User::View`` class, which defines the
 behavior for performing user-related operations on a database. You can access a database's
 user view by calling the ``users`` method on the correpsonding ``Mongo::Database`` object:
@@ -94,7 +94,7 @@ when performed on a replica set.
 
 User Info
 `````````
-To view information about a user that has already been created in the database, use the ``info`` method:
+To view information about a user that already exists in the database, use the ``info`` method:
 
 .. code-block:: ruby
 
@@ -112,7 +112,7 @@ which allows you to specify a ``Mongo::Session`` object to use for this
 operation.
 
 The Ruby Driver does not have a method that lists all of the users
-that currently exist on a database.
+that currently exist in a database.
 
 .. seealso::
   :ref:`Sessions <sessions>`
@@ -172,7 +172,7 @@ options for the ``remove`` method are ``:session`` and ``:write_concern``.
 this operation. ``:write_concern`` specifies the write concern
 of the operation if you are running this command against a replica set.
 
-The Ruby Driver does not implement a method for removing all users
+The Ruby Driver does not provide a method for removing all users
 from a database.
 
 .. seealso::

--- a/lib/mongo/auth/user/view.rb
+++ b/lib/mongo/auth/user/view.rb
@@ -127,7 +127,7 @@ module Mongo
         #
         # @option options [ Session ] :session The session to use for the operation.
         #
-        # @return [ Hash ] A document containing information on a particular user.
+        # @return [ Array ] An array wrapping a document containing information on a particular user.
         #
         # @since 2.1.0
         def info(name, options = {})


### PR DESCRIPTION
- Remove user documentation from the Authentication tutorial
- Create a separate User Management tutorial with information about creating, viewing, updating, and removing users