### PR TITLE
RUBY-2105 In auto-encryption, when top-level client disconnects/reconnects, make sure that the slaved clients also reconnect

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -883,7 +883,6 @@ module Mongo
     # for auto-encryption
     def set_auto_encryption_options
       opts_copy = @options[:auto_encryption_options].dup
-      return unless opts_copy
 
       opts_copy[:extra_options] ||= {}
       opts_copy[:extra_options][:mongocryptd_client_monitoring_io] = self.options[:monitoring_io]

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -729,7 +729,9 @@ module Mongo
 
         @cluster = Cluster.new(addresses, monitoring, cluster_options)
 
-        set_auto_encryption_options(@options[:auto_encryption_options])
+        if @options[:auto_encryption_options]
+          set_auto_encryption_options(@options[:auto_encryption_options])
+        end
       end
 
       true

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -161,7 +161,6 @@ module Mongo
       # @return [ true ] Always true
       def teardown_encrypter
         @mongocryptd_client.close if @mongocryptd_client
-        @key_vault_client.close if @key_vault_client
 
         @mongocryptd_client = nil
         @key_vault_client = nil

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -164,6 +164,7 @@ module Mongo
 
         @mongocryptd_client = nil
         @key_vault_client = nil
+        @encryption_options = nil
 
         true
       end

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -59,9 +59,7 @@ module Mongo
           # Mongo::Client used for encryption. Update options so that key vault
           # client does not perform auto-encryption/decryption, and keep a reference
           # to it so it is destroyed later.
-          @key_vault_client = self.with({ auto_encryption_options: nil })
-
-          opts[:key_vault_client] = @key_vault_client
+          opts[:key_vault_client] = self.with({ auto_encryption_options: nil })
         end
 
         mongocryptd_client_monitoring_io = opts.delete(:mongocryptd_client_monitoring_io)
@@ -69,12 +67,14 @@ module Mongo
 
         super(opts)
 
+        @key_vault_client = opts[:key_vault_client]
+
         # Set server selection timeout to 1 to prevent the client waiting for a
         # long timeout before spawning mongocryptd
         @mongocryptd_client = Client.new(
           @encryption_options[:mongocryptd_uri],
           monitoring_io: mongocryptd_client_monitoring_io,
-          server_selection_timeout: 1
+          server_selection_timeout: 1,
         )
 
         # Tests fail with live background threads if the @mongocryptd client is not closed at the

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -165,7 +165,6 @@ module Mongo
 
         @mongocryptd_client = nil
         @key_vault_client = nil
-        @encryption_options = nil
 
         true
       end

--- a/spec/integration/fle_reconnect_spec.rb
+++ b/spec/integration/fle_reconnect_spec.rb
@@ -1,5 +1,29 @@
 require 'spec_helper'
 
 describe 'Client with auto encryption after reconnect' do
+  let(:client) do
+    new_local_client(
+      'mongodb://localhost:27017/test',
+      {
+        auto_encryption_options: {
+          kms_providers: { local: { key: key } },
+          key_vault_namespace: 'admin.datakeys',
+        }
+      }
+    )
+  end
 
+  context 'when reconnecting without closing' do
+
+  end
+
+  context 'when reconnecting after closing' do
+
+  end
+
+  context 'after killing monitor thread' do
+
+  end
+
+  
 end

--- a/spec/integration/fle_reconnect_spec.rb
+++ b/spec/integration/fle_reconnect_spec.rb
@@ -62,24 +62,53 @@ describe 'Client with auto encryption after reconnect' do
     it_behaves_like 'a functioning mongocryptd client'
   end
 
-  context 'after closing and reconnecting main client' do
+  # context 'after closing and reconnecting main client' do
+  #   before do
+  #     client.close
+  #     client.reconnect
+  #   end
 
-  end
+  #   it_behaves_like 'a functioning client'
+  #   it_behaves_like 'a functioning mongocryptd client'
+  # end
 
   context 'after killing client monitor thread' do
+    before do
+      thread = client.cluster.servers.first.monitor.instance_variable_get('@thread')
+      expect(thread).to be_alive
 
+      thread.kill
+
+      sleep 0.1
+      expect(thread).not_to be_alive
+
+      client.reconnect
+    end
+
+    it_behaves_like 'a functioning client'
+    it_behaves_like 'a functioning mongocryptd client'
   end
 
-  context 'after reconnecting without closing mongocryptd client' do
+  # context 'after closing and reconnecting mongocryptd client' do
 
-  end
-
-  context 'after closing and reconnecting mongocryptd client' do
-
-  end
+  # end
 
   context 'after killing mongocryptd client monitor thread' do
+    before do
+      byebug
+      thread = mongocryptd_client.cluster.servers.first.monitor.instance_variable_get('@thread')
+      expect(thread).to be_alive
 
+      thread.kill
+
+      sleep 0.1
+      expect(thread).not_to be_alive
+
+      mongocryptd_client.reconnect
+    end
+
+    it_behaves_like 'a functioning client'
+    it_behaves_like 'a functioning mongocryptd client'
   end
 
 end

--- a/spec/integration/fle_reconnect_spec.rb
+++ b/spec/integration/fle_reconnect_spec.rb
@@ -6,24 +6,80 @@ describe 'Client with auto encryption after reconnect' do
       'mongodb://localhost:27017/test',
       {
         auto_encryption_options: {
-          kms_providers: { local: { key: key } },
+          kms_providers: { local: { key: Base64.encode64('ruby' * 24) } },
           key_vault_namespace: 'admin.datakeys',
         }
       }
     )
   end
 
-  context 'when reconnecting without closing' do
+  let(:mongocryptd_client) { client.mongocryptd_client }
+  let(:key_vault_client) { client.key_vault_client }
+
+  let(:json_schema) do
+    BSON::ExtJSON.parse(File.read('spec/mongo/crypt/data/schema_map.json'))
+  end
+
+  before do
+    client['test'].insert_one('testk' => 'testv')
+  end
+
+  shared_examples 'a functioning client' do
+    it 'can find the document' do
+      doc = client['test'].find('testk' => 'testv').first
+      expect(doc).not_to be_nil
+      expect(doc['testk']).to eq('testv')
+    end
+  end
+
+  shared_examples 'a functioning mongocryptd client' do
+    it 'can perform a schemaRequiresEncryption command' do
+      client.spawn_mongocryptd
+      sleep 5
+      response = mongocryptd_client.database.command(
+        insert: 'users',
+        ordered: true,
+        lsid: { id: BSON::Binary.new("\v8#O\xE6\xF2D\xAF\x85)E\x86\xE9\x06\xF2\x8D", :uuid) },
+        documents: [{
+          ssn: '123-456-7890',
+          _id: BSON::ObjectId('5e16516e781d8a89b94df6df'),
+        }],
+        jsonSchema: json_schema,
+        isRemoteSchema: false
+      )
+
+      expect(response).to be_ok
+      expect(response.documents.first['schemaRequiresEncryption']).to be true
+    end
+  end
+
+  context 'after reconnecting without closing main client' do
+    before do
+      client.reconnect
+    end
+
+    it_behaves_like 'a functioning client'
+    it_behaves_like 'a functioning mongocryptd client'
+  end
+
+  context 'after closing and reconnecting main client' do
 
   end
 
-  context 'when reconnecting after closing' do
+  context 'after killing client monitor thread' do
 
   end
 
-  context 'after killing monitor thread' do
+  context 'after reconnecting without closing mongocryptd client' do
 
   end
 
-  
+  context 'after closing and reconnecting mongocryptd client' do
+
+  end
+
+  context 'after killing mongocryptd client monitor thread' do
+
+  end
+
 end

--- a/spec/integration/fle_reconnect_spec.rb
+++ b/spec/integration/fle_reconnect_spec.rb
@@ -1,0 +1,5 @@
+require 'spec_helper'
+
+describe 'Client with auto encryption after reconnect' do
+
+end

--- a/spec/integration/fle_reconnect_spec.rb
+++ b/spec/integration/fle_reconnect_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'Client with auto encryption after reconnect' do
+describe 'Client with auto encryption #reconnect' do
   require_libmongocrypt
   require_enterprise
 

--- a/spec/integration/fle_reconnect_spec.rb
+++ b/spec/integration/fle_reconnect_spec.rb
@@ -121,6 +121,24 @@ describe 'Client with auto encryption #reconnect' do
       it_behaves_like 'a functioning key vault client'
     end
 
+    context 'after killing mongocryptd client monitor thread and reconnecting' do
+      before do
+        thread = mongocryptd_client.cluster.servers.first.monitor.instance_variable_get('@thread')
+        expect(thread).to be_alive
+
+        thread.kill
+
+        sleep 0.1
+        expect(thread).not_to be_alive
+
+        client.reconnect
+      end
+
+      it_behaves_like 'a functioning client'
+      it_behaves_like 'a functioning mongocryptd client'
+      it_behaves_like 'a functioning key vault client'
+    end
+
     context 'after closing key_vault_client and reconnecting' do
       before do
         key_vault_client.close

--- a/spec/mongo/client_updating_spec.rb
+++ b/spec/mongo/client_updating_spec.rb
@@ -31,20 +31,6 @@ describe Mongo::Client do
       }
     end
 
-    describe '#update_options' do
-      it 'updates auto encryption options' do
-        client.update_options({ auto_encryption_options: new_auto_encryption_options })
-        expect(client.encryption_options[:key_vault_namespace]).to eq('new.namespace')
-      end
-
-      it 'removes auto encryption options' do
-        new_options = { auto_encryption_options: nil }
-        client.update_options(new_options)
-
-        expect(client.encryption_options).to be_nil
-      end
-    end
-
     describe '#with' do
       it 'updates auto encryption options' do
         new_client = client.with({ auto_encryption_options: new_auto_encryption_options })


### PR DESCRIPTION
[https://jira.mongodb.org/browse/RUBY-2105](https://jira.mongodb.org/browse/RUBY-2105)

Test that the master client, mongocryptd_client, and key_vault_client all function when `reconnect` is called on the master client.

I also refactored the logic for updating client_encryption_options. It now tears down all the encryption logic and builds it back up again whenever encryption options change.