### PR TITLE
RUBY-1926 Ensure that key vault client has auto encryption options

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -406,7 +406,7 @@ module Mongo
     #     view.
     #   - Automatic encryption requires the authenticated user to have the
     #     listCollections privilege.
-    #   - At worst, automatic encryption may double the number of connections
+    #   - At worst, automatic encryption may triple the number of connections
     #     used by the Client at any one time.
     #   - If automatic encryption fails on an operation, use a MongoClient
     #     configured with bypass_auto_encryption: true and use

--- a/lib/mongo/crypt/encryption_io.rb
+++ b/lib/mongo/crypt/encryption_io.rb
@@ -54,7 +54,7 @@ module Mongo
 
         @client = client
         @mongocryptd_client = mongocryptd_client
-        @key_vault_db, @key_vault_coll = key_vault_namespace.split('.')
+        @key_vault_db_name, @key_vault_coll_name = key_vault_namespace.split('.')
         @key_vault_client = key_vault_client
         @options = mongocryptd_options
       end
@@ -166,7 +166,7 @@ module Mongo
       # Mongo::Collection object representing the key vault collection.
       def key_vault_collection
         @key_vault_collection ||=
-          @key_vault_client.use(@key_vault_db)[@key_vault_coll]
+          @key_vault_client.use(@key_vault_db_name)[@key_vault_coll_name]
       end
 
       # Spawn a new mongocryptd process using the mongocryptd_spawn_path

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -383,7 +383,7 @@ EOT
       # query to key vault connection triggered from libmongocrypt.
       # In the worst case using FLE may end up doubling the number of
       # connections that the driver uses at any one time.
-      max_pool_size: 2,
+      max_pool_size: 3,
 
       heartbeat_frequency: 20,
 

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -377,11 +377,13 @@ EOT
   # Base test options.
   def base_test_options
     {
-      # Automatic encryption tests require a minimum of two connections,
-      # because the driver checks out a connection to build a command,
-      # and then may need to encrypt the command which could require a
-      # query to key vault connection triggered from libmongocrypt.
-      # In the worst case using FLE may end up doubling the number of
+      # Automatic encryption tests require a minimum of three connections:
+      # - The driver checks out a connection to build a command.
+      # - It may need to encrypt the command, which could require a query to
+      #   the key vault collection triggered by libmongocrypt.
+      # - If the key vault client has auto encryption options, it will also
+      #   attempt to encrypt this query, resulting in a third connection.
+      # In the worst case using FLE may end up tripling the number of
       # connections that the driver uses at any one time.
       max_pool_size: 3,
 


### PR DESCRIPTION
Based on the way that the auto encrypter was previously being set up, the key vault client was not actually getting auto encryption options. I have fixed that, added tests that would fail without this change, and updated documentation about the number of connections required by auto encryption.