### PR TITLE
RUBY-1974 Add a tutorial for Automatic Encryption

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -77,6 +77,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mong
       /tutorials/ruby-driver-text-search
       /tutorials/ruby-driver-geospatial-search
       /tutorials/ruby-driver-gridfs
+      /tutorials/client-side-encryption
       bson-tutorials
       API <http://api.mongodb.com/ruby/current/>
       /reference/driver-compatibility

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -35,10 +35,10 @@ on the machine running your Ruby program.
 
 To download a pre-built binary:
 
-- Download a tarball of all libmongocrypt variations from this `AWS bucket <https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz>`_.
+- Download a tarball of all libmongocrypt variations `here <https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz>`_.
 
-- Unzip the file you downloaded. You will see a list of folders, each
-  corresponding to an operating system. Find the folder that matches your
+- Extract the file you downloaded. You will see a list of directories, each
+  corresponding to an operating system. Find the directory that matches your
   operating system and open it.
 
 - Inside that folder, open the folder called "nocrypto." In either the
@@ -48,9 +48,9 @@ To download a pre-built binary:
 - Move that file to wherever you want to keep it on your machine. You may delete
   the other files included in the tarball.
 
-To build binary from source:
+To build the binary from source:
 
-- Follow the instructions in the README on the `libmongocrypt GitHub repo <https://github.com/mongodb/libmongocrypt>`_.
+- Follow the instructions in the README in the `libmongocrypt GitHub repo <https://github.com/mongodb/libmongocrypt>`_.
 
 Once you have the libmongocrypt binary on your machine, specify the path to the
 binary using the LIBMONGOCRYPT_PATH environment variable. It is recommended that
@@ -90,6 +90,8 @@ master key.
   require 'mongo'
 
   # Generate a local encryption master key
+  # To reuse this master key, persist it to a file or environment variable
+  # on your machine.
   local_master_key = Base64.encode64(SecureRandom.random_bytes(96))
 
   kms_providers = {
@@ -111,7 +113,7 @@ master key.
 
   data_key_id = client_encryption.create_data_key('local')
 
-  # Create schema map
+  # Create a schema map
   schema_map = {
     'encryption_db.encryption_coll': {
       properties: {
@@ -127,7 +129,7 @@ master key.
     }
   }
 
-  # Configure client for automatic encryption
+  # Configure the client for automatic encryption
   client = Mongo::Client.new(
     ['localhost:27017'],
     auto_encryption_options: {

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -9,7 +9,7 @@ Client-Side Encryption
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
 New in MongoDB 4.2, client-side encryption allows administrators and developers
@@ -50,8 +50,7 @@ To download a pre-built binary (recommended):
 
 To build from source:
 
-- Follow the instructions in the README on the libmongocrypt GitHub repo:
-  https://github.com/mongodb/libmongocrypt.
+- Follow the instructions in the README on the `libmongocrypt GitHub repo <https://github.com/mongodb/libmongocrypt>`_.
 
 mongocryptd
 ~~~~~~~~~~~
@@ -63,6 +62,69 @@ skip this step.
 
 Mongocryptd comes pre-packaged with enterprise builds of the MongoDB server
 (versions 4.2 and newer). If you must install mongocryptd separately, follow
-the installation instructions on this page:
-https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/#installation.
+the `installation instructions in the MongoDB manual <https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/#installation>`_.
+
+Automatic Encryption
+--------------------
+
+Automatic encryption is a feature that allows users to configure a
+``Mongo::Client`` instance to always encrypt specific data fields when performing
+document operations. Once the ``Mongo::Client`` is configured, the experience of
+using it is unchanged, but it automatically encrypts fields when writing data to
+the database and automatically decrypts fields when reading data. Automatic
+encryption is an enterprise feature.
+
+Creating a Master Key
+~~~~~~~~~~~~~~~~~~~~~
+
+The first step to configuting an auto-encryption client is to create an encryption
+master key and set up the key management service (KMS) that you plan to use. You may
+either set up a local master key or use Amazon's AWS Key Management Service. In
+both cases, you must set up the ``:kms_providers`` option, which you will use to
+create encryption data keys and configure the ``Mongo::Client`` instance used
+to encrypt data.
+
+1. Local KMS Setup
+To set up local KMS information, you must generate a new master key. A local
+master key is a Base64-encoded 96-byte string.
+
+.. code-block:: ruby
+
+  require 'base64'
+  require 'securerandom'
+
+  key = Base64.encode64(SecureRandom.random_bytes(96))
+  kms_providers = {
+    local: {
+      key: key
+    }
+  }
+
+1. AWS KMS Setup
+To use the AWS KMS provider, create an encryption master key in the AWS Key
+Management Service. For more information, read the
+`Amazon Web Services KMS section in the MongoDB Manual <https://docs.mongodb.com/manual/core/security-client-side-encryption-key-management/#field-level-encryption-aws-kms>`_.
+
+Locate the access key and secret access key for the IAM user who has permissions
+to use your AWS master key, and use that information to create the ``:kms_providers``
+option:
+
+.. code-block:: ruby
+
+  kms_providers = {
+    aws: {
+      access_key_id: "YOUR AWS ACCESS KEY ID",
+      secret_access_key: "YOUR AWS SECRET ACCESS KEY"
+    }
+  }
+
+Creating a Data Key
+~~~~~~~~~~~~~~~~~~~
+
+It is necessary to 
+
+
+Explicit Encryption
+-------------------
+Documentation for explicit encryption will be provided soon.
 

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -158,21 +158,21 @@ returns its Base64-encoded 16-byte UUID.
 
 *Option 1: Create a data key using a local master key*
 
-  .. code-block::ruby
+.. code-block:: ruby
 
-    data_key_id = client_encryption.create_data_key('local')
+  data_key_id = client_encryption.create_data_key('local')
 
 *Option 2: Create a data key using an AWS master key*
 
-  .. code-block::ruby
+.. code-block:: ruby
 
-    data_key_id = client_encryption.create_data_key(
-      'aws',
-      {
-        region: "YOUR AWS REGION",
-        key: "MASTER KEY ARN"
-      }
-    )
+  data_key_id = client_encryption.create_data_key(
+    'aws',
+    {
+      region: "YOUR AWS REGION",
+      key: "MASTER KEY ARN"
+    }
+  )
 
 Creating a Schema Map
 ~~~~~~~~~~~~~~~~~~~~~

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -48,9 +48,16 @@ To download a pre-built binary (recommended):
 - Move that file to wherever you want to keep it on your machine. You may delete
   the other files included in the tarball.
 
-To build from source:
+To build binary from source:
 
 - Follow the instructions in the README on the `libmongocrypt GitHub repo <https://github.com/mongodb/libmongocrypt>`_.
+
+Once you have the libmongocrypt binary on your machine, specify the path to the
+binary using the LIBMONGOCRYPT_PATH environment variable. It is recommended that
+you add this variable to your rc files. For example:
+
+.. code-block:: bash
+  export LIBMONGOCRYPT_PATH=/path/to/your/libmongocrypt.so
 
 mongocryptd
 ~~~~~~~~~~~

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -9,7 +9,7 @@ Client-Side Encryption
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 2
+   :depth: 1
    :class: singlecol
 
 New in MongoDB 4.2, client-side encryption allows administrators and developers
@@ -69,13 +69,92 @@ Automatic Encryption
 
 Automatic encryption is a feature that allows users to configure a
 ``Mongo::Client`` instance to always encrypt specific data fields when performing
-document operations. Once the ``Mongo::Client`` is configured, the experience of
-using it is unchanged, but it automatically encrypts fields when writing data to
-the database and automatically decrypts fields when reading data. Automatic
-encryption is an enterprise feature.
+document operations. Once the ``Mongo::Client`` is configured, it can be used
+to read and write data in a typical manner. However, a properly configured client
+will automatically encrypt data when writing to the database and automatically
+decrypt data when reading. Automatic encryption is an enterprise-only feature
+and is only applied to operations on a collection.
+
+The following example provides a demonstration of auto-encryption using a local
+master key. See the later sections of this tutorial for more information on
+creating a master key, creating a data key, and creating a schema map.
+
+.. code-block:: ruby
+
+  require 'base64'
+  require 'bson'
+  require 'securerandom'
+
+  # Generate a local encryption master key
+  local_master_key = Base64.encode64(SecureRandom.random_bytes(96))
+
+  kms_providers = {
+    local: {
+      key: local_master_key
+    }
+  }
+
+  # Create an encryption data key and insert it into the key vault collection
+  key_vault_client = Mongo::Client.new(['localhost:27017'])
+
+  client_encryption = Mongo::ClientEncryption.new(
+    key_vault_client,
+    {
+      key_vault_namespace: 'admin.datakeys',
+      kms_providers: kms_providers
+    }
+  )
+
+  data_key_id = client_encryption.create_data_key('local')
+
+  # Create schema map
+  schema_map = {
+    'encryption_db.encryption_coll': {
+      properties: {
+        encrypted_field: {
+          encrypt: {
+            keyId: [BSON::Binary.new(data_key_id, :uuid)],
+            bsonType: "string",
+            algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+          }
+        }
+      },
+      bsonType: "object"
+    }
+  }
+
+  # Configure client for automatic encryption
+  client = Mongo::Client.new(
+    ['localhost:27017'],
+    auto_encryption_options: {
+      key_vault_namespace: 'admin.datakeys',
+      kms_providers: kms_providers,
+      schema_map: schema_map
+    }
+  )
+
+  collection = client.use(:encryption_db)[:encryption_coll]
+  collection.drop
+
+  # The string "sensitive data" will be encrypted and stored in the database
+  # as ciphertext
+  collection.insert_one(encrypted_field: 'sensitive data')
+
+  # The data is decrypted before being returned to the user
+  collection.find(encrypted_field: 'sensitive data').first['encrypted_field']
+  # => "sensitive data"
+
+  # A client with no auto_encryption_options is unable to decrypt the data
+  client_no_encryption = Mongo::Client.new(['localhost:27017'])
+  client_no_encryption.use(:encryption_db)[:encryption_coll].find.first['encrypted_field']
+  # => <BSON::Binary...>
+
+Explicit Encryption
+-------------------
+Documentation for explicit encryption will be provided soon.
 
 Creating a Master Key
-~~~~~~~~~~~~~~~~~~~~~
+---------------------
 
 The first step to configuting an auto-encryption client is to create an encryption
 master key and set up the key management service (KMS) that you plan to use. You may
@@ -121,7 +200,7 @@ option:
   }
 
 Creating a Data Key
-~~~~~~~~~~~~~~~~~~~
+-------------------
 
 To perform automatic encryption, you must first generate an encryption data key,
 which is encrypted using the master key generated in the previous step. This
@@ -175,16 +254,8 @@ returns its Base64-encoded 16-byte UUID.
   )
 
 Creating a Schema Map
-~~~~~~~~~~~~~~~~~~~~~
-
-Configuring ``Mongo::Client``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-A Complete Example
-~~~~~~~~~~~~~~~~~~
+---------------------
 
 
-Explicit Encryption
--------------------
-Documentation for explicit encryption will be provided soon.
+
 

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -35,24 +35,23 @@ have the libmongocrypt binary on your machine.
 
 To download a pre-built binary (recommended):
 
-- Download a tarball of all libmongocrypt variations from this `AWS bucket
-<https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz>`_.
+- Download a tarball of all libmongocrypt variations from this `AWS bucket <https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz>`_.
 
 - Unzip the file you downloaded. You will see a list of folders, each
-corresponding to an operating system. Find the folder that matches your
-operating system and open it.
+  corresponding to an operating system. Find the folder that matches your
+  operating system and open it.
 
 - Inside that folder, open the folder called "nocrypto." In either the
-lib or lb64 folder, you will find the libmongocrypt.so or
-libmongocrypt.dylib or libmongocrypt.dll file, depending on your OS.
+  lib or lb64 folder, you will find the libmongocrypt.so or
+  libmongocrypt.dylib or libmongocrypt.dll file, depending on your OS.
 
 - Move that file to wherever you want to keep it on your machine. You may delete
-the other files included in the tarball.
+  the other files included in the tarball.
 
 To build from source:
 
 - Follow the instructions in the README on the libmongocrypt GitHub repo:
-    https://github.com/mongodb/libmongocrypt.
+  https://github.com/mongodb/libmongocrypt.
 
 mongocryptd
 ~~~~~~~~~~~

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -34,18 +34,23 @@ client-side encryption functionality. To use client-side encryption, you must
 have the libmongocrypt binary on your machine.
 
 To download a pre-built binary (recommended):
+
 - Download a tarball of all libmongocrypt variations from this `AWS bucket
 <https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz>`_.
+
 - Unzip the file you downloaded. You will see a list of folders, each
 corresponding to an operating system. Find the folder that matches your
 operating system and open it.
+
 - Inside that folder, open the folder called "nocrypto." In either the
 lib or lb64 folder, you will find the libmongocrypt.so or
 libmongocrypt.dylib or libmongocrypt.dll file, depending on your OS.
+
 - Move that file to wherever you want to keep it on your machine. You may delete
 the other files included in the tarball.
 
 To build from source:
+
 - Follow the instructions in the README on the libmongocrypt GitHub repo:
     https://github.com/mongodb/libmongocrypt.
 

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -157,9 +157,9 @@ For more information about creating an encryption master key, creating a data ke
 or creating a schema map, see later sections of this tutorial.
 
 .. seealso::
-  :manual:`Creating A Master Key</tutorials/client-side-encryption#creating-a-master-key>`
-  :manual:`Creating A Data Key</tutorials/client-side-encryption#creating-a-data-key>`,
-  :manual:`Creating A Schema Map</tutorials/client-side-encryption#creating-a-schema-map>`,
+  `Creating A Master Key`_,
+  `Creating A Data Key`_,
+  `Creating A Schema Map`_,
 
 Explicit Encryption
 -------------------

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -36,13 +36,13 @@ have the libmongocrypt binary on your machine.
 To download a pre-built binary (recommended):
 - Download a tarball of all libmongocrypt variations from this `AWS bucket
 <https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz>`_.
-* Unzip the file you downloaded. You will see a list of folders, each
+- Unzip the file you downloaded. You will see a list of folders, each
 corresponding to an operating system. Find the folder that matches your
 operating system and open it.
-* Inside that folder, open the folder called "nocrypto." In either the
+- Inside that folder, open the folder called "nocrypto." In either the
 lib or lb64 folder, you will find the libmongocrypt.so or
 libmongocrypt.dylib or libmongocrypt.dll file, depending on your OS.
-* Move that file to wherever you want to keep it on your machine. You may delete
+- Move that file to wherever you want to keep it on your machine. You may delete
 the other files included in the tarball.
 
 To build from source:

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -84,7 +84,8 @@ both cases, you must set up the ``:kms_providers`` option, which you will use to
 create encryption data keys and configure the ``Mongo::Client`` instance used
 to encrypt data.
 
-1. Local KMS Setup
+*Option 1: Local KMS Setup*
+
 To set up local KMS information, you must generate a new master key. A local
 master key is a Base64-encoded 96-byte string.
 
@@ -100,7 +101,8 @@ master key is a Base64-encoded 96-byte string.
     }
   }
 
-1. AWS KMS Setup
+*Option 2: AWS KMS Setup*
+
 To use the AWS KMS provider, create an encryption master key in the AWS Key
 Management Service. For more information, read the
 `Amazon Web Services KMS section in the MongoDB Manual <https://docs.mongodb.com/manual/core/security-client-side-encryption-key-management/#field-level-encryption-aws-kms>`_.
@@ -121,7 +123,65 @@ option:
 Creating a Data Key
 ~~~~~~~~~~~~~~~~~~~
 
-It is necessary to 
+To perform automatic encryption, you must first generate an encryption data key,
+which is encrypted using the master key generated in the previous step. This
+data key will be used to encrypt fields in your MongoDB documents.
+
+The generated data key will be stored in the key vault collection. This collection
+can be located on the same database as the collection in which you want to store
+encrypted data.
+
+To generate the data key, use an instance of the ``Mongo::ClientEncryption``
+class. This object takes an instance of ``Mongo::Client``, which it will use to
+connect to the key vault collection. It also takes two options:
+``:key_vault_namespace``, which is the namespace of the key vault collection
+in the format `"database.collection"`, and ``:kms_providers``, which is a ``Hash``
+of KMS options. See the `Creating a Master Key <Creating a Master Key>`_ section
+for more information about the ``:kms_providers`` option.
+
+.. code-block:: ruby
+
+  key_vault_client = Mongo::Client.new(['localhost:27017'])
+
+  client_encryption = Mongo::ClientEncryption.new(
+    key_vault_client,
+    {
+      key_vault_namespace: 'admin.datakeys',
+      kms_providers: kms_providers
+    }
+  )
+
+Once you have created a ``Mongo::ClientEncryption`` instance, you can use it
+to create an encryption data key by calling the ``create_data_key`` method. This
+method generates a new data key, inserts it into the key vault client, and
+returns its Base64-encoded 16-byte UUID.
+
+*Option 1: Create a data key using a local master key*
+
+  .. code-block::ruby
+
+    data_key_id = client_encryption.create_data_key('local')
+
+*Option 2: Create a data key using an AWS master key*
+
+  .. code-block::ruby
+
+    data_key_id = client_encryption.create_data_key(
+      'aws',
+      {
+        region: "YOUR AWS REGION",
+        key: "MASTER KEY ARN"
+      }
+    )
+
+Creating a Schema Map
+~~~~~~~~~~~~~~~~~~~~~
+
+Configuring ``Mongo::Client``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A Complete Example
+~~~~~~~~~~~~~~~~~~
 
 
 Explicit Encryption

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -29,11 +29,11 @@ Client-side encryption requires the installation of additional packages.
 libmongocrypt
 ~~~~~~~~~~~~~
 
-Libmongocrypt is a C library that the driver uses to perform much of the
-client-side encryption functionality. To use client-side encryption, you must
-have the libmongocrypt binary on your machine.
+Libmongocrypt is a C library used by the driver for client-side encryption.
+To use client-side encryption, you must install the libmongocrypt binary
+on the machine running your Ruby program.
 
-To download a pre-built binary (recommended):
+To download a pre-built binary:
 
 - Download a tarball of all libmongocrypt variations from this `AWS bucket <https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz>`_.
 
@@ -57,6 +57,7 @@ binary using the LIBMONGOCRYPT_PATH environment variable. It is recommended that
 you add this variable to your rc files. For example:
 
 .. code-block:: bash
+
   export LIBMONGOCRYPT_PATH=/path/to/your/libmongocrypt.so
 
 mongocryptd
@@ -75,22 +76,18 @@ Automatic Encryption
 --------------------
 
 Automatic encryption is a feature that allows users to configure a
-``Mongo::Client`` instance to always encrypt specific data fields when performing
-document operations. Once the ``Mongo::Client`` is configured, it can be used
-to read and write data in a typical manner. However, a properly configured client
-will automatically encrypt data when writing to the database and automatically
-decrypt data when reading. Automatic encryption is an enterprise-only feature
-and is only applied to operations on a collection.
+``Mongo::Client`` instance to always encrypt specific document fields when
+performing database operations. Once the ``Mongo::Client`` is configured, it
+will automatically encrypt any field that requires encryption before writing
+it to the database, and it will automatically decrypt those fields when reading
+them. Automatic encryption is an enterprise-only feature.
 
 The following example provides a demonstration of auto-encryption using a local
-master key. See the later sections of this tutorial for more information on
-creating a master key, creating a data key, and creating a schema map.
+master key.
 
 .. code-block:: ruby
 
-  require 'base64'
-  require 'bson'
-  require 'securerandom'
+  require 'mongo'
 
   # Generate a local encryption master key
   local_master_key = Base64.encode64(SecureRandom.random_bytes(96))
@@ -141,7 +138,7 @@ creating a master key, creating a data key, and creating a schema map.
   )
 
   collection = client.use(:encryption_db)[:encryption_coll]
-  collection.drop
+  collection.drop # Make sure there is no data in the collection
 
   # The string "sensitive data" will be encrypted and stored in the database
   # as ciphertext
@@ -156,113 +153,26 @@ creating a master key, creating a data key, and creating a schema map.
   client_no_encryption.use(:encryption_db)[:encryption_coll].find.first['encrypted_field']
   # => <BSON::Binary...>
 
+For more information about creating an encryption master key, creating a data key,
+or creating a schema map, see later sections of this tutorial.
+
+.. seealso::
+  :manual:`Creating A Master Key</tutorials/client-side-encryption#creating-a-master-key>`
+  :manual:`Creating A Data Key</tutorials/client-side-encryption#creating-a-data-key>`,
+  :manual:`Creating A Schema Map</tutorials/client-side-encryption#creating-a-schema-map>`,
+
 Explicit Encryption
 -------------------
 Documentation for explicit encryption will be provided soon.
 
 Creating a Master Key
 ---------------------
-
-The first step to configuting an auto-encryption client is to create an encryption
-master key and set up the key management service (KMS) that you plan to use. You may
-either set up a local master key or use Amazon's AWS Key Management Service. In
-both cases, you must set up the ``:kms_providers`` option, which you will use to
-create encryption data keys and configure the ``Mongo::Client`` instance used
-to encrypt data.
-
-*Option 1: Local KMS Setup*
-
-To set up local KMS information, you must generate a new master key. A local
-master key is a Base64-encoded 96-byte string.
-
-.. code-block:: ruby
-
-  require 'base64'
-  require 'securerandom'
-
-  key = Base64.encode64(SecureRandom.random_bytes(96))
-  kms_providers = {
-    local: {
-      key: key
-    }
-  }
-
-*Option 2: AWS KMS Setup*
-
-To use the AWS KMS provider, create an encryption master key in the AWS Key
-Management Service. For more information, read the
-`Amazon Web Services KMS section in the MongoDB Manual <https://docs.mongodb.com/manual/core/security-client-side-encryption-key-management/#field-level-encryption-aws-kms>`_.
-
-Locate the access key and secret access key for the IAM user who has permissions
-to use your AWS master key, and use that information to create the ``:kms_providers``
-option:
-
-.. code-block:: ruby
-
-  kms_providers = {
-    aws: {
-      access_key_id: "YOUR AWS ACCESS KEY ID",
-      secret_access_key: "YOUR AWS SECRET ACCESS KEY"
-    }
-  }
+Documentation coming soon.
 
 Creating a Data Key
 -------------------
-
-To perform automatic encryption, you must first generate an encryption data key,
-which is encrypted using the master key generated in the previous step. This
-data key will be used to encrypt fields in your MongoDB documents.
-
-The generated data key will be stored in the key vault collection. This collection
-can be located on the same database as the collection in which you want to store
-encrypted data.
-
-To generate the data key, use an instance of the ``Mongo::ClientEncryption``
-class. This object takes an instance of ``Mongo::Client``, which it will use to
-connect to the key vault collection. It also takes two options:
-``:key_vault_namespace``, which is the namespace of the key vault collection
-in the format `"database.collection"`, and ``:kms_providers``, which is a ``Hash``
-of KMS options. See the `Creating a Master Key <Creating a Master Key>`_ section
-for more information about the ``:kms_providers`` option.
-
-.. code-block:: ruby
-
-  key_vault_client = Mongo::Client.new(['localhost:27017'])
-
-  client_encryption = Mongo::ClientEncryption.new(
-    key_vault_client,
-    {
-      key_vault_namespace: 'admin.datakeys',
-      kms_providers: kms_providers
-    }
-  )
-
-Once you have created a ``Mongo::ClientEncryption`` instance, you can use it
-to create an encryption data key by calling the ``create_data_key`` method. This
-method generates a new data key, inserts it into the key vault client, and
-returns its Base64-encoded 16-byte UUID.
-
-*Option 1: Create a data key using a local master key*
-
-.. code-block:: ruby
-
-  data_key_id = client_encryption.create_data_key('local')
-
-*Option 2: Create a data key using an AWS master key*
-
-.. code-block:: ruby
-
-  data_key_id = client_encryption.create_data_key(
-    'aws',
-    {
-      region: "YOUR AWS REGION",
-      key: "MASTER KEY ARN"
-    }
-  )
+Documentation coming soon.
 
 Creating a Schema Map
 ---------------------
-
-
-
-
+Documentation coming soon.

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -34,16 +34,16 @@ client-side encryption functionality. To use client-side encryption, you must
 have the libmongocrypt binary on your machine.
 
 To download a pre-built binary (recommended):
-- Download a tarball of all libmongocrypt variations from this link:
-    https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz
-- Unzip the file you downloaded. You will see a list of folders, each
-    corresponding to an operating system. Find the folder that matches
-    your operating system and open it.
-- Inside that folder, open the folder called "nocrypto." In either the
-    lib or lb64 folder, you will find the libmongocrypt.so or
-    libmongocrypt.dylib or libmongocrypt.dll file, depending on your OS.
-- Move that file to wherever you want to keep it on your machine. You may delete
-    the other files included in the tarball.
+- Download a tarball of all libmongocrypt variations from this `AWS bucket
+<https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz>`_.
+* Unzip the file you downloaded. You will see a list of folders, each
+corresponding to an operating system. Find the folder that matches your
+operating system and open it.
+* Inside that folder, open the folder called "nocrypto." In either the
+lib or lb64 folder, you will find the libmongocrypt.so or
+libmongocrypt.dylib or libmongocrypt.dll file, depending on your OS.
+* Move that file to wherever you want to keep it on your machine. You may delete
+the other files included in the tarball.
 
 To build from source:
 - Follow the instructions in the README on the libmongocrypt GitHub repo:

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -1,0 +1,64 @@
+.. _client-side-encryption:
+
+======================
+Client-Side Encryption
+======================
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+New in MongoDB 4.2, client-side encryption allows administrators and developers
+to encrypt specific fields in MongoDB documents before inserting them into the
+database.
+
+With client-side encryption, developers can encrypt fields client-side without
+any server-side configuration or directives. Client-side field-level encryption
+supports workloads where applications must guarantee that unauthorized parties,
+including server administrators, cannot read the encrypted data.
+
+Installation
+------------
+
+Client-side encryption requires the installation of additional packages.
+
+libmongocrypt
+~~~~~~~~~~~~~
+
+Libmongocrypt is a C library that the driver uses to perform much of the
+client-side encryption functionality. To use client-side encryption, you must
+have the libmongocrypt binary on your machine.
+
+To download a pre-built binary (recommended):
+- Download a tarball of all libmongocrypt variations from this link:
+    https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz
+- Unzip the file you downloaded. You will see a list of folders, each
+    corresponding to an operating system. Find the folder that matches
+    your operating system and open it.
+- Inside that folder, open the folder called "nocrypto." In either the
+    lib or lb64 folder, you will find the libmongocrypt.so or
+    libmongocrypt.dylib or libmongocrypt.dll file, depending on your OS.
+- Move that file to wherever you want to keep it on your machine. You may delete
+    the other files included in the tarball.
+
+To build from source:
+- Follow the instructions in the README on the libmongocrypt GitHub repo:
+    https://github.com/mongodb/libmongocrypt.
+
+mongocryptd
+~~~~~~~~~~~
+
+Mongocryptd is a daemon that tells the driver which fields to encrypt in a
+given operation. It is only required for automatic encryption, which is an
+enterprise-only feature. If you only intend to use explicit encryption, you may
+skip this step.
+
+Mongocryptd comes pre-packaged with enterprise builds of the MongoDB server
+(versions 4.2 and newer). If you must install mongocryptd separately, follow
+the installation instructions on this page:
+https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/#installation.
+


### PR DESCRIPTION
This PR creates a client-side encryption tutorial. The sections filled in so far are installation instructions and automatic encryption. I have run the auto-encryption code on my machine and confirmed that it behaves as expected.

Once everything looks good here, I will create a follow-up PR for explicit encryption, and another one for the three sections at the bottom. I want to explain how to create a master key, a data key, and a schema map using local KMS options as well as AWS KMS options.