### PR TITLE
RUBY-1965 Introduce a block API for the Mongo::Crypt::Binary object

### DIFF
--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -84,9 +84,8 @@ module Mongo
       # @since 2.12.0
       def self.with_binary(data)
         binary = self.new(data)
-
         begin
-          yield binary
+          yield(binary)
         ensure
           binary.close
         end

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -72,6 +72,28 @@ module Mongo
 
         true
       end
+
+      # Convenient API for using binary object without having
+      # to perform cleanup.
+      #
+      # @example
+      #   Mongo::Crypt::Binary.with_binary([73, 76, 111, 118, 101, 82, 117, 98, 121]) do |binary|
+      #     binary.to_bytes # => [73, 76, 111, 118, 101, 82, 117, 98, 121]
+      #   end
+      #
+      # @since 2.12.0
+      def self.with_binary(data)
+        binary = self.new(data)
+
+        begin
+          yield(binary)
+        rescue => e
+          binary.close
+          raise e
+        end
+
+        binary.close
+      end
     end
   end
 end

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -86,13 +86,10 @@ module Mongo
         binary = self.new(data)
 
         begin
-          yield(binary)
-        rescue => e
+          yield binary
+        ensure
           binary.close
-          raise e
         end
-
-        binary.close
       end
     end
   end

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -42,4 +42,29 @@ describe Mongo::Crypt::Binary do
       expect(binary.to_bytes).to eq(bytes)
     end
   end
+
+  describe '#self.with_binary' do
+    before do
+      allow(described_class)
+        .to receive(:new)
+        .and_return(binary)
+    end
+
+    context 'when yield errors' do
+      it 'closes the created binary and raises the error' do
+        expect(binary).to receive(:close).once
+
+        expect do
+          described_class.with_binary(bytes) do |bin|
+            raise StandardError.new("an error")
+          end
+        end.to raise_error(StandardError, /an error/)
+      end
+    end
+
+    it 'creates a new binary and closes it' do
+      expect(binary).to receive(:close).once
+      described_class.with_binary(bytes) { |bin| }
+    end
+  end
 end

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -64,7 +64,10 @@ describe Mongo::Crypt::Binary do
 
     it 'creates a new binary and closes it' do
       expect(binary).to receive(:close).once
-      described_class.with_binary(bytes) { |bin| }
+
+      described_class.with_binary(bytes) do |bin|
+        expect(bin.to_bytes).to eq(bytes)
+      end
     end
   end
 end


### PR DESCRIPTION
It isn't great API design to force users of the libmongocrypt binding to do their own memory management, so I'm introducing an API that creates a new `Mongo::Crypt::Binary` object in the context of a block and then closes it upon completion of that block (or upon rescuing an error).