### PR TITLE
RUBY-2007 Make sure all contexts initialize properly when Mongocrypt uses AWS KMS options

### DIFF
--- a/spec/mongo/crypt/auto_decryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_decryption_context_spec.rb
@@ -1,9 +1,5 @@
 require 'mongo'
-require 'support/lite_constraints'
-
-RSpec.configure do |config|
-  config.extend(LiteConstraints)
-end
+require 'lite_spec_helper'
 
 describe Mongo::Crypt::AutoDecryptionContext do
   require_libmongocrypt

--- a/spec/mongo/crypt/auto_decryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_decryption_context_spec.rb
@@ -32,10 +32,29 @@ describe Mongo::Crypt::AutoDecryptionContext do
 
   describe '#initialize' do
     context 'with valid options' do
-      it 'does not raise an exception' do
-        expect do
-          context
-        end.not_to raise_error
+      context 'when mongocrypt is initialized with local KMS provider options' do
+        it 'initializes context' do
+          expect do
+            context
+          end.not_to raise_error
+        end
+      end
+
+      context 'when mongocrypt is initialized with AWS KMS provider options' do
+        let(:kms_providers) do
+          {
+            aws: {
+              access_key_id: ENV['FLE_AWS_ACCESS_KEY'],
+              secret_access_key: ENV['FLE_AWS_SECRET_ACCESS_KEY']
+            }
+          }
+        end
+
+        it 'initializes context' do
+          expect do
+            context
+          end.not_to raise_error
+        end
       end
 
       context 'with verbose logging' do

--- a/spec/mongo/crypt/auto_decryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_decryption_context_spec.rb
@@ -40,8 +40,8 @@ describe Mongo::Crypt::AutoDecryptionContext do
         let(:kms_providers) do
           {
             aws: {
-              access_key_id: ENV['FLE_AWS_ACCESS_KEY'],
-              secret_access_key: ENV['FLE_AWS_SECRET_ACCESS_KEY']
+              access_key_id: ENV['MONGO_RUBY_DRIVER_AWS_KEY'],
+              secret_access_key: ENV['MONGO_RUBY_DRIVER_AWS_SECRET']
             }
           }
         end

--- a/spec/mongo/crypt/auto_encryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_encryption_context_spec.rb
@@ -47,10 +47,29 @@ describe Mongo::Crypt::AutoEncryptionContext do
     end
 
     context 'with valid options' do
-      it 'does not raise an exception' do
-        expect do
-          context
-        end.not_to raise_error
+      context 'when mongocrypt is initialized with local KMS provider options' do
+        it 'initializes context' do
+          expect do
+            context
+          end.not_to raise_error
+        end
+      end
+
+      context 'when mongocrypt is initialized with AWS KMS provider options' do
+        let(:kms_providers) do
+          {
+            aws: {
+              access_key_id: ENV['FLE_AWS_ACCESS_KEY'],
+              secret_access_key: ENV['FLE_AWS_SECRET_ACCESS_KEY']
+            }
+          }
+        end
+
+        it 'initializes context' do
+          expect do
+            context
+          end.not_to raise_error
+        end
       end
 
       context 'with verbose logging' do

--- a/spec/mongo/crypt/auto_encryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_encryption_context_spec.rb
@@ -1,9 +1,5 @@
 require 'mongo'
-require 'support/lite_constraints'
-
-RSpec.configure do |config|
-  config.extend(LiteConstraints)
-end
+require 'lite_spec_helper'
 
 describe Mongo::Crypt::AutoEncryptionContext do
   require_libmongocrypt

--- a/spec/mongo/crypt/auto_encryption_context_spec.rb
+++ b/spec/mongo/crypt/auto_encryption_context_spec.rb
@@ -55,8 +55,8 @@ describe Mongo::Crypt::AutoEncryptionContext do
         let(:kms_providers) do
           {
             aws: {
-              access_key_id: ENV['FLE_AWS_ACCESS_KEY'],
-              secret_access_key: ENV['FLE_AWS_SECRET_ACCESS_KEY']
+              access_key_id: ENV['MONGO_RUBY_DRIVER_AWS_KEY'],
+              secret_access_key: ENV['MONGO_RUBY_DRIVER_AWS_SECRET']
             }
           }
         end

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -32,10 +32,29 @@ describe Mongo::Crypt::ExplicitDecryptionContext do
   end
 
   describe '#initialize' do
-    it 'initializes context' do
-      expect do
-        context
-      end.not_to raise_error
+    context 'when mongocrypt is initialized with local KMS provider options' do
+      it 'initializes context' do
+        expect do
+          context
+        end.not_to raise_error
+      end
+    end
+
+    context 'when mongocrypt is initialized with AWS KMS provider options' do
+      let(:kms_providers) do
+        {
+          aws: {
+            access_key_id: ENV['FLE_AWS_ACCESS_KEY'],
+            secret_access_key: ENV['FLE_AWS_SECRET_ACCESS_KEY']
+          }
+        }
+      end
+
+      it 'initializes context' do
+        expect do
+          context
+        end.not_to raise_error
+      end
     end
 
     context 'with verbose logging' do

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -40,8 +40,8 @@ describe Mongo::Crypt::ExplicitDecryptionContext do
       let(:kms_providers) do
         {
           aws: {
-            access_key_id: ENV['FLE_AWS_ACCESS_KEY'],
-            secret_access_key: ENV['FLE_AWS_SECRET_ACCESS_KEY']
+            access_key_id: ENV['MONGO_RUBY_DRIVER_AWS_KEY'],
+            secret_access_key: ENV['MONGO_RUBY_DRIVER_AWS_SECRET']
           }
         }
       end

--- a/spec/mongo/crypt/explicit_decryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_decryption_context_spec.rb
@@ -1,9 +1,5 @@
 require 'mongo'
-require 'support/lite_constraints'
-
-RSpec.configure do |config|
-  config.extend(LiteConstraints)
-end
+require 'lite_spec_helper'
 
 describe Mongo::Crypt::ExplicitDecryptionContext do
   require_libmongocrypt

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -83,8 +83,8 @@ describe Mongo::Crypt::ExplicitEncryptionContext do
         let(:kms_providers) do
           {
             aws: {
-              access_key_id: ENV['FLE_AWS_ACCESS_KEY'],
-              secret_access_key: ENV['FLE_AWS_SECRET_ACCESS_KEY']
+              access_key_id: ENV['MONGO_RUBY_DRIVER_AWS_KEY'],
+              secret_access_key: ENV['MONGO_RUBY_DRIVER_AWS_SECRET']
             }
           }
         end

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -75,10 +75,29 @@ describe Mongo::Crypt::ExplicitEncryptionContext do
     end
 
     context 'with valid options' do
-      it 'initializes context' do
-        expect do
-          context
-        end.not_to raise_error
+      context 'when mongocrypt is initialized with local KMS provider options' do
+        it 'initializes context' do
+          expect do
+            context
+          end.not_to raise_error
+        end
+      end
+
+      context 'when mongocrypt is initialized with AWS KMS provider options' do
+        let(:kms_providers) do
+          {
+            aws: {
+              access_key_id: ENV['FLE_AWS_ACCESS_KEY'],
+              secret_access_key: ENV['FLE_AWS_SECRET_ACCESS_KEY']
+            }
+          }
+        end
+
+        it 'initializes context' do
+          expect do
+            context
+          end.not_to raise_error
+        end
       end
 
       context 'with verbose logging' do

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -1,9 +1,5 @@
 require 'mongo'
-require 'support/lite_constraints'
-
-RSpec.configure do |config|
-  config.extend(LiteConstraints)
-end
+require 'lite_spec_helper'
 
 describe Mongo::Crypt::ExplicitEncryptionContext do
   require_libmongocrypt


### PR DESCRIPTION
There is some copy + paste in these specs, which I will clean up in a follow-up PR. 