### PR TITLE
Fix RUBY-2030 Client/Cluster construction fails when duplicate seed addresses are provided

### DIFF
--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -109,6 +109,8 @@ module Mongo
         options[:cleanup] = false
       end
 
+      seeds = seeds.uniq
+
       @servers = []
       @monitoring = monitoring
       @event_listeners = Event::Listeners.new

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -31,8 +31,8 @@ describe Mongo::Cluster do
         described_class.new(addresses, monitoring, SpecConfig.instance.test_options)
       end
 
-      it 'does not error out' do
-        cluster_with_dup_addresses
+      it 'does not raise an exception' do
+        expect { cluster_with_dup_addresses }.not_to raise_error
       end
     end
 

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -20,6 +20,24 @@ describe Mongo::Cluster do
 
   let(:cluster) { cluster_without_io }
 
+  describe 'initialize' do
+
+    context 'when there are duplicate addresses' do
+
+      let(:addresses) do
+        SpecConfig.instance.addresses + SpecConfig.instance.addresses
+      end
+      let(:cluster_with_dup_addresses) do
+        described_class.new(addresses, monitoring, SpecConfig.instance.test_options)
+      end
+
+      it 'does not error out' do
+        cluster_with_dup_addresses
+      end
+    end
+
+  end
+
   describe '#==' do
 
     context 'when the other is a cluster' do

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -31,6 +31,10 @@ describe Mongo::Cluster do
         described_class.new(addresses, monitoring, SpecConfig.instance.test_options)
       end
 
+      after do
+        cluster_with_dup_addresses.disconnect!
+      end
+
       it 'does not raise an exception' do
         expect { cluster_with_dup_addresses }.not_to raise_error
       end

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -28,11 +28,8 @@ describe Mongo::Cluster do
         SpecConfig.instance.addresses + SpecConfig.instance.addresses
       end
       let(:cluster_with_dup_addresses) do
-        described_class.new(addresses, monitoring, SpecConfig.instance.test_options)
-      end
-
-      after do
-        cluster_with_dup_addresses.disconnect!
+        register_cluster(
+          described_class.new(addresses, monitoring, SpecConfig.instance.test_options))
       end
 
       it 'does not raise an exception' do


### PR DESCRIPTION
We made a configuration change for our connection strings and mistakenly duplicated a mongoS host, which then broke processes when they tried to start up. The issue is that Cluster#add will return nil if the address already exists, and you'll receive this error (taken from the test without the patch).

```
NoMethodError: undefined method `start_monitoring' for nil:NilClass

  0) Mongo::Cluster initialize when there are duplicate addresses does not error out
     Failure/Error:[0mserver.start_monitoring

     NoMethodError:
       undefined method `start_monitoring' for nil:NilClass
     # ./lib/mongo/cluster.rb:188:in `block in initialize'
     # ./lib/mongo/cluster.rb:187:in `each'
```