### PR TITLE
Suppress the warning "warning: URI.unescape is obsolete".

### DIFF
--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -454,7 +454,7 @@ module Mongo
     end
 
     def decode(value)
-      ::URI.decode(value)
+      ::URI.decode_www_form_component(value)
     end
 
     def encode(value)


### PR DESCRIPTION
Hello.

URI.decode (alias of URI.unescape) is obsolete in latest Ruby 2.5, 2.6. coming 2.7.

Following the way to test with standalone mongod: https://github.com/mongodb/mongo-ruby-driver/blob/master/spec/README.md#standalone , you see many warnings `URI.unescape is obsolete` in Ruby 2.6.5 and Ruby 2.7.0 preview3 in the process of `rake`.

```
$ bundle exec rake
...
/home/jaruga/git/mongo-ruby-driver/lib/mongo/uri.rb:457: warning: URI.unescape is obsolete
```

References: 
* https://ruby-doc.org/stdlib-2.6.5/libdoc/uri/rdoc/URI/Escape.html#method-i-unescape
* https://ruby-doc.org/stdlib-2.5.7/libdoc/uri/rdoc/URI/Escape.html#method-i-unescape

I referred this page: https://github.com/hanami/utils/pull/130 .
