### PR TITLE
Fix broken JRuby test for FLE

### DIFF
--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -52,7 +52,7 @@ module Mongo
         end
 
         len = Binding.mongocrypt_binary_len(@bin)
-        data.read_array_of_type(FFI::TYPE_UINT8, :read_uint8, len)
+        data.get_array_of_uint8(0, len)
       end
 
       # Returns the reference to the underlying mongocrypt_binary_t

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -37,7 +37,7 @@ module Mongo
 
         # FFI::MemoryPointer automatically frees memory when it goes out of scope
         @data_p = FFI::MemoryPointer.new(bytes.length)
-                  .write_array_of_type(FFI::TYPE_UINT8, :put_uint8, bytes)
+                  .write_array_of_uint8(bytes)
 
         @bin = Binding.mongocrypt_binary_new_from_data(@data_p, bytes.length)
       end


### PR DESCRIPTION
I accidentally used an FFI API method that has no corresponding Java implementation.