### PR TITLE
Fix RUBY-1151 Commands should have a limit of maxBsonObjectSize + 16K

### DIFF
--- a/lib/mongo/server/connection_base.rb
+++ b/lib/mongo/server/connection_base.rb
@@ -166,6 +166,13 @@ module Mongo
         start_size = 0
         final_message = message.maybe_compress(compressor, options[:zlib_compression_level])
 
+        # Driver specifications only mandate the fixed 16MiB limit for
+        # serialized BSON documents. However, the server returns its
+        # active serialized BSON document size limit in the ismaster response,
+        # which is +max_bson_object_size+ below. The +DEFAULT_MAX_BSON_OBJECT_SIZE+
+        # is the 16MiB value mandated by the specifications which we use
+        # only as the default if the server's ismaster did not contain
+        # maxBsonObjectSize.
         max_bson_size = max_bson_object_size || DEFAULT_MAX_BSON_OBJECT_SIZE
         if client && client.encrypter && client.encrypter.encrypt?
           # From client-side encryption spec: Because automatic encryption

--- a/lib/mongo/server/connection_base.rb
+++ b/lib/mongo/server/connection_base.rb
@@ -26,6 +26,23 @@ module Mongo
       extend Forwardable
       include Monitoring::Publishable
 
+      # The maximum allowed size in bytes that a user-supplied document may
+      # take up when serialized, if the server's ismaster response does not
+      # include maxBsonObjectSize field.
+      #
+      # The commands that are sent to the server may exceed this size by
+      # MAX_BSON_COMMAND_OVERHEAD.
+      #
+      # @api private
+      DEFAULT_MAX_BSON_OBJECT_SIZE = 16777216
+
+      # The additional overhead allowed for command data (i.e. fields added
+      # to the command document by the driver, as opposed to documents
+      # provided by the user) when serializing a complete command to BSON.
+      #
+      # @api private
+      MAX_BSON_COMMAND_OVERHEAD = 16384
+
       # @return [ Hash ] options The passed in options.
       attr_reader :options
 
@@ -149,12 +166,14 @@ module Mongo
         start_size = 0
         final_message = message.maybe_compress(compressor, options[:zlib_compression_level])
 
-        max_bson_size = max_bson_object_size
+        max_bson_size = max_bson_object_size || DEFAULT_MAX_BSON_OBJECT_SIZE
         if client && client.encrypter && client.encrypter.encrypt?
           # From client-side encryption spec: Because automatic encryption
           # increases the size of commands, the driver MUST split bulk writes
           # at a reduced size limit before undergoing automatic encryption.
           max_bson_size = 2097152
+        else
+          max_bson_size += MAX_BSON_COMMAND_OVERHEAD
         end
 
         final_message.serialize(buffer, max_bson_size)

--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -40,6 +40,11 @@ module Mongo
     # @since 2.0.0
     TIMEOUT_PACK = 'l_2'.freeze
 
+    # Write data to the socket in chunks of this size.
+    #
+    # @api private
+    WRITE_CHUNK_SIZE = 65536
+
     # @return [ Integer ] family The type of host family.
     attr_reader :family
 
@@ -172,7 +177,29 @@ module Mongo
     #
     # @since 2.0.0
     def write(*args)
-      handle_errors { @socket.write(*args) }
+      handle_errors do
+        # This method used to forward arguments to @socket.write in a
+        # single call like so:
+        #
+        # @socket.write(*args)
+        #
+        # Turns out, when each buffer to be written is large (e.g. 32 MiB),
+        # this write call would take an extremely long time (20+ seconds)
+        # while using 100% CPU. Splitting the writes into chunks produced
+        # massively better performance (0.05 seconds to write the 32 MiB of
+        # data on the same hardware). Unfortunately splitting the data,
+        # one would assume, results in it being copied, but this seems to be
+        # a much more minor issue compared to CPU cost of writing large buffers.
+        args.each do |buf|
+          buf = buf.to_s
+          i = 0
+          while i < buf.length
+            chunk = buf[i...i+WRITE_CHUNK_SIZE]
+            @socket.write(chunk)
+            i += WRITE_CHUNK_SIZE
+          end
+        end
+      end
     end
 
     # Tests if this socket has reached EOF. Primarily used for liveness checks.

--- a/spec/integration/size_limit_spec.rb
+++ b/spec/integration/size_limit_spec.rb
@@ -1,13 +1,12 @@
 require 'spec_helper'
 
-describe 'BSON object size' do
+describe 'BSON & command size limits' do
   it 'raises an exception when document size is 16MiB' do
-    client = new_local_client(SpecConfig.instance.addresses)
-    max_size = 16777216 # 16 MiB
+    max_size = 16*1024*1024
 
     document = { key: 'a' * (max_size - 15) }
     expect(document.to_bson.length).to eq(max_size)
 
-    client.use(:db)[:coll].insert_one(document)
+    authorized_collection.insert_one(document)
   end
 end

--- a/spec/integration/size_limit_spec.rb
+++ b/spec/integration/size_limit_spec.rb
@@ -1,12 +1,94 @@
 require 'spec_helper'
 
 describe 'BSON & command size limits' do
-  it 'raises an exception when document size is 16MiB' do
-    max_size = 16*1024*1024
+  let(:max_document_size) { 16*1024*1024 }
 
-    document = { key: 'a' * (max_size - 15) }
-    expect(document.to_bson.length).to eq(max_size)
+  before do
+    authorized_collection.delete_many
+  end
+
+  # This test uses a large document that is significantly smaller than the
+  # size limit. It is a basic sanity check.
+  it 'allows user-provided documents to be 15MiB' do
+    document = { key: 'a' * 15*1024*1024, _id: 'foo' }
 
     authorized_collection.insert_one(document)
+  end
+
+  # This test uses a large document that is significantly larger than the
+  # size limit. It is a basic sanity check.
+  it 'fails single write of oversized documents' do
+    document = { key: 'a' * 17*1024*1024, _id: 'foo' }
+
+    lambda do
+      authorized_collection.insert_one(document)
+    end.should raise_error(Mongo::Error::MaxBSONSize, /The document exceeds maximum allowed BSON object size after serialization/)
+  end
+
+  # This test checks our bulk write splitting when documents are not close
+  # to the limit, but where splitting is definitely required.
+  it 'allows split bulk write of medium sized documents' do
+    # 8 documents of 4 MiB each = 32 MiB total data, should be split over
+    # either 2 or 3 bulk writes depending on how well the driver splits
+    documents = []
+    1.upto(8) do |index|
+      documents << { key: 'a' * 4*1024*1024, _id: "in#{index}" }
+    end
+
+    authorized_collection.insert_many(documents)
+    authorized_collection.count_documents({}).should == 8
+  end
+
+  # This test ensures that document which are too big definitely fail insertion.
+  it 'fails bulk write of oversized documents' do
+    documents = []
+    1.upto(3) do |index|
+      documents << { key: 'a' * 17*1024*1024, _id: "in#{index}" }
+    end
+
+    lambda do
+      authorized_collection.insert_many(documents)
+    end.should raise_error(Mongo::Error::MaxBSONSize, /The document exceeds maximum allowed BSON object size after serialization/)
+    authorized_collection.count_documents({}).should == 0
+  end
+
+  it 'allows user-provided documents to be exactly 16MiB' do
+    # The document must contain the _id field, otherwise the server will
+    # add it which will increase the size of the document as persisted by
+    # the server.
+    document = { key: 'a' * (max_document_size - 28), _id: 'foo' }
+    expect(document.to_bson.length).to eq(max_document_size)
+
+    authorized_collection.insert_one(document)
+  end
+
+  it 'fails on the server when a document larger than 16MiB is inserted' do
+    document = { key: 'a' * (max_document_size - 27), _id: 'foo' }
+    expect(document.to_bson.length).to eq(max_document_size+1)
+
+    lambda do
+      authorized_collection.insert_one(document)
+    end.should raise_error(Mongo::Error::OperationFailure, /object to insert too large/)
+  end
+
+  it 'fails in the driver when a document larger than 16MiB+16KiB is inserted' do
+    document = { key: 'a' * (max_document_size - 27 + 16*1024), _id: 'foo' }
+    expect(document.to_bson.length).to eq(max_document_size+16*1024+1)
+
+    lambda do
+      authorized_collection.insert_one(document)
+    end.should raise_error(Mongo::Error::MaxBSONSize, /The document exceeds maximum allowed BSON object size after serialization/)
+  end
+
+  it 'allows bulk writes of multiple documents of exactly 16 MiB each' do
+    documents = []
+    1.upto(3) do |index|
+      document = { key: 'a' * (max_document_size - 28), _id: "in#{index}" }
+      expect(document.to_bson.length).to eq(max_document_size)
+      documents << document
+    end
+
+    authorized_collection.insert_many(documents)
+    authorized_collection.count_documents({}).should == 3
   end
 end

--- a/spec/integration/test_bson_size_spec.rb
+++ b/spec/integration/test_bson_size_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe 'BSON object size' do
+  it 'raises an exception when document size is 16MiB' do
+    client = new_local_client(SpecConfig.instance.addresses)
+    max_size = 16777216 # 16 MiB
+
+    document = { key: 'a' * (max_size - 15) }
+    expect(document.to_bson.length).to eq(max_size)
+
+    client.use(:db)[:coll].insert_one(document)
+  end
+end

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -731,7 +731,10 @@ describe Mongo::Server::Connection, retry: 3 do
         skip_if_linting
 
         let(:selector) do
-          { :getlasterror => '1' }
+          # The driver allows up to 16KiB for command overhead on top of
+          # the max bson object size reported by the server.
+          # Add that much padding.
+          { :getlasterror => '1', 'padding' => 'x'*16384 }
         end
 
         let(:command) do


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-1151