### PR TITLE
RUBY-1939 Bind Ruby crypto hooks to libmongocrypt

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -289,7 +289,7 @@ functions:
         script: |
           ${PREPARE_SHELL}
           .evergreen/run-x509-tests.sh
-  
+
   "run field level encryption tests":
     - command: shell.exec
       type: test
@@ -487,7 +487,7 @@ axes:
         display_name: "2.6"
         variables:
            VERSION: "2.6"
-  
+
   - id: fcv
     display_name: FCV
     values:
@@ -511,7 +511,7 @@ axes:
         display_name: Sharded
         variables:
            TOPOLOGY: "sharded_cluster"
-  
+
   - id: "auth-and-ssl"
     display_name: Authentication and SSL
     values:
@@ -535,7 +535,7 @@ axes:
         variables:
            AUTH: "noauth"
            SSL: "nossl"
-  
+
   - id: "ruby"
     display_name: Ruby Version
     # Local TLS tests run on all Ruby versions, thus no versions should be
@@ -569,7 +569,7 @@ axes:
         display_name: jruby-9.2
         variables:
            RVM_RUBY: "jruby-9.2"
-  
+
   - id: "os"
     display_name: OS
     values:
@@ -582,7 +582,7 @@ axes:
       - id: rhel70
         display_name: "RHEL 7.0"
         run_on: rhel70-small
-  
+
   - id: "compressor"
     display_name: Compressor
     values:
@@ -590,7 +590,7 @@ axes:
         display_name: Zlib
         variables:
            COMPRESSOR: "zlib"
-  
+
   - id: retry-reads
     display_name: Retry Reads
     values:
@@ -598,7 +598,7 @@ axes:
         display_name: No Retry Reads
         variables:
           RETRY_READS: 'false'
-  
+
   - id: retry-writes
     display_name: Retry Writes
     values:
@@ -606,7 +606,7 @@ axes:
         display_name: No Retry Writes
         variables:
           RETRY_WRITES: 'false'
-  
+
   - id: lint
     display_name: Lint
     values:
@@ -614,7 +614,7 @@ axes:
         display_name: On
         variables:
           LINT: '1'
-  
+
   - id: "as"
     display_name: ActiveSupport
     values:
@@ -622,7 +622,7 @@ axes:
         display_name: AS
         variables:
           WITH_ACTIVE_SUPPORT: true
-  
+
   - id: bson
     display_name: BSON
     values:
@@ -634,7 +634,7 @@ axes:
         display_name: master
         variables:
           BSON: master
-  
+
   - id: "single-mongos"
     display_name: Single Mongos
     values:
@@ -642,7 +642,7 @@ axes:
         display_name: Single Mongos
         variables:
           SINGLE_MONGOS: 'true'
-  
+
   - id: storage-engine
     display_name: Storage Engine
     values:
@@ -654,277 +654,278 @@ axes:
 
 
 buildvariants:
--
-  matrix_name: "ruby-min"
-  matrix_spec:
-    auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-    ruby: "ruby-2.3"
-    mongodb-version: "3.6"
-    topology: "*"
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "ruby-min"
+#   matrix_spec:
+#     auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
+#     ruby: "ruby-2.3"
+#     mongodb-version: "3.6"
+#     topology: "*"
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "ruby-mid"
-  matrix_spec:
-    auth-and-ssl: "auth-and-ssl"
-    ruby: [ruby-2.4, ruby-2.5]
-    mongodb-version: "4.0"
-    topology: "*"
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "ruby-mid"
+#   matrix_spec:
+#     auth-and-ssl: "auth-and-ssl"
+#     ruby: [ruby-2.4, ruby-2.5]
+#     mongodb-version: "4.0"
+#     topology: "*"
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "mongo"
-  matrix_spec:
-    auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-    ruby: "ruby-2.7"
-    mongodb-version: "*"
-    topology: "*"
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "mongo"
+#   matrix_spec:
+#     auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
+#     ruby: "ruby-2.7"
+#     mongodb-version: "*"
+#     topology: "*"
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "single-mongos"
-  matrix_spec:
-    auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-    ruby: "ruby-2.6"
-    mongodb-version: ["4.2", latest]
-    topology: "sharded-cluster"
-    single-mongos: single-mongos
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} single-mongos ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "single-mongos"
+#   matrix_spec:
+#     auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
+#     ruby: "ruby-2.6"
+#     mongodb-version: ["4.2", latest]
+#     topology: "sharded-cluster"
+#     single-mongos: single-mongos
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} single-mongos ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "partial-auth-ssl"
-  matrix_spec:
-    auth-and-ssl: ["auth-and-nossl", "noauth-and-ssl"]
-    ruby: "ruby-2.6"
-    mongodb-version: ["4.0"]
-    topology: "*"
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "partial-auth-ssl"
+#   matrix_spec:
+#     auth-and-ssl: ["auth-and-nossl", "noauth-and-ssl"]
+#     ruby: "ruby-2.6"
+#     mongodb-version: ["4.0"]
+#     topology: "*"
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "no-retry-reads"
-  matrix_spec:
-    retry-reads: no-retry-reads
-    ruby: "ruby-2.6"
-    mongodb-version: ["4.0"]
-    topology: "*"
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} ${retry-reads} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "no-retry-reads"
+#   matrix_spec:
+#     retry-reads: no-retry-reads
+#     ruby: "ruby-2.6"
+#     mongodb-version: ["4.0"]
+#     topology: "*"
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} ${retry-reads} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "no-retry-writes"
-  matrix_spec:
-    retry-writes: no-retry-writes
-    ruby: "ruby-2.6"
-    mongodb-version: ["4.0"]
-    topology: [replica-set, sharded-cluster]
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} ${retry-writes} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "no-retry-writes"
+#   matrix_spec:
+#     retry-writes: no-retry-writes
+#     ruby: "ruby-2.6"
+#     mongodb-version: ["4.0"]
+#     topology: [replica-set, sharded-cluster]
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} ${retry-writes} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: mmapv1
-  matrix_spec:
-    ruby: "ruby-2.6"
-    mongodb-version: [3.4, 3.6, 4.0]
-    topology: '*'
-    storage-engine: mmapv1
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} mmapv1 ${ruby}"
-  tasks:
-     - name: "test-mlaunch"
+# -
+#   matrix_name: mmapv1
+#   matrix_spec:
+#     ruby: "ruby-2.6"
+#     mongodb-version: [3.4, 3.6, 4.0]
+#     topology: '*'
+#     storage-engine: mmapv1
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} mmapv1 ${ruby}"
+#   tasks:
+#      - name: "test-mlaunch"
 
--
-  matrix_name: "lint"
-  matrix_spec:
-    lint: on
-    ruby: "ruby-2.6"
-    mongodb-version: ["4.0", "4.2"]
-    topology: [replica-set, sharded-cluster]
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} ${lint} ${ruby}"
-  tasks:
-     - name: "test-mlaunch"
+# -
+#   matrix_name: "lint"
+#   matrix_spec:
+#     lint: on
+#     ruby: "ruby-2.6"
+#     mongodb-version: ["4.0", "4.2"]
+#     topology: [replica-set, sharded-cluster]
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} ${lint} ${ruby}"
+#   tasks:
+#      - name: "test-mlaunch"
 
--
-  matrix_name: "jruby-auth"
-  matrix_spec:
-    auth-and-ssl: "auth-and-ssl"
-    ruby: "jruby-9.2"
-    mongodb-version: "4.2"
-    topology: "*"
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "jruby-auth"
+#   matrix_spec:
+#     auth-and-ssl: "auth-and-ssl"
+#     ruby: "jruby-9.2"
+#     mongodb-version: "4.2"
+#     topology: "*"
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "jruby-noauth"
-  matrix_spec:
-    auth-and-ssl: "noauth-and-nossl"
-    ruby: "jruby-9.2"
-    mongodb-version: "2.6"
-    topology: "*"
-    os: rhel70
-  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "jruby-noauth"
+#   matrix_spec:
+#     auth-and-ssl: "noauth-and-nossl"
+#     ruby: "jruby-9.2"
+#     mongodb-version: "2.6"
+#     topology: "*"
+#     os: rhel70
+#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "zlib-auth"
-  matrix_spec:
-    auth-and-ssl: "auth-and-ssl"
-    ruby: "ruby-2.6"
-    mongodb-version: "4.2"
-    topology: "*"
-    compressor: 'zlib'
-    os: rhel70
-  display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "zlib-auth"
+#   matrix_spec:
+#     auth-and-ssl: "auth-and-ssl"
+#     ruby: "ruby-2.6"
+#     mongodb-version: "4.2"
+#     topology: "*"
+#     compressor: 'zlib'
+#     os: rhel70
+#   display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "zlib-noauth"
-  matrix_spec:
-    auth-and-ssl: "noauth-and-nossl"
-    ruby: "ruby-2.3"
-    mongodb-version: "3.6"
-    topology: "*"
-    compressor: 'zlib'
-    os: rhel70
-  display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "zlib-noauth"
+#   matrix_spec:
+#     auth-and-ssl: "noauth-and-nossl"
+#     ruby: "ruby-2.3"
+#     mongodb-version: "3.6"
+#     topology: "*"
+#     compressor: 'zlib'
+#     os: rhel70
+#   display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "ruby-head"
-  matrix_spec:
-    auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-    ruby: ["ruby-head"]
-    mongodb-version: "4.0"
-    topology: "*"
-    os: ubuntu1604
-  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-  tasks:
-     - name: "test"
+# -
+#   matrix_name: "ruby-head"
+#   matrix_spec:
+#     auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
+#     ruby: ["ruby-head"]
+#     mongodb-version: "4.0"
+#     topology: "*"
+#     os: ubuntu1604
+#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#   tasks:
+#      - name: "test"
 
-- matrix_name: "activesupport"
-  matrix_spec:
-    ruby: ruby-2.5
-    mongodb-version: '4.0'
-    topology: replica-set
-    as: as
-    os: rhel70
-  display_name: "AS ${mongodb-version} ${topology} ${ruby}"
-  tasks:
-     - name: "test"
+# - matrix_name: "activesupport"
+#   matrix_spec:
+#     ruby: ruby-2.5
+#     mongodb-version: '4.0'
+#     topology: replica-set
+#     as: as
+#     os: rhel70
+#   display_name: "AS ${mongodb-version} ${topology} ${ruby}"
+#   tasks:
+#      - name: "test"
 
-- matrix_name: "bson"
-  matrix_spec:
-    ruby: ruby-2.6
-    mongodb-version: '4.2'
-    topology: replica-set
-    bson: "*"
-    os: rhel70
-  display_name: "AS ${mongodb-version} ${topology} ${ruby} ${bson}"
-  tasks:
-     - name: "test"
+# - matrix_name: "bson"
+#   matrix_spec:
+#     ruby: ruby-2.6
+#     mongodb-version: '4.2'
+#     topology: replica-set
+#     bson: "*"
+#     os: rhel70
+#   display_name: "AS ${mongodb-version} ${topology} ${ruby} ${bson}"
+#   tasks:
+#      - name: "test"
 
--
-  matrix_name: "3.6-with-3.4-fcv"
-  matrix_spec:
-    fcv: '3.4'
-    ruby: ["ruby-2.5"]
-    mongodb-version: '3.6'
-    topology: replica-set
-    os: rhel70
-  display_name: "3.6 Replica Set with 3.4 FCV"
-  tasks:
-    - name: "test"
+# -
+#   matrix_name: "3.6-with-3.4-fcv"
+#   matrix_spec:
+#     fcv: '3.4'
+#     ruby: ["ruby-2.5"]
+#     mongodb-version: '3.6'
+#     topology: replica-set
+#     os: rhel70
+#   display_name: "3.6 Replica Set with 3.4 FCV"
+#   tasks:
+#     - name: "test"
 
--
-  matrix_name: "local-tls"
-  matrix_spec:
-    ruby: "*"
-    mongodb-version: ['4.0', '4.2']
-    topology: standalone
-    os: ubuntu1604
-  display_name: "Local TLS ${mongodb-version} ${ruby}"
-  tasks:
-    - name: "local-tls-tests"
+# -
+#   matrix_name: "local-tls"
+#   matrix_spec:
+#     ruby: "*"
+#     mongodb-version: ['4.0', '4.2']
+#     topology: standalone
+#     os: ubuntu1604
+#   display_name: "Local TLS ${mongodb-version} ${ruby}"
+#   tasks:
+#     - name: "local-tls-tests"
 
--
-  matrix_name: "enterprise-auth-tests-ubuntu"
-  matrix_spec:
-    auth-and-ssl: "auth-and-ssl"
-    # Ruby 2.6 and 2.4 segfault
-    ruby: ["ruby-2.5", "jruby-9.2"]
-  display_name: "Enterprise Auth Ubuntu ${ruby}"
-  run_on:
-    - ubuntu1604-test
-  tasks:
-    - name: "enterprise-auth-tests"
+# -
+#   matrix_name: "enterprise-auth-tests-ubuntu"
+#   matrix_spec:
+#     auth-and-ssl: "auth-and-ssl"
+#     # Ruby 2.6 and 2.4 segfault
+#     ruby: ["ruby-2.5", "jruby-9.2"]
+#   display_name: "Enterprise Auth Ubuntu ${ruby}"
+#   run_on:
+#     - ubuntu1604-test
+#   tasks:
+#     - name: "enterprise-auth-tests"
 
--
-  matrix_name: "enterprise-auth-tests-rhel"
-  matrix_spec:
-    auth-and-ssl: "auth-and-ssl"
-    # Ruby 2.6 and 2.5 segfault
-    ruby: ["ruby-2.3", "ruby-2.4"]
-    os: rhel70
-  display_name: "Enterprise Auth ${ruby} ${os}"
-  tasks:
-    - name: "enterprise-auth-tests"
+# -
+#   matrix_name: "enterprise-auth-tests-rhel"
+#   matrix_spec:
+#     auth-and-ssl: "auth-and-ssl"
+#     # Ruby 2.6 and 2.5 segfault
+#     ruby: ["ruby-2.3", "ruby-2.4"]
+#     os: rhel70
+#   display_name: "Enterprise Auth ${ruby} ${os}"
+#   tasks:
+#     - name: "enterprise-auth-tests"
 
-# Enterprise auth tests on debian are omitted due to segfaults:
-# https://jira.mongodb.org/browse/RUBY-1534
+# # Enterprise auth tests on debian are omitted due to segfaults:
+# # https://jira.mongodb.org/browse/RUBY-1534
 
--
-  matrix_name: "kerberos-tests"
-  matrix_spec:
-    auth-and-ssl: "noauth-and-nossl"
-    ruby: "ruby-2.6"
-    mongodb-version: "4.2"
-    topology: standalone
-    os: rhel70
-  display_name: "Kerberos Tests"
-  tasks:
-    - name: "kerberos-tests"
+# -
+#   matrix_name: "kerberos-tests"
+#   matrix_spec:
+#     auth-and-ssl: "noauth-and-nossl"
+#     ruby: "ruby-2.6"
+#     mongodb-version: "4.2"
+#     topology: standalone
+#     os: rhel70
+#   display_name: "Kerberos Tests"
+#   tasks:
+#     - name: "kerberos-tests"
 
--
-  matrix_name: "x509-tests"
-  matrix_spec:
-    auth-and-ssl: "auth-and-ssl"
-    ruby: "ruby-2.6"
-    mongodb-version: "4.2"
-    topology: standalone
-    os: rhel70
-  display_name: "X.509 Tests"
-  tasks:
-    - name: "x509-tests"
+# -
+#   matrix_name: "x509-tests"
+#   matrix_spec:
+#     auth-and-ssl: "auth-and-ssl"
+#     ruby: "ruby-2.6"
+#     mongodb-version: "4.2"
+#     topology: standalone
+#     os: rhel70
+#   display_name: "X.509 Tests"
+#   tasks:
+#     - name: "x509-tests"
 
 -
   matrix_name: "fle-tests"
   matrix_spec:
     auth-and-ssl: "noauth-and-nossl"
-    ruby: ["ruby-2.3", "ruby-2.4", "ruby-2.5", "ruby-2.6", "jruby-9.2"]
+    # ruby: ["ruby-2.3", "ruby-2.4", "ruby-2.5", "ruby-2.6", "jruby-9.2"]
+    ruby: ["ruby-2.6", "jruby-9.2"]
     topology: standalone
     mongodb-version: "4.2"
     os: rhel70

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -654,278 +654,277 @@ axes:
 
 
 buildvariants:
-# -
-#   matrix_name: "ruby-min"
-#   matrix_spec:
-#     auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-#     ruby: "ruby-2.3"
-#     mongodb-version: "3.6"
-#     topology: "*"
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "ruby-min"
+  matrix_spec:
+    auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
+    ruby: "ruby-2.3"
+    mongodb-version: "3.6"
+    topology: "*"
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "ruby-mid"
-#   matrix_spec:
-#     auth-and-ssl: "auth-and-ssl"
-#     ruby: [ruby-2.4, ruby-2.5]
-#     mongodb-version: "4.0"
-#     topology: "*"
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "ruby-mid"
+  matrix_spec:
+    auth-and-ssl: "auth-and-ssl"
+    ruby: [ruby-2.4, ruby-2.5]
+    mongodb-version: "4.0"
+    topology: "*"
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "mongo"
-#   matrix_spec:
-#     auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-#     ruby: "ruby-2.7"
-#     mongodb-version: "*"
-#     topology: "*"
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "mongo"
+  matrix_spec:
+    auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
+    ruby: "ruby-2.7"
+    mongodb-version: "*"
+    topology: "*"
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "single-mongos"
-#   matrix_spec:
-#     auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-#     ruby: "ruby-2.6"
-#     mongodb-version: ["4.2", latest]
-#     topology: "sharded-cluster"
-#     single-mongos: single-mongos
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} single-mongos ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "single-mongos"
+  matrix_spec:
+    auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
+    ruby: "ruby-2.6"
+    mongodb-version: ["4.2", latest]
+    topology: "sharded-cluster"
+    single-mongos: single-mongos
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} single-mongos ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "partial-auth-ssl"
-#   matrix_spec:
-#     auth-and-ssl: ["auth-and-nossl", "noauth-and-ssl"]
-#     ruby: "ruby-2.6"
-#     mongodb-version: ["4.0"]
-#     topology: "*"
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "partial-auth-ssl"
+  matrix_spec:
+    auth-and-ssl: ["auth-and-nossl", "noauth-and-ssl"]
+    ruby: "ruby-2.6"
+    mongodb-version: ["4.0"]
+    topology: "*"
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "no-retry-reads"
-#   matrix_spec:
-#     retry-reads: no-retry-reads
-#     ruby: "ruby-2.6"
-#     mongodb-version: ["4.0"]
-#     topology: "*"
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} ${retry-reads} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "no-retry-reads"
+  matrix_spec:
+    retry-reads: no-retry-reads
+    ruby: "ruby-2.6"
+    mongodb-version: ["4.0"]
+    topology: "*"
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} ${retry-reads} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "no-retry-writes"
-#   matrix_spec:
-#     retry-writes: no-retry-writes
-#     ruby: "ruby-2.6"
-#     mongodb-version: ["4.0"]
-#     topology: [replica-set, sharded-cluster]
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} ${retry-writes} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "no-retry-writes"
+  matrix_spec:
+    retry-writes: no-retry-writes
+    ruby: "ruby-2.6"
+    mongodb-version: ["4.0"]
+    topology: [replica-set, sharded-cluster]
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} ${retry-writes} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: mmapv1
-#   matrix_spec:
-#     ruby: "ruby-2.6"
-#     mongodb-version: [3.4, 3.6, 4.0]
-#     topology: '*'
-#     storage-engine: mmapv1
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} mmapv1 ${ruby}"
-#   tasks:
-#      - name: "test-mlaunch"
+-
+  matrix_name: mmapv1
+  matrix_spec:
+    ruby: "ruby-2.6"
+    mongodb-version: [3.4, 3.6, 4.0]
+    topology: '*'
+    storage-engine: mmapv1
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} mmapv1 ${ruby}"
+  tasks:
+     - name: "test-mlaunch"
 
-# -
-#   matrix_name: "lint"
-#   matrix_spec:
-#     lint: on
-#     ruby: "ruby-2.6"
-#     mongodb-version: ["4.0", "4.2"]
-#     topology: [replica-set, sharded-cluster]
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} ${lint} ${ruby}"
-#   tasks:
-#      - name: "test-mlaunch"
+-
+  matrix_name: "lint"
+  matrix_spec:
+    lint: on
+    ruby: "ruby-2.6"
+    mongodb-version: ["4.0", "4.2"]
+    topology: [replica-set, sharded-cluster]
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} ${lint} ${ruby}"
+  tasks:
+     - name: "test-mlaunch"
 
-# -
-#   matrix_name: "jruby-auth"
-#   matrix_spec:
-#     auth-and-ssl: "auth-and-ssl"
-#     ruby: "jruby-9.2"
-#     mongodb-version: "4.2"
-#     topology: "*"
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "jruby-auth"
+  matrix_spec:
+    auth-and-ssl: "auth-and-ssl"
+    ruby: "jruby-9.2"
+    mongodb-version: "4.2"
+    topology: "*"
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "jruby-noauth"
-#   matrix_spec:
-#     auth-and-ssl: "noauth-and-nossl"
-#     ruby: "jruby-9.2"
-#     mongodb-version: "2.6"
-#     topology: "*"
-#     os: rhel70
-#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "jruby-noauth"
+  matrix_spec:
+    auth-and-ssl: "noauth-and-nossl"
+    ruby: "jruby-9.2"
+    mongodb-version: "2.6"
+    topology: "*"
+    os: rhel70
+  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "zlib-auth"
-#   matrix_spec:
-#     auth-and-ssl: "auth-and-ssl"
-#     ruby: "ruby-2.6"
-#     mongodb-version: "4.2"
-#     topology: "*"
-#     compressor: 'zlib'
-#     os: rhel70
-#   display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "zlib-auth"
+  matrix_spec:
+    auth-and-ssl: "auth-and-ssl"
+    ruby: "ruby-2.6"
+    mongodb-version: "4.2"
+    topology: "*"
+    compressor: 'zlib'
+    os: rhel70
+  display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "zlib-noauth"
-#   matrix_spec:
-#     auth-and-ssl: "noauth-and-nossl"
-#     ruby: "ruby-2.3"
-#     mongodb-version: "3.6"
-#     topology: "*"
-#     compressor: 'zlib'
-#     os: rhel70
-#   display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "zlib-noauth"
+  matrix_spec:
+    auth-and-ssl: "noauth-and-nossl"
+    ruby: "ruby-2.3"
+    mongodb-version: "3.6"
+    topology: "*"
+    compressor: 'zlib'
+    os: rhel70
+  display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "ruby-head"
-#   matrix_spec:
-#     auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-#     ruby: ["ruby-head"]
-#     mongodb-version: "4.0"
-#     topology: "*"
-#     os: ubuntu1604
-#   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#   tasks:
-#      - name: "test"
+-
+  matrix_name: "ruby-head"
+  matrix_spec:
+    auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
+    ruby: ["ruby-head"]
+    mongodb-version: "4.0"
+    topology: "*"
+    os: ubuntu1604
+  display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  tasks:
+     - name: "test"
 
-# - matrix_name: "activesupport"
-#   matrix_spec:
-#     ruby: ruby-2.5
-#     mongodb-version: '4.0'
-#     topology: replica-set
-#     as: as
-#     os: rhel70
-#   display_name: "AS ${mongodb-version} ${topology} ${ruby}"
-#   tasks:
-#      - name: "test"
+- matrix_name: "activesupport"
+  matrix_spec:
+    ruby: ruby-2.5
+    mongodb-version: '4.0'
+    topology: replica-set
+    as: as
+    os: rhel70
+  display_name: "AS ${mongodb-version} ${topology} ${ruby}"
+  tasks:
+     - name: "test"
 
-# - matrix_name: "bson"
-#   matrix_spec:
-#     ruby: ruby-2.6
-#     mongodb-version: '4.2'
-#     topology: replica-set
-#     bson: "*"
-#     os: rhel70
-#   display_name: "AS ${mongodb-version} ${topology} ${ruby} ${bson}"
-#   tasks:
-#      - name: "test"
+- matrix_name: "bson"
+  matrix_spec:
+    ruby: ruby-2.6
+    mongodb-version: '4.2'
+    topology: replica-set
+    bson: "*"
+    os: rhel70
+  display_name: "AS ${mongodb-version} ${topology} ${ruby} ${bson}"
+  tasks:
+     - name: "test"
 
-# -
-#   matrix_name: "3.6-with-3.4-fcv"
-#   matrix_spec:
-#     fcv: '3.4'
-#     ruby: ["ruby-2.5"]
-#     mongodb-version: '3.6'
-#     topology: replica-set
-#     os: rhel70
-#   display_name: "3.6 Replica Set with 3.4 FCV"
-#   tasks:
-#     - name: "test"
+-
+  matrix_name: "3.6-with-3.4-fcv"
+  matrix_spec:
+    fcv: '3.4'
+    ruby: ["ruby-2.5"]
+    mongodb-version: '3.6'
+    topology: replica-set
+    os: rhel70
+  display_name: "3.6 Replica Set with 3.4 FCV"
+  tasks:
+    - name: "test"
 
-# -
-#   matrix_name: "local-tls"
-#   matrix_spec:
-#     ruby: "*"
-#     mongodb-version: ['4.0', '4.2']
-#     topology: standalone
-#     os: ubuntu1604
-#   display_name: "Local TLS ${mongodb-version} ${ruby}"
-#   tasks:
-#     - name: "local-tls-tests"
+-
+  matrix_name: "local-tls"
+  matrix_spec:
+    ruby: "*"
+    mongodb-version: ['4.0', '4.2']
+    topology: standalone
+    os: ubuntu1604
+  display_name: "Local TLS ${mongodb-version} ${ruby}"
+  tasks:
+    - name: "local-tls-tests"
 
-# -
-#   matrix_name: "enterprise-auth-tests-ubuntu"
-#   matrix_spec:
-#     auth-and-ssl: "auth-and-ssl"
-#     # Ruby 2.6 and 2.4 segfault
-#     ruby: ["ruby-2.5", "jruby-9.2"]
-#   display_name: "Enterprise Auth Ubuntu ${ruby}"
-#   run_on:
-#     - ubuntu1604-test
-#   tasks:
-#     - name: "enterprise-auth-tests"
+-
+  matrix_name: "enterprise-auth-tests-ubuntu"
+  matrix_spec:
+    auth-and-ssl: "auth-and-ssl"
+    # Ruby 2.6 and 2.4 segfault
+    ruby: ["ruby-2.5", "jruby-9.2"]
+  display_name: "Enterprise Auth Ubuntu ${ruby}"
+  run_on:
+    - ubuntu1604-test
+  tasks:
+    - name: "enterprise-auth-tests"
 
-# -
-#   matrix_name: "enterprise-auth-tests-rhel"
-#   matrix_spec:
-#     auth-and-ssl: "auth-and-ssl"
-#     # Ruby 2.6 and 2.5 segfault
-#     ruby: ["ruby-2.3", "ruby-2.4"]
-#     os: rhel70
-#   display_name: "Enterprise Auth ${ruby} ${os}"
-#   tasks:
-#     - name: "enterprise-auth-tests"
+-
+  matrix_name: "enterprise-auth-tests-rhel"
+  matrix_spec:
+    auth-and-ssl: "auth-and-ssl"
+    # Ruby 2.6 and 2.5 segfault
+    ruby: ["ruby-2.3", "ruby-2.4"]
+    os: rhel70
+  display_name: "Enterprise Auth ${ruby} ${os}"
+  tasks:
+    - name: "enterprise-auth-tests"
 
-# # Enterprise auth tests on debian are omitted due to segfaults:
-# # https://jira.mongodb.org/browse/RUBY-1534
+# Enterprise auth tests on debian are omitted due to segfaults:
+# https://jira.mongodb.org/browse/RUBY-1534
 
-# -
-#   matrix_name: "kerberos-tests"
-#   matrix_spec:
-#     auth-and-ssl: "noauth-and-nossl"
-#     ruby: "ruby-2.6"
-#     mongodb-version: "4.2"
-#     topology: standalone
-#     os: rhel70
-#   display_name: "Kerberos Tests"
-#   tasks:
-#     - name: "kerberos-tests"
+-
+  matrix_name: "kerberos-tests"
+  matrix_spec:
+    auth-and-ssl: "noauth-and-nossl"
+    ruby: "ruby-2.6"
+    mongodb-version: "4.2"
+    topology: standalone
+    os: rhel70
+  display_name: "Kerberos Tests"
+  tasks:
+    - name: "kerberos-tests"
 
-# -
-#   matrix_name: "x509-tests"
-#   matrix_spec:
-#     auth-and-ssl: "auth-and-ssl"
-#     ruby: "ruby-2.6"
-#     mongodb-version: "4.2"
-#     topology: standalone
-#     os: rhel70
-#   display_name: "X.509 Tests"
-#   tasks:
-#     - name: "x509-tests"
+-
+  matrix_name: "x509-tests"
+  matrix_spec:
+    auth-and-ssl: "auth-and-ssl"
+    ruby: "ruby-2.6"
+    mongodb-version: "4.2"
+    topology: standalone
+    os: rhel70
+  display_name: "X.509 Tests"
+  tasks:
+    - name: "x509-tests"
 
 -
   matrix_name: "fle-tests"
   matrix_spec:
     auth-and-ssl: "noauth-and-nossl"
-    # ruby: ["ruby-2.3", "ruby-2.4", "ruby-2.5", "ruby-2.6", "jruby-9.2"]
-    ruby: ["ruby-2.6", "jruby-9.2"]
+    ruby: ["ruby-2.3", "ruby-2.4", "ruby-2.5", "ruby-2.6", "jruby-9.2"]
     topology: standalone
     mongodb-version: "4.2"
     os: rhel70

--- a/.evergreen/run-fle-tests.sh
+++ b/.evergreen/run-fle-tests.sh
@@ -8,7 +8,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 wget "https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz"
 tar -xvf libmongocrypt-all.tar.gz
 
-export LIBMONGOCRYPT_PATH=`pwd`/rhel-70-64-bit/nocrypto/lib/libmongocrypt.so
+export LIBMONGOCRYPT_PATH=`pwd`/rhel-70-64-bit/nocrypto/lib64/libmongocrypt.so
 
 set_env_vars
 setup_ruby

--- a/.evergreen/run-fle-tests.sh
+++ b/.evergreen/run-fle-tests.sh
@@ -15,6 +15,8 @@ setup_ruby
 
 install_deps
 
-bundle exec rake
+# bundle exec rake
+bundle exec rake spec:prepare
+bundle exec rspec spec/mongo/crypt
 
 kill_jruby

--- a/.evergreen/run-fle-tests.sh
+++ b/.evergreen/run-fle-tests.sh
@@ -15,8 +15,6 @@ setup_ruby
 
 install_deps
 
-# bundle exec rake
-bundle exec rake spec:prepare
-bundle exec rspec spec/mongo/crypt
+bundle exec rake
 
 kill_jruby

--- a/.evergreen/run-fle-tests.sh
+++ b/.evergreen/run-fle-tests.sh
@@ -8,7 +8,7 @@ set -o errexit  # Exit the script with error if any of the commands fail
 wget "https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz"
 tar -xvf libmongocrypt-all.tar.gz
 
-export LIBMONGOCRYPT_PATH=`pwd`/rhel-70-64-bit/lib64/libmongocrypt.so
+export LIBMONGOCRYPT_PATH=`pwd`/rhel-70-64-bit/nocrypto/lib/libmongocrypt.so
 
 set_env_vars
 setup_ruby

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -43,9 +43,7 @@ module Mongo
     # @return [ String ] Base64-encoded UUID string representing the
     #   data key _id
     def create_data_key
-      byebug
       result = Crypt::DataKeyContext.new(@crypt_handle).run_state_machine
-      byebug
 
       data_key_document = Hash.from_bson(BSON::ByteBuffer.new(result))
       insert_result = @encryption_io.insert(data_key_document)

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -71,7 +71,6 @@ module Mongo
     def encrypt(value, opts={})
       value = { 'v': value }.to_bson.to_s
 
-      byebug
       Crypt::ExplicitEncryptionContext.new(
         @crypt_handle,
         @encryption_io,

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -43,7 +43,9 @@ module Mongo
     # @return [ String ] Base64-encoded UUID string representing the
     #   data key _id
     def create_data_key
+      byebug
       result = Crypt::DataKeyContext.new(@crypt_handle).run_state_machine
+      byebug
 
       data_key_document = Hash.from_bson(BSON::ByteBuffer.new(result))
       insert_result = @encryption_io.insert(data_key_document)
@@ -69,6 +71,7 @@ module Mongo
     def encrypt(value, opts={})
       value = { 'v': value }.to_bson.to_s
 
+      byebug
       Crypt::ExplicitEncryptionContext.new(
         @crypt_handle,
         @encryption_io,

--- a/lib/mongo/crypt.rb
+++ b/lib/mongo/crypt.rb
@@ -17,6 +17,7 @@ module Mongo
     autoload(:Binding, 'mongo/crypt/binding')
     autoload(:Binary, 'mongo/crypt/binary')
     autoload(:Status, 'mongo/crypt/status')
+    autoload(:Hooks, 'mongo/crypt/hooks')
     autoload(:Handle, 'mongo/crypt/handle')
     autoload(:Context, 'mongo/crypt/context')
     autoload(:DataKeyContext, 'mongo/crypt/data_key_context')

--- a/lib/mongo/crypt/auto_decryption_context.rb
+++ b/lib/mongo/crypt/auto_decryption_context.rb
@@ -16,6 +16,8 @@ module Mongo
   module Crypt
 
     # A Context object initialized for auto decryption
+    #
+    # @api private
     class AutoDecryptionContext < Context
 
       # Create a new AutoEncryptionContext object

--- a/lib/mongo/crypt/auto_decryption_context.rb
+++ b/lib/mongo/crypt/auto_decryption_context.rb
@@ -39,7 +39,7 @@ module Mongo
       private
 
       def initialize_ctx
-        binary = Binary.new(@command.to_bson.to_s)
+        binary = Binary.from_data(@command.to_bson.to_s)
         success = Binding.mongocrypt_ctx_decrypt_init(@ctx, binary.ref)
 
         raise_from_status unless success

--- a/lib/mongo/crypt/auto_encryption_context.rb
+++ b/lib/mongo/crypt/auto_encryption_context.rb
@@ -41,7 +41,7 @@ module Mongo
 
       # Initialize the ctx object for auto encryption
       def initialize_ctx
-        binary = Binary.new(@command.to_bson.to_s)
+        binary = Binary.from_data(@command.to_bson.to_s)
         success = Binding.mongocrypt_ctx_encrypt_init(@ctx, @db_name, -1, binary.ref)
 
         raise_from_status unless success

--- a/lib/mongo/crypt/auto_encryption_context.rb
+++ b/lib/mongo/crypt/auto_encryption_context.rb
@@ -16,6 +16,8 @@ module Mongo
   module Crypt
 
     # A Context object initialized for auto encryption
+    #
+    # @api private
     class AutoEncryptionContext < Context
 
       # Create a new AutoEncryptionContext object

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -62,6 +62,7 @@ module Mongo
         self.new(pointer: pointer)
       end
 
+      # TODO: documentation
       def self.from_data(data)
         self.new(data: data)
       end
@@ -70,7 +71,7 @@ module Mongo
       def write(data)
         bytes = data.unpack('C*')
 
-        data_p = Binding.mongocrypt_binary_data(@bin)
+        @data_p = Binding.mongocrypt_binary_data(@bin)
                   .write_array_of_uint8(bytes)
 
         true

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -50,6 +50,24 @@ module Mongo
         end
       end
 
+      # TODO: documentation
+      def self.from_pointer(pointer)
+        # If the Binary class is used this way, it means that the pointer
+        # for the underlying mongocrypt_binary_t object is allocated somewhere
+        # else. The Binary object is not responsible for deallocating data.
+        @bin = pointer
+      end
+
+      # TODO: documentation
+      def write(data)
+        bytes = data.unpack('C*')
+
+        data_p = Binding.mongocrypt_binary_data(@bin)
+                  .write_array_of_uint8(bytes)
+
+        true
+      end
+
       # Returns the data stored as a byte array
       #
       # @return [ Array<Int> ] Byte array stored in mongocrypt_binary_t

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -275,16 +275,46 @@ module Mongo
       # Returns a boolean indicating the success of the operation
       callback :mongocrypt_hmac_fn, [:pointer, :pointer, :pointer, :pointer, :pointer], :bool
 
+      # A callback to a crypto hash (SHA-256) function. Takes:
+      # - An optional pointer to a mongocrypt_ctx_t object
+      # - A pointer to a mongocrypt_binary_t object that wraps the encryption input
+      # - A pointer to a mongocrypt_binary_t object to which the output will be written
+      # - An optional pointer to a mongocrypt_status_t object for error messages
+      # Returns a boolean indicating the success of the operation
+      callback :mongocrypt_hash_fn, [:pointer, :pointer, :pointer, :pointer], :bool
 
-            # Mongocrypt log function signature. Takes a log level, a log message as a string,
-      # an integer representing the length of the message, and a pointer to a context provided
-      # by the caller (can be set to nil).
-      # callback :mongocrypt_log_fn_t, [:log_level, :string, :int, :pointer], :void
+      # A callback to a crypto secure random function. Takes:
+      # - An optional pointer to a mongocrypt_ctx_t object
+      # - A pointer to a mongocrypt_binary_t object to which the output will be written
+      # - The number of random bytes requested
+      # - An optional pointer to a mongocrypt_status_t object for error messages
+      # Returns a boolean indicating the success of the operation
+      callback :mongocrypt_random_fn, [:pointer, :pointer, :int, :pointer], :bool
 
-      # # Sets a method to be called on every log message. Takes a pointer to a mongocrypt_t object,
-      # # a mongocrypt_log_fn_t callback, and a pointer to a log_ctx. Returns a boolean indicating
-      # # success of the operation.
-      # attach_function :mongocrypt_setopt_log_handler, [:pointer, :mongocrypt_log_fn_t, :pointer], :boo
+      # Sets crypto hooks on mongocrypt_t object. Takes:
+      # - A pointer to a mongocrypt_t object, which will use the hooks for encryption
+      # - A mongocrypt_crypto_fn for encryption
+      # - A mongocrypt_crypto_fn for decryption
+      # - A mongocrypt_random_fn
+      # - A mongocrypt_hmac_fn with an HMAC SHA-512 function
+      # - A mongocrypt_hmac_fn with an HMAC SHA-256 function
+      # - A mongocrypt_hash_fn
+      # - An optional pointer to a mongocrypt_ctx_t object
+      # Returns a boolean indicating the success of the operation
+      attach_function(
+        :mongocrypt_setopt_crypto_hooks,
+        [
+          :pointer,
+          :mongocrypt_crypto_fn,
+          :mongocrypt_crypto_fn,
+          :mongocrypt_random_fn,
+          :mongocrypt_hmac_fn,
+          :mongocrypt_hmac_fn,
+          :mongocrypt_hash_fn,
+          :pointer
+        ],
+        :bool
+      )
     end
   end
 end

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -254,6 +254,20 @@ module Mongo
       #
       # This method is not currently unit tested.
       attach_function :mongocrypt_ctx_finalize, [:pointer, :pointer], :void
+
+      # A callback to a crypto AES-256-CBC encrypt function. Takes:
+      # - 
+      callback :mongocrypt_crypto_fn, [:pointer, :pointer, :pointer, :pointer, :pointer, :pointer, :pointer], :bool
+
+            # Mongocrypt log function signature. Takes a log level, a log message as a string,
+      # an integer representing the length of the message, and a pointer to a context provided
+      # by the caller (can be set to nil).
+      # callback :mongocrypt_log_fn_t, [:log_level, :string, :int, :pointer], :void
+
+      # # Sets a method to be called on every log message. Takes a pointer to a mongocrypt_t object,
+      # # a mongocrypt_log_fn_t callback, and a pointer to a log_ctx. Returns a boolean indicating
+      # # success of the operation.
+      # attach_function :mongocrypt_setopt_log_handler, [:pointer, :mongocrypt_log_fn_t, :pointer], :boo
     end
   end
 end

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -255,9 +255,26 @@ module Mongo
       # This method is not currently unit tested.
       attach_function :mongocrypt_ctx_finalize, [:pointer, :pointer], :void
 
-      # A callback to a crypto AES-256-CBC encrypt function. Takes:
-      # - 
+      # A callback to a crypto AES-256-CBC encrypt/decrypt function. Takes:
+      # - An optional pointer to a mongocrypt_ctx_t object
+      # - A pointer to a mongocrypt_binary_t object that wraps a 32-byte encryption key
+      # - A pointer to a mongocrypt_binary_t object that wraps a 16-byte iv
+      # - A pointer to a mongocrypt_binary_t object that wraps the encryption/decryption input
+      # - A pointer to a mongocrypt_binary_t object to which the encryption/decryption output will be written
+      # - A pointer to an int32 where the number of bytes of the output will be written
+      # - An optional pointer to a mongocrypt_status_t object for error messages
+      # Returns a boolean indicating the success of the operation
       callback :mongocrypt_crypto_fn, [:pointer, :pointer, :pointer, :pointer, :pointer, :pointer, :pointer], :bool
+
+      # A callback to a crypto HMAC SHA-512 or SHA-256 function. Takes:
+      # - An optional pointer to a mongocrypt_ctx_t object
+      # - A pointer to a mongocrypt_binary_t object that wraps a 32-byte encryption key
+      # - A pointer to a mongocrypt_binary_t object that wraps the encryption input
+      # - A pointer to a mongocrypt_binary_t object to which the output will be written
+      # - An optional pointer to a mongocrypt_status_t object for error messages
+      # Returns a boolean indicating the success of the operation
+      callback :mongocrypt_hmac_fn, [:pointer, :pointer, :pointer, :pointer, :pointer], :bool
+
 
             # Mongocrypt log function signature. Takes a log level, a log message as a string,
       # an integer representing the length of the message, and a pointer to a context provided

--- a/lib/mongo/crypt/context.rb
+++ b/lib/mongo/crypt/context.rb
@@ -21,6 +21,8 @@ module Mongo
     # This class is a superclass that defines shared methods
     # amongst contexts that are initialized for different purposes
     # (e.g. data key creation, encryption, explicit encryption, etc.)
+    #
+    # @api private
     class Context
       #  Create a new Context object
       #

--- a/lib/mongo/crypt/context.rb
+++ b/lib/mongo/crypt/context.rb
@@ -128,7 +128,7 @@ module Mongo
       # Feeds the result of a Mongo operation to the underlying mongocrypt_ctx_t
       # object. The result param should be a binary string.
       def mongo_feed(result)
-        binary = Binary.new(result)
+        binary = Binary.from_data(result)
         success = Binding.mongocrypt_ctx_mongo_feed(@ctx, binary.ref)
 
         raise_from_status unless success

--- a/lib/mongo/crypt/data_key_context.rb
+++ b/lib/mongo/crypt/data_key_context.rb
@@ -17,6 +17,8 @@ module Mongo
 
     # A Context object initialized specifically for the purpose of creating
     # a data key in the key managemenet system.
+    #
+    # @api private
     class DataKeyContext < Context
 
       # Create a new DataKeyContext object

--- a/lib/mongo/crypt/explicit_decryption_context.rb
+++ b/lib/mongo/crypt/explicit_decryption_context.rb
@@ -39,7 +39,7 @@ module Mongo
       # Initialize the underlying mongocrypt_ctx_t object to perform
       # explicit decryption
       def initialize_ctx
-        binary = Binary.new(@value)
+        binary = Binary.from_data(@value)
         success = Binding.mongocrypt_ctx_explicit_decrypt_init(@ctx, binary.ref)
 
         raise_from_status unless success

--- a/lib/mongo/crypt/explicit_decryption_context.rb
+++ b/lib/mongo/crypt/explicit_decryption_context.rb
@@ -16,6 +16,8 @@ module Mongo
   module Crypt
 
     # A Context object initialized for explicit decryption
+    #
+    # @api private
     class ExplicitDecryptionContext < Context
 
       # Create a new ExplicitDecryptionContext object

--- a/lib/mongo/crypt/explicit_encryption_context.rb
+++ b/lib/mongo/crypt/explicit_encryption_context.rb
@@ -55,7 +55,7 @@ module Mongo
           raise ArgumentError.new(':key_id option must not be nil')
         end
 
-        binary = Binary.new(@options[:key_id])
+        binary = Binary.from_data(@options[:key_id])
         success = Binding.mongocrypt_ctx_setopt_key_id(@ctx, binary.ref)
 
         raise_from_status unless success
@@ -76,7 +76,7 @@ module Mongo
       # Initializes the mongocrypt_ctx_t object for explicit encryption and
       # passes in the value to be encrypted as a Mongo::Crypt::Binary reference
       def initialize_ctx
-        binary = Binary.new(@value)
+        binary = Binary.from_data(@value)
         success = Binding.mongocrypt_ctx_explicit_encrypt_init(@ctx, binary.ref)
 
         raise_from_status unless success

--- a/lib/mongo/crypt/explicit_encryption_context.rb
+++ b/lib/mongo/crypt/explicit_encryption_context.rb
@@ -16,6 +16,8 @@ module Mongo
   module Crypt
 
     # A Context object initialized for explicit encryption
+    #
+    # @api private
     class ExplicitEncryptionContext < Context
 
       # Create a new ExplicitEncryptionContext object

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -21,6 +21,8 @@ module Mongo
     # A handle to the libmongocrypt library that wraps a mongocrypt_t object,
     # allowing clients to set options on that object or perform operations such
     # as encryption and decryption
+    #
+    # @api private
     class Handle
       # Creates a new Handle object and initializes it with options
       #

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -53,7 +53,7 @@ module Mongo
         @logger = options[:logger]
         set_logger_callback if @logger
 
-        set_crypto_hooks
+        # set_crypto_hooks
 
         set_kms_providers(kms_providers)
         initialize_mongocrypt
@@ -95,6 +95,7 @@ module Mongo
         # TODO: documentation
         @aes_encrypt_fn = Proc.new do |ctx_p, key_binary_p, iv_binary_p, input_binary_p, output_binary_p, int_p, status_p|
           begin
+            byebug
             cipher = OpenSSL::Cipher::AES256.new(:CBC)
 
             cipher.encrypt
@@ -119,6 +120,7 @@ module Mongo
 
         @aes_decrypt_fn = Proc.new do |ctx_p, key_binary_p, iv_binary_p, input_binary_p, output_binary_p, int_p, status_p|
           begin
+            byebug
             cipher = OpenSSL::Cipher::AES256.new(:CBC)
 
             cipher.decrypt
@@ -143,6 +145,7 @@ module Mongo
 
         @random_fn = Proc.new do |ctx_p, output_binary_p, num_bytes, status_p|
           begin
+            byebug
             Binary.from_pointer(output_binary_p).write(SecureRandom.random_bytes(num_bytes))
           rescue => e
             status = Status.from_pointer(status_p)
@@ -156,11 +159,9 @@ module Mongo
 
         @hmac_sha_512_fn = Proc.new do |ctx_p, key_binary_p, input_binary_p, output_binary_p, status_p|
           begin
+            byebug
             key = Binary.from_pointer(key_binary_p).to_string
             data = Binary.from_pointer(input_binary_p).to_string
-
-            key = key.unpack('H*')
-            data =
 
             hmac = OpenSSL::HMAC.digest("SHA512", key, data)
             Binary.from_pointer(output_binary_p).write(hmac)
@@ -194,6 +195,7 @@ module Mongo
 
         @hmac_hash_fn = Proc.new do |ctx_p, input_binary_p, output_binary_p, status_p|
           begin
+            byebug
             data = Binary.from_pointer(input_binary_p).to_string
 
             hashed = Digest::SHA2.new(256).digest(data)

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -28,15 +28,15 @@ module Mongo
       #   is currently :local. Local KMS options must be passed in the format
       #   { local: { key: <master key> } } where the master key is a 96-byte, base64
       #   encoded string.
-      # @param [ Hash | nil ] schema_map A hash representing the JSON schema of the collection
-      #   that stores auto encrypted documents.
       # @param [ Hash ] options A hash of options
       #
+      # @option [ Hash | nil ] :schema_map A hash representing the JSON schema of the collection
+      #   that stores auto encrypted documents.
       # @option [ Logger ] :logger A Logger object to which libmongocrypt logs
       #   will be sent
       #
       # There will be more arguemnts to this method once automatic encryption is introduced.
-      def initialize(kms_providers, schema_map: nil, options: {})
+      def initialize(kms_providers, options={})
         @logger = options[:logger]
 
         # FFI::AutoPointer uses a custom release strategy to automatically free
@@ -46,7 +46,9 @@ module Mongo
           Binding.method(:mongocrypt_destroy)
         )
 
+        schema_map = options[:schema_map]
         set_schema_map(schema_map) if schema_map
+
         set_logger_callback if @logger
         set_kms_providers(kms_providers)
         initialize_mongocrypt

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -73,7 +73,7 @@ module Mongo
           raise ArgumentError.new("#{@schema_map} is an invalid schema_map; schema_map must be a Hash or nil")
         end
 
-        binary = Binary.new(@schema_map.to_bson.to_s)
+        binary = Binary.from_data(@schema_map.to_bson.to_s)
         success = Binding.mongocrypt_setopt_schema_map(@mongocrypt, binary.ref)
 
         raise_from_status unless success
@@ -251,7 +251,7 @@ module Mongo
 
         master_key = kms_providers[:local][:key]
 
-        binary = Binary.new(Base64.decode64(master_key))
+        binary = Binary.from_data(Base64.decode64(master_key))
         success = Binding.mongocrypt_setopt_kms_provider_local(@mongocrypt, binary.ref)
 
         raise_from_status unless success

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -87,14 +87,20 @@ module Mongo
         raise_from_status unless success
       end
 
-      # TODO: documentation
+      # We are buildling libmongocrypt without crypto functions to remove the
+      # external dependency on OpenSSL. This method binds native Ruby crypto methods
+      # to the underlying mongocrypt_t object so that libmongocrypt can still perform
+      # cryptography.
+      #
+      # Every crypto binding ignores its first argument, which is an option mongocrypt_ctx_t
+      # object and is not required to use crypto hooks.
       def set_crypto_hooks
         @aes_encrypt_fn = Proc.new do |_, key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p|
           Hooks.aes(key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p)
         end
 
         @aes_decrypt_fn = Proc.new do |_, key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p|
-          Hooks.aes(key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p, true)
+          Hooks.aes(key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p, decrypt: true)
         end
 
         @random_fn = Proc.new do |_, output_binary_p, num_bytes, status_p|

--- a/lib/mongo/crypt/hooks.rb
+++ b/lib/mongo/crypt/hooks.rb
@@ -21,6 +21,8 @@ module Mongo
     # A helper module that implements cryptography methods required
     # for native Ruby crypto hooks. These methods are passed into FFI
     # as C callbacks and called from the libmongocrypt library.
+    #
+    # @api private
     module Hooks
 
       # An AES encrypt or decrypt method.

--- a/lib/mongo/crypt/hooks.rb
+++ b/lib/mongo/crypt/hooks.rb
@@ -1,0 +1,100 @@
+# Copyright (C) 2019 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'securerandom'
+require 'digest'
+
+module Mongo
+  module Crypt
+
+    # TODO: documentation
+    module Hooks
+
+      # TODO: documentation
+      def aes(key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p, decrypt=false)
+        begin
+          cipher = OpenSSL::Cipher::AES.new(256, :CBC)
+
+          decrypt ? cipher.decrypt : cipher.encrypt
+          cipher.key = Binary.from_pointer(key_binary_p).to_string
+          cipher.iv = Binary.from_pointer(iv_binary_p).to_string
+          cipher.padding = 0
+
+          data = Binary.from_pointer(input_binary_p).to_string
+          encrypted = cipher.update(data)
+
+          Binary.from_pointer(output_binary_p).write(encrypted)
+
+          response_length_p.write(:int, encrypted.length)
+        rescue => e
+          handle_error(status_p, e)
+          return false
+        end
+
+        true
+      end
+      module_function :aes
+
+      def random(output_binary_p, num_bytes, status_p)
+        begin
+          Binary.from_pointer(output_binary_p).write(SecureRandom.random_bytes(num_bytes))
+        rescue => e
+          handle_error(status_p, e)
+          return false
+        end
+
+        true
+      end
+      module_function :random
+
+      def hmac_sha(digest, key_binary_p, input_binary_p, output_binary_p, status_p)
+        begin
+          key = Binary.from_pointer(key_binary_p).to_string
+          data = Binary.from_pointer(input_binary_p).to_string
+
+          hmac = OpenSSL::HMAC.digest(digest, key, data)
+          Binary.from_pointer(output_binary_p).write(hmac)
+        rescue => e
+          handle_error(status_p, e)
+          return false
+        end
+
+        true
+      end
+      module_function :hmac_sha
+
+      def hash_sha256(input_binary_p, output_binary_p, status_p)
+        begin
+          data = Binary.from_pointer(input_binary_p).to_string
+
+          hashed = Digest::SHA2.new(256).digest(data)
+          Binary.from_pointer(output_binary_p).write(hashed)
+        rescue => e
+          handle_error(status_p, e)
+          return false
+        end
+      end
+      module_function :hash_sha256
+
+      private
+
+      # TODO: documentation
+      def handle_error(status_p, e)
+        status = Status.from_pointer(status_p)
+        status.update(:error_client, 1, e.message)
+      end
+      module_function :handle_error
+    end
+  end
+end

--- a/lib/mongo/crypt/hooks.rb
+++ b/lib/mongo/crypt/hooks.rb
@@ -58,7 +58,7 @@ module Mongo
 
           Binary.from_pointer(output_binary_p).write(encrypted)
 
-          response_length_p.write(:int, encrypted.length)
+          response_length_p.write_int(encrypted.length)
         rescue => e
           handle_error(status_p, e)
           return false

--- a/lib/mongo/crypt/status.rb
+++ b/lib/mongo/crypt/status.rb
@@ -21,19 +21,19 @@ module Mongo
     # a mongocrypt_t handle.
     class Status
       # Create a new Status object
-      def initialize
+      def initialize(pointer=nil)
         # FFI::AutoPointer uses a custom release strategy to automatically free
         # the pointer once this object goes out of scope
-        @status = FFI::AutoPointer.new(
-          Binding.mongocrypt_status_new,
-          Binding.method(:mongocrypt_status_destroy)
-        )
+        @status = pointer || FFI::AutoPointer.new(
+                              Binding.mongocrypt_status_new,
+                              Binding.method(:mongocrypt_status_destroy)
+                            )
       end
 
       # TODO: documentation
       def self.from_pointer(pointer)
         # TODO: info here
-        @status = pointer
+        self.new(pointer)
       end
 
       # Set a label, code, and message on the Status

--- a/lib/mongo/crypt/status.rb
+++ b/lib/mongo/crypt/status.rb
@@ -30,6 +30,12 @@ module Mongo
         )
       end
 
+      # TODO: documentation
+      def self.from_pointer(pointer)
+        # TODO: info here
+        @status = pointer
+      end
+
       # Set a label, code, and message on the Status
       #
       # @param [ Symbol ] label One of :ok, :error_client, or :error_kms

--- a/lib/mongo/crypt/status.rb
+++ b/lib/mongo/crypt/status.rb
@@ -23,7 +23,16 @@ module Mongo
     # @api private
     class Status
       # Create a new Status object
-      def initialize(pointer=nil)
+      #
+      # @param [ FFI::Pointer | nil ] pointer A pointer to an existing
+      #   mongocrypt_status_t object. Defaults to nil.
+      #
+      # @note When initializing a Status object with a pointer, it is
+      # recommended that you use the #self.from_pointer method
+      def initialize(pointer: nil)
+        # If a pointer is passed in, this class is not responsible for
+        # destroying that pointer and deallocating data.
+        #
         # FFI::AutoPointer uses a custom release strategy to automatically free
         # the pointer once this object goes out of scope
         @status = pointer || FFI::AutoPointer.new(
@@ -32,10 +41,15 @@ module Mongo
                             )
       end
 
-      # TODO: documentation
+      # Initialize a Status object from an existing pointer to a
+      # mongocrypt_status_t object.
+      #
+      # @param [ FFI::Pointer ] pointer A pointer to an existing
+      #   mongocrypt_status_t object
+      #
+      # @return [ Mongo::Crypt::Status ] A new Status object
       def self.from_pointer(pointer)
-        # TODO: info here
-        self.new(pointer)
+        self.new(pointer: pointer)
       end
 
       # Set a label, code, and message on the Status

--- a/lib/mongo/crypt/status.rb
+++ b/lib/mongo/crypt/status.rb
@@ -19,6 +19,8 @@ module Mongo
 
     # A wrapper around mongocrypt_status_t, representing the status of
     # a mongocrypt_t handle.
+    #
+    # @api private
     class Status
       # Create a new Status object
       def initialize(pointer=nil)

--- a/spec/mongo/client_encryption_spec.rb
+++ b/spec/mongo/client_encryption_spec.rb
@@ -6,8 +6,8 @@ require 'base64'
 describe Mongo::ClientEncryption do
   require_libmongocrypt
 
-  let(:key_vault_db) { SpecConfig.instance.test_db }
-  let(:key_vault_coll) { 'keys' }
+  let(:key_vault_db) { 'admin' }
+  let(:key_vault_coll) { 'datakeys' }
   let(:key_vault_namespace) { "#{key_vault_db}.#{key_vault_coll}" }
 
   let(:client) do
@@ -19,7 +19,7 @@ describe Mongo::ClientEncryption do
   let(:kms_providers) do
     {
       local: {
-        key: Base64.encode64("ru\xfe\x00" * 24)
+        key: "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
       }
     }
   end
@@ -74,7 +74,6 @@ describe Mongo::ClientEncryption do
   end
 
   describe '#create_data_key' do
-
     let(:result) { client_encryption.create_data_key }
 
     it 'returns a string' do
@@ -82,6 +81,58 @@ describe Mongo::ClientEncryption do
 
       # make sure that the key actually exists in the DB
       expect(client.use(key_vault_db)[key_vault_coll].find(_id: BSON::Binary.new(result, :uuid)).count).to eq(1)
+    end
+  end
+
+  describe '#encrypt' do
+    let(:data_key) do
+      Utils.parse_extended_json(JSON.parse(File.read('spec/mongo/crypt/data/key_document.json')))
+    end
+
+    let(:value) { 'Hello world' }
+
+    let(:expected_encrypted_value) { "bwAAAAV2AGIAAAAGASzggCwAAAAAAAAAAAAAAAACk0TG2WPKVdChK2Oay9QT\nYNYHvplIMWjXWlnxAVC2hUwayNZmKBSAVgW0D9tnEMdDdxJn+OxqQq3b9MGI\nJ4pHUwVPSiNqfFTKu3OewGtKV9AA\n" }
+
+    before do
+      key_vault_collection = client.use(key_vault_db)[key_vault_coll]
+      key_vault_collection.drop
+
+      key_vault_collection.insert_one(data_key)
+    end
+
+    it 'returns the correct encrypted string' do
+      encrypted = client_encryption.encrypt(
+        value,
+        {
+          key_id: data_key['_id'].data,
+          algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+        }
+      )
+
+      expect(encrypted).to be_a_kind_of(String)
+      expect(encrypted).to eq(Base64.decode64(expected_encrypted_value))
+    end
+  end
+
+  describe '#decrypt' do
+    let(:data_key) do
+      Utils.parse_extended_json(JSON.parse(File.read('spec/mongo/crypt/data/key_document.json')))
+    end
+
+    let(:value) { 'Hello world' }
+
+    let(:encrypted_value) { "bwAAAAV2AGIAAAAGASzggCwAAAAAAAAAAAAAAAACk0TG2WPKVdChK2Oay9QT\nYNYHvplIMWjXWlnxAVC2hUwayNZmKBSAVgW0D9tnEMdDdxJn+OxqQq3b9MGI\nJ4pHUwVPSiNqfFTKu3OewGtKV9AA\n" }
+
+    before do
+      key_vault_collection = client.use(key_vault_db)[key_vault_coll]
+      key_vault_collection.drop
+
+      key_vault_collection.insert_one(data_key)
+    end
+
+    it 'returns the correct unencrypted value' do
+      result = client_encryption.decrypt(Base64.decode64(encrypted_value))
+      expect(result).to eq(value)
     end
   end
 end

--- a/spec/mongo/crypt/auto_decryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_decryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::AutoDecryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, options: { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, logger: logger) }
   let(:context) { described_class.new(mongocrypt, io, command) }
 
   let(:logger) { nil }

--- a/spec/mongo/crypt/auto_encryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_encryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::AutoEncryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, options: { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, logger: logger) }
   let(:context) { described_class.new(mongocrypt, io, db_name, command) }
 
   let(:logger) { nil }

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -9,10 +9,12 @@ describe Mongo::Crypt::Binary do
   require_libmongocrypt
 
   let(:data) { 'I love Ruby' }
-  let(:binary) { described_class.new(data) }
+  let(:binary) { described_class.from_data(data) }
 
   describe '#initialize' do
     context 'with nil data' do
+      let(:binary) { described_class.new }
+
       it 'creates a new Mongo::Crypt::Binary object' do
         expect do
           binary
@@ -21,11 +23,57 @@ describe Mongo::Crypt::Binary do
     end
 
     context 'with valid data' do
+      let(:binary) { described_class.new(data: data) }
+
       it 'creates a new Mongo::Crypt::Binary object' do
         expect do
           binary
         end.not_to raise_error
       end
+    end
+
+    context 'with pointer' do
+      let(:pointer) { Mongo::Crypt::Binding.mongocrypt_binary_new }
+      let(:binary) { described_class.new(pointer: pointer) }
+
+      after do
+        Mongo::Crypt::Binding.mongocrypt_binary_destroy(pointer)
+      end
+
+      it 'creates a new Mongo::Crypt::Binary object from pointer' do
+        expect do
+          binary
+        end.not_to raise_error
+
+        expect(binary.ref).to eq(pointer)
+      end
+    end
+  end
+
+  describe '#self.from_data' do
+    let(:binary) { described_class.from_data(data) }
+
+    it 'creates a new Mongo::Crypt::Binary object' do
+      expect do
+        binary
+      end.not_to raise_error
+    end
+  end
+
+  describe '#self.from_pointer' do
+    let(:pointer) { Mongo::Crypt::Binding.mongocrypt_binary_new }
+    let(:binary) { described_class.from_pointer(pointer) }
+
+    after do
+      Mongo::Crypt::Binding.mongocrypt_binary_destroy(pointer)
+    end
+
+    it 'creates a new Mongo::Crypt::Binary object from pointer' do
+      expect do
+        binary
+      end.not_to raise_error
+
+      expect(binary.ref).to eq(pointer)
     end
   end
 

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -88,4 +88,16 @@ describe Mongo::Crypt::Binary do
       expect(binary.to_string).to eq(data)
     end
   end
+
+  describe '#write' do
+    let(:binary) { described_class.from_data("\0" * 11) }
+
+    it 'writes data to the binary object' do
+      expect do
+        binary.write(data)
+      end.not_to raise_error
+
+      expect(binary.to_string).to eq(data)
+    end
+  end
 end

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -1,5 +1,6 @@
 require 'mongo'
 require 'support/lite_constraints'
+require 'byebug'
 
 RSpec.configure do |config|
   config.extend(LiteConstraints)
@@ -91,16 +92,27 @@ describe Mongo::Crypt::Binary do
 
   describe '#write' do
     # Binary must have enough space pre-allocated
-    let(:binary) { described_class.from_data("\0" * 11) }
+    let(:binary) { described_class.from_data("\00" * data.length) }
 
     it 'writes data to the binary object' do
-      expect do
-        binary.write(data)
-      end.not_to raise_error
-
+      expect(binary.write(data)).to be true
       expect(binary.to_string).to eq(data)
     end
 
-    # TODO: test case without space pre-allocated
+    context 'with no space allocated' do
+      let(:binary) { described_class.new }
+
+      it 'returns false' do
+        expect(binary.write(data)).to be false
+      end
+    end
+
+    context 'without enough space allocated' do
+      let(:binary) { described_class.from_data("\00" * (data.length - 1)) }
+
+      it 'returns false' do
+        expect(binary.write(data)).to be false
+      end
+    end
   end
 end

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -1,6 +1,5 @@
 require 'mongo'
 require 'support/lite_constraints'
-require 'byebug'
 
 RSpec.configure do |config|
   config.extend(LiteConstraints)

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -102,7 +102,9 @@ describe Mongo::Crypt::Binary do
       let(:binary) { described_class.new }
 
       it 'returns false' do
-        expect(binary.write(data)).to be false
+        expect do
+          binary.write(data)
+        end.to raise_error(ArgumentError, /Cannot write #{data.length} bytes of data to a Binary object that was initialized with 0 bytes/)
       end
     end
 
@@ -110,7 +112,9 @@ describe Mongo::Crypt::Binary do
       let(:binary) { described_class.from_data("\00" * (data.length - 1)) }
 
       it 'returns false' do
-        expect(binary.write(data)).to be false
+        expect do
+          binary.write(data)
+        end.to raise_error(ArgumentError, /Cannot write #{data.length} bytes of data to a Binary object that was initialized with #{data.length - 1} bytes/)
       end
     end
   end

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -90,6 +90,7 @@ describe Mongo::Crypt::Binary do
   end
 
   describe '#write' do
+    # Binary must have enough space pre-allocated
     let(:binary) { described_class.from_data("\0" * 11) }
 
     it 'writes data to the binary object' do
@@ -99,5 +100,7 @@ describe Mongo::Crypt::Binary do
 
       expect(binary.to_string).to eq(data)
     end
+
+    # TODO: test case without space pre-allocated
   end
 end

--- a/spec/mongo/crypt/binding/context_spec.rb
+++ b/spec/mongo/crypt/binding/context_spec.rb
@@ -1,5 +1,6 @@
 require 'mongo'
 require 'support/lite_constraints'
+require 'mongo/crypt/helpers/crypto_hooks_helper'
 
 RSpec.configure do |config|
   config.extend(LiteConstraints)
@@ -23,6 +24,7 @@ shared_context 'initialized for data key creation' do
 
   before do
     Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, binary)
+    CryptoHooksHelper.bind_crypto_hooks(mongocrypt)
     Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)
 
     Mongo::Crypt::Binding.mongocrypt_ctx_setopt_masterkey_local(context)

--- a/spec/mongo/crypt/binding/context_spec.rb
+++ b/spec/mongo/crypt/binding/context_spec.rb
@@ -1,6 +1,6 @@
 require 'mongo'
 require 'support/lite_constraints'
-require 'mongo/crypt/helpers/crypto_hooks_helper'
+require 'mongo/crypt/helpers/mongo_crypt_spec_helper'
 
 RSpec.configure do |config|
   config.extend(LiteConstraints)
@@ -24,7 +24,7 @@ shared_context 'initialized for data key creation' do
 
   before do
     Mongo::Crypt::Binding.mongocrypt_setopt_kms_provider_local(mongocrypt, binary)
-    CryptoHooksHelper.bind_crypto_hooks(mongocrypt)
+    MongoCryptSpecHelper.bind_crypto_hooks(mongocrypt)
     Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)
 
     Mongo::Crypt::Binding.mongocrypt_ctx_setopt_masterkey_local(context)
@@ -47,6 +47,7 @@ shared_context 'initialized for explicit encryption' do
   let(:value_binary) { mongocrypt_binary_t_from(value) }
 
   before do
+    MongoCryptSpecHelper.bind_crypto_hooks(mongocrypt)
     Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)
 
     Mongo::Crypt::Binding.mongocrypt_ctx_setopt_key_id(context, key_id_binary)

--- a/spec/mongo/crypt/binding/context_spec.rb
+++ b/spec/mongo/crypt/binding/context_spec.rb
@@ -66,6 +66,7 @@ end
 describe 'Mongo::Crypt::Binding' do
   describe 'mongocrypt_ctx_t bindings' do
     require_libmongocrypt
+    fails_on_jruby
 
     let(:mongocrypt) { Mongo::Crypt::Binding.mongocrypt_new }
     let(:context) { Mongo::Crypt::Binding.mongocrypt_ctx_new(mongocrypt) }

--- a/spec/mongo/crypt/binding/mongocrypt_spec.rb
+++ b/spec/mongo/crypt/binding/mongocrypt_spec.rb
@@ -1,5 +1,6 @@
 require 'mongo'
 require 'support/lite_constraints'
+require 'mongo/crypt/helpers/mongo_crypt_spec_helper'
 
 RSpec.configure do |config|
   config.extend(LiteConstraints)
@@ -75,7 +76,7 @@ describe 'Mongo::Crypt::Binding' do
 
       context 'with valid kms option' do
         before do
-          CryptoHooksHelper.bind_crypto_hooks(mongocrypt)
+          MongoCryptSpecHelper.bind_crypto_hooks(mongocrypt)
         end
 
         it 'returns true' do
@@ -91,7 +92,7 @@ describe 'Mongo::Crypt::Binding' do
 
       context 'with invalid kms option' do
         before do
-          CryptoHooksHelper.bind_crypto_hooks(mongocrypt)
+          MongoCryptSpecHelper.bind_crypto_hooks(mongocrypt)
         end
 
         let(:key_bytes) { [114, 117, 98, 121] * 23 } # NOT 96 bytes

--- a/spec/mongo/crypt/binding/mongocrypt_spec.rb
+++ b/spec/mongo/crypt/binding/mongocrypt_spec.rb
@@ -53,6 +53,8 @@ describe 'Mongo::Crypt::Binding' do
     end
 
     describe '#mongocrypt_init' do
+      let(:key_bytes) { [114, 117, 98, 121] * 24 } # 96 bytes
+
       let(:binary) do
         p = FFI::MemoryPointer.new(key_bytes.size)
               .write_array_of_type(FFI::TYPE_UINT8, :put_uint8, key_bytes)
@@ -72,14 +74,26 @@ describe 'Mongo::Crypt::Binding' do
       end
 
       context 'with valid kms option' do
-        let(:key_bytes) { [114, 117, 98, 121] * 24 } # 96 bytes
+        before do
+          CryptoHooksHelper.bind_crypto_hooks(mongocrypt)
+        end
 
         it 'returns true' do
           expect(Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)).to be true
         end
       end
 
+      context 'without binding crypto hooks' do
+        it 'returns false' do
+          expect(Mongo::Crypt::Binding.mongocrypt_init(mongocrypt)).to be false
+        end
+      end
+
       context 'with invalid kms option' do
+        before do
+          CryptoHooksHelper.bind_crypto_hooks(mongocrypt)
+        end
+
         let(:key_bytes) { [114, 117, 98, 121] * 23 } # NOT 96 bytes
 
         it 'returns false' do

--- a/spec/mongo/crypt/data/key_document.json
+++ b/spec/mongo/crypt/data/key_document.json
@@ -1,0 +1,31 @@
+{
+  "status": {
+      "$numberInt": "1"
+  },
+  "_id": {
+      "$binary": {
+          "base64": "LOCALAAAAAAAAAAAAAAAAA==",
+          "subType": "04"
+      }
+  },
+  "masterKey": {
+      "provider": "local"
+  },
+  "updateDate": {
+      "$date": {
+          "$numberLong": "1557827033449"
+      }
+  },
+  "keyMaterial": {
+      "$binary": {
+          "base64": "Ce9HSz/HKKGkIt4uyy+jDuKGA+rLC2cycykMo6vc8jXxqa1UVDYHWq1r+vZKbnnSRBfB981akzRKZCFpC05CTyFqDhXv6OnMjpG97OZEREGIsHEYiJkBW0jJJvfLLgeLsEpBzsro9FztGGXASxyxFRZFhXvHxyiLOKrdWfs7X1O/iK3pEoHMx6uSNSfUOgbebLfIqW7TO++iQS5g1xovXA==",
+          "subType": "00"
+      }
+  },
+  "creationDate": {
+      "$date": {
+          "$numberLong": "1557827033449"
+      }
+  },
+  "keyAltNames": [ "local" ]
+}

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::ExplicitDecryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, options: { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, logger: logger) }
   let(:context) { described_class.new(mongocrypt, io, value) }
   let(:logger) { nil }
 

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::ExplicitEncryptionContext do
   require_libmongocrypt
 
-  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, options: { logger: logger }) }
+  let(:mongocrypt) { Mongo::Crypt::Handle.new(kms_providers, logger: logger) }
   let(:context) { described_class.new(mongocrypt, io, value, options) }
 
   let(:logger) { nil }

--- a/spec/mongo/crypt/helpers/crypto_hooks_helper.rb
+++ b/spec/mongo/crypt/helpers/crypto_hooks_helper.rb
@@ -1,0 +1,27 @@
+module CryptoHooksHelper
+  def bind_crypto_hooks(mongocrypt)
+    Mongo::Crypt::Binding.mongocrypt_setopt_crypto_hooks(
+      mongocrypt,
+      Proc.new do |_, key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p|
+        Mongo::Crypt::Hooks.aes(key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p)
+      end,
+      Proc.new do |_, key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p|
+        Mongo::Crypt::Hooks.aes(key_binary_p, iv_binary_p, input_binary_p, output_binary_p, response_length_p, status_p, decrypt: true)
+      end,
+      Proc.new do |_, output_binary_p, num_bytes, status_p|
+        Mongo::Crypt::Hooks.random(output_binary_p, num_bytes, status_p)
+      end,
+      Proc.new do |_, key_binary_p, input_binary_p, output_binary_p, status_p|
+        Mongo::Crypt::Hooks.hmac_sha('SHA512', key_binary_p, input_binary_p, output_binary_p, status_p)
+      end,
+      Proc.new do |_, key_binary_p, input_binary_p, output_binary_p, status_p|
+        Mongo::Crypt::Hooks.hmac_sha('SHA256', key_binary_p, input_binary_p, output_binary_p, status_p)
+      end,
+      Proc.new do |_, input_binary_p, output_binary_p, status_p|
+        Mongo::Crypt::Hooks.hash_sha256(input_binary_p, output_binary_p, status_p)
+      end,
+      nil
+    )
+  end
+  module_function :bind_crypto_hooks
+end

--- a/spec/mongo/crypt/helpers/mongo_crypt_spec_helper.rb
+++ b/spec/mongo/crypt/helpers/mongo_crypt_spec_helper.rb
@@ -1,4 +1,4 @@
-module CryptoHooksHelper
+module MongoCryptSpecHelper
   def bind_crypto_hooks(mongocrypt)
     Mongo::Crypt::Binding.mongocrypt_setopt_crypto_hooks(
       mongocrypt,

--- a/spec/mongo/crypt/status_spec.rb
+++ b/spec/mongo/crypt/status_spec.rb
@@ -8,7 +8,7 @@ end
 describe Mongo::Crypt::Status do
   require_libmongocrypt
 
-  let(:status) { Mongo::Crypt::Status.new }
+  let(:status) { described_class.new }
 
   let(:label) { :error_client }
   let(:code) { 401 }
@@ -21,6 +21,23 @@ describe Mongo::Crypt::Status do
   describe '#initialize' do
     it 'doesn\'t throw an error' do
       expect { status }.not_to raise_error
+    end
+  end
+
+  describe '#self.from_pointer' do
+    let(:pointer) { Mongo::Crypt::Binding.mongocrypt_status_new }
+    let(:status) { described_class.from_pointer(pointer) }
+
+    after do
+      Mongo::Crypt::Binding.mongocrypt_status_destroy(pointer)
+    end
+
+    it 'creates a status from the pointer passed in' do
+      expect do
+        status
+      end.not_to raise_error
+
+      expect(status.ref).to eq(pointer)
     end
   end
 

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -1,4 +1,45 @@
+require 'base64'
+
 module Utils
+  # TODO: documentation
+  def parse_extended_json(doc)
+    if doc.is_a?(Hash)
+      doc.each do |key, val|
+        doc[key] = parse_json_key_val(key, val)
+
+        if doc[key].is_a?(Hash) || doc[key].is_a?(Array)
+          doc[key] = parse_extended_json(val)
+        end
+      end
+    elsif doc.is_a?(Array)
+      doc.each.with_index do |val, key|
+        doc[key] = parse_json_key_val(key, val)
+
+        if doc[key].is_a?(Hash) || doc[key].is_a?(Array)
+          doc[key] = parse_extended_json(val)
+        end
+      end
+    end
+  end
+  module_function :parse_extended_json
+
+  # TODO: documentation
+  def parse_json_key_val(key, val)
+    if val.is_a?(Hash) && val.key?('$binary')
+      data = Base64.decode64(val['$binary']['base64'])
+      subtype = val['$binary']['subType'].to_i == 4 ? :uuid : :generic
+
+      BSON::Binary.new(data, subtype)
+    elsif val.is_a?(Hash) && val.key?('$date')
+      time = val['$date']['$numberLong']
+      DateTime.strptime(time, '%Q')
+    elsif val.is_a?(Hash) && val.key?('$numberInt')
+      val['$numberInt'].to_i
+    else
+      val
+    end
+  end
+  module_function :parse_json_key_val
 
   # Converts a 'camelCase' string or symbol to a :under_score symbol.
   def underscore(str)

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -3,6 +3,8 @@ require 'base64'
 module Utils
   # A limited extended JSON parser to use in FLE specs.
   # DO NOT consider this a complete extended JSON parser.
+  # This method will be removed once a complete extended
+  # JSON parser has been implemented.
   #
   # This method may modify the provided argument
   def parse_extended_json(doc)


### PR DESCRIPTION
Crypto functionality now works with a nocrypto build of libmongocrypt!

I have also made some API changes:
- Make the entire crypto API private except for the things designated as public by the client-side encryption spec
- Change the `Binary` and `Status` APIs to allow those objects to be initialized using an existing pointer to an underlying C object (for use in crypto hooks)
- Change the `Handle` API to be more consistent (make every argument that is optional part of `options` rather than its own argument)