### PR TITLE
RUBY-1926 Don't Base64 encode local master keys

### DIFF
--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -92,7 +92,7 @@ master key.
   # Generate a local encryption master key
   # To reuse this master key, persist it to a file or environment variable
   # on your machine.
-  local_master_key = Base64.encode64(SecureRandom.random_bytes(96))
+  local_master_key = SecureRandom.random_bytes(96)
 
   kms_providers = {
     local: {
@@ -182,7 +182,7 @@ and then decrypting it after reading it from the database.
   # Generate a local encryption master key
   # To reuse this master key, persist it to a file or environment variable
   # on your machine.
-  local_master_key = Base64.encode64(SecureRandom.random_bytes(96))
+  local_master_key = SecureRandom.random_bytes(96)
 
   kms_providers = {
     local: {
@@ -249,7 +249,7 @@ Service (AWS KMS).
 
 Local Master Key
 ~~~~~~~~~~~~~~~~
-A local master key is a Base64-encoded, 96-byte string. It should be persisted
+A local master key is a 96-byte binary string. It should be persisted
 on your machine as an environment variable or in a text file.
 
 .. warning::
@@ -261,10 +261,9 @@ Run the following code to generate a local master key using Ruby:
 
 .. code-block:: ruby
 
-  require 'base64'
   require 'securerandom'
 
-  local_master_key = Base64.encode64(SecureRandom.random_bytes(96))
+  local_master_key = SecureRandom.random_bytes(96)
 
 AWS Master Key
 ~~~~~~~~~~~~~~

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -282,11 +282,11 @@ module Mongo
       # Set local KMS provider options on the Mongo::Crypt::Handle object
       #
       # @param [ Mongo::Crypt::Handle ] handle
-      # @param [ String ] raw_master_key The 96-byte local KMS master key
+      # @param [ String ] master_key The 96-byte local KMS master key
       #
       # @raise [ Mongo::Error::CryptError ] If the option is not set successfully
-      def self.setopt_kms_provider_local(handle, raw_master_key)
-        Binary.wrap_string(raw_master_key) do |master_key_p|
+      def self.setopt_kms_provider_local(handle, master_key)
+        Binary.wrap_string(master_key) do |master_key_p|
           check_status(handle) do
             mongocrypt_setopt_kms_provider_local(handle.ref, master_key_p)
           end

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -256,9 +256,7 @@ module Mongo
         end
 
         master_key = kms_providers[:local][:key]
-        raw_master_key = Base64.decode64(master_key)
-
-        Binding.setopt_kms_provider_local(self, raw_master_key)
+        Binding.setopt_kms_provider_local(self, master_key)
       end
 
       # Validate and set the aws KMS provider information on the underlying

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -78,7 +78,7 @@ describe Mongo::Crypt::Handle do
       let(:kms_providers) do
         {
           local: {
-            key: Base64.encode64('ruby' * 23) # NOT 96 bytes
+            key: 'ruby' * 23 # NOT 96 bytes
           }
         }
       end

--- a/spec/support/crypt.rb
+++ b/spec/support/crypt.rb
@@ -16,10 +16,12 @@ module Crypt
   # For all FLE-related tests
   shared_context 'define shared FLE helpers' do
     # 96-byte binary string, base64-encoded local master key
-    let(:local_master_key) do
+    let(:local_master_key_b64) do
       "Mng0NCt4ZHVUYUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3" +
         "YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
     end
+
+    let(:local_master_key) { Base64.decode64(local_master_key_b64) }
 
     # Data key id as a binary string
     let(:key_id) { data_key['_id'].data }


### PR DESCRIPTION
Though I think it makes more sense to to convert the master key to base64 before storing it, it isn't consistent with the spec, so just store it as a string of bytes.