### PR TITLE
RUBY-2173 Improvements to Client-Side Encryption documentation

### DIFF
--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -239,6 +239,9 @@ or creating a schema map, see later sections of this tutorial.
   `Creating A Data Key`_,
   `Creating A Schema Map`_,
 
+The ``kms_providers`` option
+----------------------------
+
 Creating a Master Key
 ---------------------
 Both automatic encryption and explicit encryption require an encryption master key.

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -74,8 +74,8 @@ enterprise-only feature. If you only intend to use explicit encryption, you may
 skip this step.
 
 Mongocryptd comes pre-packaged with enterprise builds of the MongoDB server
-(versions 4.2 and newer). If you must install mongocryptd separately, follow
-the `installation instructions in the MongoDB manual <https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/#installation>`_.
+(versions 4.2 and newer). For installation instructions, see
+`the MongoDB manual <https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/#installation>`_.
 
 Automatic Encryption
 --------------------
@@ -86,6 +86,17 @@ performing database operations. Once the ``Mongo::Client`` is configured, it
 will automatically encrypt any field that requires encryption before writing
 it to the database, and it will automatically decrypt those fields when reading
 them.
+
+Client-side encryption implements envelope encryption, which is the practice of
+encrypting data with a data key, which is in turn encrypted using a master key.
+Thus, using client-side encryption with MongoDB involves three main steps:
+
+1. Create a master key
+2. Create a data key (and encrypt it using the master key)
+3. Encrypt data using the data key
+
+The example below demonstrates how to follow these steps with a local master key
+in order to perform automatic encryption.
 
 .. note::
 
@@ -100,27 +111,27 @@ them.
 
   Automatic encryption requires the authenticated user to have the listCollections privilege action.
 
-The following example provides a demonstration of auto-encryption using a local
-master key.
-
 .. code-block:: ruby
 
   require 'mongo'
 
-  # Generate a local encryption master key
-  # To reuse this master key, persist it to a file or environment variable
-  # on your machine.
+  # Step 1: Create a local master key
+  # A local master key is a 96-byte binary blob.
   local_master_key = SecureRandom.random_bytes(96)
+  # => "\xB2\xBE\x8EN\xD4\x14\xC2\x13\xC3..."
 
+  # Step 2: Create a data key
   kms_providers = {
     local: {
       key: local_master_key
     }
   }
 
-  # Create an encryption data key and insert it into the key vault collection
+  # The key vault client is a Mongo::Client instance connected to the collection
+  # that will store your data keys.
   key_vault_client = Mongo::Client.new(['localhost:27017'])
 
+  # Use an instance of Mongo::ClientEncryption to create a new data key
   client_encryption = Mongo::ClientEncryption.new(
     key_vault_client,
     key_vault_namespace: 'admin.datakeys',
@@ -128,8 +139,10 @@ master key.
   )
 
   data_key_id = client_encryption.create_data_key('local')
+  # => <BSON::Binary... type=ciphertext...>
 
-  # Create a schema map
+  # Step 3: Configure a Mongo::Client instance for automatic encryption
+  # Create a schema map, which tells the Mongo::Client which fields to encrypt
   schema_map = {
     'encryption_db.encryption_coll': {
       properties: {
@@ -169,15 +182,14 @@ master key.
   # A client with no auto_encryption_options is unable to decrypt the data
   client_no_encryption = Mongo::Client.new(['localhost:27017'])
   client_no_encryption.use('encryption_db')['encryption_coll'].find.first['encrypted_field']
-  # => <BSON::Binary...>
+  # => <BSON::Binary... type=ciphertext...>
 
-For more information about creating an encryption master key, creating a data key,
-or creating a schema map, see later sections of this tutorial.
+The example above demonstrates using automatic encryption with a local master key.
+For more information about using the AWS Key Management Service to create a
+master key and create data keys, see the following sections of this tutorial:
 
-.. seealso::
-  `Creating A Master Key`_,
-  `Creating A Data Key`_,
-  `Creating A Schema Map`_,
+- `Creating A Master Key`_,
+- `Creating A Data Key`_,
 
 Explicit Encryption
 -------------------
@@ -187,28 +199,38 @@ encryption is a community feature and does not require an enterprise build
 of the MongoDB server to use. To perform all explicit encryption and decryption
 operations, use an instance of the ClientEncryption class.
 
-The following is an example of using explicit encryption with a local encryption
-master key to encrypt a piece of data before inserting it into the database,
-and then decrypting it after reading it from the database.
+Client-side encryption implements envelope encryption, which is the practice of
+encrypting data with a data key, which is in turn encrypted using a master key.
+Thus, using client-side encryption with MongoDB involves three main steps:
+
+1. Create a master key
+2. Create a data key (and encrypt it using the master key)
+3. Encrypt data using the data key
+
+The example below demonstrates how to follow these steps with a local master key
+in order to perform explicit encryption.
 
 .. code-block:: ruby
 
   require 'mongo'
 
-  # Generate a local encryption master key
-  # To reuse this master key, persist it to a file or environment variable
-  # on your machine.
+  # Step 1: Create a local master key
+  # A local master key is a 96-byte binary blob.
   local_master_key = SecureRandom.random_bytes(96)
+  # => "\xB2\xBE\x8EN\xD4\x14\xC2\x13\xC3..."
 
+  # Step 2: Create a data key
   kms_providers = {
     local: {
       key: local_master_key
     }
   }
 
-  # Create an encryption data key and insert it into the key vault collection
+  # The key vault client is a Mongo::Client instance connected to the collection
+  # that will store your data keys.
   key_vault_client = Mongo::Client.new(['localhost:27017'])
 
+  # Use an instance of Mongo::ClientEncryption to create a new data key
   client_encryption = Mongo::ClientEncryption.new(
     key_vault_client,
     key_vault_namespace: 'admin.datakeys',
@@ -216,6 +238,9 @@ and then decrypting it after reading it from the database.
   )
 
   data_key_id = client_encryption.create_data_key('local')
+  # => <BSON::Binary... type=ciphertext...>
+
+  # Step 3: Explicitly encrypt a string
 
   # The value to encrypt
   value = 'sensitive data'
@@ -245,16 +270,12 @@ and then decrypting it after reading it from the database.
   unencrypted_result = client_encryption.decrypt(find_result)
   # => "sensitive data"
 
-For more information about creating an encryption master key, creating a data key,
-or creating a schema map, see later sections of this tutorial.
+The example above demonstrates using explicit encryption with a local master key.
+For more information about using the AWS Key Management Service to create a
+master key and create data keys, see the following sections of this tutorial:
 
-.. seealso::
-  `Creating A Master Key`_,
-  `Creating A Data Key`_,
-  `Creating A Schema Map`_,
-
-The ``kms_providers`` option
-----------------------------
+- `Creating A Master Key`_,
+- `Creating A Data Key`_,
 
 Creating a Master Key
 ---------------------
@@ -281,6 +302,7 @@ Run the following code to generate a local master key using Ruby:
   require 'securerandom'
 
   local_master_key = SecureRandom.random_bytes(96)
+  # => "\xB2\xBE\x8EN\xD4\x14\xC2\x13\xC3..." (a binary blob)
 
 AWS Master Key
 ~~~~~~~~~~~~~~
@@ -289,11 +311,9 @@ store your master key. To do so, follow steps 1 and 2 of the
 :manual:`"Convert to a Remote Master Key" section</ecosystem/use-cases/client-side-field-level-encryption-local-key-to-kms/#convert-to-a-remote-master-key>`
 in the MongoDB Client-Side Encryption documentation.
 
-For more information about creating a master key, see the MongoDB manual.
-
-.. seealso::
-
-  :manual:`Create a Master Key </ecosystem/use-cases/client-side-field-level-encryption-guide/#a-create-a-master-key>`
+For more information about creating a master key, see the
+:manual:`Create a Master Key </ecosystem/use-cases/client-side-field-level-encryption-guide/#a-create-a-master-key>`
+section of the MongoDB manual.
 
 Creating a Data Key
 -------------------
@@ -309,6 +329,11 @@ Create a Data Key Using a Local Master Key
 
 If you have created a local master key, you may use it to generate a new data
 key with the following code snippet:
+
+.. warning::
+
+  Using a local master key is insecure and not recommended if you plan
+  to use client-side encryption in production.
 
 .. code-block:: ruby
 
@@ -329,6 +354,7 @@ key with the following code snippet:
   )
 
   data_key_id = client_encryption.create_data_key('local')
+  # => <BSON::Binary... type=ciphertext...>
 
 See the `Local Master Key`_ section for more information about generating a new
 local master key.
@@ -370,16 +396,15 @@ use that information to generate a data key.
 
     }
   )
+  # => <BSON::Binary... type=ciphertext...>
 
 See the `AWS Master Key`_ section of this tutorial  for more information about
 generating a new master key on AWS and finding the information you need to
 create data keys.
 
-For more information about creating a data key, see the MongoDB manual.
-
-.. seealso::
-
-  :manual:`Create a Data Encryption Key </ecosystem/use-cases/client-side-field-level-encryption-guide/#b-create-a-data-encryption-key>`
+For more information about creating a data key, see the
+:manual:`Create a Data Encryption Key </ecosystem/use-cases/client-side-field-level-encryption-guide/#b-create-a-data-encryption-key>`
+section of the MongoDB manual.
 
 Creating a Schema Map
 ---------------------
@@ -425,7 +450,7 @@ Before creating the JSON file, Base64-encode the UUID of the your data key.
   require 'base64'
 
   # Take note of the Base64-encoded uuid
-  Base64.encode64(data_key_id)
+  Base64.encode64(data_key_id).data
 
 Then, create a new JSON file containing your schema map in the extended JSON
 format defined by the :manual:`Extended JSON v2 Documentation`</reference/mongodb-extended-json>`.

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -21,6 +21,11 @@ any server-side configuration or directives. Client-side field-level encryption
 supports workloads where applications must guarantee that unauthorized parties,
 including server administrators, cannot read the encrypted data.
 
+.. warning::
+
+  Enabling Client Side Encryption reduces the maximum write batch size and may
+  have a negative performance impact.
+
 Installation
 ------------
 
@@ -80,7 +85,20 @@ Automatic encryption is a feature that allows users to configure a
 performing database operations. Once the ``Mongo::Client`` is configured, it
 will automatically encrypt any field that requires encryption before writing
 it to the database, and it will automatically decrypt those fields when reading
-them. Automatic encryption is an enterprise-only feature.
+them.
+
+.. note::
+
+  Automatic encryption is an enterprise only feature that only applies to
+  operations on a collection. Automatic encryption is not supported for operations
+  on a database or view, and operations that are not bypassed will result in
+  error (see `libmongocrypt: Auto Encryption Whitelist<https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-whitelist>`
+  ). To bypass automatic encryption for all operations, set ``bypass_auto_encryption``
+  to true in ``auto_encryption_options``.
+
+.. note::
+
+  Automatic encryption requires the authenticated user to have the listCollections privilege action.
 
 The following example provides a demonstration of auto-encryption using a local
 master key.
@@ -366,14 +384,33 @@ For more information about creating a data key, see the MongoDB manual.
 Creating a Schema Map
 ---------------------
 
-.. note::
-
-  Schema maps are only used in automatic encryption.
-
 Once you have created a data key, you can use it to encrypt and decrypt data
 during automatic encryption by referencing it in a schema map. A schema map
 is a Hash that provides the ``Mongo::Client`` with information about which
 fields to automatically encrypt and decrypt.
+
+.. note::
+
+  Schema maps are only used in automatic encryption.
+
+Remote Schema Map
+~~~~~~~~~~~~~~~~~
+
+.. warning::
+
+  Supplying a schemaMap provides more security than relying on JSON Schemas
+  obtained from the server. It protects against a malicious server advertising
+  a false JSON Schema, which could trick the client into sending unencrypted
+  data that should be encrypted.
+
+.. note::
+
+  Schemas supplied in the schemaMap only apply to configuring automatic encryption
+  for client side encryption. Other validation rules in the JSON schema will not
+  be enforced by the driver and will result in an error.
+
+Local Schema Map
+~~~~~~~~~~~~~~~~
 
 The code snippet at the top of this tutorial demonstrates creating a schema
 map using a Ruby ``Hash``. While this will work, schema maps can grow quite

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -115,12 +115,18 @@ in order to perform automatic encryption.
 
   require 'mongo'
 
-  # Step 1: Create a local master key
+  #####################################
+  # Step 1: Create a local master key #
+  #####################################
+
   # A local master key is a 96-byte binary blob.
   local_master_key = SecureRandom.random_bytes(96)
   # => "\xB2\xBE\x8EN\xD4\x14\xC2\x13\xC3..."
 
-  # Step 2: Create a data key
+  #############################
+  # Step 2: Create a data key #
+  #############################
+
   kms_providers = {
     local: {
       key: local_master_key
@@ -141,7 +147,10 @@ in order to perform automatic encryption.
   data_key_id = client_encryption.create_data_key('local')
   # => <BSON::Binary... type=ciphertext...>
 
-  # Step 3: Configure a Mongo::Client instance for automatic encryption
+  #######################################################
+  # Step 3: Configure Mongo::Client for auto-encryption #
+  #######################################################
+
   # Create a schema map, which tells the Mongo::Client which fields to encrypt
   schema_map = {
     'encryption_db.encryption_coll': {
@@ -188,8 +197,8 @@ The example above demonstrates using automatic encryption with a local master ke
 For more information about using the AWS Key Management Service to create a
 master key and create data keys, see the following sections of this tutorial:
 
-- `Creating A Master Key`_,
-- `Creating A Data Key`_,
+- `Creating A Master Key`_
+- `Creating A Data Key`_
 
 Explicit Encryption
 -------------------
@@ -214,12 +223,18 @@ in order to perform explicit encryption.
 
   require 'mongo'
 
-  # Step 1: Create a local master key
+  #####################################
+  # Step 1: Create a local master key #
+  #####################################
+
   # A local master key is a 96-byte binary blob.
   local_master_key = SecureRandom.random_bytes(96)
   # => "\xB2\xBE\x8EN\xD4\x14\xC2\x13\xC3..."
 
-  # Step 2: Create a data key
+  #############################
+  # Step 2: Create a data key #
+  #############################
+
   kms_providers = {
     local: {
       key: local_master_key
@@ -240,7 +255,9 @@ in order to perform explicit encryption.
   data_key_id = client_encryption.create_data_key('local')
   # => <BSON::Binary... type=ciphertext...>
 
-  # Step 3: Explicitly encrypt a string
+  #####################################################
+  # Step 3: Encrypt a string with explicit encryption #
+  #####################################################
 
   # The value to encrypt
   value = 'sensitive data'
@@ -465,7 +482,6 @@ Before creating the JSON file, Base64-encode the UUID of the your data key.
 
 .. code-block:: ruby
 
-  # Take note of the Base64-encoded uuid
   Base64.encode64(data_key_id.data)
   # => "sr6OTtQUwhPD..." (a base64-encoded string)
 
@@ -554,22 +570,27 @@ Every option in this ``Hash`` has a default value, so it is only necessary to
 provide the options whose defaults you want to override.
 
 **``:mongocryptd_spawn_args``**
+
 This is an ``Array<String>`` containing arguments for spawning mongocryptd.
 The Ruby driver will pass these arguments to mongocryptd on spawning the daemon.
 Possible arguments are:
+
 - ``"--idleShutdownTimeoutSecs"`` - The number of seconds mongocryptd must remain
   idle before it shuts itself down. The default value is 60.
 - ``"--port"`` - The port at which mongocryptd will listen for connections. The
   default is 27020.
 
 **``:mongocryptd_uri``**
+
 The URI that the driver will use to connect to mongocryptd. By default, this is
 ``"mongodb://localhost:27020"``.
 
 **``:mongocryptd_spawn_path``**
+
 The path to the mongocryptd executable. The default is ``"mongocryptd"``.
 
 **``:mongocryptd_bypass_spawn``**
+
 A ``Boolean`` indicating whether the driver should skip spawning mongocryptd.
 
 For example, if you would like to run mongocryptd on port 30000, provide

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -105,10 +105,8 @@ master key.
 
   client_encryption = Mongo::ClientEncryption.new(
     key_vault_client,
-    {
-      key_vault_namespace: 'admin.datakeys',
-      kms_providers: kms_providers
-    }
+    key_vault_namespace: 'admin.datakeys',
+    kms_providers: kms_providers
   )
 
   data_key_id = client_encryption.create_data_key('local')
@@ -195,10 +193,8 @@ and then decrypting it after reading it from the database.
 
   client_encryption = Mongo::ClientEncryption.new(
     key_vault_client,
-    {
-      key_vault_namespace: 'admin.datakeys',
-      kms_providers: kms_providers
-    }
+    key_vault_namespace: 'admin.datakeys',
+    kms_providers: kms_providers
   )
 
   data_key_id = client_encryption.create_data_key('local')
@@ -305,13 +301,11 @@ key with the following code snippet:
 
   client_encryption = Mongo::ClientEncryption.new(
     key_vault_client,
-    {
-      # Replace with the database and collection names for your key vault collection
-      key_vault_namespace: 'admin.datakeys',
-      kms_providers: {
-        local: {
-          key: local_master_key
-        }
+    # Replace with the database and collection names for your key vault collection
+    key_vault_namespace: 'admin.datakeys',
+    kms_providers: {
+      local: {
+        key: local_master_key
       }
     }
   )
@@ -338,14 +332,12 @@ use that information to generate a data key.
 
   client_encryption = Mongo::ClientEncryption.new(
     key_vault_client,
-    {
-      # Replace with the database and collection names for your key vault collection
-      key_vault_namespace: 'admin.datakeys',
-      kms_providers: {
-        aws: {
-          access_key_id: 'IAM-ACCESS-KEY-ID',
-          secret_access_key: 'IAM-SECRET-ACCESS-KEY'
-        }
+    # Replace with the database and collection names for your key vault collection
+    key_vault_namespace: 'admin.datakeys',
+    kms_providers: {
+      aws: {
+        access_key_id: 'IAM-ACCESS-KEY-ID',
+        secret_access_key: 'IAM-SECRET-ACCESS-KEY'
       }
     }
   )

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -103,7 +103,7 @@ in order to perform automatic encryption.
   Automatic encryption is an enterprise only feature that only applies to
   operations on a collection. Automatic encryption is not supported for operations
   on a database or view, and operations that are not bypassed will result in
-  error (see `libmongocrypt: Auto Encryption Whitelist<https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-whitelist>`
+  error (see `Auto Encryption Whitelist <https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#libmongocrypt-auto-encryption-whitelist>`_
   ). To bypass automatic encryption for all operations, set ``bypass_auto_encryption``
   to true in ``auto_encryption_options``.
 

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -139,7 +139,7 @@ master key.
     }
   )
 
-  collection = client.use(:encryption_db)[:encryption_coll]
+  collection = client.use('encryption_db')['encryption_coll']
   collection.drop # Make sure there is no data in the collection
 
   # The string "sensitive data" will be encrypted and stored in the database
@@ -152,7 +152,7 @@ master key.
 
   # A client with no auto_encryption_options is unable to decrypt the data
   client_no_encryption = Mongo::Client.new(['localhost:27017'])
-  client_no_encryption.use(:encryption_db)[:encryption_coll].find.first['encrypted_field']
+  client_no_encryption.use('encryption_db')['encryption_coll'].find.first['encrypted_field']
   # => <BSON::Binary...>
 
 For more information about creating an encryption master key, creating a data key,
@@ -217,7 +217,7 @@ and then decrypting it after reading it from the database.
 
   # Create the client you will use to read and write the data to MongoDB
   client = Mongo::Client.new(['localhost:27017'])
-  collection = client.use(:encryption_db)[:encryption_coll]
+  collection = client.use('encryption_db')['encryption_coll']
   collection.drop # Make sure there is no data in the collection
 
   # Insert the encrypted value into the collection

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -574,29 +574,23 @@ decryption of any previously-encrypted data.
 Every option in this ``Hash`` has a default value, so it is only necessary to
 provide the options whose defaults you want to override.
 
-**``:mongocryptd_spawn_args``**
+- ``:mongocryptd_spawn_args`` - This is an ``Array<String>`` containing arguments
+  for spawning mongocryptd. The Ruby driver will pass these arguments to
+  mongocryptd on spawning the daemon. Possible arguments are:
 
-This is an ``Array<String>`` containing arguments for spawning mongocryptd.
-The Ruby driver will pass these arguments to mongocryptd on spawning the daemon.
-Possible arguments are:
+  - ``"--idleShutdownTimeoutSecs"`` - The number of seconds mongocryptd must remain
+    idle before it shuts itself down. The default value is 60.
+  - ``"--port"`` - The port at which mongocryptd will listen for connections. The
+    default is 27020.
 
-- ``"--idleShutdownTimeoutSecs"`` - The number of seconds mongocryptd must remain
-  idle before it shuts itself down. The default value is 60.
-- ``"--port"`` - The port at which mongocryptd will listen for connections. The
-  default is 27020.
+- ``:mongocryptd_uri`` - The URI that the driver will use to connect to mongocryptd.
+  By default, this is ``"mongodb://localhost:27020"``.
 
-**``:mongocryptd_uri``**
+- ``:mongocryptd_spawn_path`` - The path to the mongocryptd executable. The default
+  is ``"mongocryptd"``.
 
-The URI that the driver will use to connect to mongocryptd. By default, this is
-``"mongodb://localhost:27020"``.
-
-**``:mongocryptd_spawn_path``**
-
-The path to the mongocryptd executable. The default is ``"mongocryptd"``.
-
-**``:mongocryptd_bypass_spawn``**
-
-A ``Boolean`` indicating whether the driver should skip spawning mongocryptd.
+- ``:mongocryptd_bypass_spawn`` - A ``Boolean`` indicating whether the driver should
+  skip spawning mongocryptd.
 
 For example, if you would like to run mongocryptd on port 30000, provide
 ``extra_options`` as follows:

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -77,6 +77,11 @@ Mongocryptd comes pre-packaged with enterprise builds of the MongoDB server
 (versions 4.2 and newer). For installation instructions, see
 `the MongoDB manual <https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/#installation>`_.
 
+In order to configure mongocryptd (for example, which port it listens on or the
+path used to spawn the daemon), it is necessary to pass different options to the
+``Mongo::Client`` performing automatic encryption. See the `:extra_options`_
+section of this tutorial for more information.
+
 Automatic Encryption
 --------------------
 

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -404,7 +404,7 @@ For more information about creating a data key, see the
 :manual:`Create a Data Encryption Key </ecosystem/use-cases/client-side-field-level-encryption-guide/#b-create-a-data-encryption-key>`
 section of the MongoDB manual.
 
-auto_encryption_options
+Auto-Encryption Options
 -----------------------
 Automatic encryption can be configured on a ``Mongo::Client`` using the
 ``auto_encryption_options`` option ``Hash``. This section provides an overview
@@ -412,7 +412,7 @@ of the fields inside ``auto_encryption_options`` and explains how to choose thei
 values.
 
 ``:key_vault_client``
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 The key vault client is a ``Mongo::Client`` instance that will be used to connect
 to the MongoDB collection containing your encryption data keys. For example, if
 your key vault was hosted on a MongoDB instance at ``localhost:30000``:
@@ -433,7 +433,7 @@ data, you may leave this option blank, and the top-level client will be used
 to insert and fetch data keys.
 
 ``:key_vault_namespace``
-~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~
 The key vault namespace is a ``String`` in the format ``"database_name.collection_name"``,
 where ``database_name`` and ``collection_name`` are the name of the database and
 collection in which you would like to store your data keys. For example, if your data
@@ -451,7 +451,7 @@ keys are stored in the ``admin`` database in the ``datakeys`` collection:
 There is no default key vault namespace, and this option must be provided.
 
 ``:schema_map``
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~
 A schema map is a Hash with information about which fields to automatically
 encrypt and decrypt.
 

--- a/docs/tutorials/client-side-encryption.txt
+++ b/docs/tutorials/client-side-encryption.txt
@@ -299,8 +299,6 @@ Run the following code to generate a local master key using Ruby:
 
 .. code-block:: ruby
 
-  require 'securerandom'
-
   local_master_key = SecureRandom.random_bytes(96)
   # => "\xB2\xBE\x8EN\xD4\x14\xC2\x13\xC3..." (a binary blob)
 
@@ -406,36 +404,56 @@ For more information about creating a data key, see the
 :manual:`Create a Data Encryption Key </ecosystem/use-cases/client-side-field-level-encryption-guide/#b-create-a-data-encryption-key>`
 section of the MongoDB manual.
 
-Creating a Schema Map
----------------------
+auto_encryption_options
+-----------------------
+Automatic encryption can be configured on a ``Mongo::Client`` using the
+``auto_encryption_options`` option ``Hash``. This section provides an overview
+of the fields inside ``auto_encryption_options`` and explains how to choose their
+values.
 
-Once you have created a data key, you can use it to encrypt and decrypt data
-during automatic encryption by referencing it in a schema map. A schema map
-is a Hash that provides the ``Mongo::Client`` with information about which
-fields to automatically encrypt and decrypt.
+``:key_vault_client``
+~~~~~~~~~~~~~~~~~~~~
+The key vault client is a ``Mongo::Client`` instance that will be used to connect
+to the MongoDB collection containing your encryption data keys. For example, if
+your key vault was hosted on a MongoDB instance at ``localhost:30000``:
 
-.. note::
+.. code-block:: ruby
 
-  Schema maps are only used in automatic encryption.
+  key_vault_client = Mongo::Client.new(['localhost:30000'])
 
-Remote Schema Map
-~~~~~~~~~~~~~~~~~
+  Mongo::Client.new(['localhost:27017],
+    auto_encryption_options: {
+      key_vault_client: key_vault_client,
+      # ... (Fill in other options here)
+    }
+  )
 
-.. warning::
+If your data keys are stored in the same MongoDB instance that stores your encrypted
+data, you may leave this option blank, and the top-level client will be used
+to insert and fetch data keys.
 
-  Supplying a schemaMap provides more security than relying on JSON Schemas
-  obtained from the server. It protects against a malicious server advertising
-  a false JSON Schema, which could trick the client into sending unencrypted
-  data that should be encrypted.
+``:key_vault_namespace``
+~~~~~~~~~~~~~~~~~~~~~~~
+The key vault namespace is a ``String`` in the format ``"database_name.collection_name"``,
+where ``database_name`` and ``collection_name`` are the name of the database and
+collection in which you would like to store your data keys. For example, if your data
+keys are stored in the ``admin`` database in the ``datakeys`` collection:
 
-.. note::
+.. code-block:: ruby
 
-  Schemas supplied in the schemaMap only apply to configuring automatic encryption
-  for client side encryption. Other validation rules in the JSON schema will not
-  be enforced by the driver and will result in an error.
+  Mongo::Client.new(['localhost:27017],
+    auto_encryption_options: {
+      key_vault_namespace: 'admin.datakeys',
+      # ... (Fill in other options here)
+    }
+  )
 
-Local Schema Map
-~~~~~~~~~~~~~~~~
+There is no default key vault namespace, and this option must be provided.
+
+``:schema_map``
+~~~~~~~~~~~~~~
+A schema map is a Hash with information about which fields to automatically
+encrypt and decrypt.
 
 The code snippet at the top of this tutorial demonstrates creating a schema
 map using a Ruby ``Hash``. While this will work, schema maps can grow quite
@@ -447,21 +465,14 @@ Before creating the JSON file, Base64-encode the UUID of the your data key.
 
 .. code-block:: ruby
 
-  require 'base64'
-
   # Take note of the Base64-encoded uuid
-  Base64.encode64(data_key_id).data
+  Base64.encode64(data_key_id.data)
+  # => "sr6OTtQUwhPD..." (a base64-encoded string)
 
-Then, create a new JSON file containing your schema map in the extended JSON
-format defined by the :manual:`Extended JSON v2 Documentation`</reference/mongodb-extended-json>`.
-
-Note that:
-
-* ``encryption_db`` and ``encryption_coll`` should be replaced with the
-  names of the database and collection where you plan to store encrypted data.
-* ``encrypted_field`` should be replaced with the name of the field you want to encrypt.
-* ``"bsonType": "string"`` should be replaced with the data type you intend to
-  encrypt, such as ``"bsonType": "integer"`` or ``"bsonType": "symbol"``.
+Then, create a new JSON file containing your schema map in the format defined by
+the JSON Schema Draft 4 standard syntax. You can read more about formatting
+your schema map in the :manual:`Automatic Encryption Rules</reference/security-client-side-automatic-json-schema/>`
+section of the MongoDB manual.
 
 .. code-block:: json
 
@@ -490,13 +501,93 @@ When you intend to use your schema map, convert it to a Ruby ``Hash`` using the
 
 .. code-block:: ruby
 
-  require 'bson'
+  schema_map = BSON::ExtJSON.parse(File.read('/path/to/your/file.json'))
+  # => { 'encryption_db.encryption_coll' => { ... } }
 
-  # schema_map is a Ruby Hash
-  schema_map = BSON::ExtJSON.parse(File.open('/path/to/your/file.json'))
+  Mongo::Client.new(['localhost:27017],
+    auto_encryption_options: {
+      schema_map: schema_map,
+      # ... (Fill in other options here)
+    }
+  )
 
-For more information about schema maps, see the MongoDB manual.
+.. note::
+
+  It is also possible to supply a schema map as a validator on a MongoDB collection.
+  This is referred to as a "remote schema map," while providing the schema map as
+  an option on the ``Mongo::Client`` is called a "local schema map."
+
+  Supplying a local schema map provides more security than relying on JSON schemas
+  obtained from the server. It protects against a malicious server advertising
+  a false JSON schema, which could trick the client into sending unencrypted
+  data that should be encrypted.
+
+  See :manual:`Server-Side Field Level Encryption Enforcement</core/security-automatic-client-side-encryption/#server-side-field-level-encryption-enforcement>`
+  in the MongoDB manual for more information about using the schema map to
+  create a JSON schema validator on your collection.
 
 .. seealso::
 
-  :manual:`Specify Encrypted Fields Using JSON Schema`</ecosystem/use-cases/client-side-field-level-encryption-guide/#c-specify-encrypted-fields-using-json-schema>`
+  :manual:`Specify Encrypted Fields Using JSON Schema</ecosystem/use-cases/client-side-field-level-encryption-guide/#c-specify-encrypted-fields-using-json-schema>`,
+  :manual:`Automatic Encryption Rules</reference/security-client-side-automatic-json-schema/>`
+
+``:bypass_auto_encryption``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``:bypass_auto_encryption`` option is a ``Boolean`` that specifies whether the
+``Mongo::Client`` should skip encryption when writing to the database. If
+``:bypass_auto_encryption`` is ``true``, the client will still perform automatic
+decryption of any previously-encrypted data.
+
+.. code-block:: ruby
+
+  Mongo::Client.new(['localhost:27017],
+    auto_encryption_options: {
+      bypass_auto_encryption: true,
+      # ... (Fill in other options here)
+    }
+  )
+
+``:extra_options``
+~~~~~~~~~~~~~~~~~~
+``:extra_options`` is a ``Hash`` of options related to spawning mongocryptd.
+Every option in this ``Hash`` has a default value, so it is only necessary to
+provide the options whose defaults you want to override.
+
+**``:mongocryptd_spawn_args``**
+This is an ``Array<String>`` containing arguments for spawning mongocryptd.
+The Ruby driver will pass these arguments to mongocryptd on spawning the daemon.
+Possible arguments are:
+- ``"--idleShutdownTimeoutSecs"`` - The number of seconds mongocryptd must remain
+  idle before it shuts itself down. The default value is 60.
+- ``"--port"`` - The port at which mongocryptd will listen for connections. The
+  default is 27020.
+
+**``:mongocryptd_uri``**
+The URI that the driver will use to connect to mongocryptd. By default, this is
+``"mongodb://localhost:27020"``.
+
+**``:mongocryptd_spawn_path``**
+The path to the mongocryptd executable. The default is ``"mongocryptd"``.
+
+**``:mongocryptd_bypass_spawn``**
+A ``Boolean`` indicating whether the driver should skip spawning mongocryptd.
+
+For example, if you would like to run mongocryptd on port 30000, provide
+``extra_options`` as follows:
+
+.. code-block:: ruby
+
+    Mongo::Client.new(['localhost:27017],
+    auto_encryption_options: {
+      extra_options: {
+        mongocryptd_spawn_args: ['--port=30000'],
+        mongocryptd_uri: 'mongodb://localhost:30000',
+      }
+      # ... (Fill in other options here)
+    }
+  )
+
+.. warning::
+
+  The contents of ``:extra_options`` is subject to change in future versions
+  of the client-side encryption API.

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -141,6 +141,26 @@ Ruby Options
      - For MongoDB 2.6 and later: **admin** if credentials are
        supplied, otherwise the current database
 
+   * - ``:auto_encryption_options``
+     - A ``Hash`` of options for configuring automatic encryption.
+
+       - ``:key_vault_client`` - A client connected to the MongoDB instance
+         storing the encryption data keys (``Mongo::Client``, defaults to the
+         top-level client instance).
+       - ``:key_vault_namespace`` - The namespace of the key vault collection
+         in the format ``"database.collection"`` (``String``, required).
+       - ``:kms_providers`` - Key management service configuration information.
+         One or both of the keys ``:local`` and ``:aws`` must be specified
+         (``Hash``, required). See the :ref:`Client-Side Encryption tutorial<client-side-encryption>`
+         for more information about how to format this option.
+       - ``:schema_map`` - The JSONSchema for one or more collections specifying
+         which fields should be encrypted (``Hash``, optional, defaults to nil).
+         For more information about the format of this field, see the
+         :manual:`Auto Encryption Rules documentation</reference/security-client-side-automatic-json-schema/>`
+         in the MongoDB manual.
+     - ``Hash``
+     - none
+
    * - ``:compressors``
      - A list of potential compressors to use, in order of preference. The driver chooses the first
        compressor that is also supported by the server. Currently the driver only supports 'zlib'.
@@ -325,7 +345,7 @@ Ruby Options
        context in ``extra_chain_cert`` attribute. If intermediate certificates
        are provided, they must follow the client certificate which must be
        the first certificate in the file.
-       
+
        This option, if present, takes precedence over ``:ssl_cert_string`` and
        ``:ssl_cert_object`` options.
      - ``String``
@@ -348,7 +368,7 @@ Ruby Options
        to the OpenSSL context in ``extra_chain_cert`` attribute. If intermediate
        certificates are provided, they must follow the client certificate which
        must be the first certificatet in the string.
-       
+
        This option, if present, takes precedence over the ``:ssl_cert_object``
        option.
      - ``String``
@@ -463,17 +483,17 @@ URI options are explained in detail in the :manual:`Connection URI reference
 
    * - authMechanism=String
      - ``:auth_mech => Symbol``
-     
+
        Auth mechanism values are converted as follows from URI options to
        Ruby options:
-       
+
        - ``GSSAPI`` => ``:gssapi``
        - ``MONGODB-CR`` => ``:mongodb_cr``
        - ``MONGODB-X509`` => ``:mongodb_x509``
        - ``PLAIN`` => ``:plain``
        - ``SCRAM-SHA-1`` => ``:scram``
        - ``SCRAM-SHA-256`` => ``:scram256``
-       
+
        If a different value is provided for auth mechanism, it is converted
        to the Ruby option unmodified and retains its ``String`` type.
        Note that, while currently the driver allows a ``Client`` instance
@@ -521,7 +541,7 @@ URI options are explained in detail in the :manual:`Connection URI reference
 
    * - maxStalenessSeconds=Integer
      - ``{ :read => { :max_staleness => Integer }}``
-     
+
        If the maxStalenessSeconds URI option value is -1, the driver treats
        this as if the option was not given at all. Otherwise,
        if the option value is numeric, the Ruby option is set to the

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -162,7 +162,7 @@ Ruby Options
          optional, defaults to ``nil``).
 
        For more information about formatting these options, see the
-       "Auto-Encryption Options" section of the :ref:`Client-Side Encryption tutorial <client-side-encryption#auto-encryption-options>`.
+       "Auto-Encryption Options" section of the :ref:`Client-Side Encryption tutorial<client-side-encryption>`.
      - ``Hash``
      - none
 

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -162,7 +162,7 @@ Ruby Options
          optional, defaults to ``nil``).
 
        For more information about formatting these options, see the
-       "Auto-Encryption Options" section of the :ref:`Client-Side Encryption tutorial<client-side-encryption>`.
+       "Auto-Encryption Options" section of the :ref:`Client-Side Encryption tutorial <client-side-encryption#auto-encryption-options>`.
      - ``Hash``
      - none
 

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -156,17 +156,12 @@ Ruby Options
          information about this option.
        - ``:schema_map`` - The JSONSchema for one or more collections specifying
          which fields should be encrypted (``Hash``, optional, defaults to ``nil``).
-         For more information about the format of this field, see the
-         :manual:`Auto Encryption Rules documentation</reference/security-client-side-automatic-json-schema/>`
-         in the MongoDB manual.
        - ``:bypass_auto_encryption`` - Whether to skip automatic encryption when
          performing database operations (``Boolean``, defaults to ``false``).
        - ``:extra_options`` - Options related to spawning mongocryptd (``Hash``,
-         optional, defaults to ``nil``). See the "Spawning mongocryptd" section
-         of the :ref:`Client-Side Encryption tutorial<client-side-encryption>`
-         for more information about this option.
+         optional, defaults to ``nil``).
 
-       For more information about automatic encryption, see the :ref:`Client-Side Encryption tutorial<client-side-encryption>`.
+       For more information about formatting these options, see the :ref:`Client-Side Encryption tutorial<client-side-encryption#auto-encryption-options>`.
      - ``Hash``
      - none
 

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -161,7 +161,8 @@ Ruby Options
        - ``:extra_options`` - Options related to spawning mongocryptd (``Hash``,
          optional, defaults to ``nil``).
 
-       For more information about formatting these options, see the :ref:`Client-Side Encryption tutorial<client-side-encryption#auto-encryption-options>`.
+       For more information about formatting these options, see the
+       "Auto-Encryption Options" section of the :ref:`Client-Side Encryption tutorial<client-side-encryption>`.
      - ``Hash``
      - none
 

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -151,13 +151,22 @@ Ruby Options
          in the format ``"database.collection"`` (``String``, required).
        - ``:kms_providers`` - Key management service configuration information.
          One or both of the keys ``:local`` and ``:aws`` must be specified
-         (``Hash``, required). See the :ref:`Client-Side Encryption tutorial<client-side-encryption>`
-         for more information about how to format this option.
+         (``Hash``, required). See the "The ``kms_providers`` option`` section of the
+         :ref:`Client-Side Encryption tutorial<client-side-encryption>` for more
+         information about this option.
        - ``:schema_map`` - The JSONSchema for one or more collections specifying
-         which fields should be encrypted (``Hash``, optional, defaults to nil).
+         which fields should be encrypted (``Hash``, optional, defaults to ``nil``).
          For more information about the format of this field, see the
          :manual:`Auto Encryption Rules documentation</reference/security-client-side-automatic-json-schema/>`
          in the MongoDB manual.
+       - ``:bypass_auto_encryption`` - Whether to skip automatic encryption when
+         performing database operations (``Boolean``, defaults to ``false``).
+       - ``:extra_options`` - Options related to spawning mongocryptd (``Hash``,
+         optional, defaults to ``nil``). See the "Spawning mongocryptd" section
+         of the :ref:`Client-Side Encryption tutorial<client-side-encryption>`
+         for more information about this option.
+
+       For more information about automatic encryption, see the :ref:`Client-Side Encryption tutorial<client-side-encryption>`.
      - ``Hash``
      - none
 


### PR DESCRIPTION
This PR adds an `auto_encryption_options` section to the Client Ruby options documentation and makes some improvements to the Client-Side Encryption documentation.

Client-Side Encryption documentation Improvements:
- Add documentation required by the spec to the documentation
- Convert db and collection names from symbols to strings
- Remove unnecessary curly braces
- Add comments about expected results to the code
- Add a section about auto encryption options, which should provide more info about spawning mongocryptd
- Break up big code examples into three major steps and explain why those steps are necessary (envelope encryption)

See the Ruby options documentation on staging [here](https://docs-mongodbcom-staging.corp.mongodb.com/ruby-driver/root/master/tutorials/ruby-driver-create-client.html#ruby-options)

See the Client-side encryption documentation on staging [here](https://docs-mongodbcom-staging.corp.mongodb.com/ruby-driver/root/master/tutorials/client-side-encryption.html)