### PR TITLE
RUBY-2022 Use FFI::AutoPointer to automatically de-allocate memory for libmongocrypt

### DIFF
--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -93,9 +93,8 @@ module Mongo
     # @return [ String ] Base64-encoded UUID string representing the
     #   data key _id
     def create_data_key
-      result = Crypt::DataKeyContext.with_context(@crypt_handle.ref) do |context|
-        context.run_state_machine
-      end
+      context = Crypt::DataKeyContext.new(@crypt_handle.ref)
+      result = context.run_state_machine
 
       data_key_document = Hash.from_bson(BSON::ByteBuffer.new(result))
       insert_result = @collection.insert_one(data_key_document)
@@ -121,9 +120,8 @@ module Mongo
     def encrypt(value, opts={})
       value = { 'v': value }.to_bson.to_s
 
-      Crypt::ExplicitEncryptionContext.with_context(@crypt_handle.ref, @io, value, opts) do |context|
-        context.run_state_machine
-      end
+      context = Crypt::ExplicitEncryptionContext.new(@crypt_handle.ref, @io, value, opts)
+      context.run_state_machine
     end
 
     # Decrypts a value that has already been encrypted
@@ -135,9 +133,8 @@ module Mongo
     # This method is not currently unit tested.
     # Find tests in spec/integration/explicit_encryption_spec.rb
     def decrypt(value)
-      result = Crypt::ExplicitDecryptionContext.with_context(@crypt_handle.ref, @io, value) do |context|
-        context.run_state_machine
-      end
+      context = Crypt::ExplicitDecryptionContext.new(@crypt_handle.ref, @io, value)
+      result = context.run_state_machine
 
       Hash.from_bson(BSON::ByteBuffer.new(result))['v']
     end

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -69,23 +69,6 @@ module Mongo
       @crypt_handle = Crypt::Handle.new(options[:kms_providers])
     end
 
-    # Closes the underlying crypt_handle object and cleans
-    # up resources
-    #
-    # @return [ true ] Always true
-    def close
-      # Will eventually revisit the experience of using a
-      # Mongo::Crypt::Handle object -- having to close it manually
-      # is not the best.
-      @crypt_handle.close if @crypt_handle
-
-      @collection = nil
-      @io = nil
-      @crypt_handle = nil
-
-      true
-    end
-
     # Generates a data key used for encryption/decryption and stores
     # that key in the KMS collection. The generated key is encrypted with
     # the KMS master key.

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -76,8 +76,7 @@ module Mongo
     # @return [ String ] Base64-encoded UUID string representing the
     #   data key _id
     def create_data_key
-      context = Crypt::DataKeyContext.new(@crypt_handle.ref)
-      result = context.run_state_machine
+      result = Crypt::DataKeyContext.new(@crypt_handle.ref).run_state_machine
 
       data_key_document = Hash.from_bson(BSON::ByteBuffer.new(result))
       insert_result = @collection.insert_one(data_key_document)
@@ -103,8 +102,9 @@ module Mongo
     def encrypt(value, opts={})
       value = { 'v': value }.to_bson.to_s
 
-      context = Crypt::ExplicitEncryptionContext.new(@crypt_handle.ref, @io, value, opts)
-      context.run_state_machine
+      Crypt::ExplicitEncryptionContext
+        .new(@crypt_handle.ref, @io, value, opts)
+        .run_state_machine
     end
 
     # Decrypts a value that has already been encrypted
@@ -116,8 +116,9 @@ module Mongo
     # This method is not currently unit tested.
     # Find tests in spec/integration/explicit_encryption_spec.rb
     def decrypt(value)
-      context = Crypt::ExplicitDecryptionContext.new(@crypt_handle.ref, @io, value)
-      result = context.run_state_machine
+      result = Crypt::ExplicitDecryptionContext
+                .new(@crypt_handle.ref, @io, value)
+                .run_state_machine
 
       Hash.from_bson(BSON::ByteBuffer.new(result))['v']
     end

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -37,7 +37,7 @@ module Mongo
           # FFI::AutoPointer uses a custom release strategy to automatically free
           # the pointer once this object goes out of scope
           @bin = FFI::AutoPointer.new(
-            Binding.mongocrypt_binary_new_from_data(@data_p, bytes.length)
+            Binding.mongocrypt_binary_new_from_data(@data_p, bytes.length),
             Binding.method(:mongocrypt_binary_destroy)
           )
         else

--- a/lib/mongo/crypt/context/context.rb
+++ b/lib/mongo/crypt/context/context.rb
@@ -32,18 +32,12 @@ module Mongo
       def initialize(mongocrypt, io)
         # Ideally, this level of the API wouldn't be passing around pointer
         # references between objects, so this method signature is subject to change.
-        @ctx = Binding.mongocrypt_ctx_new(mongocrypt)
+        @ctx = FFI::AutoPointer.new(
+          Binding.mongocrypt_ctx_new(mongocrypt),
+          Binding.method(:mongocrypt_ctx_destroy)
+        )
+
         @io = io
-      end
-
-      # Releases allocated memory and cleans up resources
-      #
-      # @return [ true ] Always true
-      def close
-        Binding.mongocrypt_ctx_destroy(@ctx) if @ctx
-        @ctx = nil
-
-        true
       end
 
       # Returns the state of the mongocrypt_ctx_t

--- a/lib/mongo/crypt/context/context.rb
+++ b/lib/mongo/crypt/context/context.rb
@@ -101,10 +101,10 @@ module Mongo
       # Raise a Mongo::Error::CryptError based on the status of the underlying
       # mongocrypt_ctx_t object
       def raise_from_status
-        Status.with_status do |status|
-          Binding.mongocrypt_ctx_status(@ctx, status.ref)
-          status.raise_crypt_error
-        end
+        status = Status.new
+
+        Binding.mongocrypt_ctx_status(@ctx, status.ref)
+        status.raise_crypt_error
       end
 
       # Finalize the state machine and return the result as a string

--- a/lib/mongo/crypt/context/context.rb
+++ b/lib/mongo/crypt/context/context.rb
@@ -109,11 +109,11 @@ module Mongo
 
       # Finalize the state machine and return the result as a string
       def finalize_state_machine
-        Binary.with_binary do |binary|
-          success = Binding.mongocrypt_ctx_finalize(@ctx, binary.ref)
-          raise_from_status unless success
-          return binary.to_string
-        end
+        binary = Binary.new
+        success = Binding.mongocrypt_ctx_finalize(@ctx, binary.ref)
+        raise_from_status unless success
+
+        binary.to_string
       end
 
       # Returns a binary string representing a mongo operation that the
@@ -121,20 +121,20 @@ module Mongo
       # continue with encryption/decryption (for example, a filter for
       # a key vault query).
       def mongo_operation
-        Binary.with_binary do |binary|
-          success = Binding.mongocrypt_ctx_mongo_op(@ctx, binary.ref)
-          raise_from_status unless success
-          return binary.to_string
-        end
+        binary = Binary.new
+        success = Binding.mongocrypt_ctx_mongo_op(@ctx, binary.ref)
+        raise_from_status unless success
+
+        binary.to_string
       end
 
       # Feeds the result of a Mongo operation to the underlying mongocrypt_ctx_t
       # object. The result param should be a binary string.
       def mongo_feed(result)
-        Binary.with_binary(result) do |binary|
-          success = Binding.mongocrypt_ctx_mongo_feed(@ctx, binary.ref)
-          raise_from_status unless success
-        end
+        binary = Binary.new(result)
+        success = Binding.mongocrypt_ctx_mongo_feed(@ctx, binary.ref)
+
+        raise_from_status unless success
       end
     end
   end

--- a/lib/mongo/crypt/context/context.rb
+++ b/lib/mongo/crypt/context/context.rb
@@ -32,6 +32,9 @@ module Mongo
       def initialize(mongocrypt, io)
         # Ideally, this level of the API wouldn't be passing around pointer
         # references between objects, so this method signature is subject to change.
+
+        # FFI::AutoPointer uses a custom release strategy to automatically free
+        # the pointer once this object goes out of scope
         @ctx = FFI::AutoPointer.new(
           Binding.mongocrypt_ctx_new(mongocrypt),
           Binding.method(:mongocrypt_ctx_destroy)

--- a/lib/mongo/crypt/context/data_key_context.rb
+++ b/lib/mongo/crypt/context/data_key_context.rb
@@ -30,30 +30,8 @@ module Mongo
 
         super(mongocrypt, nil)
 
-        begin
-          set_local_master_key
-          initialize_ctx
-        rescue => e
-          # Setting options on or initializing the context could raise errors.
-          # Make sure the reference to the underlying mongocrypt_ctx_t is destroyed
-          # before passing those errors along.
-          self.close
-          raise e
-        end
-      end
-
-      # Convenient API for using context object without having
-      # to perform cleanup.
-      #
-      # @param [ FFI::Pointer ] mongocrypt A pointer to a mongocrypt_t object
-      #   used to create a new mongocrypt_ctx_t in the context of this block.
-      def self.with_context(mongocrypt)
-        context = self.new(mongocrypt)
-        begin
-          yield(context)
-        ensure
-          context.close
-        end
+        set_local_master_key
+        initialize_ctx
       end
 
       private

--- a/lib/mongo/crypt/context/explicit_decryption_context.rb
+++ b/lib/mongo/crypt/context/explicit_decryption_context.rb
@@ -31,33 +31,7 @@ module Mongo
 
         @value = value
 
-        begin
-          initialize_ctx
-        rescue => e
-          # Initializing the context could raise errors.
-          # Make sure the reference to the underlying mongocrypt_ctx_t is destroyed
-          # before passing those errors along.
-          self.close
-          raise e
-        end
-      end
-
-      # Convenient API for using context object without having
-      # to perform cleanup.
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_t object
-      #   used to create a new mongocrypt_ctx_t
-      # @param [ ClientEncryption::IO ] A instance of the IO class
-      #   that implements driver I/O methods required to run the
-      #   state machine
-      # @param [ String ] value A BSON value to decrypt
-      def self.with_context(mongocrypt, io, value)
-        context = self.new(mongocrypt, io, value)
-        begin
-          yield(context)
-        ensure
-          context.close
-        end
+        initialize_ctx
       end
 
       private

--- a/lib/mongo/crypt/context/explicit_decryption_context.rb
+++ b/lib/mongo/crypt/context/explicit_decryption_context.rb
@@ -65,10 +65,10 @@ module Mongo
       # Initialize the underlying mongocrypt_ctx_t object to perform
       # explicit decryption
       def initialize_ctx
-        Binary.with_binary(@value) do |binary|
-          success = Binding.mongocrypt_ctx_explicit_decrypt_init(@ctx, binary.ref)
-          raise_from_status unless success
-        end
+        binary = Binary.new(@value)
+        success = Binding.mongocrypt_ctx_explicit_decrypt_init(@ctx, binary.ref)
+
+        raise_from_status unless success
       end
     end
   end

--- a/lib/mongo/crypt/context/explicit_encryption_context.rb
+++ b/lib/mongo/crypt/context/explicit_encryption_context.rb
@@ -41,44 +41,9 @@ module Mongo
         @value = value
         @options = options
 
-        begin
-          set_key_id
-          set_algorithm
-          initialize_ctx
-        rescue => e
-          # Setting options on or initializing the context could raise errors.
-          # Make sure the reference to the underlying mongocrypt_ctx_t is destroyed
-          # before passing those errors along.
-          self.close
-          raise e
-        end
-      end
-
-      # Convenient API for using context object without having
-      # to perform cleanup.
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_t object
-      #   used to create a new mongocrypt_ctx_t
-      # @param [ ClientEncryption::IO ] A instance of the IO class
-      #   that implements driver I/O methods required to run the
-      #   state machine
-      # @param [ String|Integer ] value A value to encrypt
-      # @param [ Hash ] options
-      #
-      # @option [ String ] :key_id The UUID of the data key that
-      #   will be used to encrypt the value
-      # @option [ String ] :algorithm The algorithm used to encrypt the
-      #   value. Valid algorithms are "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
-      #   or "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
-      #
-      # @raises [ ArgumentError|Mongo::Error::CryptError ] If invalid options are provided
-      def self.with_context(mongocrypt, value, io, options={})
-        context = self.new(mongocrypt, value, io, options)
-        begin
-          yield(context)
-        ensure
-          context.close
-        end
+        set_key_id
+        set_algorithm
+        initialize_ctx
       end
 
       private

--- a/lib/mongo/crypt/context/explicit_encryption_context.rb
+++ b/lib/mongo/crypt/context/explicit_encryption_context.rb
@@ -90,10 +90,10 @@ module Mongo
           raise ArgumentError.new(':key_id option must not be nil')
         end
 
-        Binary.with_binary(@options[:key_id]) do |binary|
-          success = Binding.mongocrypt_ctx_setopt_key_id(@ctx, binary.ref)
-          raise_from_status unless success
-        end
+        binary = Binary.new(@options[:key_id])
+        success = Binding.mongocrypt_ctx_setopt_key_id(@ctx, binary.ref)
+
+        raise_from_status unless success
       end
 
       # Set the algorithm option on the mongocrypt_ctx_t object and raises
@@ -111,10 +111,10 @@ module Mongo
       # Initializes the mongocrypt_ctx_t object for explicit encryption and
       # passes in the value to be encrypted as a Mongo::Crypt::Binary reference
       def initialize_ctx
-        Binary.with_binary(@value) do |binary|
-          success = Binding.mongocrypt_ctx_explicit_encrypt_init(@ctx, binary.ref)
-          raise_from_status unless success
-        end
+        binary = Binary.new(@value)
+        success = Binding.mongocrypt_ctx_explicit_encrypt_init(@ctx, binary.ref)
+
+        raise_from_status unless success
       end
     end
   end

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -113,10 +113,10 @@ module Mongo
       # Raise a Mongo::Error::CryptError based on the status of the underlying
       # mongocrypt_t object
       def raise_from_status
-        Status.with_status do |status|
-          Binding.mongocrypt_status(@mongocrypt, status.ref)
-          status.raise_crypt_error
-        end
+        status = Status.new
+
+        Binding.mongocrypt_status(@mongocrypt, status.ref)
+        status.raise_crypt_error
       end
     end
   end

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -32,7 +32,10 @@ module Mongo
       #
       # There will be more arguemnts to this method once automatic encryption is introduced.
       def initialize(kms_providers)
-        @mongocrypt = Binding.mongocrypt_new
+        @mongocrypt = FFI::AutoPointer.new(
+          Binding.mongocrypt_new,
+          Binding.method(:mongocrypt_destroy)
+        )
 
         set_kms_providers(kms_providers)
         initialize_mongocrypt

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -34,28 +34,8 @@ module Mongo
       def initialize(kms_providers)
         @mongocrypt = Binding.mongocrypt_new
 
-        begin
-          set_kms_providers(kms_providers)
-          initialize_mongocrypt
-        rescue => e
-          # Setting options or initializing mongocrypt_t could cause validation/status
-          # errors; if that happens, make sure the reference to the mongocrypt_t object
-          # is destroyed before passing on the error
-          self.close
-          raise e
-        end
-      end
-
-
-      # Destroy the reference to the underlying mongocrypt_t object and
-      # clean up resources
-      #
-      # @return [ true ] Always true
-      def close
-        Binding.mongocrypt_destroy(@mongocrypt) if @mongocrypt
-        @mongocrypt = nil
-
-        true
+        set_kms_providers(kms_providers)
+        initialize_mongocrypt
       end
 
       # Return the reference to the underlying @mongocrypt object

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -97,10 +97,10 @@ module Mongo
 
         master_key = kms_providers[:local][:key]
 
-        Binary.with_binary(Base64.decode64(master_key)) do |binary|
-          success = Binding.mongocrypt_setopt_kms_provider_local(@mongocrypt, binary.ref)
-          raise_from_status unless success
-        end
+        binary = Binary.new(Base64.decode64(master_key))
+        success = Binding.mongocrypt_setopt_kms_provider_local(@mongocrypt, binary.ref)
+
+        raise_from_status unless success
       end
 
       # Initialize the underlying mongocrypt_t object and raise an error if the operation fails

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -32,6 +32,8 @@ module Mongo
       #
       # There will be more arguemnts to this method once automatic encryption is introduced.
       def initialize(kms_providers)
+        # FFI::AutoPointer uses a custom release strategy to automatically free
+        # the pointer once this object goes out of scope
         @mongocrypt = FFI::AutoPointer.new(
           Binding.mongocrypt_new,
           Binding.method(:mongocrypt_destroy)

--- a/lib/mongo/crypt/status.rb
+++ b/lib/mongo/crypt/status.rb
@@ -22,6 +22,8 @@ module Mongo
     class Status
       # Create a new Status object
       def initialize
+        # FFI::AutoPointer uses a custom release strategy to automatically free
+        # the pointer once this object goes out of scope
         @status = FFI::AutoPointer.new(
           Binding.mongocrypt_status_new,
           Binding.method(:mongocrypt_status_destroy)

--- a/lib/mongo/crypt/status.rb
+++ b/lib/mongo/crypt/status.rb
@@ -22,7 +22,10 @@ module Mongo
     class Status
       # Create a new Status object
       def initialize
-        @status = Binding.mongocrypt_status_new
+        @status = FFI::AutoPointer.new(
+          Binding.mongocrypt_status_new,
+          Binding.method(:mongocrypt_status_destroy)
+        )
       end
 
       # Set a label, code, and message on the Status
@@ -99,33 +102,6 @@ module Mongo
         end
 
         raise error
-      end
-
-      # Destroys reference to mongocrypt_status_t object and
-      # cleans up resources.
-      #
-      # @return [ true ] Always true
-      def close
-        Binding.mongocrypt_status_destroy(@status)
-        @status = nil
-
-        true
-      end
-
-      # Convenient API for using status object without having
-      # to perform cleanup.
-      #
-      # @example
-      #   Mongo::Crypt::Status.with_status do |status|
-      #     status.ok? # => true
-      #   end
-      def self.with_status
-        status = self.new
-        begin
-          yield(status)
-        ensure
-          status.close
-        end
       end
     end
   end

--- a/spec/integration/explicit_encryption_spec.rb
+++ b/spec/integration/explicit_encryption_spec.rb
@@ -35,9 +35,6 @@ describe 'Explicit Encryption' do
       decrypted = client_encryption.decrypt(encrypted)
       expect(decrypted).to eq(value)
       expect(decrypted).to be_a_kind_of(value.class)
-
-      client_encryption.close
-      client.close
     end
   end
 

--- a/spec/mongo/client_encryption_spec.rb
+++ b/spec/mongo/client_encryption_spec.rb
@@ -65,10 +65,6 @@ describe Mongo::ClientEncryption do
     end
 
     context 'with valid options' do
-      after do
-        client_encryption.close
-      end
-
       it 'creates a ClientEncryption object' do
         expect do
           client_encryption
@@ -80,10 +76,6 @@ describe Mongo::ClientEncryption do
   describe '#create_data_key' do
 
     let(:result) { client_encryption.create_data_key }
-
-    after do
-      client_encryption.close
-    end
 
     it 'returns a string' do
       expect(result).to be_a_kind_of(String)

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -12,10 +12,6 @@ describe Mongo::Crypt::Binary do
   let(:binary) { described_class.new(data) }
 
   describe '#initialize' do
-    after do
-      binary.close
-    end
-
     context 'with nil data' do
       it 'creates a new Mongo::Crypt::Binary object' do
         expect do
@@ -34,51 +30,14 @@ describe Mongo::Crypt::Binary do
   end
 
   describe '#to_bytes' do
-    after do
-      binary.close
-    end
-
     it 'returns the string as a byte array' do
       expect(binary.to_bytes).to eq(data.unpack("C*"))
     end
   end
 
   describe '#to_string' do
-    after do
-      binary.close
-    end
-
     it 'returns the original string' do
       expect(binary.to_string).to eq(data)
-    end
-  end
-
-  describe '#self.with_binary' do
-    before do
-      allow(described_class)
-        .to receive(:new)
-        .with(data)
-        .and_return(binary)
-    end
-
-    context 'when yield errors' do
-      it 'closes the created binary and raises the error' do
-        expect(binary).to receive(:close).once
-
-        expect do
-          described_class.with_binary(data) do |bin|
-            raise StandardError.new("an error")
-          end
-        end.to raise_error(StandardError, /an error/)
-      end
-    end
-
-    it 'creates a new binary and closes it' do
-      expect(binary).to receive(:close).once
-
-      described_class.with_binary(data) do |bin|
-        expect(bin.to_bytes).to eq(data.unpack("C*"))
-      end
     end
   end
 end

--- a/spec/mongo/crypt/data_key_context_spec.rb
+++ b/spec/mongo/crypt/data_key_context_spec.rb
@@ -32,8 +32,6 @@ describe Mongo::Crypt::DataKeyContext do
       end
 
       it 'raises an exception' do
-        expect_any_instance_of(described_class).to receive(:close).once
-
         expect do
           context
         end.to raise_error(Mongo::Error::CryptClientError, /requested kms provider not configured/)
@@ -48,50 +46,12 @@ describe Mongo::Crypt::DataKeyContext do
 
       after do
         Mongo::Crypt::Binding.mongocrypt_binary_destroy(master_key)
-        context.close
       end
 
       it 'does not raise an exception' do
         expect do
           context
         end.not_to raise_error
-      end
-    end
-  end
-
-  describe '#with_context' do
-    before do
-      Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, master_key)
-      Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)
-
-      allow(described_class)
-        .to receive(:new)
-        .with(mongocrypt)
-        .and_return(context)
-    end
-
-    after do
-      Mongo::Crypt::Binding.mongocrypt_binary_destroy(master_key)
-    end
-
-    context 'when yield errors' do
-      it 'closes the created context and raises the error' do
-        expect(context).to receive(:close).once
-
-        expect do
-          described_class.with_context(mongocrypt) do |_|
-            raise StandardError.new("an error")
-          end
-        end.to raise_error(StandardError, /an error/)
-      end
-    end
-
-    it 'creates a new context and closes it' do
-      expect(described_class).to receive(:new).once
-      expect(context).to receive(:close).once
-
-      described_class.with_context(mongocrypt) do |_|
-        # something here
       end
     end
   end
@@ -107,7 +67,6 @@ describe Mongo::Crypt::DataKeyContext do
 
     after do
       Mongo::Crypt::Binding.mongocrypt_binary_destroy(master_key)
-      context.close
     end
 
     it 'returns :ready' do
@@ -127,7 +86,6 @@ describe Mongo::Crypt::DataKeyContext do
 
     after do
       Mongo::Crypt::Binding.mongocrypt_binary_destroy(master_key)
-      context.close
     end
 
     it 'creates a data key' do

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -67,7 +67,6 @@ describe Mongo::Crypt::Handle do
       end
 
       it 'raises an exception' do
-        expect_any_instance_of(Mongo::Crypt::Binary).to receive(:close).once # make sure binary is closed
         expect_any_instance_of(Mongo::Crypt::Status).to receive(:close).once # make sure status is closed
         expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(Mongo::Error::CryptClientError, 'Code 1: local key must be 96 bytes')
@@ -88,7 +87,6 @@ describe Mongo::Crypt::Handle do
       end
 
       it 'does not raise an exception' do
-        expect_any_instance_of(Mongo::Crypt::Binary).to receive(:close).once # make sure binary is closed
         expect { handle }.not_to raise_error
       end
     end

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -16,7 +16,6 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { {} }
 
       it 'raises an exception' do
-        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /must have one of the following keys: :aws, :local/)
       end
     end
@@ -25,7 +24,6 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { { aws: {} } }
 
       it 'raises an exception' do
-        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /:aws is not yet a supported kms_providers option/)
       end
     end
@@ -34,7 +32,6 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { { random_kms_provider: {} } }
 
       it 'raises an exception' do
-        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /must have one of the following keys: :aws, :local/)
       end
     end
@@ -43,7 +40,6 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { { local: {} } }
 
       it 'raises an exception' do
-        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /kms_providers with :local key must be in the format: { local: { key: 'MASTER-KEY' } }/)
       end
     end
@@ -52,7 +48,6 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) { { local: { invalid_key: 'Some stuff' } } }
 
       it 'raises an exception' do
-        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(ArgumentError, /kms_providers with :local key must be in the format: { local: { key: 'MASTER-KEY' } }/)
       end
     end
@@ -67,16 +62,11 @@ describe Mongo::Crypt::Handle do
       end
 
       it 'raises an exception' do
-        expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(Mongo::Error::CryptClientError, 'Code 1: local key must be 96 bytes')
       end
     end
 
     context 'with valid local kms_providers' do
-      after do
-        handle.close
-      end
-
       let(:kms_providers) do
         {
           local: {

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -67,7 +67,6 @@ describe Mongo::Crypt::Handle do
       end
 
       it 'raises an exception' do
-        expect_any_instance_of(Mongo::Crypt::Status).to receive(:close).once # make sure status is closed
         expect_any_instance_of(Mongo::Crypt::Handle).to receive(:close).once # make sure handle is closed
         expect { handle }.to raise_error(Mongo::Error::CryptClientError, 'Code 1: local key must be 96 bytes')
       end

--- a/spec/mongo/crypt/status_spec.rb
+++ b/spec/mongo/crypt/status_spec.rb
@@ -19,20 +19,12 @@ describe Mongo::Crypt::Status do
   end
 
   describe '#initialize' do
-    after do
-      status.close
-    end
-
     it 'doesn\'t throw an error' do
       expect { status }.not_to raise_error
     end
   end
 
   describe '#update' do
-    after do
-      status.close
-    end
-
     context 'with invalid label' do
       it 'raises an exception' do
         expect do
@@ -48,10 +40,6 @@ describe Mongo::Crypt::Status do
   end
 
   describe '#label' do
-    after do
-      status.close
-    end
-
     context 'new status' do
       it 'returns :ok' do
         expect(status.label).to eq(:ok)
@@ -66,10 +54,6 @@ describe Mongo::Crypt::Status do
   end
 
   describe '#code' do
-    after do
-      status.close
-    end
-
     context 'new status' do
       it 'returns 0' do
         expect(status.code).to eq(0)
@@ -84,10 +68,6 @@ describe Mongo::Crypt::Status do
   end
 
   describe '#message' do
-    after do
-      status.close
-    end
-
     context 'new status' do
       it 'returns an empty string' do
         expect(status.message).to eq('')
@@ -102,10 +82,6 @@ describe Mongo::Crypt::Status do
   end
 
   describe '#ok?' do
-    after do
-      status.close
-    end
-
     context 'new status' do
       it 'returns true' do
         expect(status.ok?).to be true
@@ -120,10 +96,6 @@ describe Mongo::Crypt::Status do
   end
 
   describe '#crypt_error' do
-    after do
-      status.close
-    end
-
     context 'when status is ok' do
       before do
         status.update(:ok, 0, '')
@@ -157,34 +129,6 @@ describe Mongo::Crypt::Status do
         expect do
           status.raise_crypt_error
         end.to raise_error(Mongo::Error::CryptClientError, /Code 2: Client Error/)
-      end
-    end
-  end
-
-  describe '#self.with_status' do
-    before do
-      allow(described_class)
-        .to receive(:new)
-        .and_return(status)
-    end
-
-    context 'when yield errors' do
-      it 'closes the created status and raises the error' do
-        expect(status).to receive(:close).once
-
-        expect do
-          described_class.with_status do |s|
-            raise StandardError.new("an error")
-          end
-        end.to raise_error(StandardError, /an error/)
-      end
-
-      it 'creates a new status and closes it' do
-        expect(status).to receive(:close).once
-
-        described_class.with_status do |s|
-          expect(s.ok?).to be true
-        end
       end
     end
   end


### PR DESCRIPTION
`FFI::AutoPointer` takes a custom release method and automatically releases memory allocated by libmongocrypt when the associated Ruby object goes out of scope.

- This means there is no need for `close` methods on Ruby objects
- There is also no need for these objects to have block APIs