### PR TITLE
RUBY-1924 Remove references to multiple replies in Operation::Result

### DIFF
--- a/spec/mongo/collection/view/change_stream_spec.rb
+++ b/spec/mongo/collection/view/change_stream_spec.rb
@@ -723,7 +723,7 @@ describe Mongo::Collection::View::ChangeStream do
 
         let(:error) do
           Mongo::Error::OperationFailure.new('not master',
-            Mongo::Operation::GetMore::Result.new([]))
+            Mongo::Operation::GetMore::Result.new(nil))
         end
 
         it_behaves_like 'a change stream that encounters an error from a getMore'
@@ -733,7 +733,7 @@ describe Mongo::Collection::View::ChangeStream do
 
         let(:error) do
           Mongo::Error::OperationFailure.new('node is recovering',
-            Mongo::Operation::GetMore::Result.new([]))
+            Mongo::Operation::GetMore::Result.new(nil))
         end
 
         it_behaves_like 'a change stream that encounters an error from a getMore'

--- a/spec/mongo/error/operation_failure_spec.rb
+++ b/spec/mongo/error/operation_failure_spec.rb
@@ -72,7 +72,7 @@ describe Mongo::Error::OperationFailure do
     context 'when there is a network error' do
       context 'getMore' do
         let(:error) { Mongo::Error::OperationFailure.new('problem: socket exception',
-          Mongo::Operation::GetMore::Result.new([])) }
+          Mongo::Operation::GetMore::Result.new(nil)) }
 
         it 'returns true' do
           expect(error.change_stream_resumable?).to be true
@@ -91,7 +91,7 @@ describe Mongo::Error::OperationFailure do
     context 'when there is a resumable message' do
       context 'getMore response' do
         let(:error) { Mongo::Error::OperationFailure.new('problem: node is recovering',
-          Mongo::Operation::GetMore::Result.new([])) }
+          Mongo::Operation::GetMore::Result.new(nil)) }
 
         it 'returns true' do
           expect(error.change_stream_resumable?).to eql(true)
@@ -110,7 +110,7 @@ describe Mongo::Error::OperationFailure do
     context 'when there is a resumable code' do
       context 'getMore response' do
         let(:error) { Mongo::Error::OperationFailure.new('no message',
-          Mongo::Operation::GetMore::Result.new([]),
+          Mongo::Operation::GetMore::Result.new(nil),
           :code => 91, :code_name => 'ShutdownInProgress') }
 
         it 'returns true' do
@@ -131,7 +131,7 @@ describe Mongo::Error::OperationFailure do
     context 'when there is a non-resumable code' do
       context 'getMore response' do
         let(:error) { Mongo::Error::OperationFailure.new('no message',
-          Mongo::Operation::GetMore::Result.new([]),
+          Mongo::Operation::GetMore::Result.new(nil),
           :code => 136, :code_name => 'CappedPositionLost') }
 
         it 'returns false' do
@@ -152,7 +152,7 @@ describe Mongo::Error::OperationFailure do
     context 'when there is a non-resumable label' do
       context 'getMore response' do
         let(:error) { Mongo::Error::OperationFailure.new('no message',
-          Mongo::Operation::GetMore::Result.new([]),
+          Mongo::Operation::GetMore::Result.new(nil),
           :code => 91, :code_name => 'ShutdownInProgress',
           :labels => ['NonResumableChangeStreamError']) }
 
@@ -175,7 +175,7 @@ describe Mongo::Error::OperationFailure do
     context 'when there is another label' do
       context 'getMore response' do
         let(:error) { Mongo::Error::OperationFailure.new('no message',
-          Mongo::Operation::GetMore::Result.new([]),
+          Mongo::Operation::GetMore::Result.new(nil),
           :code => 91, :code_name => 'ShutdownInProgress',
           :labels => %w(TransientTransactionError)) }
 


### PR DESCRIPTION
The driver currently supports either zero or one replies per operation.
Remove references to multiple replies.

This commit also revises docstrings in Operation::Result to match
current code behavior.