### PR TITLE
RUBY-1965 Create Mongocrypt handle binding

### DIFF
--- a/lib/mongo/crypt.rb
+++ b/lib/mongo/crypt.rb
@@ -14,8 +14,9 @@
 
 module Mongo
   module Crypt
-    autoload(:Binding, 'mongo/crypt/binding.rb')
-    autoload(:Binary, 'mongo/crypt/binary.rb')
-    autoload(:Status, 'mongo/crypt/status.rb')
+    autoload(:Binding, 'mongo/crypt/binding')
+    autoload(:Binary, 'mongo/crypt/binary')
+    autoload(:Status, 'mongo/crypt/status')
+    autoload(:Handle, 'mongo/crypt/handle')
   end
 end

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -34,7 +34,7 @@ module Mongo
       # @since 2.12.0
       def initialize(data)
         unless data
-          raise Error::CryptError.new('Cannot create new Binary object with no data')
+          raise ArgumentError.new('Cannot create new Binary object with no data')
         end
 
         # FFI::MemoryPointer automatically frees memory when it goes out of scope

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -23,8 +23,6 @@ module Mongo
     #
     # @since 2.12.0
     class Binary
-      attr_accessor :bin
-
       # Create a new Binary object that wraps a string
       #
       # @example Instantiate a Binary object

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -61,6 +61,12 @@ module Mongo
         data.read_array_of_type(FFI::TYPE_UINT8, :read_uint8, len)
       end
 
+      # Returns the reference to the underlying mongocrypt_binary_t
+      # object
+      #
+      # @return [ FFI::Pointer ] The underlying mongocrypt_binary_t object
+      #
+      # @since 2.12.0
       def ref
         @bin
       end

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -37,7 +37,7 @@ module Mongo
         end
 
         # Represent data string as array of uint-8 bytes
-        bytes = data.unpack("C*")
+        bytes = data.unpack('C*')
 
         # FFI::MemoryPointer automatically frees memory when it goes out of scope
         @data_p = FFI::MemoryPointer.new(bytes.length)

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -20,17 +20,13 @@ module Mongo
     # A wrapper around mongocrypt_binary_t, a non-owning buffer of
     # uint-8 byte data. Each Binary instance keeps a copy of the data
     # passed to it in order to keep that data alive.
-    #
-    # @since 2.12.0
     class Binary
-      # Create a new Binary object that wraps a string
+      # Create a new Binary object that wraps a byte string
       #
       # @example Instantiate a Binary object
       #   Mongo::Crypt::Binary.new('Hello, world!')
       #
       # @param [ String ] data
-      #
-      # @since 2.12.0
       def initialize(data)
         unless data
           raise ArgumentError.new('Cannot create new Binary object with no data')
@@ -49,8 +45,6 @@ module Mongo
       # Returns the data stored as a byte array
       #
       # @return [ Array<Int> ] Byte array stored in mongocrypt_binary_t
-      #
-      # @since 2.12.0
       def to_bytes
         data = Binding.mongocrypt_binary_data(@bin)
         if data == FFI::Pointer::NULL
@@ -65,8 +59,6 @@ module Mongo
       # object
       #
       # @return [ FFI::Pointer ] The underlying mongocrypt_binary_t object
-      #
-      # @since 2.12.0
       def ref
         @bin
       end
@@ -74,8 +66,6 @@ module Mongo
       # Releases allocated memory and cleans up resources
       #
       # @return [ true ] Always true.
-      #
-      # @since 2.12.0
       def close
         Binding.mongocrypt_binary_destroy(@bin) if @bin
 
@@ -92,8 +82,6 @@ module Mongo
       #   Mongo::Crypt::Binary.with_binary('Hello, world!') do |binary|
       #     binary.to_bytes # => [72, 101, 108, 108, 111, 44, 32, 119, 111, 114, 108, 100, 33]
       #   end
-      #
-      # @since 2.12.0
       def self.with_binary(data)
         binary = self.new(data)
         begin

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -102,6 +102,30 @@ module Mongo
       # Takes a pointer to a mongocrypt_status_t object and destroys the
       # reference to that status
       attach_function :mongocrypt_status_destroy, [:pointer], :void
+
+      # Creates a new mongocrypt_t object and returns a pointer to that object
+      attach_function :mongocrypt_new, [], :pointer
+
+      # Takes a pointer to a mongocrypt_t object and a pointer to a mongocrypt_binary_t
+      # object wrapping a 96-byte master key for encryption/decryption.
+      # Configures the mongocrypt_t with the KMS provider options and returns a boolean
+      # indicating the success of the operation.
+      attach_function :mongocrypt_setopt_kms_provider_local, [:pointer, :pointer], :bool
+
+      # Takes a pointer to a mongocrypt_t object and initializes that object.
+      # Should be called after mongocrypt_setopt_kms_provider_local and other methods that
+      # set options on the mongocrypt_t object.
+      # Returns a boolean indicating the success of the operation.
+      attach_function :mongocrypt_init, [:pointer], :bool
+
+      # Takes a pointer to a mongocrypt_t object and a pointer to a mongocrypt_status_t
+      # object as an out parameter. Sets the status information of the mongocrypt_t
+      # on the specified status object. Returns a boolean indicating the success of
+      # the operation.
+      attach_function :mongocrypt_status, [:pointer, :pointer], :bool
+
+      # Takes a pointer to a mongocrypt_t object and destroys the reference to that object.
+      attach_function :mongocrypt_destroy, [:pointer], :void
     end
   end
 end

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -20,8 +20,6 @@ module Mongo
     # A Ruby binding for the libmongocrypt C library
     #
     # @api private
-    #
-    # @since 2.12.0
     class Binding
       extend FFI::Library
 

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -18,7 +18,9 @@ require 'base64'
 module Mongo
   module Crypt
 
-    # TODO: documentation
+    # A handle to the libmongocrypt library that wraps a mongocrypt_t object,
+    # allowing clients to set options on that object or perform operations such
+    # as encryption and decryption
     class Handle
 
       # Creates a new Handle object and initializes it with options
@@ -53,7 +55,12 @@ module Mongo
       end
 
 
-      # TODO: documentation
+      # Destroy the reference to the underlying mongocrypt_t object and
+      # clean up resources
+      #
+      # @return [ true ] Always true
+      #
+      # @since 2.12.0
       def close
         Binding.mongocrypt_destroy(@mongocrypt) if @mongocrypt
         @status.close if @status

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -14,7 +14,6 @@
 
 require 'ffi'
 require 'base64'
-require 'byebug'
 
 module Mongo
   module Crypt
@@ -102,7 +101,7 @@ module Mongo
       # Only called once it has been validated that @options[:kms_providers][:local][:key]
       # is present and a String
       #
-      # Raises an error if the master key is not a 96-byte string once it has been base64 decoded
+      # Raises an error if the operation fails
       def set_kms_provider_local
         master_key = @options[:kms_providers][:local][:key]
 
@@ -110,6 +109,12 @@ module Mongo
           success = Binding.mongocrypt_setopt_kms_provider_local(@mongocrypt, binary.ref)
           raise_from_status unless success
         end
+      end
+
+      # Initialize the underlying mongocrypt_t object and raise an error if the operation fails
+      def initialize_mongocrypt
+        success = Binding.mongocrypt_init(@mongocrypt)
+        raise_from_status unless success
       end
 
       # Raise a Mongo::Error::CryptError based on the status of the underlying
@@ -130,11 +135,6 @@ module Mongo
 
           raise error
         end
-      end
-
-      def initialize_mongocrypt
-        success = Binding.mongocrypt_init(@mongocrypt)
-        raise_from_status unless success
       end
     end
   end

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -1,0 +1,128 @@
+# Copyright (C) 2019 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ffi'
+require 'base64'
+require 'byebug'
+
+module Mongo
+  module Crypt
+
+    # TODO: documentation
+    class Handle
+
+      # Creates a new Handle object and initializes it with options
+      #
+      # @example Instantiate a Handle object with local KMS provider options
+      #   Mongo::Crypt::Handle.new({
+      #     kms_providers: {
+      #       local: { key: 'MASTER-KEY' }
+      #     }
+      #   })
+      #
+      # @param [ Hash ] options The options used to initialize the mongocrypt handle
+      #
+      # @options option [ Hash ] kms_providers A hash of KMS settings. The only supported key
+      #   is currently :local. Local KMS options must be passed in the format { local: { key: 'MASTER-KEY' } }
+      #   where the master key is a 96-byte, base64 encoded string.
+      #
+      # @since 2.12.0
+      def initialize(options = {})
+        raise ArgumentError.new("Options must not be blank") unless options
+
+        @options = options
+        @mongocrypt = Binding.mongocrypt_new
+
+        begin
+          set_kms_providers
+          initialize_mongocrypt
+        rescue => e
+          self.close
+          raise e
+        end
+      end
+
+
+      # TODO: documentation
+      def close
+        Binding.mongocrypt_destroy(@mongocrypt) if @mongocrypt
+        @status.close if @status
+
+        @mongocrypt = nil
+        @status = nil
+        @options = nil
+
+        true
+      end
+
+      private
+
+      def set_kms_providers
+        unless @options[:kms_providers]
+          raise ArgumentError.new("The kms_providers option must not be blank")
+        end
+
+        kms_providers = @options[:kms_providers]
+
+        unless kms_providers.key?(:local) || kms_providers.key?(:aws)
+          raise ArgumentError.new('The kms_providers option must have one of the following keys: :aws, :local')
+        end
+
+        if kms_providers.key?(:local)
+          unless kms_providers[:local][:key] && kms_providers[:local][:key].is_a?(String)
+            raise ArgumentError.new(
+              "The specified kms_providers option is invalid: #{kms_providers}. " +
+              "kms_providers with :local key must be in the format: { local: { key: 'MASTER-KEY' } }"
+            )
+          end
+
+          set_kms_provider_local
+        end
+
+        if kms_providers.key?(:aws)
+          raise ArgumentError.new(':aws is not yet a supported kms_providers option. Use :local instead')
+        end
+      end
+
+      def set_kms_provider_local
+        master_key = @options[:kms_providers][:local][:key]
+
+        Binary.with_binary(Base64.decode64(master_key)) do |binary|
+          success = Binding.mongocrypt_setopt_kms_provider_local(@mongocrypt, binary.ref)
+          raise_from_status unless success
+        end
+      end
+
+      def raise_from_status
+        Status.with_status do |status|
+          Binding.mongocrypt_status(@mongocrypt, status.ref)
+
+          component = case status.label
+          when :error_kms
+            'KMS'
+          when :error_client
+            'Client'
+          end
+
+          raise Error::CryptError.new(status.code, "#{component} error with code #{status.code}: #{status.message}")
+        end
+      end
+
+      def initialize_mongocrypt
+        success = Binding.mongocrypt_init(@mongocrypt)
+        raise_from_status unless success
+      end
+    end
+  end
+end

--- a/lib/mongo/crypt/status.rb
+++ b/lib/mongo/crypt/status.rb
@@ -19,12 +19,8 @@ module Mongo
 
     # A wrapper around mongocrypt_status_t, representing the status of
     # a mongocrypt_t handle.
-    #
-    # @since 2.12.0
     class Status
       # Create a new Status object
-      #
-      # @since 2.12.0
       def initialize
         @status = Binding.mongocrypt_status_new
       end
@@ -36,8 +32,6 @@ module Mongo
       # @param [ String ] message
       #
       # @return [ Mongo::Crypt::Status ] returns self
-      #
-      # @since 2.12.0
       def update(label, code, message)
         unless [:ok, :error_client, :error_kms].include?(label)
           raise ArgumentError.new(
@@ -56,8 +50,6 @@ module Mongo
       #
       # @return [ Symbol ] The status label, either :ok, :error_kms, or :error_client,
       #   defaults to :ok
-      #
-      # @since 2.12.0
       def label
         Binding.mongocrypt_status_type(@status)
       end
@@ -65,8 +57,6 @@ module Mongo
       # Return the integer code associated with the status
       #
       # @return [ Integer ] The status code, defaults to 0
-      #
-      # @since 2.12.0
       def code
         Binding.mongocrypt_status_code(@status)
       end
@@ -74,8 +64,6 @@ module Mongo
       # Return the status message
       #
       # @return [ String ] The status message, defaults to empty string
-      #
-      # @since 2.12.0
       def message
         message = Binding.mongocrypt_status_message(@status, nil)
         message || ''
@@ -84,8 +72,6 @@ module Mongo
       # Checks whether the status is labeled :ok
       #
       # @return [ Boolean ] Whether the status is :ok
-      #
-      # @since 2.12.0
       def ok?
         Binding.mongocrypt_status_ok(@status)
       end
@@ -94,8 +80,6 @@ module Mongo
       # object
       #
       # @return [ FFI::Pointer ] Pointer to the underlying mongocrypt_status_t oject
-      #
-      # @since 2.12.0
       def ref
         @status
       end
@@ -104,8 +88,6 @@ module Mongo
       # cleans up resources.
       #
       # @return [ true ] Always true
-      #
-      # @since 2.12.0
       def close
         Binding.mongocrypt_status_destroy(@status)
         @status = nil
@@ -120,8 +102,6 @@ module Mongo
       #   Mongo::Crypt::Status.with_status do |status|
       #     status.ok? # => true
       #   end
-      #
-      # @since 2.12.0
       def self.with_status
         status = self.new
         begin

--- a/lib/mongo/crypt/status.rb
+++ b/lib/mongo/crypt/status.rb
@@ -90,6 +90,16 @@ module Mongo
         Binding.mongocrypt_status_ok(@status)
       end
 
+      # Returns the reference to the underlying mongocrypt_status_t
+      # object
+      #
+      # @return [ FFI::Pointer ] Pointer to the underlying mongocrypt_status_t oject
+      #
+      # @since 2.12.0
+      def ref
+        @status
+      end
+
       # Destroys reference to mongocrypt_status_t object and
       # cleans up resources.
       #

--- a/lib/mongo/error/crypt_error.rb
+++ b/lib/mongo/error/crypt_error.rb
@@ -24,17 +24,9 @@ module Mongo
         @code = code
         super(message)
       end
-
-      # Raise a new Mongo::Error::CryptError based on a Mongo::Crypt::Status object
-      #
-      # @param [ Mongo::Crypt::Status ]
-      #
-      # @since 2.12.0
-      # def self.from_status(status)
-      #   return if status.ok?
-
-      #   self.new(status.label, status.code, status.message)
-      # end
     end
+
+    class CryptClientError < CryptError; end
+    class CryptKmsError < CryptError; end
   end
 end

--- a/lib/mongo/error/crypt_error.rb
+++ b/lib/mongo/error/crypt_error.rb
@@ -8,12 +8,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+require 'byebug'
+
 module Mongo
   class Error
 
     # An error related to the libmongocrypt binding.
     #
+    # @param [ Symbol ] :error_client or :error_kms
     # @since 2.12.0
-    class CryptError < Mongo::Error; end
+    class CryptError < Mongo::Error
+      attr_accessor :code
+
+      def initialize(code, message)
+        @code = code
+        super(message)
+      end
+
+      # Raise a new Mongo::Error::CryptError based on a Mongo::Crypt::Status object
+      #
+      # @param [ Mongo::Crypt::Status ]
+      #
+      # @since 2.12.0
+      # def self.from_status(status)
+      #   return if status.ok?
+
+      #   self.new(status.label, status.code, status.message)
+      # end
+    end
   end
 end

--- a/lib/mongo/error/crypt_error.rb
+++ b/lib/mongo/error/crypt_error.rb
@@ -8,21 +8,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-require 'byebug'
-
 module Mongo
   class Error
 
     # An error related to the libmongocrypt binding.
     #
-    # @param [ Symbol ] :error_client or :error_kms
+    # @param [ Integer ] code The error code
+    # @param [ String ] message The error message
+    #
     # @since 2.12.0
     class CryptError < Mongo::Error
       attr_accessor :code
 
       def initialize(code, message)
         @code = code
-        super(message)
+        super("Code #{code}: #{message}")
       end
     end
 

--- a/lib/mongo/error/crypt_error.rb
+++ b/lib/mongo/error/crypt_error.rb
@@ -15,8 +15,6 @@ module Mongo
     #
     # @param [ Integer ] code The error code
     # @param [ String ] message The error message
-    #
-    # @since 2.12.0
     class CryptError < Mongo::Error
       attr_accessor :code
 

--- a/lib/mongo/error/crypt_error.rb
+++ b/lib/mongo/error/crypt_error.rb
@@ -26,7 +26,10 @@ module Mongo
       end
     end
 
+    # A libmongocrypt error relating to the client
     class CryptClientError < CryptError; end
+
+    # A libmongocrypt error relating to the KMS
     class CryptKmsError < CryptError; end
   end
 end

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -8,8 +8,8 @@ end
 describe Mongo::Crypt::Binary do
   require_libmongocrypt
 
-  let(:bytes) { [104, 101, 108, 108, 111] }
-  let(:binary) { described_class.new(bytes) }
+  let(:data) { 'I love Ruby' }
+  let(:binary) { described_class.new(data) }
 
   describe '#initialize' do
     context 'with nil data' do
@@ -39,7 +39,7 @@ describe Mongo::Crypt::Binary do
     end
 
     it 'returns the string as a byte array' do
-      expect(binary.to_bytes).to eq(bytes)
+      expect(binary.to_bytes).to eq(data.unpack("C*"))
     end
   end
 
@@ -47,6 +47,7 @@ describe Mongo::Crypt::Binary do
     before do
       allow(described_class)
         .to receive(:new)
+        .with(data)
         .and_return(binary)
     end
 
@@ -55,7 +56,7 @@ describe Mongo::Crypt::Binary do
         expect(binary).to receive(:close).once
 
         expect do
-          described_class.with_binary(bytes) do |bin|
+          described_class.with_binary(data) do |bin|
             raise StandardError.new("an error")
           end
         end.to raise_error(StandardError, /an error/)
@@ -65,8 +66,8 @@ describe Mongo::Crypt::Binary do
     it 'creates a new binary and closes it' do
       expect(binary).to receive(:close).once
 
-      described_class.with_binary(bytes) do |bin|
-        expect(bin.to_bytes).to eq(bytes)
+      described_class.with_binary(data) do |bin|
+        expect(bin.to_bytes).to eq(data.unpack("C*"))
       end
     end
   end

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -16,7 +16,7 @@ describe Mongo::Crypt::Binary do
       it 'raises an exception' do
         expect do
           described_class.new(nil)
-        end.to raise_error(Mongo::Error::CryptError, /Cannot create new Binary object/)
+        end.to raise_error(ArgumentError, /Cannot create new Binary object/)
       end
     end
 

--- a/spec/mongo/crypt/binding/mongocrypt_spec.rb
+++ b/spec/mongo/crypt/binding/mongocrypt_spec.rb
@@ -1,0 +1,129 @@
+require 'mongo'
+require 'support/lite_constraints'
+
+RSpec.configure do |config|
+  config.extend(LiteConstraints)
+end
+
+describe 'Mongo::Crypt::Binding' do
+  describe 'mongocrypt_t binding' do
+    require_libmongocrypt
+
+    after do
+      Mongo::Crypt::Binding.mongocrypt_destroy(mongocrypt)
+    end
+
+    describe '#mongocrypt_new' do
+      let(:mongocrypt) { Mongo::Crypt::Binding.mongocrypt_new }
+
+      it 'returns a pointer' do
+        expect(mongocrypt).to be_a_kind_of(FFI::Pointer)
+      end
+    end
+
+    describe '#mongocrypt_setopt_kms_provider_local' do
+      let(:mongocrypt) { Mongo::Crypt::Binding.mongocrypt_new }
+
+      let(:binary) do
+        p = FFI::MemoryPointer.new(key_bytes.size)
+              .write_array_of_type(FFI::TYPE_UINT8, :put_uint8, key_bytes)
+
+        Mongo::Crypt::Binding.mongocrypt_binary_new_from_data(p, key_bytes.length)
+      end
+
+      after do
+        Mongo::Crypt::Binding.mongocrypt_binary_destroy(binary)
+      end
+
+      context 'with valid key' do
+        let(:key_bytes) { [114, 117, 98, 121] * 24 } # 96 bytes
+
+        it 'returns true' do
+          expect(Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, binary)).to be true
+        end
+      end
+
+      context 'with invalid key' do
+        let(:key_bytes) { [114, 117, 98, 121] * 23 } # NOT 96 bytes
+
+        it 'returns false' do
+          expect(Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, binary)).to be false
+        end
+      end
+    end
+
+    describe '#mongocrypt_init' do
+      let(:binary) do
+        p = FFI::MemoryPointer.new(key_bytes.size)
+              .write_array_of_type(FFI::TYPE_UINT8, :put_uint8, key_bytes)
+
+        Mongo::Crypt::Binding.mongocrypt_binary_new_from_data(p, key_bytes.length)
+      end
+
+      let(:mongocrypt) do
+        mongocrypt = Mongo::Crypt::Binding.mongocrypt_new
+        Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, binary)
+
+        mongocrypt
+      end
+
+      after do
+        Mongo::Crypt::Binding.mongocrypt_binary_destroy(binary)
+      end
+
+      context 'with valid kms option' do
+        let(:key_bytes) { [114, 117, 98, 121] * 24 } # 96 bytes
+
+        it 'returns true' do
+          expect(Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)).to be true
+        end
+      end
+
+      context 'with invalid kms option' do
+        let(:key_bytes) { [114, 117, 98, 121] * 23 } # NOT 96 bytes
+
+        it 'returns false' do
+          expect(Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)).to be false
+        end
+      end
+    end
+
+    describe '#mongocrypt_status' do
+      let(:status) { Mongo::Crypt::Binding.mongocrypt_status_new }
+      let(:mongocrypt) { mongocrypt = Mongo::Crypt::Binding.mongocrypt_new }
+
+      after do
+        Mongo::Crypt::Binding.mongocrypt_status_destroy(status)
+      end
+
+      context 'for a new mongocrypt_t object' do
+        it 'returns an ok status' do
+          Mongo::Crypt::Binding.mongocrypt_status(mongocrypt, status)
+          expect(Mongo::Crypt::Binding.mongocrypt_status_type(status)).to eq(:ok)
+        end
+      end
+
+      context 'for a mongocrypt_t object with invalid kms options' do
+        let(:key_bytes) { [114, 117, 98, 121] * 23 } # NOT 96 bytes
+
+        let(:binary) do
+          p = FFI::MemoryPointer.new(key_bytes.size)
+                .write_array_of_type(FFI::TYPE_UINT8, :put_uint8, key_bytes)
+
+          Mongo::Crypt::Binding.mongocrypt_binary_new_from_data(p, key_bytes.length)
+        end
+
+        after do
+          Mongo::Crypt::Binding.mongocrypt_binary_destroy(binary)
+        end
+
+        it 'returns a error_client status' do
+          Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, binary)
+
+          Mongo::Crypt::Binding.mongocrypt_status(mongocrypt, status)
+          expect(Mongo::Crypt::Binding.mongocrypt_status_type(status)).to eq(:error_client)
+        end
+      end
+    end
+  end
+end

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -25,6 +25,7 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { {} }
 
       it 'raises an exception' do
+        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /must have one of the following keys: :aws, :local/)
       end
     end
@@ -33,6 +34,7 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { { aws: {} } }
 
       it 'raises an exception' do
+        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /:aws is not yet a supported kms_providers option/)
       end
     end
@@ -41,6 +43,7 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { { random_kms_provider: {} } }
 
       it 'raises an exception' do
+        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /must have one of the following keys: :aws, :local/)
       end
     end
@@ -49,6 +52,7 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { { local: {} } }
 
       it 'raises an exception' do
+        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /kms_providers with :local key must be in the format: { local: { key: 'MASTER-KEY' } }/)
       end
     end
@@ -57,6 +61,7 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { { local: { invalid_key: 'Some stuff' } } }
 
       it 'raises an exception' do
+        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /kms_providers with :local key must be in the format: { local: { key: 'MASTER-KEY' } }/)
       end
     end
@@ -71,6 +76,9 @@ describe Mongo::Crypt::Handle do
       end
 
       it 'raises an exception' do
+        expect_any_instance_of(Mongo::Crypt::Binary).to receive(:close).once # make sure binary is closed
+        expect_any_instance_of(Mongo::Crypt::Status).to receive(:close).once # make sure status is closed
+        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(Mongo::Error::CryptClientError, 'Code 1: local key must be 96 bytes')
       end
     end
@@ -89,6 +97,7 @@ describe Mongo::Crypt::Handle do
       end
 
       it 'does not raise an exception' do
+        expect_any_instance_of(Mongo::Crypt::Binary).to receive(:close).once # make sure binary is closed
         expect { handle }.not_to raise_error
       end
     end

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -71,7 +71,7 @@ describe Mongo::Crypt::Handle do
       end
 
       it 'raises an exception' do
-        expect { handle }.to raise_error(Mongo::Error::CryptError, 'Client error with code 1: local key must be 96 bytes')
+        expect { handle }.to raise_error(Mongo::Error::CryptClientError, 'Code 1: local key must be 96 bytes')
       end
     end
 

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -10,16 +10,7 @@ describe Mongo::Crypt::Handle do
   require_libmongocrypt
 
   describe '#initialize' do
-    let(:handle) { described_class.new(options) }
-    let(:options) { { kms_providers: kms_providers } }
-
-    context 'with empty options' do
-      let(:options) { nil }
-
-      it 'raises an exception' do
-        expect { handle }.to raise_error(ArgumentError, /Options must not be blank/)
-      end
-    end
+    let(:handle) { described_class.new(kms_providers) }
 
     context 'with empty kms_providers' do
       let(:kms_providers) { {} }

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -1,0 +1,96 @@
+require 'mongo'
+require 'base64'
+require 'support/lite_constraints'
+
+RSpec.configure do |config|
+  config.extend(LiteConstraints)
+end
+
+describe Mongo::Crypt::Handle do
+  require_libmongocrypt
+
+  describe '#initialize' do
+    let(:handle) { described_class.new(options) }
+    let(:options) { { kms_providers: kms_providers } }
+
+    context 'with empty options' do
+      let(:options) { nil }
+
+      it 'raises an exception' do
+        expect { handle }.to raise_error(ArgumentError, /Options must not be blank/)
+      end
+    end
+
+    context 'with empty kms_providers' do
+      let(:kms_providers) { {} }
+
+      it 'raises an exception' do
+        expect { handle }.to raise_error(ArgumentError, /must have one of the following keys: :aws, :local/)
+      end
+    end
+
+    context 'with aws kms_providers key' do
+      let(:kms_providers) { { aws: {} } }
+
+      it 'raises an exception' do
+        expect { handle }.to raise_error(ArgumentError, /:aws is not yet a supported kms_providers option/)
+      end
+    end
+
+    context 'with invalid kms_providers key' do
+      let(:kms_providers) { { random_kms_provider: {} } }
+
+      it 'raises an exception' do
+        expect { handle }.to raise_error(ArgumentError, /must have one of the following keys: :aws, :local/)
+      end
+    end
+
+    context 'with empty local kms_providers' do
+      let(:kms_providers) { { local: {} } }
+
+      it 'raises an exception' do
+        expect { handle }.to raise_error(ArgumentError, /kms_providers with :local key must be in the format: { local: { key: 'MASTER-KEY' } }/)
+      end
+    end
+
+    context 'with invalid local kms_providers' do
+      let(:kms_providers) { { local: { invalid_key: 'Some stuff' } } }
+
+      it 'raises an exception' do
+        expect { handle }.to raise_error(ArgumentError, /kms_providers with :local key must be in the format: { local: { key: 'MASTER-KEY' } }/)
+      end
+    end
+
+    context 'with invalid local kms master key' do
+      let(:kms_providers) do
+        {
+          local: {
+            key: Base64.encode64('ruby' * 23) # NOT 96 bytes
+          }
+        }
+      end
+
+      it 'raises an exception' do
+        expect { handle }.to raise_error(Mongo::Error::CryptError, 'Client error with code 1: local key must be 96 bytes')
+      end
+    end
+
+    context 'with valid local kms_providers' do
+      after do
+        handle.close
+      end
+
+      let(:kms_providers) do
+        {
+          local: {
+            key: Base64.encode64('ruby' * 24)
+          }
+        }
+      end
+
+      it 'does not raise an exception' do
+        expect { handle }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -82,7 +82,7 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) do
         {
           local: {
-            key: Base64.encode64('ruby' * 24)
+            key: Base64.encode64("ru\xfe\x00" * 24)
           }
         }
       end

--- a/spec/mongo/error/crypt_error_spec.rb
+++ b/spec/mongo/error/crypt_error_spec.rb
@@ -10,7 +10,7 @@ describe Mongo::Error::CryptError do
   describe '#initialize' do
     it 'properly populates fields' do
       expect(error.code).to eq(code)
-      expect(error.message).to eq(message)
+      expect(error.message).to eq("Code #{code}: #{message}")
     end
   end
 end

--- a/spec/mongo/error/crypt_error_spec.rb
+++ b/spec/mongo/error/crypt_error_spec.rb
@@ -1,0 +1,47 @@
+require 'lite_spec_helper'
+
+describe Mongo::Error::CryptError do
+  let(:label) { :error_client }
+  let(:code) { 401 }
+  let(:message) { 'Operation unauthorized' }
+
+  let(:error) { described_class.new(code, message) }
+
+  describe '#initialize' do
+    it 'properly populates fields' do
+      expect(error.code).to eq(code)
+      expect(error.message).to eq(message)
+    end
+  end
+
+  # describe '#self.from_status' do
+  #   let(:status) do
+  #     status = Mongo::Crypt::Status.new
+  #     status.update(label, code, message)
+  #   end
+
+  #   let(:error) { described_class.from_status(status) }
+
+  #   after do
+  #     status.close
+  #   end
+
+  #   context 'with error status' do
+  #     it 'returns an error based on status information' do
+  #       expect(error.label).to eq(label)
+  #       expect(error.code).to eq(code)
+  #       expect(error.message).to eq(message)
+  #     end
+  #   end
+
+  #   context 'with ok status' do
+  #     let(:label) { :ok }
+  #     let(:code) { 200 }
+  #     let(:message) { 'Success' }
+
+  #     it 'does not return an error' do
+  #       expect(error).to be_nil
+  #     end
+  #   end
+  # end
+end

--- a/spec/mongo/error/crypt_error_spec.rb
+++ b/spec/mongo/error/crypt_error_spec.rb
@@ -13,35 +13,4 @@ describe Mongo::Error::CryptError do
       expect(error.message).to eq(message)
     end
   end
-
-  # describe '#self.from_status' do
-  #   let(:status) do
-  #     status = Mongo::Crypt::Status.new
-  #     status.update(label, code, message)
-  #   end
-
-  #   let(:error) { described_class.from_status(status) }
-
-  #   after do
-  #     status.close
-  #   end
-
-  #   context 'with error status' do
-  #     it 'returns an error based on status information' do
-  #       expect(error.label).to eq(label)
-  #       expect(error.code).to eq(code)
-  #       expect(error.message).to eq(message)
-  #     end
-  #   end
-
-  #   context 'with ok status' do
-  #     let(:label) { :ok }
-  #     let(:code) { 200 }
-  #     let(:message) { 'Success' }
-
-  #     it 'does not return an error' do
-  #       expect(error).to be_nil
-  #     end
-  #   end
-  # end
 end


### PR DESCRIPTION
This is the last PR for RUBY-1965 -- after this I should be able to initialize a ClientEncryption object and start using some of these objects.

In this PR:
- Change `Mongo::Crypt::Binary` to take a string as input rather than an array of bytes.
- Add binding for mongocrypt_t methods
- Add an API around mongocrypt_t called `Mongo::Crypt::Handle` (this is what it's called in the spec)
- Change the API of `Mongo::Error::CryptError` to be an error specifically returned from libmongocrypt