### PR TITLE
RUBY-2142 Add a filter option to list_collections

### DIFF
--- a/lib/mongo/crypt/encryption_io.rb
+++ b/lib/mongo/crypt/encryption_io.rb
@@ -80,7 +80,7 @@ module Mongo
       #
       # @return [ Hash ] The collection information
       def collection_info(filter)
-        @client.database.list_collections(filter).first
+        @client.database.list_collections(filter: filter).first
       end
 
       # Send the command to mongocryptd to be marked with intent-to-encrypt markings

--- a/lib/mongo/crypt/encryption_io.rb
+++ b/lib/mongo/crypt/encryption_io.rb
@@ -80,10 +80,7 @@ module Mongo
       #
       # @return [ Hash ] The collection information
       def collection_info(filter)
-        result = @client.database.list_collections
-
-        name = filter['name']
-        result.find { |r| r['name'] == name }
+        @client.database.list_collections(filter).first
       end
 
       # Send the command to mongocryptd to be marked with intent-to-encrypt markings

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -130,8 +130,8 @@ module Mongo
     #   collection in the database.
     #
     # @since 2.0.5
-    def list_collections
-      View.new(self).list_collections
+    def list_collections(filter={})
+      View.new(self).list_collections(filter)
     end
 
     # Get all the non-system collections that belong to this database.

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -126,16 +126,18 @@ module Mongo
     #   information hash per collection, depends on the MongoDB server
     #   version that fulfills the request.
     #
-    # @param [ Hash ] filter A filter on the collections returned by
-    #   this command. See https://docs.mongodb.com/manual/reference/command/listCollections/
-    #   for documentation on the filter option.
+    # @param [ Hash ] options
+    #
+    # @option options [ Hash ] :filter A filter on the collections returned.
+    #   See https://docs.mongodb.com/manual/reference/command/listCollections/
+    #   for more information and usage.
     #
     # @return [ Array<Hash> ] Array of information hashes, one for each
     #   collection in the database.
     #
     # @since 2.0.5
-    def list_collections(filter={})
-      View.new(self).list_collections(filter: filter)
+    def list_collections(**options)
+      View.new(self).list_collections(options)
     end
 
     # Get all the non-system collections that belong to this database.

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -137,7 +137,7 @@ module Mongo
     #
     # @since 2.0.5
     def list_collections(**options)
-      View.new(self).list_collections(options)
+      View.new(self).list_collections(**options)
     end
 
     # Get all the non-system collections that belong to this database.

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -127,14 +127,15 @@ module Mongo
     #   version that fulfills the request.
     #
     # @param [ Hash ] filter A filter on the collections returned by
-    #   this command.
+    #   this command. See https://docs.mongodb.com/manual/reference/command/listCollections/
+    #   for documentation on the filter option.
     #
     # @return [ Array<Hash> ] Array of information hashes, one for each
     #   collection in the database.
     #
     # @since 2.0.5
     def list_collections(filter={})
-      View.new(self).list_collections(filter)
+      View.new(self).list_collections(filter: filter)
     end
 
     # Get all the non-system collections that belong to this database.

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -126,6 +126,9 @@ module Mongo
     #   information hash per collection, depends on the MongoDB server
     #   version that fulfills the request.
     #
+    # @param [ Hash ] filter A filter on the collections returned by
+    #   this command.
+    #
     # @return [ Array<Hash> ] Array of information hashes, one for each
     #   collection in the database.
     #

--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -88,8 +88,6 @@ module Mongo
       #
       # @since 2.0.5
       def list_collections(**options)
-        filter = options[:filter] || {}
-
         session = client.send(:get_session)
         collections_info(session, ServerSelector.primary, options)
       end

--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -91,7 +91,7 @@ module Mongo
         filter = options[:filter] || {}
 
         session = client.send(:get_session)
-        collections_info(session, ServerSelector.primary, { filter: filter })
+        collections_info(session, ServerSelector.primary, options)
       end
 
       # Create the new database view.

--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -81,9 +81,9 @@ module Mongo
       # @return [ Array<Hash> ] Info for each collection in the database.
       #
       # @since 2.0.5
-      def list_collections
+      def list_collections(filter={})
         session = client.send(:get_session)
-        collections_info(session, ServerSelector.primary)
+        collections_info(session, ServerSelector.primary, { filter: filter })
       end
 
       # Create the new database view.
@@ -157,7 +157,10 @@ module Mongo
             cursor: batch_size ? { batchSize: batch_size } : {} },
           db_name: @database.name,
           session: session
-        }.tap { |spec| spec[:selector][:nameOnly] = true if options[:name_only] }
+        }.tap do |spec|
+          spec[:selector][:nameOnly] = true if options[:name_only]
+          spec[:selector][:filter] = options[:filter] if options[:filter]
+        end
       end
 
       def initial_query_op(session, options = {})

--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -78,10 +78,18 @@ module Mongo
       # @example Get info on each collection.
       #   database.list_collections
       #
+      # @param [ Hash ] options
+      #
+      # @option options [ Hash ] :filter A filter on the collections returned.
+      #   See https://docs.mongodb.com/manual/reference/command/listCollections/
+      #   for more information and usage.
+      #
       # @return [ Array<Hash> ] Info for each collection in the database.
       #
       # @since 2.0.5
-      def list_collections(filter={})
+      def list_collections(**options)
+        filter = options[:filter] || {}
+
         session = client.send(:get_session)
         collections_info(session, ServerSelector.primary, { filter: filter })
       end

--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -89,7 +89,7 @@ module Mongo
       # @since 2.0.5
       def list_collections(**options)
         session = client.send(:get_session)
-        collections_info(session, ServerSelector.primary, options)
+        collections_info(session, ServerSelector.primary, **options)
       end
 
       # Create the new database view.

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -185,6 +185,8 @@ describe Mongo::Database do
         before do
           database[:anothercol].drop
           database[:anothercol].create
+
+          expect(database.collections.length).to be > 1
         end
 
         let(:result) do

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -180,6 +180,24 @@ describe Mongo::Database do
       it 'returns a list of the collections info' do
         expect(result).to include('acol')
       end
+
+      context 'with more than one collection' do
+        before do
+          database[:anothercol].drop
+          database[:anothercol].create
+        end
+
+        let(:result) do
+          database.list_collections(name: 'anothercol').map do |info|
+            info['name']
+          end
+        end
+
+        it 'can filter by collection name' do
+          expect(result.length).to eq(1)
+          expect(result.first).to eq('anothercol')
+        end
+      end
     end
 
     context 'server 2.6' do

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -190,7 +190,7 @@ describe Mongo::Database do
         end
 
         let(:result) do
-          database.list_collections(name: 'anothercol').map do |info|
+          database.list_collections(filter: { name: 'anothercol' }).map do |info|
             info['name']
           end
         end


### PR DESCRIPTION
Integrating with libmongocrypt requires listCollections to be performed with a filter, which Ruby hasn't supported. I've been hacking around it, but that makes the FLE command monitoring specs fail, so I figured I would fix this if it was easy and didn't break the user-facing API. Let me know if you think this is okay and I'll make a JIRA ticket for it as well.