### PR TITLE
DOCSP-9414: Replace Google Groups with MongoDB Community Forum

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Support & Feedback
 For issues, questions or feedback related to the Ruby driver, please look into
 our [support channels](http://www.mongodb.org/about/support). Please
 do not email any of the Ruby developers directly with issues or
-questions - you're more likely to get an answer quickly on the [mongodb-user list](http://groups.google.com/group/mongodb-user) on Google Groups.
+questions - you're more likely to get an answer quickly on the
+[MongoDB Community Forum](https://community.mongodb.com).
 
 
 Bugs & Feature Requests

--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY
 
   s.authors           = ['Tyler Brock', 'Emily Stolfo', 'Durran Jordan']
-  s.email             = 'mongodb-dev@googlegroups.com'
   s.homepage          = 'https://docs.mongodb.com/ruby-driver/'
   s.summary           = 'Ruby driver for MongoDB'
   s.description       = 'A Ruby driver for MongoDB'
@@ -19,7 +18,6 @@ Gem::Specification.new do |s|
     'changelog_uri' => 'https://github.com/mongodb/mongo-ruby-driver/releases',
     'documentation_uri' => 'https://docs.mongodb.com/ruby-driver/',
     'homepage_uri' => 'https://docs.mongodb.com/ruby-driver/',
-    'mailing_list_uri' => 'https://groups.google.com/group/mongodb-user',
     'source_code_uri' => 'https://github.com/mongodb/mongo-ruby-driver',
   }
 


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/DOCSP-9414

Please advise on what should be done with the gemspec that references the google group as the mailing list. Thanks!