### PR TITLE
RUBY-2147 Run FLE tests on replica set

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -89,7 +89,7 @@ functions:
 
             export STRESS_SPEC=true
           EOT
-          
+
           # See what we've done
           cat expansion.yml
 
@@ -789,7 +789,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: "noauth-and-nossl"
       ruby: [ruby-2.7, ruby-2.3, jruby-9.2]
-      topology: standalone
+      topology: [standalone, replica-set]
       mongodb-version: ["4.2"]
       os: rhel70
       fle: fle

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -793,7 +793,7 @@ buildvariants:
       mongodb-version: ["4.2"]
       os: rhel70
       fle: fle
-    display_name: "FLE Tests: ${mongodb-version} ${ruby}"
+    display_name: "FLE Tests: ${topology} ${mongodb-version} ${ruby}"
     tasks:
       - name: "test-fle"
 

--- a/lib/mongo/crypt/encryption_io.rb
+++ b/lib/mongo/crypt/encryption_io.rb
@@ -179,7 +179,8 @@ module Mongo
       def key_vault_collection
         @key_vault_collection ||= @key_vault_client.with(
           database: @key_vault_db_name,
-          read_concern: { level: :majority }
+          read_concern: { level: :majority },
+          write_concern: { w: :majority }
         )[@key_vault_collection_name]
       end
 

--- a/spec/integration/client_side_encryption/auto_encryption_bulk_writes_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_bulk_writes_spec.rb
@@ -31,8 +31,8 @@ describe 'Bulk writes with auto-encryption enabled' do
   before do
     authorized_client.use('auto_encryption')['users'].drop
 
-    authorized_client.use('admin')['datakeys'].drop
-    authorized_client.use('admin')['datakeys'].insert_one(data_key)
+    key_vault_collection.drop
+    key_vault_collection.insert_one(data_key)
   end
 
   let(:command_succeeded_events) do

--- a/spec/integration/client_side_encryption/auto_encryption_bulk_writes_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_bulk_writes_spec.rb
@@ -49,7 +49,7 @@ describe 'Bulk writes with auto-encryption enabled' do
     end
 
     it 'executes an encrypted bulk write' do
-      documents = authorized_client.use(:auto_encryption)[:users].find
+      documents = authorized_client.use('auto_encryption')['users'].find
       ssns = documents.map { |doc| doc['ssn'] }
       expect(ssns).to all(be_ciphertext)
     end
@@ -295,7 +295,7 @@ describe 'Bulk writes with auto-encryption enabled' do
 
   context '#insert_many' do
     let(:perform_bulk_write) do
-      client[:users].insert_many(documents)
+      client['users'].insert_many(documents)
     end
 
     let(:command_name) { 'insert' }

--- a/spec/integration/client_side_encryption/auto_encryption_command_monitoring_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_command_monitoring_spec.rb
@@ -32,8 +32,8 @@ describe 'Auto Encryption' do
   end
 
   before(:each) do
-    authorized_client.use(key_vault_db)[key_vault_coll].drop
-    authorized_client.use(key_vault_db)[key_vault_coll].insert_one(data_key)
+    key_vault_collection.drop
+    key_vault_collection.insert_one(data_key)
 
     encryption_client[:users].drop
     result = encryption_client[:users].insert_one(ssn: ssn, age: 23)

--- a/spec/integration/client_side_encryption/auto_encryption_command_monitoring_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_command_monitoring_spec.rb
@@ -35,8 +35,8 @@ describe 'Auto Encryption' do
     key_vault_collection.drop
     key_vault_collection.insert_one(data_key)
 
-    encryption_client[:users].drop
-    result = encryption_client[:users].insert_one(ssn: ssn, age: 23)
+    encryption_client['users'].drop
+    result = encryption_client['users'].insert_one(ssn: ssn, age: 23)
   end
 
   let(:started_event) do
@@ -68,7 +68,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'aggregate' }
 
     before do
-      encryption_client[:users].aggregate([{ '$match' => { 'ssn' => ssn } }]).first
+      encryption_client['users'].aggregate([{ '$match' => { 'ssn' => ssn } }]).first
     end
 
     it 'has encrypted data in command monitoring' do
@@ -88,7 +88,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'count' }
 
     before do
-      encryption_client[:users].count(ssn: ssn)
+      encryption_client['users'].count(ssn: ssn)
     end
 
     it 'has encrypted data in command monitoring' do
@@ -104,7 +104,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'distinct' }
 
     before do
-      encryption_client[:users].distinct(:ssn)
+      encryption_client['users'].distinct(:ssn)
     end
 
     it 'has encrypted data in command monitoring' do
@@ -120,7 +120,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'delete' }
 
     before do
-      encryption_client[:users].delete_one(ssn: ssn)
+      encryption_client['users'].delete_one(ssn: ssn)
     end
 
     it 'has encrypted data in command monitoring' do
@@ -136,7 +136,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'delete' }
 
     before do
-      encryption_client[:users].delete_many(ssn: ssn)
+      encryption_client['users'].delete_many(ssn: ssn)
     end
 
     it 'has encrypted data in command monitoring' do
@@ -152,7 +152,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'find' }
 
     before do
-      encryption_client[:users].find(ssn: ssn).first
+      encryption_client['users'].find(ssn: ssn).first
     end
 
     it 'has encrypted data in command monitoring' do
@@ -170,7 +170,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'findAndModify' }
 
     before do
-      encryption_client[:users].find_one_and_delete(ssn: ssn)
+      encryption_client['users'].find_one_and_delete(ssn: ssn)
     end
 
     it 'has encrypted data in command monitoring' do
@@ -188,7 +188,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'findAndModify' }
 
     before do
-      encryption_client[:users].find_one_and_replace(
+      encryption_client['users'].find_one_and_replace(
         { ssn: ssn },
         { ssn: '555-555-5555' }
       )
@@ -210,7 +210,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'findAndModify' }
 
     before do
-      encryption_client[:users].find_one_and_update(
+      encryption_client['users'].find_one_and_update(
         { ssn: ssn },
         { ssn: '555-555-5555' }
       )
@@ -233,7 +233,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'insert' }
 
     before do
-      encryption_client[:users].insert_one(ssn: ssn)
+      encryption_client['users'].insert_one(ssn: ssn)
     end
 
     it 'has encrypted data in command monitoring' do
@@ -249,7 +249,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'update' }
 
     before do
-      encryption_client[:users].replace_one(
+      encryption_client['users'].replace_one(
         { ssn: ssn },
         { ssn: '555-555-5555' }
       )
@@ -269,7 +269,7 @@ describe 'Auto Encryption' do
     let(:command_name) { 'update' }
 
     before do
-      encryption_client[:users].update_one({ ssn: ssn }, { ssn: '555-555-5555' })
+      encryption_client['users'].update_one({ ssn: ssn }, { ssn: '555-555-5555' })
     end
 
     it 'has encrypted data in command monitoring' do
@@ -287,7 +287,7 @@ describe 'Auto Encryption' do
 
     before do
       # update_many does not support replacement-style updates
-      encryption_client[:users].update_many({ ssn: ssn }, { "$inc" => { :age => 1 } })
+      encryption_client['users'].update_many({ ssn: ssn }, { "$inc" => { :age => 1 } })
     end
 
     it 'has encrypted data in command monitoring' do

--- a/spec/integration/client_side_encryption/auto_encryption_mongocryptd_spawn_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_mongocryptd_spawn_spec.rb
@@ -31,8 +31,8 @@ describe 'Auto Encryption' do
     let(:cluster) { double("Cluster") }
 
     before do
-      authorized_client.use(:admin)[:datakeys].drop
-      authorized_client.use(:admin)[:datakeys].insert_one(data_key)
+      key_vault_collection.drop
+      key_vault_collection.insert_one(data_key)
 
       allow(server_selector).to receive(:name)
       allow(server_selector).to receive(:server_selection_timeout)
@@ -61,7 +61,7 @@ describe 'Auto Encryption' do
 
     it 'raises an exception when trying to perform auto encryption' do
       expect do
-        client[:users].insert_one(ssn: ssn)
+        client['users'].insert_one(ssn: ssn)
       end.to raise_error(
         Mongo::Error::MongocryptdSpawnError,
         /Failed to spawn mongocryptd at the path "echo hello world" with arguments/

--- a/spec/integration/client_side_encryption/auto_encryption_old_wire_version_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_old_wire_version_spec.rb
@@ -28,7 +28,7 @@ describe 'Auto Encryption' do
   end
 
   let(:bypass_auto_encryption) { false }
-  let(:client) { authorized_client.use(:auto_encryption) }
+  let(:client) { authorized_client.use('auto_encryption') }
 
   let(:encrypted_ssn_binary) do
     BSON::Binary.new(Base64.decode64(encrypted_ssn), :ciphertext)
@@ -36,8 +36,8 @@ describe 'Auto Encryption' do
 
   shared_examples 'it decrypts but does not encrypt on wire version < 8' do
     before do
-      client[:users].drop
-      client[:users].insert_one(ssn: encrypted_ssn_binary)
+      client['users'].drop
+      client['users'].insert_one(ssn: encrypted_ssn_binary)
 
       key_vault_collection.drop
       key_vault_collection.insert_one(data_key)
@@ -45,7 +45,7 @@ describe 'Auto Encryption' do
 
     it 'raises an exception when trying to encrypt' do
       expect do
-        encryption_client[:users].find(ssn: ssn).first
+        encryption_client['users'].find(ssn: ssn).first
       end.to raise_error(Mongo::Error::CryptError, /Auto-encryption requires a minimum MongoDB version of 4.2/)
     end
 
@@ -53,12 +53,12 @@ describe 'Auto Encryption' do
       let(:bypass_auto_encryption) { true }
 
       it 'does not raise an exception but doesn\'t encrypt' do
-        document = encryption_client[:users].find(ssn: ssn).first
+        document = encryption_client['users'].find(ssn: ssn).first
         expect(document).to be_nil
       end
 
       it 'still decrypts' do
-        document = encryption_client[:users].find(ssn: encrypted_ssn_binary).first
+        document = encryption_client['users'].find(ssn: encrypted_ssn_binary).first
         # ssn field is still decrypted
         expect(document['ssn']).to eq(ssn)
       end

--- a/spec/integration/client_side_encryption/auto_encryption_old_wire_version_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_old_wire_version_spec.rb
@@ -36,10 +36,11 @@ describe 'Auto Encryption' do
 
   shared_examples 'it decrypts but does not encrypt on wire version < 8' do
     before do
+      client[:users].drop
       client[:users].insert_one(ssn: encrypted_ssn_binary)
 
-      authorized_client.use(:admin)[:datakeys].drop
-      authorized_client.use(:admin)[:datakeys].insert_one(data_key)
+      key_vault_collection.drop
+      key_vault_collection.insert_one(data_key)
     end
 
     it 'raises an exception when trying to encrypt' do

--- a/spec/integration/client_side_encryption/auto_encryption_reconnect_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_reconnect_spec.rb
@@ -73,8 +73,8 @@ describe 'Client with auto encryption #reconnect' do
 
   shared_examples 'an auto-encryption client that reconnects properly' do
     before do
-      authorized_client.use(:admin)[:datakeys].drop
-      authorized_client.use(:admin)[:datakeys].insert_one(data_key)
+      key_vault_collection.drop
+      key_vault_collection.insert_one(data_key)
 
       unencrypted_client[:users].drop
       # Use a client without auto_encryption_options to insert an

--- a/spec/integration/client_side_encryption/auto_encryption_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_spec.rb
@@ -29,7 +29,6 @@ describe 'Auto Encryption' do
   end
 
   let(:client) { authorized_client.use(:auto_encryption) }
-  let(:admin_client) { authorized_client.use(:admin) }
 
   let(:bypass_auto_encryption) { false }
 
@@ -76,8 +75,8 @@ describe 'Auto Encryption' do
 
   before(:each) do
     client[:users].drop
-    admin_client[:datakeys].drop
-    admin_client[:datakeys].insert_one(data_key)
+    key_vault_collection.drop
+    key_vault_collection.insert_one(data_key)
   end
 
   shared_examples 'an encrypted command' do

--- a/spec/integration/client_side_encryption/auto_encryption_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_spec.rb
@@ -28,7 +28,7 @@ describe 'Auto Encryption' do
     )
   end
 
-  let(:client) { authorized_client.use(:auto_encryption) }
+  let(:client) { authorized_client.use('auto_encryption') }
 
   let(:bypass_auto_encryption) { false }
 
@@ -44,7 +44,7 @@ describe 'Auto Encryption' do
     let(:local_schema) { nil }
 
     before do
-      client[:users,
+      client['users',
         {
           'validator' => { '$jsonSchema' => schema_map }
         }
@@ -56,25 +56,25 @@ describe 'Auto Encryption' do
     let(:local_schema) { { "auto_encryption.users" => schema_map } }
 
     before do
-      client[:users].create
+      client['users'].create
     end
   end
 
   shared_context 'encrypted document in collection' do
     before do
-      client[:users].insert_one(ssn: encrypted_ssn_binary)
+      client['users'].insert_one(ssn: encrypted_ssn_binary)
     end
   end
 
   shared_context 'multiple encrypted documents in collection' do
     before do
-      client[:users].insert_one(ssn: encrypted_ssn_binary)
-      client[:users].insert_one(ssn: encrypted_ssn_binary)
+      client['users'].insert_one(ssn: encrypted_ssn_binary)
+      client['users'].insert_one(ssn: encrypted_ssn_binary)
     end
   end
 
   before(:each) do
-    client[:users].drop
+    client['users'].drop
     key_vault_collection.drop
     key_vault_collection.insert_one(data_key)
   end
@@ -114,7 +114,7 @@ describe 'Auto Encryption' do
       include_context 'encrypted document in collection'
 
       let(:result) do
-        encryption_client[:users].aggregate([
+        encryption_client['users'].aggregate([
           { '$match' => { 'ssn' => ssn } }
         ]).first
       end
@@ -132,7 +132,7 @@ describe 'Auto Encryption' do
         end
 
         it 'does auto decrypt the response' do
-          result = encryption_client[:users].aggregate([
+          result = encryption_client['users'].aggregate([
             { '$match' => { 'ssn' => encrypted_ssn_binary } }
           ]).first
 
@@ -149,7 +149,7 @@ describe 'Auto Encryption' do
     shared_examples 'it performs an encrypted command' do
       include_context 'multiple encrypted documents in collection'
 
-      let(:result) { encryption_client[:users].count(ssn: ssn) }
+      let(:result) { encryption_client['users'].count(ssn: ssn) }
 
       it 'encrypts the command and finds the documents' do
         expect(result).to eq(2)
@@ -171,7 +171,7 @@ describe 'Auto Encryption' do
     shared_examples 'it performs an encrypted command' do
       include_context 'encrypted document in collection'
 
-      let(:result) { encryption_client[:users].distinct(:ssn) }
+      let(:result) { encryption_client['users'].distinct(:ssn) }
 
       it 'decrypts the SSN field' do
         expect(result.length).to eq(1)
@@ -195,7 +195,7 @@ describe 'Auto Encryption' do
     shared_examples 'it performs an encrypted command' do
       include_context 'encrypted document in collection'
 
-      let(:result) { encryption_client[:users].delete_one(ssn: ssn) }
+      let(:result) { encryption_client['users'].delete_one(ssn: ssn) }
 
       it 'encrypts the SSN field' do
         expect(result.deleted_count).to eq(1)
@@ -217,7 +217,7 @@ describe 'Auto Encryption' do
     shared_examples 'it performs an encrypted command' do
       include_context 'multiple encrypted documents in collection'
 
-      let(:result) { encryption_client[:users].delete_many(ssn: ssn) }
+      let(:result) { encryption_client['users'].delete_many(ssn: ssn) }
 
       it 'decrypts the SSN field' do
         expect(result.deleted_count).to eq(2)
@@ -239,7 +239,7 @@ describe 'Auto Encryption' do
     shared_examples 'it performs an encrypted command' do
       include_context 'encrypted document in collection'
 
-      let(:result) { encryption_client[:users].find(ssn: ssn).first }
+      let(:result) { encryption_client['users'].find(ssn: ssn).first }
 
       it 'encrypts the command and decrypts the response' do
         result.should_not be_nil
@@ -262,7 +262,7 @@ describe 'Auto Encryption' do
     shared_examples 'it performs an encrypted command' do
       include_context 'encrypted document in collection'
 
-      let(:result) { encryption_client[:users].find_one_and_delete(ssn: ssn) }
+      let(:result) { encryption_client['users'].find_one_and_delete(ssn: ssn) }
 
       it 'encrypts the command and decrypts the response' do
         expect(result['ssn']).to eq(ssn)
@@ -276,7 +276,7 @@ describe 'Auto Encryption' do
         end
 
         it 'still decrypts the command' do
-          result = encryption_client[:users].find_one_and_delete(ssn: encrypted_ssn_binary)
+          result = encryption_client['users'].find_one_and_delete(ssn: encrypted_ssn_binary)
           expect(result['ssn']).to eq(ssn)
         end
       end
@@ -293,7 +293,7 @@ describe 'Auto Encryption' do
         include_context 'encrypted document in collection'
 
         let(:result) do
-          encryption_client[:users].find_one_and_replace(
+          encryption_client['users'].find_one_and_replace(
             { ssn: ssn },
             { name: name },
             return_document: :before
@@ -303,7 +303,7 @@ describe 'Auto Encryption' do
         it 'encrypts the command and decrypts the response, returning original document' do
           expect(result['ssn']).to eq(ssn)
 
-          documents = client[:users].find
+          documents = client['users'].find
           expect(documents.count).to eq(1)
           expect(documents.first['ssn']).to be_nil
         end
@@ -311,11 +311,11 @@ describe 'Auto Encryption' do
 
       context 'with :return_document => :after' do
         before do
-          client[:users].insert_one(name: name)
+          client['users'].insert_one(name: name)
         end
 
         let(:result) do
-          encryption_client[:users].find_one_and_replace(
+          encryption_client['users'].find_one_and_replace(
             { name: name },
             { ssn: ssn },
             return_document: :after
@@ -325,7 +325,7 @@ describe 'Auto Encryption' do
         it 'encrypts the command and decrypts the response, returning new document' do
           expect(result['ssn']).to eq(ssn)
 
-          documents = client[:users].find
+          documents = client['users'].find
           expect(documents.count).to eq(1)
           expect(documents.first['ssn']).to eq(encrypted_ssn_binary)
         end
@@ -336,7 +336,7 @@ describe 'Auto Encryption' do
         include_context 'encrypted document in collection'
 
         let(:result) do
-          encryption_client[:users].find_one_and_replace(
+          encryption_client['users'].find_one_and_replace(
             { ssn: encrypted_ssn_binary },
             { name: name },
             :return_document => :before
@@ -346,7 +346,7 @@ describe 'Auto Encryption' do
         it 'does not encrypt the command but still decrypts the response, returning original document' do
           expect(result['ssn']).to eq(ssn)
 
-          documents = client[:users].find
+          documents = client['users'].find
           expect(documents.count).to eq(1)
           expect(documents.first['ssn']).to be_nil
         end
@@ -363,7 +363,7 @@ describe 'Auto Encryption' do
       let(:name) { 'Alan Turing' }
 
       let(:result) do
-        encryption_client[:users].find_one_and_update(
+        encryption_client['users'].find_one_and_update(
           { ssn: ssn },
           { name: name }
         )
@@ -372,7 +372,7 @@ describe 'Auto Encryption' do
       it 'encrypts the command and decrypts the response' do
         expect(result['ssn']).to eq(ssn)
 
-        documents = client[:users].find
+        documents = client['users'].find
         expect(documents.count).to eq(1)
         expect(documents.first['ssn']).to be_nil
       end
@@ -386,7 +386,7 @@ describe 'Auto Encryption' do
 
         it 'still decrypts the response' do
           # Query using the encrypted ssn value so the find will succeed
-          result = encryption_client[:users].find_one_and_update(
+          result = encryption_client['users'].find_one_and_update(
             { ssn: encrypted_ssn_binary },
             { name: name }
           )
@@ -401,7 +401,7 @@ describe 'Auto Encryption' do
 
   describe '#insert_one' do
     let(:query) { { ssn: ssn } }
-    let(:result) { encryption_client[:users].insert_one(query) }
+    let(:result) { encryption_client['users'].insert_one(query) }
 
     shared_examples 'it performs an encrypted command' do
       it 'encrypts the ssn field' do
@@ -410,7 +410,7 @@ describe 'Auto Encryption' do
 
         id = result.inserted_ids.first
 
-        document = client[:users].find(_id: id).first
+        document = client['users'].find(_id: id).first
         document.should_not be_nil
         expect(document['ssn']).to eq(encrypted_ssn_binary)
       end
@@ -420,13 +420,13 @@ describe 'Auto Encryption' do
       include_context 'bypass auto encryption'
 
       it 'does not encrypt the command' do
-        result = encryption_client[:users].insert_one(ssn: ssn)
+        result = encryption_client['users'].insert_one(ssn: ssn)
         expect(result).to be_ok
         expect(result.inserted_ids.length).to eq(1)
 
         id = result.inserted_ids.first
 
-        document = client[:users].find(_id: id).first
+        document = client['users'].find(_id: id).first
         expect(document['ssn']).to eq(ssn)
       end
     end
@@ -460,7 +460,7 @@ describe 'Auto Encryption' do
         expect(result).to be_ok
         id = result.inserted_ids.first
 
-        document = client[:users].find(_id: id).first
+        document = client['users'].find(_id: id).first
         document.should_not be_nil
         # Document was not encrypted
         expect(document['ssn']).to eq(ssn)
@@ -480,7 +480,7 @@ describe 'Auto Encryption' do
 
           id = result.inserted_ids.first
 
-          document = client[:users].find(_id: id).first
+          document = client['users'].find(_id: id).first
           document.should_not be_nil
           # Auto-encryption with key alt names only works with random encryption,
           # so it will not generate the same result on every test run.
@@ -496,7 +496,7 @@ describe 'Auto Encryption' do
 
           id = result.inserted_ids.first
 
-          document = client[:users].find(_id: id).first
+          document = client['users'].find(_id: id).first
           document.should_not be_nil
           # Auto-encryption with key alt names only works with random encryption,
           # so it will not generate the same result on every test run.
@@ -513,7 +513,7 @@ describe 'Auto Encryption' do
       let(:replacement_ssn) { '098-765-4321' }
 
       let(:result) do
-        encryption_client[:users].replace_one(
+        encryption_client['users'].replace_one(
           { ssn: ssn },
           { ssn: replacement_ssn }
         )
@@ -522,7 +522,7 @@ describe 'Auto Encryption' do
       it 'encrypts the ssn field' do
         expect(result.modified_count).to eq(1)
 
-        find_result = encryption_client[:users].find(ssn: '098-765-4321')
+        find_result = encryption_client['users'].find(ssn: '098-765-4321')
         expect(find_result.count).to eq(1)
       end
 
@@ -543,13 +543,13 @@ describe 'Auto Encryption' do
       include_context 'encrypted document in collection'
 
       let(:result) do
-        encryption_client[:users].update_one({ ssn: ssn }, { ssn: '098-765-4321' })
+        encryption_client['users'].update_one({ ssn: ssn }, { ssn: '098-765-4321' })
       end
 
       it 'encrypts the ssn field' do
         expect(result.n).to eq(1)
 
-        find_result = encryption_client[:users].find(ssn: '098-765-4321')
+        find_result = encryption_client['users'].find(ssn: '098-765-4321')
         expect(find_result.count).to eq(1)
       end
 
@@ -568,18 +568,18 @@ describe 'Auto Encryption' do
   describe '#update_many' do
     shared_examples 'it performs an encrypted command' do
       before do
-        client[:users].insert_one(ssn: encrypted_ssn_binary, age: 25)
-        client[:users].insert_one(ssn: encrypted_ssn_binary, age: 43)
+        client['users'].insert_one(ssn: encrypted_ssn_binary, age: 25)
+        client['users'].insert_one(ssn: encrypted_ssn_binary, age: 43)
       end
 
       let(:result) do
-        encryption_client[:users].update_many({ ssn: ssn }, { "$inc" => { :age =>  1 } })
+        encryption_client['users'].update_many({ ssn: ssn }, { "$inc" => { :age =>  1 } })
       end
 
       it 'encrypts the ssn field' do
         expect(result.n).to eq(2)
 
-        updated_documents = encryption_client[:users].find(ssn: ssn)
+        updated_documents = encryption_client['users'].find(ssn: ssn)
         ages = updated_documents.map { |doc| doc['age'] }
         expect(ages).to include(26)
         expect(ages).to include(44)

--- a/spec/integration/client_side_encryption/bson_size_limit_spec.rb
+++ b/spec/integration/client_side_encryption/bson_size_limit_spec.rb
@@ -47,8 +47,8 @@ describe 'Client-Side Encryption' do
         }
       ].create
 
-      client.use('admin')['datakeys'].drop
-      client.use('admin')['datakeys'].insert_one(
+      key_vault_collection.drop
+      key_vault_collection.insert_one(
         BSON::ExtJSON.parse(File.read('spec/support/crypt/limits/limits-key.json'))
       )
     end

--- a/spec/integration/client_side_encryption/bson_size_limit_spec.rb
+++ b/spec/integration/client_side_encryption/bson_size_limit_spec.rb
@@ -47,6 +47,8 @@ describe 'Client-Side Encryption' do
         }
       ].create
 
+      key_vault_collection = client.use('admin')['datakeys', write_concern: { w: :majority }]
+
       key_vault_collection.drop
       key_vault_collection.insert_one(
         BSON::ExtJSON.parse(File.read('spec/support/crypt/limits/limits-key.json'))
@@ -85,7 +87,7 @@ describe 'Client-Side Encryption' do
     context 'when bulk inserting two unencrypted documents under 2MiB' do
       it 'can perform bulk insert using the encrypted client' do
         bulk_write = Mongo::BulkWrite.new(
-          client_encrypted[:coll],
+          client_encrypted['coll'],
           [
             { insert_one: { _id: 'over_2mib_1', unencrypted: 'a' * _2mib } },
             { insert_one: { _id: 'over_2mib_2', unencrypted: 'a' * _2mib } },
@@ -107,7 +109,7 @@ describe 'Client-Side Encryption' do
       it 'can perform bulk delete using the encrypted client' do
         # Insert documents that we can match and delete later
         bulk_write = Mongo::BulkWrite.new(
-          client_encrypted[:coll],
+          client_encrypted['coll'],
           [
             { insert_one: { _id: 'over_2mib_1', unencrypted: 'a' * _2mib } },
             { insert_one: { _id: 'over_2mib_2', unencrypted: 'a' * _2mib } },
@@ -128,7 +130,7 @@ describe 'Client-Side Encryption' do
     context 'when bulk inserting two encrypted documents under 2MiB' do
       it 'can perform bulk_insert using the encrypted client' do
         bulk_write = Mongo::BulkWrite.new(
-          client_encrypted[:coll],
+          client_encrypted['coll'],
           [
             {
               insert_one: limits_doc.merge(
@@ -158,7 +160,7 @@ describe 'Client-Side Encryption' do
 
     context 'when a single document is just smaller than 16MiB' do
       it 'can perform insert_one using the encrypted client' do
-        result = client_encrypted[:coll].insert_one(
+        result = client_encrypted['coll'].insert_one(
           _id: "under_16mib",
           unencrypted: "a" * (_16mib - 2000)
         )
@@ -170,7 +172,7 @@ describe 'Client-Side Encryption' do
     context 'when an encrypted document is greater than the 16MiB limit' do
       it 'raises an exception when attempting to insert the document' do
         expect do
-          client_encrypted[:coll].insert_one(
+          client_encrypted['coll'].insert_one(
             limits_doc.merge(
               _id: "encryption_exceeds_16mib",
               unencrypted: "a" * (16*1024*1024 + 500*1024),

--- a/spec/integration/client_side_encryption/bypass_mongocryptd_spawn_spec.rb
+++ b/spec/integration/client_side_encryption/bypass_mongocryptd_spawn_spec.rb
@@ -34,7 +34,7 @@ describe 'Client-Side Encryption' do
 
       it 'does not spawn' do
         lambda do
-          client[:coll].insert_one(encrypted: 'test')
+          client['coll'].insert_one(encrypted: 'test')
         end.should raise_error(Mongo::Error::NoServerAvailable, /Server address=localhost:27090 UNKNOWN/)
       end
     end

--- a/spec/integration/client_side_encryption/bypass_mongocryptd_spawn_spec.rb
+++ b/spec/integration/client_side_encryption/bypass_mongocryptd_spawn_spec.rb
@@ -27,7 +27,7 @@ describe 'Client-Side Encryption' do
                 mongocryptd_spawn_args: [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27090"],
               },
             },
-            database: :db
+            database: 'db'
           ),
         )
       end
@@ -52,7 +52,7 @@ describe 'Client-Side Encryption' do
                 mongocryptd_spawn_args: [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27090"],
               },
             },
-            database: :db
+            database: 'db'
           ),
         )
       end
@@ -63,7 +63,7 @@ describe 'Client-Side Encryption' do
 
       it 'does not spawn' do
         lambda do
-          client[:coll].insert_one(encrypted: 'test')
+          client['coll'].insert_one(encrypted: 'test')
         end.should_not raise_error
         lambda do
           mongocryptd_client.database.command(ismaster: 1)

--- a/spec/integration/client_side_encryption/client_close_spec.rb
+++ b/spec/integration/client_side_encryption/client_close_spec.rb
@@ -18,7 +18,7 @@ describe 'Auto encryption client' do
             key_vault_namespace: 'admin.datakeys',
             schema_map: { 'auto_encryption.users' => schema_map },
           },
-          database: :auto_encryption,
+          database: 'auto_encryption',
         )
       )
     end

--- a/spec/integration/client_side_encryption/client_close_spec.rb
+++ b/spec/integration/client_side_encryption/client_close_spec.rb
@@ -6,7 +6,6 @@ describe 'Auto encryption client' do
   min_server_fcv '4.2'
 
   context 'after client is disconnected' do
-
     include_context 'define shared FLE helpers'
     include_context 'with local kms_providers'
 
@@ -26,11 +25,11 @@ describe 'Auto encryption client' do
 
     shared_examples 'a functioning auto-encrypter' do
       it 'can still perform encryption' do
-        result = client[:users].insert_one(ssn: '000-000-0000')
+        result = client['users'].insert_one(ssn: '000-000-0000')
         expect(result).to be_ok
 
         encrypted_document = authorized_client
-          .use(:auto_encryption)[:users]
+          .use('auto_encryption')['users']
           .find(_id: result.inserted_ids.first)
           .first
 
@@ -40,7 +39,10 @@ describe 'Auto encryption client' do
 
     context 'after performing operation with auto encryption' do
       before do
-        client[:users].insert_one(ssn: ssn)
+        key_vault_collection.drop
+        key_vault_collection.insert_one(data_key)
+
+        client['users'].insert_one(ssn: ssn)
         client.close
       end
 
@@ -49,7 +51,7 @@ describe 'Auto encryption client' do
 
     context 'after performing operation without auto encryption' do
       before do
-        client[:users].insert_one(age: 23)
+        client['users'].insert_one(age: 23)
         client.close
       end
 

--- a/spec/integration/client_side_encryption/corpus_spec.rb
+++ b/spec/integration/client_side_encryption/corpus_spec.rb
@@ -36,7 +36,7 @@ describe 'Client-Side Encryption' do
             key_vault_namespace: 'admin.datakeys',
             schema_map: local_schema_map,
           },
-          database: :db,
+          database: 'db',
         )
       )
     end

--- a/spec/integration/client_side_encryption/corpus_spec.rb
+++ b/spec/integration/client_side_encryption/corpus_spec.rb
@@ -8,11 +8,13 @@ describe 'Client-Side Encryption' do
 
     include_context 'define shared FLE helpers'
 
-    let(:client) do
-      new_local_client(
-        SpecConfig.instance.addresses,
-        SpecConfig.instance.test_options
-      )
+    let(:client) { authorized_client }
+
+    let(:key_vault_client) do
+      client.with(
+        database: 'admin',
+        write_concern: { w: :majority }
+      )['datakeys']
     end
 
     let(:test_schema_map) { BSON::ExtJSON.parse(File.read('spec/support/crypt/corpus/corpus-schema.json')) }
@@ -123,18 +125,19 @@ describe 'Client-Side Encryption' do
     end
 
     before do
-      client.use(:db)[:coll].drop
+      client.use('db')['coll'].drop
 
-      client.use(:admin)[:datakeys].drop
-      client.use(:admin)[:datakeys].insert_one(local_data_key)
-      client.use(:admin)[:datakeys].insert_one(aws_data_key)
+      key_vault_collection = client.use('admin')['datakeys', write_concern: { w: :majority }]
+      key_vault_collection.drop
+      key_vault_collection.insert_one(local_data_key)
+      key_vault_collection.insert_one(aws_data_key)
     end
 
     shared_context 'with jsonSchema collection validator' do
       let(:local_schema_map) { nil }
 
       before do
-        client.use(:db)[:coll,
+        client.use('db')['coll',
           {
             'validator' => { '$jsonSchema' => test_schema_map }
           }
@@ -148,11 +151,11 @@ describe 'Client-Side Encryption' do
 
     shared_examples 'a functioning encrypter' do
       it 'properly encrypts and decrypts a document' do
-        corpus_encrypted_id = client_encrypted[:coll]
+        corpus_encrypted_id = client_encrypted['coll']
           .insert_one(corpus_copied)
           .inserted_id
 
-        corpus_decrypted = client_encrypted[:coll]
+        corpus_decrypted = client_encrypted['coll']
           .find(_id: corpus_encrypted_id)
           .first
 
@@ -166,7 +169,7 @@ describe 'Client-Side Encryption' do
         end
 
         corpus_encrypted_actual = client
-          .use(:db)[:coll]
+          .use('db')['coll']
           .find(_id: corpus_encrypted_id)
           .first
 

--- a/spec/integration/client_side_encryption/data_key_spec.rb
+++ b/spec/integration/client_side_encryption/data_key_spec.rb
@@ -73,8 +73,8 @@ describe 'Client-Side Encryption' do
     end
 
     before do
-      client.use(:admin)[:datakeys].drop
-      client.use(:db)[:coll].drop
+      client.use('admin')['datakeys'].drop
+      client.use('db')['coll'].drop
     end
 
     shared_examples 'can create and use a data key' do
@@ -86,7 +86,7 @@ describe 'Client-Side Encryption' do
 
         expect(data_key_id).to be_uuid
 
-        keys = client.use(:admin)[:datakeys].find(_id: data_key_id)
+        keys = client.use('admin')['datakeys'].find(_id: data_key_id)
 
         expect(keys.count).to eq(1)
         expect(keys.first['masterKey']['provider']).to eq(kms_provider_name)
@@ -107,12 +107,12 @@ describe 'Client-Side Encryption' do
 
         expect(encrypted).to be_ciphertext
 
-        client_encrypted[:coll].insert_one(
+        client_encrypted['coll'].insert_one(
           _id: kms_provider_name,
-          'value': encrypted,
+          value: encrypted,
         )
 
-        document = client_encrypted[:coll].find(_id: kms_provider_name).first
+        document = client_encrypted['coll'].find(_id: kms_provider_name).first
 
         expect(document['value']).to eq(value_to_encrypt)
 
@@ -128,7 +128,7 @@ describe 'Client-Side Encryption' do
         expect(encrypted_with_alt_name).to eq(encrypted)
 
         expect do
-          client_encrypted[:coll].insert_one(encrypted_placeholder: encrypted)
+          client_encrypted['coll'].insert_one(encrypted_placeholder: encrypted)
         end.to raise_error(Mongo::Error::OperationFailure, /Cannot encrypt element of type binData/)
       end
     end

--- a/spec/integration/client_side_encryption/data_key_spec.rb
+++ b/spec/integration/client_side_encryption/data_key_spec.rb
@@ -51,7 +51,7 @@ describe 'Client-Side Encryption' do
             key_vault_namespace: 'admin.datakeys',
             schema_map: test_schema_map,
           },
-          database: :db,
+          database: 'db',
         )
       )
     end

--- a/spec/integration/client_side_encryption/external_key_vault_spec.rb
+++ b/spec/integration/client_side_encryption/external_key_vault_spec.rb
@@ -53,7 +53,7 @@ describe 'Client-Side Encryption' do
               key_vault_namespace: 'admin.datakeys',
               schema_map: test_schema_map,
             },
-            database: :db,
+            database: 'db',
           )
         )
       end
@@ -100,7 +100,7 @@ describe 'Client-Side Encryption' do
               schema_map: test_schema_map,
               key_vault_client: external_key_vault_client,
             },
-            database: :db,
+            database: 'db',
           )
         )
       end

--- a/spec/integration/client_side_encryption/external_key_vault_spec.rb
+++ b/spec/integration/client_side_encryption/external_key_vault_spec.rb
@@ -36,11 +36,11 @@ describe 'Client-Side Encryption' do
     end
 
     before do
-      client.use(:admin)[:datakeys].drop
-      client.use(:db)[:coll].drop
+      client.use('admin')['datakeys'].drop
+      client.use('db')['coll'].drop
 
       data_key = BSON::ExtJSON.parse(File.read('spec/support/crypt/external/external-key.json'))
-      client.use(:admin)[:datakeys].insert_one(data_key)
+      client.use('admin')['datakeys', write_concern: { w: :majority }].insert_one(data_key)
     end
 
     context 'with default key vault client' do
@@ -69,10 +69,10 @@ describe 'Client-Side Encryption' do
       end
 
       it 'inserts an encrypted document with client' do
-        result = client_encrypted[:coll].insert_one(encrypted: 'test')
+        result = client_encrypted['coll'].insert_one(encrypted: 'test')
         expect(result).to be_ok
 
-        encrypted = client.use(:db)[:coll].find.first['encrypted']
+        encrypted = client.use('db')['coll'].find.first['encrypted']
         expect(encrypted).to be_ciphertext
       end
 
@@ -117,7 +117,7 @@ describe 'Client-Side Encryption' do
 
        it 'raises an authentication exception when auto encrypting' do
         expect do
-          client_encrypted[:coll].insert_one(encrypted: 'test')
+          client_encrypted['coll'].insert_one(encrypted: 'test')
         end.to raise_error(Mongo::Auth::Unauthorized, /fake-user/)
       end
 

--- a/spec/integration/client_side_encryption/views_spec.rb
+++ b/spec/integration/client_side_encryption/views_spec.rb
@@ -23,19 +23,19 @@ describe 'Client-Side Encryption' do
             kms_providers: local_kms_providers,
             key_vault_namespace: 'admin.datakeys',
           },
-          database: :db,
+          database: 'db',
         )
       )
     end
 
     before do
-      client.use(:db)[:view].drop
-      client.use(:db).database.command(create: "view", viewOn: "coll")
+      client.use('db')['view'].drop
+      client.use('db').database.command(create: 'view', viewOn: 'coll')
     end
 
     it 'does not perform encryption on views' do
       expect do
-        client_encrypted[:view].insert_one({})
+        client_encrypted['view'].insert_one({})
       end.to raise_error(Mongo::Error::CryptError, /cannot auto encrypt a view/)
     end
   end

--- a/spec/mongo/client_encryption_spec.rb
+++ b/spec/mongo/client_encryption_spec.rb
@@ -1,6 +1,4 @@
-require 'mongo'
-require 'base64'
-require 'lite_spec_helper'
+require 'spec_helper'
 
 describe Mongo::ClientEncryption do
   require_libmongocrypt
@@ -8,7 +6,8 @@ describe Mongo::ClientEncryption do
 
   let(:client) do
     ClientRegistry.instance.new_local_client(
-      [SpecConfig.instance.addresses.first]
+      SpecConfig.instance.addresses,
+      SpecConfig.instance.test_options
     )
   end
 
@@ -345,9 +344,7 @@ describe Mongo::ClientEncryption do
     let(:encrypted_value) { encrypted_ssn }
 
     before do
-      key_vault_collection = client.use(key_vault_db)[key_vault_coll]
       key_vault_collection.drop
-
       key_vault_collection.insert_one(data_key)
     end
 

--- a/spec/mongo/crypt/auto_encrypter_spec.rb
+++ b/spec/mongo/crypt/auto_encrypter_spec.rb
@@ -81,7 +81,6 @@ describe Mongo::Crypt::AutoEncrypter do
   end
 
   before do
-    key_vault_collection = client.use(key_vault_db)[key_vault_coll]
     key_vault_collection.drop
     key_vault_collection.insert_one(data_key)
   end

--- a/spec/runners/transactions.rb
+++ b/spec/runners/transactions.rb
@@ -30,14 +30,12 @@ def define_transactions_spec_tests(test_paths)
         spec.tests.each do |test|
 
           before do
-            if test.multiple_mongoses?
-              if ClusterConfig.instance.topology == :sharded && SpecConfig.instance.addresses.length == 1
+            if ClusterConfig.instance.topology == :sharded
+              if test.multiple_mongoses? && SpecConfig.instance.addresses.length == 1
                 skip "Test requires multiple mongoses"
-              end
-            else
-              # Many transaction spec tests that do not specifically deal with
-              # sharded transactions fail when run against a multi-mongos cluster
-              if SpecConfig.instance.addresses.length > 1
+              elsif !test.multiple_mongoses? && SpecConfig.instance.addresses.length > 1
+                # Many transaction spec tests that do not specifically deal with
+                # sharded transactions fail when run against a multi-mongos cluster
                 skip "Test does not specify multiple mongoses"
               end
             end

--- a/spec/spec_tests/client_side_encryption_spec.rb
+++ b/spec/spec_tests/client_side_encryption_spec.rb
@@ -4,10 +4,5 @@ describe 'Client-Side Encryption' do
   require_libmongocrypt
   require_enterprise
 
-  before do
-    unless ClusterConfig.instance.single_server?
-      skip "SPEC-2147: tests only work on single server"
-    end
-  end
   define_transactions_spec_tests(CLIENT_SIDE_ENCRYPTION_TESTS)
 end

--- a/spec/support/crypt.rb
+++ b/spec/support/crypt.rb
@@ -52,6 +52,13 @@ module Crypt
 
     # Example value to encrypt
     let(:ssn) { '123-456-7890' }
+
+    let(:key_vault_collection) do
+      authorized_client.with(
+        database: key_vault_db,
+        write_concern: { w: :majority }
+      )[key_vault_coll]
+    end
   end
 
   # For tests that require local KMS to be configured


### PR DESCRIPTION
Changes in this PR:
- Run FLE tests on a replica set in CI
- In the FLE prose tests, perform all key vault operations using write concern majority
- Fix all instances of db/collection names as symbols.