### PR TITLE
RUBY-1924: Schema Map

### DIFF
--- a/lib/mongo/auth/user.rb
+++ b/lib/mongo/auth/user.rb
@@ -156,6 +156,7 @@ module Mongo
       #
       # @since 2.0.0
       def initialize(options)
+        byebug
         @database = options[:database] || Database::ADMIN
         @auth_source = options[:auth_source] || self.class.default_auth_source(options)
         @name = options[:user]

--- a/lib/mongo/auth/user.rb
+++ b/lib/mongo/auth/user.rb
@@ -156,7 +156,6 @@ module Mongo
       #
       # @since 2.0.0
       def initialize(options)
-        byebug
         @database = options[:database] || Database::ADMIN
         @auth_source = options[:auth_source] || self.class.default_auth_source(options)
         @name = options[:user]

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -129,6 +129,11 @@ module Mongo
       # indicating the success of the operation.
       attach_function :mongocrypt_setopt_kms_provider_local, [:pointer, :pointer], :bool
 
+      # Takes a pointer to a mongocrypt_t object and a pointer to a mongocrypt_binary_t
+      # object. Sets the mongocrypt schema map to the string wrapped by the binary and
+      # returns a boolean indicating the success of the operation.
+      attach_function :mongocrypt_setopt_schema_map, [:pointer, :pointer], :bool
+
       # Takes a pointer to a mongocrypt_t object and initializes that object.
       # Should be called after mongocrypt_setopt_kms_provider_local and other methods that
       # set options on the mongocrypt_t object.

--- a/lib/mongo/crypt/encrypter.rb
+++ b/lib/mongo/crypt/encrypter.rb
@@ -39,7 +39,7 @@ module Mongo
         validate_key_vault_namespace!
         validate_key_vault_client!
 
-        @crypt_handle = Crypt::Handle.new(options[:kms_providers], options[:schema_map])
+        @crypt_handle = Crypt::Handle.new(options[:kms_providers], schema_map: options[:schema_map])
         @encryption_io = EncryptionIO.new(options[:key_vault_client], options[:key_vault_namespace])
       end
 

--- a/lib/mongo/crypt/encrypter.rb
+++ b/lib/mongo/crypt/encrypter.rb
@@ -39,7 +39,7 @@ module Mongo
         validate_key_vault_namespace!
         validate_key_vault_client!
 
-        @crypt_handle = Crypt::Handle.new(options[:kms_providers])
+        @crypt_handle = Crypt::Handle.new(options[:kms_providers], options[:schema_map])
         @encryption_io = EncryptionIO.new(options[:key_vault_client], options[:key_vault_namespace])
       end
 

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -36,7 +36,7 @@ module Mongo
       #   will be sent
       #
       # There will be more arguemnts to this method once automatic encryption is introduced.
-      def initialize(kms_providers, schema_map, options={})
+      def initialize(kms_providers, schema_map: nil, options: {})
         @logger = options[:logger]
 
         # FFI::AutoPointer uses a custom release strategy to automatically free

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -63,6 +63,10 @@ module Mongo
 
       # Set the schema map option on the underlying mongocrypt_t object
       def set_schema_map(schema_map)
+        unless schema_map.is_a?(Hash)
+          raise ArgumentError.new("#{schema_map} is an invalid schema_map; schema_map must be a Hash or nil")
+        end
+
         binary = Binary.new(schema_map.to_bson.to_s)
         success = Binding.mongocrypt_setopt_schema_map(@mongocrypt, binary.ref)
 

--- a/spec/mongo/client_construction_spec.rb
+++ b/spec/mongo/client_construction_spec.rb
@@ -274,6 +274,14 @@ describe Mongo::Client do
           end
         end
 
+        context 'with an invalid schema map' do
+          let(:schema_map) { '' }
+
+          it 'raises an exception' do
+            expect { client }.to raise_error(ArgumentError, /schema_map must be a Hash or nil/)
+          end
+        end
+
         context 'with valid options' do
           it 'does not raise an exception' do
             expect { client }.not_to raise_error

--- a/spec/mongo/client_construction_spec.rb
+++ b/spec/mongo/client_construction_spec.rb
@@ -279,6 +279,14 @@ describe Mongo::Client do
             expect { client }.not_to raise_error
           end
 
+          context 'with a nil schema_map' do
+            let(:schema_map) { nil }
+
+            it 'does not raise an exception' do
+              expect { client }.not_to raise_error
+            end
+          end
+
           it 'sets options on the client' do
             client_options = client.encryption_options
 

--- a/spec/mongo/crypt/auto_encryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_encryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::AutoEncryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, nil, { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, options: { logger: logger }) }
   let(:context) { described_class.new(mongocrypt, io, db_name, command) }
 
   let(:logger) { nil }

--- a/spec/mongo/crypt/auto_encryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_encryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::AutoEncryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, nil, { logger: logger }) }
   let(:context) { described_class.new(mongocrypt, io, db_name, command) }
 
   let(:logger) { nil }

--- a/spec/mongo/crypt/data_key_context_spec.rb
+++ b/spec/mongo/crypt/data_key_context_spec.rb
@@ -11,8 +11,7 @@ describe Mongo::Crypt::DataKeyContext do
 
   let(:mongocrypt) do
     Mongo::Crypt::Handle.new(
-      { local: { key: Base64.encode64("ru\xfe\x00" * 24) } },
-      nil
+      { local: { key: Base64.encode64("ru\xfe\x00" * 24) } }
     )
   end
 

--- a/spec/mongo/crypt/data_key_context_spec.rb
+++ b/spec/mongo/crypt/data_key_context_spec.rb
@@ -10,11 +10,10 @@ describe Mongo::Crypt::DataKeyContext do
   require_libmongocrypt
 
   let(:mongocrypt) do
-    Mongo::Crypt::Handle.new({
-      local: {
-        key: Base64.encode64("ru\xfe\x00" * 24)
-      }
-    })
+    Mongo::Crypt::Handle.new(
+      { local: { key: Base64.encode64("ru\xfe\x00" * 24) } },
+      nil
+    )
   end
 
   let(:context) { described_class.new(mongocrypt) }

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::ExplicitDecryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, nil, { logger: logger }) }
   let(:context) { described_class.new(mongocrypt, io, value) }
   let(:logger) { nil }
 

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::ExplicitDecryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, nil, { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, options: { logger: logger }) }
   let(:context) { described_class.new(mongocrypt, io, value) }
   let(:logger) { nil }
 

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::ExplicitEncryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, nil, { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, options: { logger: logger }) }
   let(:context) { described_class.new(mongocrypt, io, value, options) }
 
   let(:logger) { nil }

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::ExplicitEncryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, nil, { logger: logger }) }
   let(:context) { described_class.new(mongocrypt, io, value, options) }
 
   let(:logger) { nil }

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -10,7 +10,24 @@ describe Mongo::Crypt::Handle do
   require_libmongocrypt
 
   describe '#initialize' do
-    let(:handle) { described_class.new(kms_providers) }
+    let(:handle) { described_class.new(kms_providers, schema_map) }
+
+    let(:kms_providers) do
+      {
+        local: {
+          key: Base64.encode64("ru\xfe\x00" * 24)
+        }
+      }
+    end
+
+    let(:schema_map) do
+      {
+        'admin.datakeys' => {
+          'bsonType' => 'object',
+          'properties' => 
+        }
+      }
+    end
 
     context 'with empty kms_providers' do
       let(:kms_providers) { {} }

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -10,7 +10,7 @@ describe Mongo::Crypt::Handle do
   require_libmongocrypt
 
   describe '#initialize' do
-    let(:handle) { described_class.new(kms_providers, schema_map) }
+    let(:handle) { described_class.new(kms_providers, schema_map: schema_map) }
 
     let(:kms_providers) do
       {

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -22,9 +22,16 @@ describe Mongo::Crypt::Handle do
 
     let(:schema_map) do
       {
-        'admin.datakeys' => {
-          'bsonType' => 'object',
-          'properties' => 
+        'admin.datakeys': {
+          bsonType: 'object',
+          properties: {
+            ssn: {
+              encrypt: {
+                keyId: BSON::Binary.new("e114f7ad-ad7a-4a68-81a7-ebcb9ea0953a", :uuid),
+                algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+              }
+            }
+          }
         }
       }
     end
@@ -83,7 +90,7 @@ describe Mongo::Crypt::Handle do
       end
     end
 
-    context 'with valid local kms_providers' do
+    context 'with valid local kms_providers and schema map' do
       let(:kms_providers) do
         {
           local: {
@@ -91,6 +98,14 @@ describe Mongo::Crypt::Handle do
           }
         }
       end
+
+      it 'does not raise an exception' do
+        expect { handle }.not_to raise_error
+      end
+    end
+
+    context 'with nil schema map' do
+      let(:schema_map) { nil }
 
       it 'does not raise an exception' do
         expect { handle }.not_to raise_error

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -90,6 +90,14 @@ describe Mongo::Crypt::Handle do
       end
     end
 
+    context 'with invalid schema map' do
+      let(:schema_map) { '' }
+
+      it 'raises an exception' do
+        expect { handle }.to raise_error(ArgumentError, /schema_map must be a Hash or nil/)
+      end
+    end
+
     context 'with valid local kms_providers and schema map' do
       let(:kms_providers) do
         {


### PR DESCRIPTION
Add the ability for a libmongocrypt Handle to accept a schema map, which specifies the fields to be encrypted/decrypted during auto encryption.