### PR TITLE
RUBY-2152 Implemented "data key and double encryption" prose test

### DIFF
--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -284,7 +284,8 @@ Once you have created a master key, create a data key by calling the
 ``#create_data_key`` method on an instance of the ``Mongo::ClientEncryption``
 class. This method generates a new data key and inserts it into the key vault
 collection, which is the MongoDB collection in which you choose to store your
-data keys. The ``#create_data_key`` method returns the UUID of the newly-created data key.
+data keys. The ``#create_data_key`` method returns id of the newly-created
+data key in the form of a BSON::Binary object.
 
 Create a Data Key Using a Local Master Key
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -58,7 +58,8 @@ module Mongo
     # @option options [ Array<String> ] :key_alt_names An optional array of
     #   strings specifying alternate names for the new data key.
     #
-    # @return [ String ] The 16-byte UUID of the new data key as a binary string.
+    # @return [ BSON::Binary ] The 16-byte UUID of the new data key as a
+    #   BSON::Binary object with type :uuid.
     def create_data_key(kms_provider, options={})
       @encrypter.create_and_insert_data_key(
         kms_provider,
@@ -71,8 +72,9 @@ module Mongo
     # @param [ Object ] value The value to encrypt.
     # @param [ Hash ] options
     #
-    # @option options [ String ] :key_id The UUID of the encryption
-    #   key as it is stored in the key vault collection.
+    # @option options [ BSON::Binary ] :key_id A BSON::Binary object of type :uuid
+    #   representing the UUID of the encryption key as it is stored in the key
+    #   vault collection.
     # @option options [ String ] :key_alt_name The alternate name for the
     #   encryption key.
     # @option options [ String ] :algorithm The algorithm used to encrypt the value.

--- a/lib/mongo/crypt/explicit_encrypter.rb
+++ b/lib/mongo/crypt/explicit_encrypter.rb
@@ -68,7 +68,7 @@ module Mongo
           options
         ).run_state_machine
 
-        @encryption_io.insert_data_key(data_key_document).inserted_id.data
+        @encryption_io.insert_data_key(data_key_document).inserted_id
       end
 
       # Encrypts a value using the specified encryption key and algorithm

--- a/lib/mongo/crypt/explicit_encrypter.rb
+++ b/lib/mongo/crypt/explicit_encrypter.rb
@@ -58,8 +58,8 @@ module Mongo
       # @option options [ Array<String> ] :key_alt_names An optional array of strings specifying
       #   alternate names for the new data key.
       #
-      # @return [ String ] Base64-encoded UUID string representing the
-      #   data key _id
+      # @return [ BSON::Binary ] The 16-byte UUID of the new data key as a
+      #   BSON::Binary object with type :uuid.
       def create_and_insert_data_key(kms_provider, options)
         data_key_document = Crypt::DataKeyContext.new(
           @crypt_handle,
@@ -76,13 +76,14 @@ module Mongo
       # @param [ Object ] value The value to encrypt
       # @param [ Hash ] options
       #
-      # @option options [ String ] :key_id The base64-encoded UUID of the encryption
-      #   key as it is stored in the key vault collection
+      # @option options [ BSON::Binary ] :key_id A BSON::Binary object of type :uuid
+      #   representing the UUID of the encryption key as it is stored in the key
+      #   vault collection.
       # @option options [ String ] :key_alt_name The alternate name for the
       #   encryption key.
       # @option options [ String ] :algorithm The algorithm used to encrypt the value.
       #   Valid algorithms are "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
-      #   or "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+      #   or "AEAD_AES_256_CBC_HMAC_SHA_512-Random".
       #
       # @note The :key_id and :key_alt_name options are mutually exclusive. Only
       #   one is required to perform explicit encryption.

--- a/spec/integration/client_side_encryption/data_key_spec.rb
+++ b/spec/integration/client_side_encryption/data_key_spec.rb
@@ -3,6 +3,9 @@ require 'spec_helper'
 describe 'Client-Side Encryption' do
   describe 'Prose tests: Data key and double encryption' do
     require_libmongocrypt
+    require_enterprise
+    min_server_fcv '4.2'
+
     include_context 'define shared FLE helpers'
 
     let(:subscriber) { EventSubscriber.new }

--- a/spec/integration/client_side_encryption/data_key_spec.rb
+++ b/spec/integration/client_side_encryption/data_key_spec.rb
@@ -1,0 +1,160 @@
+require 'spec_helper'
+
+describe 'Client-Side Encryption' do
+  describe 'Prose tests: Data key and double encryption' do
+    require_libmongocrypt
+    include_context 'define shared FLE helpers'
+
+    let(:subscriber) { EventSubscriber.new }
+
+    let(:client) do
+      new_local_client(
+        SpecConfig.instance.addresses,
+        SpecConfig.instance.test_options
+      ).tap do |client|
+        client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+      end
+    end
+
+    let(:test_schema_map) do
+      {
+        "db.coll": {
+          "bsonType": "object",
+          "properties": {
+            "encrypted_placeholder": {
+              "encrypt": {
+                "keyId": "/placeholder",
+                "bsonType": "string",
+                "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+              }
+            }
+          }
+        }
+      }
+    end
+
+    let(:client_encrypted) do
+      new_local_client(
+        SpecConfig.instance.addresses,
+        SpecConfig.instance.test_options.merge(
+          auto_encryption_options: {
+            kms_providers: {
+              local: { key: local_master_key },
+              aws: {
+                access_key_id: SpecConfig.instance.fle_aws_key,
+                secret_access_key: SpecConfig.instance.fle_aws_secret,
+              },
+            },
+            key_vault_namespace: 'admin.datakeys',
+            schema_map: test_schema_map,
+          },
+          database: :db,
+        )
+      )
+    end
+
+    let(:client_encryption) do
+      Mongo::ClientEncryption.new(
+        client,
+        {
+          kms_providers: {
+            local: { key: local_master_key },
+            aws: {
+              access_key_id: SpecConfig.instance.fle_aws_key,
+              secret_access_key: SpecConfig.instance.fle_aws_secret,
+            }
+          },
+          key_vault_namespace: 'admin.datakeys',
+        },
+      )
+    end
+
+    before do
+      client.use(:admin)[:datakeys].drop
+      client.use(:db)[:coll].drop
+    end
+
+    shared_examples 'can create and use a data key' do
+      it 'creates a data key and uses it for encryption' do
+        data_key_id = client_encryption.create_data_key(
+          kms_provider_name,
+          data_key_options.merge(key_alt_names: [key_alt_name])
+        )
+
+        expect(data_key_id).to be_uuid
+
+        keys = client.use(:admin)[:datakeys].find(_id: data_key_id)
+
+        expect(keys.count).to eq(1)
+        expect(keys.first['masterKey']['provider']).to eq(kms_provider_name)
+
+        command_started_event = subscriber.started_events.find do |event|
+          event.command_name == 'find'
+        end
+
+        expect(command_started_event).not_to be_nil
+
+        encrypted = client_encryption.encrypt(
+          value_to_encrypt,
+          {
+            key_id: data_key_id,
+            algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+          }
+        )
+
+        expect(encrypted).to be_ciphertext
+
+        client_encrypted[:coll].insert_one(
+          _id: kms_provider_name,
+          'value': encrypted,
+        )
+
+        document = client_encrypted[:coll].find(_id: kms_provider_name).first
+
+        expect(document['value']).to eq(value_to_encrypt)
+
+        encrypted_with_alt_name = client_encryption.encrypt(
+          value_to_encrypt,
+          {
+            key_alt_name: key_alt_name,
+            algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+          }
+        )
+
+        expect(encrypted_with_alt_name).to be_ciphertext
+        expect(encrypted_with_alt_name).to eq(encrypted)
+
+        expect do
+          client_encrypted[:coll].insert_one(encrypted_placeholder: encrypted)
+        end.to raise_error(Mongo::Error::OperationFailure, /Cannot encrypt element of type binData/)
+      end
+    end
+
+    context 'with local KMS options' do
+      include_context 'with local kms_providers'
+
+      let(:key_alt_name) { 'local_altname' }
+      let(:data_key_options) { {} }
+      let(:value_to_encrypt) { 'hello local' }
+
+      it_behaves_like 'can create and use a data key'
+    end
+
+    context 'with AWS KMS options' do
+      include_context 'with AWS kms_providers'
+
+      let(:key_alt_name) { 'aws_altname' }
+      let(:value_to_encrypt) { 'hello aws' }
+      let(:data_key_options) do
+        {
+          master_key: {
+            region: "us-east-1",
+            key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+          }
+        }
+      end
+
+      it_behaves_like 'can create and use a data key'
+    end
+  end
+end

--- a/spec/mongo/client_encryption_spec.rb
+++ b/spec/mongo/client_encryption_spec.rb
@@ -77,12 +77,9 @@ describe Mongo::ClientEncryption do
 
     shared_examples 'it creates a data key' do |with_key_alt_names: false|
       it 'returns the data key id and inserts it into the key vault collection' do
-        expect(data_key_id).to be_a_kind_of(String)
-        expect(data_key_id.bytesize).to eq(16)
+        expect(data_key_id).to be_uuid
 
-        documents = client.use(key_vault_db)[key_vault_coll].find(
-          _id: BSON::Binary.new(data_key_id, :uuid)
-        )
+        documents = client.use(key_vault_db)[key_vault_coll].find(_id: data_key_id)
 
         expect(documents.count).to eq(1)
 

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -49,7 +49,7 @@ describe Mongo::Crypt::ExplicitEncryptionContext do
         it 'raises an exception' do
           expect do
             context
-          end.to raise_error(Mongo::Error::CryptError, /expected 16 byte UUID/)
+          end.to raise_error(ArgumentError, /Expected the :key_id option to be a BSON::Binary object/)
         end
       end
 

--- a/spec/support/crypt.rb
+++ b/spec/support/crypt.rb
@@ -24,7 +24,7 @@ module Crypt
     let(:local_master_key) { Base64.decode64(local_master_key_b64) }
 
     # Data key id as a binary string
-    let(:key_id) { data_key['_id'].data }
+    let(:key_id) { data_key['_id'] }
 
     # Data key alternate name
     let(:key_alt_name) { 'ssn_encryption_key' }

--- a/spec/support/matchers.rb
+++ b/spec/support/matchers.rb
@@ -41,3 +41,9 @@ RSpec::Matchers.define :be_ciphertext do
     object.is_a?(BSON::Binary) && object.type == :ciphertext
   end
 end
+
+RSpec::Matchers.define :be_uuid do
+  match do |object|
+    object.is_a?(BSON::Binary) && object.type == :uuid
+  end
+end


### PR DESCRIPTION
Also change the return type of `ClientEncryption#create_data_key` as mandated by the spec.