### PR TITLE
RUBY-2072 Push Binary Pointers down

### DIFF
--- a/lib/mongo/crypt/auto_decryption_context.rb
+++ b/lib/mongo/crypt/auto_decryption_context.rb
@@ -42,7 +42,7 @@ module Mongo
 
       def initialize_ctx
         binary = Binary.from_data(@command.to_bson.to_s)
-        success = Binding.mongocrypt_ctx_decrypt_init(@ctx, binary.ref)
+        success = Binding.mongocrypt_ctx_decrypt_init(@ctx, binary.pointer)
 
         raise_from_status unless success
       end

--- a/lib/mongo/crypt/auto_encryption_context.rb
+++ b/lib/mongo/crypt/auto_encryption_context.rb
@@ -44,7 +44,7 @@ module Mongo
       # Initialize the ctx object for auto encryption
       def initialize_ctx
         binary = Binary.from_data(@command.to_bson.to_s)
-        success = Binding.mongocrypt_ctx_encrypt_init(@ctx, @db_name, -1, binary.ref)
+        success = Binding.mongocrypt_ctx_encrypt_init(@ctx, @db_name, -1, binary.pointer)
 
         raise_from_status unless success
       end

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -41,6 +41,9 @@ module Mongo
           # If the Binary class is used this way, it means that the pointer
           # for the underlying mongocrypt_binary_t object is allocated somewhere
           # else. It is not the responsibility of this class to de-allocate data.
+          #
+          # TODO: refactor this when refactoring crypto hooks; this class should
+          # never take a pointer as an argument
           @binary_p = pointer
         else
           # FFI::AutoPointer uses a custom release strategy to automatically free

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -35,8 +35,8 @@ module Mongo
       # methods
       def initialize(data: nil, pointer: nil)
         if data
-          @binary_p = Binding::Binary.with_data(data)
-          @data_p = Binding::Binary.data_p(self)
+          @data = data
+          @binary_p = Binding::Binary.with_data(@data)
         elsif pointer
           # If the Binary class is used this way, it means that the pointer
           # for the underlying mongocrypt_binary_t object is allocated somewhere
@@ -85,7 +85,7 @@ module Mongo
       # than was originally allocated or when writing to an object that
       # already owns data.
       def write(data)
-        if @data_p
+        if @data
           raise ArgumentError, 'Cannot write to an owned Binary'
         end
 

--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -105,7 +105,7 @@ module Mongo
       # object
       #
       # @return [ FFI::Pointer ] The underlying mongocrypt_binary_t object
-      def ref
+      def pointer
         @binary_p
       end
     end

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -56,6 +56,8 @@ module Mongo
           "is invalid: #{ENV['LIBMONGOCRYPT_PATH']}\n\n#{e.class}: #{e.message}"
       end
 
+      autoload(:Binary, 'mongo/crypt/binding/binary')
+
       # Takes an integer pointer as an optional out parameter specifying
       # the return string length.
       # Returns the version string for the libmongocrypt library

--- a/lib/mongo/crypt/binding/binary.rb
+++ b/lib/mongo/crypt/binding/binary.rb
@@ -30,7 +30,7 @@ module Mongo
           # @raise [ ArgumentError ] Raises when trying to write more data
           # than was originally allocated
           def write(binary, data)
-            binary_p = binary.ref
+            binary_p = binary.pointer
 
             # Cannot write a string that's longer than the space currently
             # allocated by the mongocrypt_binary_t object
@@ -56,7 +56,7 @@ module Mongo
           #
           # @return [ String ] The underlying byte data as a string
           def to_s(binary)
-            binary_p = binary.ref
+            binary_p = binary.pointer
 
             str_p = Binding.mongocrypt_binary_data(binary_p)
             len = Binding.mongocrypt_binary_len(binary_p)

--- a/lib/mongo/crypt/binding/binary.rb
+++ b/lib/mongo/crypt/binding/binary.rb
@@ -1,0 +1,114 @@
+# Copyright (C) 2019 MongoDB, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'ffi'
+
+module Mongo
+  module Crypt
+    class Binding
+
+      # @api private
+      class Binary
+        class << self
+          # Write data to a Binary object
+          #
+          # @param [ Mongo::Crypt::Binary ] binary A Binary object
+          # @param [ String ] data The data to write to the binary object
+          #
+          # @return [ true ] Always true
+          # @raise [ ArgumentError ] Raises when trying to write more data
+          # than was originally allocated
+          def write(binary, data)
+            binary_p = binary.ref
+
+            # Cannot write a string that's longer than the space currently allocated
+            # by the mongocrypt_binary_t object
+            data_p = Binding.mongocrypt_binary_data(binary_p)
+            len = Binding.mongocrypt_binary_len(binary_p)
+
+            if len < data.length
+              raise ArgumentError.new(
+                "Cannot write #{data.length} bytes of data to a Binary object " +
+                "that was initialized with #{len} bytes."
+              )
+            end
+
+            data_p.put_bytes(0, data)
+
+            true
+          end
+
+          # Return the data referenced by the mongocrypt_binary_t object
+          # as a string
+          #
+          # @param [ Mongo::Crypt::Binary ] binary A Binary object
+          #
+          # @return [ String ] The underlying byte data as a string
+          def to_s(binary)
+            binary_p = binary.ref
+
+            str_p = Binding.mongocrypt_binary_data(binary_p)
+            len = Binding.mongocrypt_binary_len(binary_p)
+            str_p.read_string(len)
+          end
+
+          # Initialize a mongocrypt_binary_t object that references the
+          #   specified string
+          #
+          # @param [ String ] string The string to be wrapped by the
+          #   mongocryt_binary_t
+          #
+          # @return [ FFI::AutoPointer ] A pointer to the new
+          #   mongocrypt_binary_t object, which will be automatically cleaned
+          #   up when this object goes out of scope
+          def with_data(string)
+            bytes = string.unpack('C*')
+
+            # FFI::MemoryPointer automatically frees memory when it goes out of scope
+            data_p = FFI::MemoryPointer
+              .new(bytes.size)
+              .write_array_of_type(FFI::TYPE_UINT8, :put_uint8, bytes)
+
+            # FFI::AutoPointer uses a custom release strategy to automatically free
+            # the pointer once this object goes out of scope
+            FFI::AutoPointer.new(
+              Binding.mongocrypt_binary_new_from_data(data_p, bytes.length),
+              Binding.method(:mongocrypt_binary_destroy)
+            )
+          end
+
+          def data_p(binary)
+            binary_p = binary.ref
+            Binding.mongocrypt_binary_data(binary_p)
+          end
+
+          # Create a new pointer to a mongocrypt_binary_t object that wraps no
+          #   data
+          #
+          # @return [ FFI::AutoPointer ] A pointer to the new
+          #   mongocrypt_binary_t object, which will be automatically cleaned
+          #   up when it goes out of scope
+          def without_data
+            # FFI::AutoPointer uses a custom release strategy to automatically free
+            # the pointer once this object goes out of scope
+            FFI::AutoPointer.new(
+              Binding.mongocrypt_binary_new,
+              Binding.method(:mongocrypt_binary_destroy)
+            )
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/mongo/crypt/binding/binary.rb
+++ b/lib/mongo/crypt/binding/binary.rb
@@ -32,8 +32,8 @@ module Mongo
           def write(binary, data)
             binary_p = binary.ref
 
-            # Cannot write a string that's longer than the space currently allocated
-            # by the mongocrypt_binary_t object
+            # Cannot write a string that's longer than the space currently
+            # allocated by the mongocrypt_binary_t object
             data_p = Binding.mongocrypt_binary_data(binary_p)
             len = Binding.mongocrypt_binary_len(binary_p)
 
@@ -88,11 +88,6 @@ module Mongo
             )
           end
 
-          def data_p(binary)
-            binary_p = binary.ref
-            Binding.mongocrypt_binary_data(binary_p)
-          end
-
           # Create a new pointer to a mongocrypt_binary_t object that wraps no
           #   data
           #
@@ -100,8 +95,8 @@ module Mongo
           #   mongocrypt_binary_t object, which will be automatically cleaned
           #   up when it goes out of scope
           def without_data
-            # FFI::AutoPointer uses a custom release strategy to automatically free
-            # the pointer once this object goes out of scope
+            # FFI::AutoPointer uses a custom release strategy to automatically
+            # free the pointer once this object goes out of scope
             FFI::AutoPointer.new(
               Binding.mongocrypt_binary_new,
               Binding.method(:mongocrypt_binary_destroy)

--- a/lib/mongo/crypt/context.rb
+++ b/lib/mongo/crypt/context.rb
@@ -122,7 +122,7 @@ module Mongo
       # Finalize the state machine and return the result as a string
       def finalize_state_machine
         binary = Binary.new
-        success = Binding.mongocrypt_ctx_finalize(@ctx, binary.ref)
+        success = Binding.mongocrypt_ctx_finalize(@ctx, binary.pointer)
         raise_from_status unless success
 
         binary.to_string
@@ -134,7 +134,7 @@ module Mongo
       # encryption/decryption (for example, a filter for a key vault query).
       def mongocrypt_operation
         binary = Binary.new
-        success = Binding.mongocrypt_ctx_mongo_op(@ctx, binary.ref)
+        success = Binding.mongocrypt_ctx_mongo_op(@ctx, binary.pointer)
         raise_from_status unless success
 
         binary.to_string
@@ -144,7 +144,7 @@ module Mongo
       # The result param should be a binary string.
       def mongocrypt_feed(result)
         binary = Binary.from_data(result)
-        success = Binding.mongocrypt_ctx_mongo_feed(@ctx, binary.ref)
+        success = Binding.mongocrypt_ctx_mongo_feed(@ctx, binary.pointer)
 
         raise_from_status unless success
       end

--- a/lib/mongo/crypt/explicit_decryption_context.rb
+++ b/lib/mongo/crypt/explicit_decryption_context.rb
@@ -42,7 +42,7 @@ module Mongo
       # explicit decryption
       def initialize_ctx
         binary = Binary.from_data(@value)
-        success = Binding.mongocrypt_ctx_explicit_decrypt_init(@ctx, binary.ref)
+        success = Binding.mongocrypt_ctx_explicit_decrypt_init(@ctx, binary.pointer)
 
         raise_from_status unless success
       end

--- a/lib/mongo/crypt/explicit_encryption_context.rb
+++ b/lib/mongo/crypt/explicit_encryption_context.rb
@@ -58,7 +58,7 @@ module Mongo
         end
 
         binary = Binary.from_data(@options[:key_id])
-        success = Binding.mongocrypt_ctx_setopt_key_id(@ctx, binary.ref)
+        success = Binding.mongocrypt_ctx_setopt_key_id(@ctx, binary.pointer)
 
         raise_from_status unless success
       end
@@ -79,7 +79,7 @@ module Mongo
       # passes in the value to be encrypted as a Mongo::Crypt::Binary reference
       def initialize_ctx
         binary = Binary.from_data(@value)
-        success = Binding.mongocrypt_ctx_explicit_encrypt_init(@ctx, binary.ref)
+        success = Binding.mongocrypt_ctx_explicit_encrypt_init(@ctx, binary.pointer)
 
         raise_from_status unless success
       end

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -74,7 +74,7 @@ module Mongo
         end
 
         binary = Binary.from_data(@schema_map.to_bson.to_s)
-        success = Binding.mongocrypt_setopt_schema_map(@mongocrypt, binary.ref)
+        success = Binding.mongocrypt_setopt_schema_map(@mongocrypt, binary.pointer)
 
         raise_from_status unless success
       end
@@ -272,7 +272,7 @@ module Mongo
         master_key = kms_providers[:local][:key]
 
         binary = Binary.from_data(Base64.decode64(master_key))
-        success = Binding.mongocrypt_setopt_kms_provider_local(@mongocrypt, binary.ref)
+        success = Binding.mongocrypt_setopt_kms_provider_local(@mongocrypt, binary.pointer)
 
         raise_from_status unless success
       end

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -45,7 +45,7 @@ describe Mongo::Crypt::Binary do
           binary
         end.not_to raise_error
 
-        expect(binary.ref).to eq(pointer)
+        expect(binary.pointer).to eq(pointer)
       end
     end
   end
@@ -73,7 +73,7 @@ describe Mongo::Crypt::Binary do
         binary
       end.not_to raise_error
 
-      expect(binary.ref).to eq(pointer)
+      expect(binary.pointer).to eq(pointer)
     end
   end
 
@@ -86,7 +86,7 @@ describe Mongo::Crypt::Binary do
   describe '#write' do
     # Binary must have enough space pre-allocated
     let(:binary) { described_class.from_data("\00" * data.length) }
-    let(:binary_p) { binary.ref }
+    let(:binary_p) { binary.pointer }
     let(:binary_without_data) { described_class.from_pointer(binary_p) }
 
     context 'to a binary that owns data' do
@@ -116,7 +116,7 @@ describe Mongo::Crypt::Binary do
 
     context 'without enough space allocated' do
       let(:binary) { described_class.from_data("\00" * (data.length - 1)) }
-      let(:binary_p) { binary.ref }
+      let(:binary_p) { binary.pointer }
       let(:binary_without_data) { described_class.from_pointer(binary_p) }
 
       it 'returns false' do


### PR DESCRIPTION
The first PR in a series for pushing pointers down into the binding code.

I'm going to try to establish a "contract" with the user where the underlying pointer is only referenced in the initializer and in a method called `pointer`, allowing the underlying binding to take  a reference to the Ruby object and manipulate the pointers.