### PR TITLE
RUBY-2014 Send logging messages from libmongocrypt to Mongo::Logger

### DIFF
--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -101,6 +101,25 @@ module Mongo
       # reference to that status
       attach_function :mongocrypt_status_destroy, [:pointer], :void
 
+      # Log level
+      enum :log_level, [
+        :fatal,   0,
+        :error,   1,
+        :warning, 2,
+        :info,    3,
+        :trace,   4,
+      ]
+
+      # Mongocrypt log function signature. Takes a log level, a log message as a string,
+      # an integer representing the length of the message, and a pointer to a context provided
+      # by the caller.
+      callback :mongocrypt_log_fn_t, [:log_level, :string, :int, :pointer], :void
+
+      # Sets a method to be called on every log message. Takes a pointer to a mongocrypt_t object,
+      # a mongocrypt_log_fn_t callback, and a pointer to a log_ctx. Returns a boolean indicating
+      # success of the operation.
+      attach_function :mongocrypt_setopt_log_handler, [:pointer, :mongocrypt_log_fn_t, :pointer], :bool
+
       # Creates a new mongocrypt_t object and returns a pointer to that object
       attach_function :mongocrypt_new, [], :pointer
 

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -112,7 +112,7 @@ module Mongo
 
       # Mongocrypt log function signature. Takes a log level, a log message as a string,
       # an integer representing the length of the message, and a pointer to a context provided
-      # by the caller.
+      # by the caller (can be set to nil).
       callback :mongocrypt_log_fn_t, [:log_level, :string, :int, :pointer], :void
 
       # Sets a method to be called on every log message. Takes a pointer to a mongocrypt_t object,

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -105,9 +105,9 @@ module Mongo
       enum :log_level, [
         :fatal,   0,
         :error,   1,
-        :warning, 2,
+        :warn,    2,
         :info,    3,
-        :trace,   4,
+        :debug,   4,
       ]
 
       # Mongocrypt log function signature. Takes a log level, a log message as a string,

--- a/lib/mongo/crypt/context/context.rb
+++ b/lib/mongo/crypt/context/context.rb
@@ -29,14 +29,14 @@ module Mongo
       # @param [ ClientEncryption::IO ] A instance of the IO class
       #   that implements driver I/O methods required to run the
       #   state machine
-      def initialize(mongocrypt, io)
+      def initialize(mongocrypt_handle, io)
         # Ideally, this level of the API wouldn't be passing around pointer
         # references between objects, so this method signature is subject to change.
 
         # FFI::AutoPointer uses a custom release strategy to automatically free
         # the pointer once this object goes out of scope
         @ctx = FFI::AutoPointer.new(
-          Binding.mongocrypt_ctx_new(mongocrypt),
+          Binding.mongocrypt_ctx_new(mongocrypt_handle.ref),
           Binding.method(:mongocrypt_ctx_destroy)
         )
 

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -52,9 +52,9 @@ module Mongo
 
       private
 
-      # TODO: documentation
+      # Send the logs from libmongocrypt to the Mongo::Logger
       def set_logger
-        @log_callback = Proc.new do |level, msg, len=nil, ctx=nil|
+        @log_callback = Proc.new do |level, msg|
           logger = Mongo::Logger.logger
 
           case level

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -28,12 +28,16 @@ module Mongo
       # is currently :local. Local KMS options must be passed in the format
       # { local: { key: <master key> } } where the master key is a 96-byte, base64
       # encoded string.
+      # @param [ Hash ] options A hash of options
+      #
+      # @option [ Logger ] :logger A Logger object to which libmongocrypt logs
+      #   will be sent
       #
       # There will be more arguemnts to this method once automatic encryption is introduced.
-      def initialize(kms_providers, logger=nil)
+      def initialize(kms_providers, options={})
         # FFI::AutoPointer uses a custom release strategy to automatically free
         # the pointer once this object goes out of scope
-        @logger = logger
+        @logger = options[:logger]
         @mongocrypt = FFI::AutoPointer.new(
           Binding.mongocrypt_new,
           Binding.method(:mongocrypt_destroy)

--- a/spec/mongo/crypt/data_key_context_spec.rb
+++ b/spec/mongo/crypt/data_key_context_spec.rb
@@ -1,5 +1,6 @@
 require 'mongo'
 require 'support/lite_constraints'
+require 'base64'
 
 RSpec.configure do |config|
   config.extend(LiteConstraints)
@@ -8,51 +9,21 @@ end
 describe Mongo::Crypt::DataKeyContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Binding.mongocrypt_new }
+  let(:mongocrypt) do
+    Mongo::Crypt::Handle.new({
+      local: {
+        key: Base64.encode64("ru\xfe\x00" * 24)
+      }
+    })
+  end
+
   let(:context) { described_class.new(mongocrypt) }
 
-  let(:master_key) do
-    bytes = ("ru\xfe\x00" * 24).unpack('C*')
-
-    p = FFI::MemoryPointer
-    .new(bytes.size)
-    .write_array_of_type(FFI::TYPE_UINT8, :put_uint8, bytes)
-
-    Mongo::Crypt::Binding.mongocrypt_binary_new_from_data(p, bytes.length)
-  end
-
-  after do
-    Mongo::Crypt::Binding.mongocrypt_destroy(mongocrypt)
-  end
-
   describe '#initialize' do
-    context 'when no kms provider has been set on mongocrypt' do
-      before do
-        Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)
-      end
-
-      it 'raises an exception' do
-        expect do
-          context
-        end.to raise_error(Mongo::Error::CryptClientError, /requested kms provider not configured/)
-      end
-    end
-
-    context 'when local kms provider has been set on mongocrypt' do
-      before do
-        Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, master_key)
-        Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)
-      end
-
-      after do
-        Mongo::Crypt::Binding.mongocrypt_binary_destroy(master_key)
-      end
-
-      it 'does not raise an exception' do
-        expect do
-          context
-        end.not_to raise_error
-      end
+    it 'does not raise an exception' do
+      expect do
+        context
+      end.not_to raise_error
     end
   end
 
@@ -60,15 +31,6 @@ describe Mongo::Crypt::DataKeyContext do
   # There should be multiple specs testing the context's state
   #   depending on how it's initialized, etc.
   describe '#state' do
-    before do
-      Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, master_key)
-      Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)
-    end
-
-    after do
-      Mongo::Crypt::Binding.mongocrypt_binary_destroy(master_key)
-    end
-
     it 'returns :ready' do
       expect(context.state).to eq(:ready)
     end
@@ -79,15 +41,6 @@ describe Mongo::Crypt::DataKeyContext do
   #   to test that the state machine returns the correct result under various
   #   conditions
   describe '#run_state_machine' do
-    before do
-      Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, master_key)
-      Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)
-    end
-
-    after do
-      Mongo::Crypt::Binding.mongocrypt_binary_destroy(master_key)
-    end
-
     it 'creates a data key' do
       expect(context.run_state_machine).to be_a_kind_of(String)
     end

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -1,6 +1,5 @@
 require 'mongo'
 require 'support/lite_constraints'
-require 'byebug'
 
 RSpec.configure do |config|
   config.extend(LiteConstraints)

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -8,14 +8,16 @@ end
 describe Mongo::Crypt::ExplicitDecryptionContext do
   require_libmongocrypt
 
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, logger) }
   let(:context) { described_class.new(mongocrypt, io, value) }
 
-  let(:mongocrypt) do
-    Mongo::Crypt::Handle.new({
+  let(:logger) { nil }
+  let(:kms_providers) do
+    {
       local: {
         key: Base64.encode64("ru\xfe\x00" * 24)
       }
-    })
+    }
   end
 
   let(:io) { double("Mongo::ClientEncryption::IO") }
@@ -40,22 +42,19 @@ describe Mongo::Crypt::ExplicitDecryptionContext do
         # while debugging any problems.
         #
         # For now, skip this test by default and revisit once we have determined how we want to
-        # package libmongocrypt with the Ruby driver.
+        # package libmongocrypt with the Ruby driver (see: https://jira.mongodb.org/browse/RUBY-1966)
         skip "These tests require libmongocrypt to be built with the '-DENABLE_TRACE=ON' cmake option." +
           " They also require the MONGOCRYPT_TRACE environment variable to be set to 'ON'."
       end
 
-      before do
-        @original_logger_level = Mongo::Logger.level
-        Mongo::Logger.level = Logger::DEBUG
-      end
-
-      after do
-        Mongo::Logger.level = @original_logger_level
+      let(:logger) do
+        ::Logger.new($stdout).tap do |logger|
+          logger.level = ::Logger::DEBUG
+        end
       end
 
       it 'receives log messages from libmongocrypt' do
-        expect(Mongo::Logger.logger).to receive(:debug).with(/mongocrypt_ctx_explicit_decrypt_init/)
+        expect(logger).to receive(:debug).with(/mongocrypt_ctx_explicit_decrypt_init/)
 
         context
       end

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -10,26 +10,55 @@ describe Mongo::Crypt::ExplicitDecryptionContext do
 
   let(:context) { described_class.new(mongocrypt, io, value) }
 
-  let(:mongocrypt) { Mongo::Crypt::Binding.mongocrypt_new }
+  let(:mongocrypt) do
+    Mongo::Crypt::Handle.new({
+      local: {
+        key: Base64.encode64("ru\xfe\x00" * 24)
+      }
+    })
+  end
+
   let(:io) { double("Mongo::ClientEncryption::IO") }
 
   # A binary string representing a value previously encrypted by libmongocrypt
   # TODO: replace with code demonstrating how to generate a value like this
   let(:value) { "o\x00\x00\x00\x05v\x00b\x00\x00\x00\x06\x01\xDF2~\x89\xD2+N}\x84;i(\xE5\xF4\xBF \x024\xE5\xD2\n\x9E\x97\x9F\xAF\x9D\xC7\xC9\x1A\a\x87z\xAE_;r\xAC\xA9\xF6n\x1D\x0F\xB5\xB1#O\xB7\xCA\xEE$/\xF1\xFA\b\xA7\xEC\xDB\xB6\xD4\xED\xEAMw3+\xBBv\x18\x97\xF9\x99\xD5\x13@\x80y\n{\x19R\xD3\xF0\xA1C\x05\xF7)\x93\x9Bh\x8AA.\xBB\xD3&\xEA\x00" }
 
-  before do
-    Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)
-  end
-
-  after do
-    Mongo::Crypt::Binding.mongocrypt_destroy(mongocrypt)
-  end
-
   describe '#initialize' do
     it 'initializes context' do
       expect do
         context
       end.not_to raise_error
+    end
+
+    context 'with verbose logging' do
+      before(:all) do
+        ENV['MONGOCRYPT_TRACE'] = 'ON'
+      end
+
+      after(:all) do
+        ENV['MONGOCRYPT_TRACE'] = nil
+      end
+
+      let(:logger) do
+        Logger.new('/dev/null'). tap do |logger|
+          logger.level = :debug
+        end
+      end
+
+      before do
+        Mongo::Logger.logger = logger
+      end
+
+      after do
+        Mongo::Logger.logger = nil
+      end
+
+      it 'receives log messages from libmongocrypt' do
+        expect(logger).to receive(:debug).with(/mongocrypt_ctx_explicit_decrypt_init/)
+
+        context
+      end
     end
   end
 end

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -1,5 +1,6 @@
 require 'mongo'
 require 'support/lite_constraints'
+require 'byebug'
 
 RSpec.configure do |config|
   config.extend(LiteConstraints)
@@ -33,29 +34,29 @@ describe Mongo::Crypt::ExplicitDecryptionContext do
 
     context 'with verbose logging' do
       before(:all) do
-        ENV['MONGOCRYPT_TRACE'] = 'ON'
-      end
-
-      after(:all) do
-        ENV['MONGOCRYPT_TRACE'] = nil
-      end
-
-      let(:logger) do
-        Logger.new('/dev/null'). tap do |logger|
-          logger.level = :debug
-        end
+        # Logging from libmongocrypt requires the C library to be built with the -DENABLE_TRACE=ON
+        # option; none of the pre-built packages on Evergreen have been built with logging enabled.
+        #
+        # It is still useful to be able to run these tests locally to confirm that logging is working
+        # while debugging any problems.
+        #
+        # For now, skip this test by default and revisit once we have determined how we want to
+        # package libmongocrypt with the Ruby driver.
+        skip "These tests require libmongocrypt to be built with the '-DENABLE_TRACE=ON' cmake option." +
+          " They also require the MONGOCRYPT_TRACE environment variable to be set to 'ON'."
       end
 
       before do
-        Mongo::Logger.logger = logger
+        @original_logger_level = Mongo::Logger.level
+        Mongo::Logger.level = Logger::DEBUG
       end
 
       after do
-        Mongo::Logger.logger = nil
+        Mongo::Logger.level = @original_logger_level
       end
 
       it 'receives log messages from libmongocrypt' do
-        expect(logger).to receive(:debug).with(/mongocrypt_ctx_explicit_decrypt_init/)
+        expect(Mongo::Logger.logger).to receive(:debug).with(/mongocrypt_ctx_explicit_decrypt_init/)
 
         context
       end

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -8,10 +8,10 @@ end
 describe Mongo::Crypt::ExplicitDecryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, logger) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, { logger: logger }) }
   let(:context) { described_class.new(mongocrypt, io, value) }
-
   let(:logger) { nil }
+
   let(:kms_providers) do
     {
       local: {

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -81,26 +81,28 @@ describe Mongo::Crypt::ExplicitEncryptionContext do
 
       context 'with verbose logging' do
         before(:all) do
-          ENV['MONGOCRYPT_TRACE'] = 'ON'
-        end
-
-        after(:all) do
-          ENV['MONGOCRYPT_TRACE'] = nil
-        end
-
-        let(:logger) do
-          Logger.new('/dev/null'). tap do |logger|
-            logger.level = :debug
-          end
+          # Logging from libmongocrypt requires the C library to be built with the -DENABLE_TRACE=ON
+          # option; none of the pre-built packages on Evergreen have been built with logging enabled.
+          #
+          # It is still useful to be able to run these tests locally to confirm that logging is working
+          # while debugging any problems.
+          #
+          # For now, skip this test by default and revisit once we have determined how we want to
+          # package libmongocrypt with the Ruby driver.
+          skip "These tests require libmongocrypt to be built with the '-DENABLE_TRACE=ON' cmake option." +
+            " They also require the MONGOCRYPT_TRACE environment variable to be set to 'ON'."
         end
 
         before do
-          Mongo::Logger.logger = logger
+          @original_logger_level = Mongo::Logger.level
+          Mongo::Logger.level = Logger::DEBUG
         end
 
         after do
-          Mongo::Logger.logger = nil
+          Mongo::Logger.level = @original_logger_level
         end
+
+        let(:logger) { Mongo::Logger.logger }
 
         it 'receives log messages from libmongocrypt' do
           expect(logger).to receive(:debug).with(/mongocrypt_ctx_setopt_key_id/)

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::ExplicitEncryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, logger) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, { logger: logger }) }
   let(:context) { described_class.new(mongocrypt, io, value, options) }
 
   let(:logger) { nil }

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -81,9 +81,11 @@ describe Mongo::Crypt::ExplicitEncryptionContext do
 
       context 'with verbose logging' do
         before(:all) do
-          unless ENV['MONGOCRYPT_TRACE'] == 'ON'
-            skip "Test requires MONGOCRYPT_TRACE environment variable to be 'ON'"
-          end
+          ENV['MONGOCRYPT_TRACE'] = 'ON'
+        end
+
+        after(:all) do
+          ENV['MONGOCRYPT_TRACE'] = nil
         end
 
         let(:logger) do


### PR DESCRIPTION
Also change the context api (data key context, explicit encryption context, explicit decryption context) to be more consistent with the rest of the `Crypt` API that's been built so far.