### PR TITLE
RUBY-2008 Allow user to specify key alt names when creating a data key

### DIFF
--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -44,7 +44,7 @@ module Mongo
     #   "aws" and "local".
     # @params [ Hash ] options
     #
-    # @option [ Hash ] :master_key Information about the AWS master key. Required
+    # @option options [ Hash ] :master_key Information about the AWS master key. Required
     #   if kms_provider is "aws".
     #   - :region [ String ] The The AWS region of the master key (required).
     #   - :key [ String ] The Amazon Resource Name (ARN) of the master key (required).
@@ -53,7 +53,7 @@ module Mongo
     #     by a colon (e.g. "kms.us-east-1.amazonaws.com" or
     #     "kms.us-east-1.amazonaws.com:443"). An endpoint in any other format
     #     will not be properly parsed.
-    # @option [ Array<String> ] :key_alt_names An optional array of strings specifying
+    # @option options [ Array<String> ] :key_alt_names An optional array of strings specifying
     #   alternate names for the new data key.
     #
     # @return [ String ] Base64-encoded UUID string representing the
@@ -74,24 +74,24 @@ module Mongo
     # Encrypts a value using the specified encryption key and algorithm
     #
     # @param [ Object ] value The value to encrypt
-    # @param [ Hash ] opts
+    # @param [ Hash ] options
     #
-    # @option [ String ] :key_id The base64-encoded UUID of the encryption
+    # @option options [ String ] :key_id The base64-encoded UUID of the encryption
     #   key as it is stored in the key vault collection
-    # @option [ String ] :algorithm The algorithm used to encrypt the value.
+    # @option options [ String ] :algorithm The algorithm used to encrypt the value.
     #   Valid algorithms are "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
     #   or "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
     #
     # @return [ BSON::Binary ] A BSON Binary object of subtype 6 (ciphertext)
     #   representing the encrypted value
-    def encrypt(value, opts={})
+    def encrypt(value, options={})
       doc = { 'v': value }
 
       Crypt::ExplicitEncryptionContext.new(
         @crypt_handle,
         @encryption_io,
         doc,
-        opts
+        options
       ).run_state_machine['v']
     end
 

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -53,7 +53,7 @@ module Mongo
     #     by a colon (e.g. "kms.us-east-1.amazonaws.com" or
     #     "kms.us-east-1.amazonaws.com:443"). An endpoint in any other format
     #     will not be properly parsed.
-    # @option [ Array ] :key_alt_names An optional array of strings, specifying
+    # @option [ Array ] :key_alt_names An optional array of strings specifying
     #   alternate names for the new data key.
     #
     # @return [ String ] Base64-encoded UUID string representing the

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -53,7 +53,7 @@ module Mongo
     #     by a colon (e.g. "kms.us-east-1.amazonaws.com" or
     #     "kms.us-east-1.amazonaws.com:443"). An endpoint in any other format
     #     will not be properly parsed.
-    # @option [ Array ] :key_alt_names An optional array of strings specifying
+    # @option [ Array<String> ] :key_alt_names An optional array of strings specifying
     #   alternate names for the new data key.
     #
     # @return [ String ] Base64-encoded UUID string representing the

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -53,6 +53,8 @@ module Mongo
     #     by a colon (e.g. "kms.us-east-1.amazonaws.com" or
     #     "kms.us-east-1.amazonaws.com:443"). An endpoint in any other format
     #     will not be properly parsed.
+    # @option [ Array ] :key_alt_names An optional array of strings, specifying
+    #   alternate names for the new data key.
     #
     # @return [ String ] Base64-encoded UUID string representing the
     #   data key _id

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -38,15 +38,15 @@ module Mongo
       #
       # @param [ Hash ] options
       #
-      # @option [ Mongo::Client ] :key_vault_client A client connected
+      # @option options [ Mongo::Client ] :key_vault_client A client connected
       #   to the MongoDB instance containing the encryption key vault.
-      # @option [ String ] :key_vault_namespace The namespace of the key
+      # @option options [ String ] :key_vault_namespace The namespace of the key
       #   vault in the format database.collection.
-      # @option [ Hash | nil ] :schema_map The JSONSchema of the collection(s)
+      # @option options [ Hash | nil ] :schema_map The JSONSchema of the collection(s)
       #   with encrypted fields.
-      # @option [ Boolean | nil ] :bypass_auto_encryption When true, disables
+      # @option options [ Boolean | nil ] :bypass_auto_encryption When true, disables
       #   auto-encryption. Default is false.
-      # @option [ Hash | nil ] :extra_options Options related to spawning
+      # @option options [ Hash | nil ] :extra_options Options related to spawning
       #   mongocryptd. These are set to default values if no option is passed in.
       #
       # @raise [ ArgumentError ] If required options are missing or incorrectly

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -394,30 +394,31 @@ module Mongo
         end
       end
 
-      # Set a key_alt_name on data key creation or explicit encryption
+      # When creating a data key, set an alternate name on that key. When
+      # performing explicit encryption, specifying which data key to use for
+      # encryption based on its keyAltName field.
       #
       # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
       # @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t
       #   object that references a BSON document in the format
       #   { "keyAltName": <BSON UTF8 value> }
       #
-      # @ return [ Boolean ] Whether the key alt name was successfully set
+      # @return [ Boolean ] Whether the alternative name was successfully set
       #
       # @note Do not initialize ctx before calling this method
-      # @return [ Boolean ] Whether the option was successfully set
       attach_function(
         :mongocrypt_ctx_setopt_key_alt_name,
         [:pointer, :pointer],
         :bool
       )
 
-      # Set key_alt_names on data key creation
+      # Set multiple alternate key names on data key creation
       #
       # @param [ Mongo::Crypt::Context ] context A DataKeyContext
-      # @param [ Array ] key_alt_names An array of string key_alt_names
+      # @param [ Array ] key_alt_names An array of alternate key names as strings
       #
-      # @raise [ Mongo::Error::CryptError ] If any of the key alt names are
-      #   not accepted
+      # @raise [ Mongo::Error::CryptError ] If any of the alternate names are
+      #   not valid UTF8 strings
       def self.ctx_setopt_key_alt_names(context, key_alt_names)
         key_alt_names.each do |key_alt_name|
           alt_name_binary = { :keyAltName => key_alt_name }.to_bson.to_s

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -421,11 +421,11 @@ module Mongo
       #   not valid UTF8 strings
       def self.ctx_setopt_key_alt_names(context, key_alt_names)
         key_alt_names.each do |key_alt_name|
-          alt_name_binary = { :keyAltName => key_alt_name }.to_bson.to_s
+          key_alt_name_bson = { :keyAltName => key_alt_name }.to_bson.to_s
 
-          Binary.wrap_string(alt_name_binary) do |alt_name_p|
+          Binary.wrap_string(key_alt_name_bson) do |key_alt_name_p|
             check_ctx_status(context) do
-              mongocrypt_ctx_setopt_key_alt_name(context.ctx_p, alt_name_p)
+              mongocrypt_ctx_setopt_key_alt_name(context.ctx_p, key_alt_name_p)
             end
           end
         end

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -382,7 +382,7 @@ module Mongo
 
       # Sets the key id option on an explicit encryption context.
       #
-      # @param [ Context ] context Explicit encryption context
+      # @param [ Mongo::Crypt::Context ] context Explicit encryption context
       # @param [ String ] key_id The key id
       #
       # @raise [ Mongo::Error::CryptError ] If the operation failed
@@ -390,6 +390,42 @@ module Mongo
         Binary.wrap_string(key_id) do |key_id_p|
           check_ctx_status(context) do
             mongocrypt_ctx_setopt_key_id(context.ctx_p, key_id_p)
+          end
+        end
+      end
+
+      # Set a key_alt_name on data key creation or explicit encryption
+      #
+      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
+      # @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t
+      #   object that references a BSON document in the format
+      #   { "keyAltName": <BSON UTF8 value> }
+      #
+      # @ return [ Boolean ] Whether the key alt name was successfully set
+      #
+      # @note Do not initialize ctx before calling this method
+      # @return [ Boolean ] Whether the option was successfully set
+      attach_function(
+        :mongocrypt_ctx_setopt_key_alt_name,
+        [:pointer, :pointer],
+        :bool
+      )
+
+      # Set key_alt_names on data key creation
+      #
+      # @param [ Mongo::Crypt::Context ] context A DataKeyContext
+      # @param [ Array ] key_alt_names An array of string key_alt_names
+      #
+      # @raise [ Mongo::Error::CryptError ] If any of the key alt names are
+      #   not accepted
+      def self.ctx_setopt_key_alt_names(context, key_alt_names)
+        key_alt_names.each do |key_alt_name|
+          alt_name_binary = { :keyAltName => key_alt_name }.to_bson.to_s
+
+          Binary.wrap_string(alt_name_binary) do |alt_name_p|
+            check_ctx_status(context) do
+              mongocrypt_ctx_setopt_key_alt_name(context.ctx_p, alt_name_p)
+            end
           end
         end
       end

--- a/lib/mongo/crypt/data_key_context.rb
+++ b/lib/mongo/crypt/data_key_context.rb
@@ -36,7 +36,7 @@ module Mongo
       #   - :region [ String ] The The AWS region of the master key (required).
       #   - :key [ String ] The Amazon Resource Name (ARN) of the master key (required).
       #   - :endpoint [ String ] An alternate host to send KMS requests to (optional).
-      # @option [ Array ] :key_alt_names An optional array of strings specifying
+      # @option [ Array<String> ] :key_alt_names An optional array of strings specifying
       #   alternate names for the new data key.
       def initialize(mongocrypt, io, kms_provider, options={})
         super(mongocrypt, io)

--- a/lib/mongo/crypt/data_key_context.rb
+++ b/lib/mongo/crypt/data_key_context.rb
@@ -31,12 +31,12 @@ module Mongo
       #   "aws" and "local".
       # @param [ Hash ] options Data key creation options.
       #
-      # @option [ Hash ] :master_key A Hash of options related to the AWS
+      # @option options [ Hash ] :master_key A Hash of options related to the AWS
       #   KMS provider option. Required if kms_provider is "aws".
       #   - :region [ String ] The The AWS region of the master key (required).
       #   - :key [ String ] The Amazon Resource Name (ARN) of the master key (required).
       #   - :endpoint [ String ] An alternate host to send KMS requests to (optional).
-      # @option [ Array<String> ] :key_alt_names An optional array of strings specifying
+      # @option options [ Array<String> ] :key_alt_names An optional array of strings specifying
       #   alternate names for the new data key.
       def initialize(mongocrypt, io, kms_provider, options={})
         super(mongocrypt, io)

--- a/lib/mongo/crypt/data_key_context.rb
+++ b/lib/mongo/crypt/data_key_context.rb
@@ -36,7 +36,7 @@ module Mongo
       #   - :region [ String ] The The AWS region of the master key (required).
       #   - :key [ String ] The Amazon Resource Name (ARN) of the master key (required).
       #   - :endpoint [ String ] An alternate host to send KMS requests to (optional).
-      # @option [ Array ] :key_alt_names An optional array of strings, specifying
+      # @option [ Array ] :key_alt_names An optional array of strings specifying
       #   alternate names for the new data key.
       def initialize(mongocrypt, io, kms_provider, options={})
         super(mongocrypt, io)

--- a/lib/mongo/crypt/data_key_context.rb
+++ b/lib/mongo/crypt/data_key_context.rb
@@ -146,7 +146,7 @@ module Mongo
         unless key_alt_names.all? { |key_alt_name| key_alt_name.is_a?(String) }
           raise ArgumentError.new(
             "#{key_alt_names} contains an invalid alternate key name. All " +
-            "values of the :key_alt_names option Array must be a String"
+            "values of the :key_alt_names option Array must be Strings"
           )
         end
 

--- a/lib/mongo/crypt/data_key_context.rb
+++ b/lib/mongo/crypt/data_key_context.rb
@@ -36,6 +36,8 @@ module Mongo
       #   - :region [ String ] The The AWS region of the master key (required).
       #   - :key [ String ] The Amazon Resource Name (ARN) of the master key (required).
       #   - :endpoint [ String ] An alternate host to send KMS requests to (optional).
+      # @option [ Array ] :key_alt_names An optional array of strings, specifying
+      #   alternate names for the new data key.
       def initialize(mongocrypt, io, kms_provider, options={})
         super(mongocrypt, io)
 
@@ -68,6 +70,7 @@ module Mongo
           )
         end
 
+        set_key_alt_names(options[:key_alt_names]) if options[:key_alt_names]
         initialize_ctx
       end
 
@@ -132,6 +135,22 @@ module Mongo
         end
 
         Binding.ctx_setopt_master_key_aws_endpoint(self, endpoint)
+      end
+
+      # Set the alt names option on the context
+      def set_key_alt_names(key_alt_names)
+        unless key_alt_names.is_a?(Array)
+          raise ArgumentError.new, 'The :key_alt_names option must be an Array'
+        end
+
+        unless key_alt_names.all? { |key_alt_name| key_alt_name.is_a?(String) }
+          raise ArgumentError.new(
+            "#{key_alt_names} contains an invalid alternate key name. All " +
+            "values of the :key_alt_names option Array must be a String"
+          )
+        end
+
+        Binding.ctx_setopt_key_alt_names(self, key_alt_names)
       end
 
       # Initializes the underlying mongocrypt_ctx_t object

--- a/lib/mongo/crypt/encrypter.rb
+++ b/lib/mongo/crypt/encrypter.rb
@@ -26,9 +26,9 @@ module Mongo
       #
       # @param options [ Hash ] options
       #
-      # @option [ Mongo::Client ] :key_vault_client A client connected
+      # @option options [ Mongo::Client ] :key_vault_client A client connected
       #   to the MongoDB instance containing the encryption key vault.
-      # @option [ String ] :key_vault_namespace The namespace of the key
+      # @option options [ String ] :key_vault_namespace The namespace of the key
       #   vault in the format database.collection.
       #
       # @raise [ ArgumentError ] If required options are missing or incorrectly

--- a/lib/mongo/crypt/explicit_encryption_context.rb
+++ b/lib/mongo/crypt/explicit_encryption_context.rb
@@ -30,9 +30,9 @@ module Mongo
       # @param [ BSON::Document ] doc A document to encrypt
       # @param [ Hash ] options
       #
-      # @option [ String ] :key_id The UUID of the data key that
+      # @option options [ String ] :key_id The UUID of the data key that
       #   will be used to encrypt the value
-      # @option [ String ] :algorithm The algorithm used to encrypt the
+      # @option options [ String ] :algorithm The algorithm used to encrypt the
       #   value. Valid algorithms are "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
       #   or "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
       #

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -32,9 +32,9 @@ module Mongo
       #   96-byte, base64 encoded string.
       # @param [ Hash ] options A hash of options
       #
-      # @option [ Hash | nil ] :schema_map A hash representing the JSON schema
+      # @option options [ Hash | nil ] :schema_map A hash representing the JSON schema
       #   of the collection that stores auto encrypted documents.
-      # @option [ Logger ] :logger A Logger object to which libmongocrypt logs
+      # @option options [ Logger ] :logger A Logger object to which libmongocrypt logs
       #   will be sent
       def initialize(kms_providers, options={})
         # FFI::AutoPointer uses a custom release strategy to automatically free

--- a/spec/mongo/crypt/data_key_context_spec.rb
+++ b/spec/mongo/crypt/data_key_context_spec.rb
@@ -13,9 +13,62 @@ describe Mongo::Crypt::DataKeyContext do
   let(:io) { double("Mongo::Crypt::EncryptionIO") }
 
   let(:context) { described_class.new(mongocrypt, io, kms_provider_name, options) }
-  let(:options) { {} }
+  let(:base_options) { {} }
+  let(:options) { base_options }
 
   describe '#initialize' do
+    shared_examples 'it properly sets key_alt_names' do
+      context 'with one key_alt_names' do
+        let(:options) { base_options.merge(key_alt_names: ['keyAltName1']) }
+
+        it 'does not raise an exception' do
+          expect do
+            context
+          end.not_to raise_error
+        end
+      end
+
+      context 'with multiple key_alt_names' do
+        let(:options) { base_options.merge(key_alt_names: ['keyAltName1', 'keyAltName2']) }
+
+        it 'does not raise an exception' do
+          expect do
+            context
+          end.not_to raise_error
+        end
+      end
+
+      context 'with empty key_alt_names' do
+        let(:options) { base_options.merge(key_alt_names: []) }
+
+        it 'does not raise an exception' do
+          expect do
+            context
+          end.not_to raise_error
+        end
+      end
+
+      context 'with invalid key_alt_names' do
+        let(:options) { base_options.merge(key_alt_names: ['keyAltName1', 3]) }
+
+        it 'does raises an exception' do
+          expect do
+            context
+          end.to raise_error(ArgumentError, /All values of the :key_alt_names option Array must be a String/)
+        end
+      end
+
+      context 'with non-array key_alt_names' do
+        let(:options) { base_options.merge(key_alt_names: "keyAltName1") }
+
+        it 'does raises an exception' do
+          expect do
+            context
+          end.to raise_error(ArgumentError, /key_alt_names option must be an Array/)
+        end
+      end
+    end
+
     context 'with invalid kms provider'do
       let(:kms_providers) { local_kms_providers }
       let(:kms_provider_name) { 'invalid' }
@@ -30,6 +83,8 @@ describe Mongo::Crypt::DataKeyContext do
     context 'with local kms provider and empty options' do
       include_context 'with local kms_providers'
 
+      it_behaves_like 'it properly sets key_alt_names'
+
       it 'does not raise an exception' do
         expect do
           context
@@ -39,6 +94,10 @@ describe Mongo::Crypt::DataKeyContext do
 
     context 'with aws kms provider' do
       include_context 'with AWS kms_providers'
+
+      let(:base_options) { { master_key: { region: 'us-east-2', key: 'arn' } } }
+
+      it_behaves_like 'it properly sets key_alt_names'
 
       context 'with empty options' do
         let(:options) { {} }
@@ -121,8 +180,6 @@ describe Mongo::Crypt::DataKeyContext do
       end
 
       context 'with valid options' do
-        let(:options) { { master_key: { region: 'us-east-2', key: 'arn' } } }
-
         it 'does not raise an exception' do
           expect do
             context

--- a/spec/mongo/crypt/data_key_context_spec.rb
+++ b/spec/mongo/crypt/data_key_context_spec.rb
@@ -54,7 +54,7 @@ describe Mongo::Crypt::DataKeyContext do
         it 'does raises an exception' do
           expect do
             context
-          end.to raise_error(ArgumentError, /All values of the :key_alt_names option Array must be a String/)
+          end.to raise_error(ArgumentError, /All values of the :key_alt_names option Array must be Strings/)
         end
       end
 


### PR DESCRIPTION
This is the first PR of a few, with the purpose of making it possible to refer to encryption keys by alternate names.