### PR TITLE
RUBY-2017 Modify result type of Mongo::Database#command within the inline docs

### DIFF
--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -157,7 +157,7 @@ module Mongo
     # @option opts :read [ Hash ] The read preference for this command.
     # @option opts :session [ Session ] The session to use for this command.
     #
-    # @return [ Hash ] The result of the command execution.
+    # @return [ Mongo::Operation::Result ] The result of the command execution.
     def command(operation, opts = {})
       txn_read_pref = if opts[:session] && opts[:session].in_transaction?
         opts[:session].txn_read_preference


### PR DESCRIPTION
Note I chose to link to `[ Mongo::Operation::Result ]` instead of simply `[ Result ]` to ensure links were generated appropriately.

![image](https://user-images.githubusercontent.com/135803/69582732-3b799400-0fa7-11ea-8bf0-20f998e5e92c.png)

Note for consistency we could change this to `[ Result ]`, but then we'd lose the link

![image](https://user-images.githubusercontent.com/135803/69583016-df633f80-0fa7-11ea-87a8-5293a07ecd5a.png)
