### PR TITLE
RUBY-2028 Allow user to update auto_encryption_options using Client#update_options

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -861,7 +861,9 @@ module Mongo
       opts_copy = @options[:auto_encryption_options].dup
 
       opts_copy.tap do |opts|
-        opts[:key_vault_client] ||= self
+        opts[:key_vault_client] ||= self.dup
+        opts[:key_vault_client].update_options({ auto_encryption_options: nil })
+
         opts[:extra_options] ||= {}
 
         opts[:extra_options][:mongocryptd_client_monitoring_io] = self.options[:monitoring_io]

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -121,6 +121,9 @@ module Mongo
     # @return [ Hash ] options The configuration options.
     attr_reader :options
 
+    # TODO: documentation
+    attr_reader :addresses_or_uri
+
     # Delegate command and collections execution to the current database.
     def_delegators :@database, :command, :collections
 
@@ -384,6 +387,8 @@ module Mongo
     # @since 2.0.0
     def initialize(addresses_or_uri, options = nil)
       options = options ? options.dup : {}
+
+      @addresses_or_uri = addresses_or_uri
 
       srv_uri = nil
       if addresses_or_uri.is_a?(::String)

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -861,11 +861,7 @@ module Mongo
       opts_copy = @options[:auto_encryption_options].dup
 
       opts_copy.tap do |opts|
-        opts[:key_vault_client] ||= self.dup
-        opts[:key_vault_client].update_options({ auto_encryption_options: nil })
-
         opts[:extra_options] ||= {}
-
         opts[:extra_options][:mongocryptd_client_monitoring_io] = self.options[:monitoring_io]
       end
 

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -121,9 +121,6 @@ module Mongo
     # @return [ Hash ] options The configuration options.
     attr_reader :options
 
-    # TODO: documentation
-    attr_reader :addresses_or_uri
-
     # Delegate command and collections execution to the current database.
     def_delegators :@database, :command, :collections
 
@@ -387,8 +384,6 @@ module Mongo
     # @since 2.0.0
     def initialize(addresses_or_uri, options = nil)
       options = options ? options.dup : {}
-
-      @addresses_or_uri = addresses_or_uri
 
       srv_uri = nil
       if addresses_or_uri.is_a?(::String)

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -649,6 +649,9 @@ module Mongo
         validate_options!
         validate_authentication_options!
 
+        # If the user specifies that auto_encryption_options are now nil, prevent the client
+        # from doing any further auto-encryption by cleaning up the resources related to
+        # auto-encryption.
         if @options.key?(:auto_encryption_options) && @options[:auto_encryption_options].nil?
           teardown_encrypter
         end
@@ -860,10 +863,8 @@ module Mongo
     def set_auto_encryption_options
       opts_copy = @options[:auto_encryption_options].dup
 
-      opts_copy.tap do |opts|
-        opts[:extra_options] ||= {}
-        opts[:extra_options][:mongocryptd_client_monitoring_io] = self.options[:monitoring_io]
-      end
+      opts_copy[:extra_options] ||= {}
+      opts_copy[:extra_options][:mongocryptd_client_monitoring_io] = self.options[:monitoring_io]
 
       setup_encrypter(opts_copy)
     end

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -54,14 +54,11 @@ module Mongo
         opts = set_default_options(options.dup)
 
         unless opts[:key_vault_client]
-          # If no key vault client is passed in, create one by duplicating the
+          # If no key vault client is passed in, create one by copying the
           # Mongo::Client used for encryption. Update options so that key vault
           # client does not perform auto-encryption/decryption, and keep a reference
           # to it so it is destroyed later.
-          @key_vault_client = Client.new(
-                                self.addresses_or_uri,
-                                self.options.dup.merge({ auto_encryption_options: nil })
-                              )
+          @key_vault_client = self.with({ auto_encryption_options: nil })
 
           opts[:key_vault_client] = @key_vault_client
         end

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -97,6 +97,7 @@ module Mongo
       # @return [ true ] Always true
       def teardown_encrypter
         @mongocryptd_client.close if @mongocryptd_client
+        @encryption_options = nil
 
         true
       end

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -58,8 +58,10 @@ module Mongo
           # Mongo::Client used for encryption. Update options so that key vault
           # client does not perform auto-encryption/decryption, and keep a reference
           # to it so it is destroyed later.
-          @key_vault_client = self.dup
-          @key_vault_client.update_options({ auto_encryption_options: nil })
+          @key_vault_client = Client.new(
+                                self.addresses_or_uri,
+                                self.options.dup.merge({ auto_encryption_options: nil })
+                              )
 
           opts[:key_vault_client] = @key_vault_client
         end

--- a/lib/mongo/crypt/encrypter.rb
+++ b/lib/mongo/crypt/encrypter.rb
@@ -19,7 +19,7 @@ module Mongo
     #
     # @api private
     module Encrypter
-      attr_accessor :encryption_options
+      attr_reader :encryption_options
 
       # Set up encryption-related options and instance variables
       # on the class that includes this module.

--- a/spec/integration/client_construction_spec.rb
+++ b/spec/integration/client_construction_spec.rb
@@ -155,6 +155,7 @@ describe 'Client construction' do
         client = ClientRegistry.instance.new_local_client([SpecConfig.instance.addresses.first], options)
 
         key_vault_client = client.encryption_options['key_vault_client']
+        expect(key_vault_client.encryption_options).to be_nil
 
         result = key_vault_client[:test].insert_one(test: 1)
         expect(result).to be_ok

--- a/spec/integration/client_construction_spec.rb
+++ b/spec/integration/client_construction_spec.rb
@@ -166,6 +166,11 @@ describe 'Client construction' do
         result = key_vault_client[:test].insert_one(test: 1)
         expect(result).to be_ok
       end
+
+      it 'creates a key vault client with a different cluster from the existing client' do
+        key_vault_client = client.encryption_options['key_vault_client']
+        expect(key_vault_client.cluster).not_to eq(client.cluster)
+      end
     end
   end
 end

--- a/spec/integration/client_construction_spec.rb
+++ b/spec/integration/client_construction_spec.rb
@@ -151,6 +151,10 @@ describe 'Client construction' do
     context 'with default key vault client' do
       let(:key_vault_client) { nil }
 
+      after do
+        client.encryption_options['key_vault_client'].close
+      end
+
       it 'creates a working key vault client' do
         client = ClientRegistry.instance.new_local_client([SpecConfig.instance.addresses.first], options)
 

--- a/spec/integration/client_construction_spec.rb
+++ b/spec/integration/client_construction_spec.rb
@@ -151,13 +151,15 @@ describe 'Client construction' do
     context 'with default key vault client' do
       let(:key_vault_client) { nil }
 
+      let(:client) do
+        ClientRegistry.instance.new_local_client([SpecConfig.instance.addresses.first], options)
+      end
+
       after do
         client.encryption_options['key_vault_client'].close
       end
 
       it 'creates a working key vault client' do
-        client = ClientRegistry.instance.new_local_client([SpecConfig.instance.addresses.first], options)
-
         key_vault_client = client.encryption_options['key_vault_client']
         expect(key_vault_client.encryption_options).to be_nil
 

--- a/spec/integration/client_construction_spec.rb
+++ b/spec/integration/client_construction_spec.rb
@@ -156,7 +156,7 @@ describe 'Client construction' do
       end
 
       after do
-        client.encryption_options['key_vault_client'].close
+        client.teardown_encrypter
       end
 
       it 'creates a working key vault client' do

--- a/spec/mongo/client_construction_spec.rb
+++ b/spec/mongo/client_construction_spec.rb
@@ -372,8 +372,13 @@ describe Mongo::Client do
           context 'with default key_vault_client' do
             let(:key_vault_client) { nil }
 
-            it 'creates a working key_vault_client' do
-              client
+            it 'creates a key_vault_client' do
+              client_options = client.encryption_options
+              key_vault_client = client_options[:key_vault_client]
+
+              expect(key_vault_client).to be_a_kind_of(Mongo::Client)
+              expect(key_vault_client.addresses_or_uri).to eq(client.addresses_or_uri)
+              expect(key_vault_client.encryption_options).to be_nil
             end
           end
         end

--- a/spec/mongo/client_construction_spec.rb
+++ b/spec/mongo/client_construction_spec.rb
@@ -368,6 +368,14 @@ describe Mongo::Client do
               expect(client_options[:mongocryptd_spawn_args]).to eq(mongocryptd_spawn_args)
             end
           end
+
+          context 'with default key_vault_client' do
+            let(:key_vault_client) { nil }
+
+            it 'creates a working key_vault_client' do
+              client
+            end
+          end
         end
       end
 

--- a/spec/mongo/client_construction_spec.rb
+++ b/spec/mongo/client_construction_spec.rb
@@ -323,8 +323,18 @@ describe Mongo::Client do
               }
             end
 
-            it 'sets key_vault_client as self' do
-              expect(client.encryption_options[:key_vault_client]).to eq(client)
+            it 'sets key_vault_client as a clone of self with no encryption options' do
+              key_vault_client = client.encryption_options[:key_vault_client]
+              expect(key_vault_client.encryption_options).to be_nil
+
+              key_vault_client_options = key_vault_client.options.to_h
+              key_vault_client_options.delete('auto_encryption_options')
+
+              client_options = client.options.dup
+              client_options.delete(:auto_encryption_options)
+
+              expect(key_vault_client_options).to eq(client_options)
+              expect(key_vault_client)
             end
 
             it 'sets bypass_auto_encryption to false' do

--- a/spec/mongo/client_construction_spec.rb
+++ b/spec/mongo/client_construction_spec.rb
@@ -377,7 +377,6 @@ describe Mongo::Client do
               key_vault_client = client_options[:key_vault_client]
 
               expect(key_vault_client).to be_a_kind_of(Mongo::Client)
-              expect(key_vault_client.addresses_or_uri).to eq(client.addresses_or_uri)
               expect(key_vault_client.encryption_options).to be_nil
             end
           end

--- a/spec/mongo/client_updating_spec.rb
+++ b/spec/mongo/client_updating_spec.rb
@@ -3,35 +3,35 @@ require 'spec_helper'
 describe Mongo::Client do
   clean_slate
 
-  describe '#update_options' do
-    context 'auto encryption options' do
-      require_libmongocrypt
+  context 'auto encryption options' do
+    require_libmongocrypt
 
-      let(:client) { new_local_client_nmio([SpecConfig.instance.addresses.first], client_opts) }
-      let(:client_opts) { { auto_encryption_options: auto_encryption_options } }
+    let(:client) { new_local_client_nmio([SpecConfig.instance.addresses.first], client_opts) }
+    let(:client_opts) { { auto_encryption_options: auto_encryption_options } }
 
-      let(:auto_encryption_options) do
-        {
-          key_vault_client: key_vault_client,
-          key_vault_namespace: key_vault_namespace,
-          kms_providers: kms_providers
-        }
-      end
+    let(:auto_encryption_options) do
+      {
+        key_vault_client: key_vault_client,
+        key_vault_namespace: key_vault_namespace,
+        kms_providers: kms_providers
+      }
+    end
 
-      let(:key_vault_client) { new_local_client_nmio('mongodb://127.0.0.1:27018') }
-      let(:key_vault_namespace) { 'database.collection' }
+    let(:key_vault_client) { new_local_client_nmio('mongodb://127.0.0.1:27018') }
+    let(:key_vault_namespace) { 'database.collection' }
 
-      let(:kms_local) { { key: Base64.encode64('ruby' * 24) } }
-      let(:kms_providers) { { local: kms_local } }
+    let(:kms_local) { { key: Base64.encode64('ruby' * 24) } }
+    let(:kms_providers) { { local: kms_local } }
 
-      let(:new_auto_encryption_options) do
-        {
-          key_vault_client: key_vault_client,
-          key_vault_namespace: 'new.namespace',
-          kms_providers: kms_providers
-        }
-      end
+    let(:new_auto_encryption_options) do
+      {
+        key_vault_client: key_vault_client,
+        key_vault_namespace: 'new.namespace',
+        kms_providers: kms_providers
+      }
+    end
 
+    describe '#update_options' do
       it 'updates auto encryption options' do
         client.update_options({ auto_encryption_options: new_auto_encryption_options })
         expect(client.encryption_options[:key_vault_namespace]).to eq('new.namespace')
@@ -42,6 +42,20 @@ describe Mongo::Client do
         client.update_options(new_options)
 
         expect(client.encryption_options).to be_nil
+      end
+    end
+
+    describe '#with' do
+      it 'updates auto encryption options' do
+        new_client = client.with({ auto_encryption_options: new_auto_encryption_options })
+        expect(new_client.encryption_options[:key_vault_namespace]).to eq('new.namespace')
+      end
+
+      it 'removes auto encryption options' do
+        new_options = { auto_encryption_options: nil }
+        new_client = client.with(new_options)
+
+        expect(new_client.encryption_options).to be_nil
       end
     end
   end

--- a/spec/mongo/client_updating_spec.rb
+++ b/spec/mongo/client_updating_spec.rb
@@ -5,6 +5,8 @@ describe Mongo::Client do
 
   describe '#update_options' do
     context 'auto encryption options' do
+      require_libmongocrypt
+
       let(:client) { new_local_client_nmio([SpecConfig.instance.addresses.first], client_opts) }
       let(:client_opts) { { auto_encryption_options: auto_encryption_options } }
 

--- a/spec/mongo/client_updating_spec.rb
+++ b/spec/mongo/client_updating_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe Mongo::Client do
+  clean_slate
+
+  describe '#update_options' do
+    context 'auto encryption options' do
+      let(:client) { new_local_client_nmio([SpecConfig.instance.addresses.first], client_opts) }
+      let(:client_opts) { { auto_encryption_options: auto_encryption_options } }
+
+      let(:auto_encryption_options) do
+        {
+          key_vault_client: key_vault_client,
+          key_vault_namespace: key_vault_namespace,
+          kms_providers: kms_providers
+        }
+      end
+
+      let(:key_vault_client) { new_local_client_nmio('mongodb://127.0.0.1:27018') }
+      let(:key_vault_namespace) { 'database.collection' }
+
+      let(:kms_local) { { key: Base64.encode64('ruby' * 24) } }
+      let(:kms_providers) { { local: kms_local } }
+
+      let(:new_auto_encryption_options) do
+        {
+          key_vault_client: key_vault_client,
+          key_vault_namespace: 'new.namespace',
+          kms_providers: kms_providers
+        }
+      end
+
+      it 'updates auto encryption options' do
+        client.update_options({ auto_encryption_options: new_auto_encryption_options })
+        expect(client.encryption_options[:key_vault_namespace]).to eq('new.namespace')
+      end
+
+      it 'removes auto encryption options' do
+        new_options = { auto_encryption_options: nil }
+        client.update_options(new_options)
+
+        expect(client.encryption_options).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
I realized that the way I was creating the key vault client meant that it was trying to auto encrypt, which it should not do. I also updated the encrypter to keep track of a key vault client that it spawns and close it on teardown.