### PR TITLE
RUBY-2147 Run FLE tests on sharded cluster

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -111,6 +111,7 @@ functions:
           MONGO_RUBY_DRIVER_AWS_SECRET="${fle_aws_secret}"
           MONGO_RUBY_DRIVER_AWS_REGION="${fle_aws_region}"
           MONGO_RUBY_DRIVER_AWS_ARN="${fle_aws_arn}"
+          MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT="${fle_mongocryptd_port}"
           EOT
 
   "export Kerberos credentials":
@@ -798,7 +799,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: "noauth-and-nossl"
       ruby: [ruby-2.7, ruby-2.3, jruby-9.2]
-      topology: [standalone, replica-set]
+      topology: [standalone, replica-set, sharded-cluster]
       mongodb-version: ["4.2"]
       os: rhel70
       fle: fle

--- a/spec/README.md
+++ b/spec/README.md
@@ -374,6 +374,21 @@ environment variable to the full path to the .so/.dll/.dylib
 LIBMONGOCRYPT_PATH=/path/to/your/libmongocrypt/nocrypto/libmongocrypt.so bundle exec rake
 ```
 
+If you would like to run the client-side encryption tests on a replica set or
+sharded cluster, be aware that the driver will try to spawn the mongocryptd daemon on
+port 27020 by default. If port 27020 is already in use by a mongod or mongos
+process, spawning mongocryptd will fail, causing the tests to fail as well.
+
+To avoid this problem, set MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT environment
+variable to the port at which you would like the driver to spawn mongocryptd.
+For example, to always have the mongocryptd process listen on port 27090:
+
+```
+MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT=27090
+```
+
+Keep in mind that this will only impact the behavior of the Ruby Driver test suite.
+
 ## Compression
 
 To test compression, set the `compressors` URI option:

--- a/spec/README.md
+++ b/spec/README.md
@@ -379,15 +379,16 @@ sharded cluster, be aware that the driver will try to spawn the mongocryptd daem
 port 27020 by default. If port 27020 is already in use by a mongod or mongos
 process, spawning mongocryptd will fail, causing the tests to fail as well.
 
-To avoid this problem, set MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT environment
+To avoid this problem, set the MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT environment
 variable to the port at which you would like the driver to spawn mongocryptd.
 For example, to always have the mongocryptd process listen on port 27090:
 
 ```
-MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT=27090
+export MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT=27090
 ```
 
-Keep in mind that this will only impact the behavior of the Ruby Driver test suite.
+Keep in mind that this will only impact the behavior of the Ruby Driver test suite,
+not the behavior of the driver itself.
 
 ## Compression
 

--- a/spec/README.md
+++ b/spec/README.md
@@ -288,6 +288,15 @@ full list of relevant test files.
 
 ## Client-Side Encryption
 
+NOTE: Client-side encryption tests require an enterprise build of MongoDB
+server version 4.2 or higher. These builds of the MongoDB server come packaged with
+mongocryptd, a daemon that is spawned by the driver during automatic encryption.
+The client-side encryption tests require the mongocryptd binary to be in the
+system path.
+
+Download enterprise versions of MongoDB here: https://www.mongodb.com/download-center/enterprise
+Read more about installing mongocryptd here: https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/#mongocryptd
+
 Install libmongocrypt on your machine:
 
 Option 1: Download a pre-built binary
@@ -356,12 +365,6 @@ by following the "Using the AWS Management Console Default View" section of this
 https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-modifying.html
 
 In one terminal, launch MongoDB:
-
-NOTE: You must be running MongoDB 4.2 or higher. All auto-encryption features
-require an enterprise build of MongoDB, but you can still run
-explicit encryption tests using the community edition of MongoDB.
-
-Download different versions of MongoDB here: https://www.mongodb.com/download-center/enterprise
 
 ```
 mkdir /tmp/mdb

--- a/spec/integration/client_construction_spec.rb
+++ b/spec/integration/client_construction_spec.rb
@@ -152,7 +152,8 @@ describe 'Client construction' do
       {
         key_vault_client: key_vault_client,
         key_vault_namespace: key_vault_namespace,
-        kms_providers: kms_providers
+        kms_providers: kms_providers,
+        extra_options: extra_options,
       }
     end
 

--- a/spec/integration/client_construction_spec.rb
+++ b/spec/integration/client_construction_spec.rb
@@ -153,6 +153,7 @@ describe 'Client construction' do
         key_vault_client: key_vault_client,
         key_vault_namespace: key_vault_namespace,
         kms_providers: kms_providers,
+        # Spawn mongocryptd on non-default port for sharded cluster tests
         extra_options: extra_options,
       }
     end

--- a/spec/integration/client_side_encryption/auto_encryption_bulk_writes_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_bulk_writes_spec.rb
@@ -18,6 +18,7 @@ describe 'Bulk writes with auto-encryption enabled' do
           kms_providers: kms_providers,
           key_vault_namespace: key_vault_namespace,
           schema_map: { "auto_encryption.users" => schema_map },
+          extra_options: extra_options,
         },
         database: 'auto_encryption'
       ),

--- a/spec/integration/client_side_encryption/auto_encryption_bulk_writes_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_bulk_writes_spec.rb
@@ -18,6 +18,7 @@ describe 'Bulk writes with auto-encryption enabled' do
           kms_providers: kms_providers,
           key_vault_namespace: key_vault_namespace,
           schema_map: { "auto_encryption.users" => schema_map },
+          # Spawn mongocryptd on non-default port for sharded cluster tests
           extra_options: extra_options,
         },
         database: 'auto_encryption'

--- a/spec/integration/client_side_encryption/auto_encryption_command_monitoring_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_command_monitoring_spec.rb
@@ -23,6 +23,7 @@ describe 'Auto Encryption' do
           kms_providers: kms_providers,
           key_vault_namespace: key_vault_namespace,
           schema_map: { "auto_encryption.users" => schema_map },
+          # Spawn mongocryptd on non-default port for sharded cluster tests
           extra_options: extra_options,
         },
         database: db_name

--- a/spec/integration/client_side_encryption/auto_encryption_command_monitoring_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_command_monitoring_spec.rb
@@ -23,6 +23,7 @@ describe 'Auto Encryption' do
           kms_providers: kms_providers,
           key_vault_namespace: key_vault_namespace,
           schema_map: { "auto_encryption.users" => schema_map },
+          extra_options: extra_options,
         },
         database: db_name
       ),

--- a/spec/integration/client_side_encryption/auto_encryption_old_wire_version_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_old_wire_version_spec.rb
@@ -21,6 +21,7 @@ describe 'Auto Encryption' do
           # do not support jsonSchema collection validator.
           schema_map: { 'auto_encryption.users' => schema_map },
           bypass_auto_encryption: bypass_auto_encryption,
+          # Spawn mongocryptd on non-default port for sharded cluster tests
           extra_options: extra_options,
         },
         database: 'auto_encryption'

--- a/spec/integration/client_side_encryption/auto_encryption_old_wire_version_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_old_wire_version_spec.rb
@@ -20,7 +20,8 @@ describe 'Auto Encryption' do
           # Must use local schema map because server versions older than 4.2
           # do not support jsonSchema collection validator.
           schema_map: { 'auto_encryption.users' => schema_map },
-          bypass_auto_encryption: bypass_auto_encryption
+          bypass_auto_encryption: bypass_auto_encryption,
+          extra_options: extra_options,
         },
         database: 'auto_encryption'
       ),

--- a/spec/integration/client_side_encryption/auto_encryption_reconnect_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_reconnect_spec.rb
@@ -21,6 +21,7 @@ describe 'Client with auto encryption #reconnect' do
             key_vault_namespace: key_vault_namespace,
             key_vault_client: key_vault_client_option,
             schema_map: { 'auto_encryption.users': schema_map },
+            # Spawn mongocryptd on non-default port for sharded cluster tests
             extra_options: extra_options,
           },
           database: 'auto_encryption'

--- a/spec/integration/client_side_encryption/auto_encryption_reconnect_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_reconnect_spec.rb
@@ -20,7 +20,8 @@ describe 'Client with auto encryption #reconnect' do
             kms_providers: kms_providers,
             key_vault_namespace: key_vault_namespace,
             key_vault_client: key_vault_client_option,
-            schema_map: { 'auto_encryption.users': schema_map }
+            schema_map: { 'auto_encryption.users': schema_map },
+            extra_options: extra_options,
           },
           database: 'auto_encryption'
         }

--- a/spec/integration/client_side_encryption/auto_encryption_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_spec.rb
@@ -22,6 +22,7 @@ describe 'Auto Encryption' do
           key_vault_namespace: key_vault_namespace,
           schema_map: local_schema,
           bypass_auto_encryption: bypass_auto_encryption,
+          # Spawn mongocryptd on non-default port for sharded cluster tests
           extra_options: extra_options,
         },
         database: 'auto_encryption'

--- a/spec/integration/client_side_encryption/auto_encryption_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_spec.rb
@@ -21,7 +21,8 @@ describe 'Auto Encryption' do
           kms_providers: kms_providers,
           key_vault_namespace: key_vault_namespace,
           schema_map: local_schema,
-          bypass_auto_encryption: bypass_auto_encryption
+          bypass_auto_encryption: bypass_auto_encryption,
+          extra_options: extra_options,
         },
         database: 'auto_encryption'
       ),

--- a/spec/integration/client_side_encryption/bson_size_limit_spec.rb
+++ b/spec/integration/client_side_encryption/bson_size_limit_spec.rb
@@ -31,6 +31,7 @@ describe 'Client-Side Encryption' do
               local: { key: local_master_key },
             },
             key_vault_namespace: 'admin.datakeys',
+            # Spawn mongocryptd on non-default port for sharded cluster tests
             extra_options: extra_options,
           },
           database: 'db',

--- a/spec/integration/client_side_encryption/bson_size_limit_spec.rb
+++ b/spec/integration/client_side_encryption/bson_size_limit_spec.rb
@@ -31,6 +31,7 @@ describe 'Client-Side Encryption' do
               local: { key: local_master_key },
             },
             key_vault_namespace: 'admin.datakeys',
+            extra_options: extra_options,
           },
           database: 'db',
         )

--- a/spec/integration/client_side_encryption/bypass_mongocryptd_spawn_spec.rb
+++ b/spec/integration/client_side_encryption/bypass_mongocryptd_spawn_spec.rb
@@ -10,7 +10,7 @@ describe 'Client-Side Encryption' do
 
     # Choose a different port for mongocryptd than the one used by all the other
     # tests to avoid failures caused by other tests spawning mongocryptd.
-    let(:mongocryptd_port) { SpecConfig.instance.mongocryptd_port + 1 }
+    let(:mongocryptd_port) { 27091 }
 
     context 'via mongocryptdBypassSpawn' do
       let(:test_schema_map) do

--- a/spec/integration/client_side_encryption/client_close_spec.rb
+++ b/spec/integration/client_side_encryption/client_close_spec.rb
@@ -17,6 +17,7 @@ describe 'Auto encryption client' do
             kms_providers: kms_providers,
             key_vault_namespace: 'admin.datakeys',
             schema_map: { 'auto_encryption.users' => schema_map },
+            # Spawn mongocryptd on non-default port for sharded cluster tests
             extra_options: extra_options,
           },
           database: 'auto_encryption',

--- a/spec/integration/client_side_encryption/client_close_spec.rb
+++ b/spec/integration/client_side_encryption/client_close_spec.rb
@@ -17,6 +17,7 @@ describe 'Auto encryption client' do
             kms_providers: kms_providers,
             key_vault_namespace: 'admin.datakeys',
             schema_map: { 'auto_encryption.users' => schema_map },
+            extra_options: extra_options,
           },
           database: 'auto_encryption',
         )

--- a/spec/integration/client_side_encryption/corpus_spec.rb
+++ b/spec/integration/client_side_encryption/corpus_spec.rb
@@ -35,6 +35,7 @@ describe 'Client-Side Encryption' do
             },
             key_vault_namespace: 'admin.datakeys',
             schema_map: local_schema_map,
+            # Spawn mongocryptd on non-default port for sharded cluster tests
             extra_options: extra_options,
           },
           database: 'db',

--- a/spec/integration/client_side_encryption/corpus_spec.rb
+++ b/spec/integration/client_side_encryption/corpus_spec.rb
@@ -35,6 +35,7 @@ describe 'Client-Side Encryption' do
             },
             key_vault_namespace: 'admin.datakeys',
             schema_map: local_schema_map,
+            extra_options: extra_options,
           },
           database: 'db',
         )

--- a/spec/integration/client_side_encryption/data_key_spec.rb
+++ b/spec/integration/client_side_encryption/data_key_spec.rb
@@ -50,6 +50,7 @@ describe 'Client-Side Encryption' do
             },
             key_vault_namespace: 'admin.datakeys',
             schema_map: test_schema_map,
+            extra_options: extra_options,
           },
           database: 'db',
         )

--- a/spec/integration/client_side_encryption/data_key_spec.rb
+++ b/spec/integration/client_side_encryption/data_key_spec.rb
@@ -50,6 +50,7 @@ describe 'Client-Side Encryption' do
             },
             key_vault_namespace: 'admin.datakeys',
             schema_map: test_schema_map,
+            # Spawn mongocryptd on non-default port for sharded cluster tests
             extra_options: extra_options,
           },
           database: 'db',

--- a/spec/integration/client_side_encryption/external_key_vault_spec.rb
+++ b/spec/integration/client_side_encryption/external_key_vault_spec.rb
@@ -52,6 +52,7 @@ describe 'Client-Side Encryption' do
               kms_providers: local_kms_providers,
               key_vault_namespace: 'admin.datakeys',
               schema_map: test_schema_map,
+              extra_options: extra_options,
             },
             database: 'db',
           )
@@ -99,6 +100,7 @@ describe 'Client-Side Encryption' do
               key_vault_namespace: 'admin.datakeys',
               schema_map: test_schema_map,
               key_vault_client: external_key_vault_client,
+              extra_options: extra_options,
             },
             database: 'db',
           )

--- a/spec/integration/client_side_encryption/external_key_vault_spec.rb
+++ b/spec/integration/client_side_encryption/external_key_vault_spec.rb
@@ -52,6 +52,7 @@ describe 'Client-Side Encryption' do
               kms_providers: local_kms_providers,
               key_vault_namespace: 'admin.datakeys',
               schema_map: test_schema_map,
+              # Spawn mongocryptd on non-default port for sharded cluster tests
               extra_options: extra_options,
             },
             database: 'db',
@@ -100,6 +101,7 @@ describe 'Client-Side Encryption' do
               key_vault_namespace: 'admin.datakeys',
               schema_map: test_schema_map,
               key_vault_client: external_key_vault_client,
+              # Spawn mongocryptd on non-default port for sharded cluster tests
               extra_options: extra_options,
             },
             database: 'db',

--- a/spec/integration/client_side_encryption/views_spec.rb
+++ b/spec/integration/client_side_encryption/views_spec.rb
@@ -22,6 +22,7 @@ describe 'Client-Side Encryption' do
           auto_encryption_options: {
             kms_providers: local_kms_providers,
             key_vault_namespace: 'admin.datakeys',
+            # Spawn mongocryptd on non-default port for sharded cluster tests
             extra_options: extra_options,
           },
           database: 'db',

--- a/spec/integration/client_side_encryption/views_spec.rb
+++ b/spec/integration/client_side_encryption/views_spec.rb
@@ -22,6 +22,7 @@ describe 'Client-Side Encryption' do
           auto_encryption_options: {
             kms_providers: local_kms_providers,
             key_vault_namespace: 'admin.datakeys',
+            extra_options: extra_options,
           },
           database: 'db',
         )

--- a/spec/integration/client_update_spec.rb
+++ b/spec/integration/client_update_spec.rb
@@ -30,6 +30,7 @@ describe Mongo::Client do
             auto_encryption_options: {
               kms_providers: kms_providers,
               key_vault_namespace: key_vault_namespace,
+              # Spawn mongocryptd on non-default port for sharded cluster tests
               extra_options: extra_options,
             },
             database: :auto_encryption
@@ -47,6 +48,7 @@ describe Mongo::Client do
             kms_providers: kms_providers,
             key_vault_namespace: key_vault_namespace,
             schema_map: { 'auto_encryption.users' => schema_map },
+            # Spawn mongocryptd on non-default port for sharded cluster tests
             extra_options: extra_options,
           }
         end
@@ -103,6 +105,7 @@ describe Mongo::Client do
             auto_encryption_options: {
               kms_providers: kms_providers,
               key_vault_namespace: key_vault_namespace,
+              # Spawn mongocryptd on non-default port for sharded cluster tests
               extra_options: extra_options,
             }
           )

--- a/spec/integration/client_update_spec.rb
+++ b/spec/integration/client_update_spec.rb
@@ -30,6 +30,7 @@ describe Mongo::Client do
             auto_encryption_options: {
               kms_providers: kms_providers,
               key_vault_namespace: key_vault_namespace,
+              extra_options: extra_options,
             },
             database: :auto_encryption
           ),
@@ -46,6 +47,7 @@ describe Mongo::Client do
             kms_providers: kms_providers,
             key_vault_namespace: key_vault_namespace,
             schema_map: { 'auto_encryption.users' => schema_map },
+            extra_options: extra_options,
           }
         end
 
@@ -101,6 +103,7 @@ describe Mongo::Client do
             auto_encryption_options: {
               kms_providers: kms_providers,
               key_vault_namespace: key_vault_namespace,
+              extra_options: extra_options,
             }
           )
         )

--- a/spec/mongo/crypt/auto_encrypter_spec.rb
+++ b/spec/mongo/crypt/auto_encrypter_spec.rb
@@ -12,6 +12,7 @@ describe Mongo::Crypt::AutoEncrypter do
     described_class.new(
       auto_encryption_options.merge(
         client: authorized_client.use(:auto_encryption),
+        # Spawn mongocryptd on non-default port for sharded cluster tests
         extra_options: extra_options
       )
     )

--- a/spec/mongo/crypt/auto_encrypter_spec.rb
+++ b/spec/mongo/crypt/auto_encrypter_spec.rb
@@ -9,7 +9,12 @@ describe Mongo::Crypt::AutoEncrypter do
   include_context 'define shared FLE helpers'
 
   let(:auto_encrypter) do
-    described_class.new(auto_encryption_options.merge(client: authorized_client.use(:auto_encryption)))
+    described_class.new(
+      auto_encryption_options.merge(
+        client: authorized_client.use(:auto_encryption),
+        extra_options: extra_options
+      )
+    )
   end
 
   let(:client) { authorized_client }
@@ -96,7 +101,7 @@ describe Mongo::Crypt::AutoEncrypter do
       {
         kms_providers: kms_providers,
         key_vault_namespace: key_vault_namespace,
-        schema_map: { "#{db_name}.#{collection_name}": schema_map }
+        schema_map: { "#{db_name}.#{collection_name}": schema_map },
       }
     end
 

--- a/spec/support/crypt.rb
+++ b/spec/support/crypt.rb
@@ -59,6 +59,13 @@ module Crypt
         write_concern: { w: :majority }
       )[key_vault_coll]
     end
+
+    let(:extra_options) do
+      {
+        mongocryptd_spawn_args: ["--port=#{SpecConfig.instance.mongocryptd_port}"],
+        mongocryptd_uri: "mongodb://localhost:#{SpecConfig.instance.mongocryptd_port}",
+      }
+    end
   end
 
   # For tests that require local KMS to be configured

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -328,6 +328,10 @@ EOT
     ENV['MONGO_RUBY_DRIVER_AWS_ARN']
   end
 
+  def mongocryptd_port
+    ENV['MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT'] || 27020
+  end
+
   # Option hashes
 
   def auth_options

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -329,7 +329,13 @@ EOT
   end
 
   def mongocryptd_port
-    ENV['MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT'] || 27020
+    if ENV['MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT'] &&
+      !ENV['MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT'].empty?
+    then
+      ENV['MONGO_RUBY_DRIVER_MONGOCRYPTD_PORT'].to_i
+    else
+      27020
+    end
   end
 
   # Option hashes

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -90,6 +90,7 @@ module Utils
         opts.merge!(
           auto_encryption_options: convert_auto_encryption_client_options(value)
             .merge(
+              # Spawn mongocryptd on non-default port for sharded cluster tests
               extra_options: {
                 mongocryptd_spawn_args: ["--port=#{SpecConfig.instance.mongocryptd_port}"],
                 mongocryptd_uri: "mongodb://localhost:#{SpecConfig.instance.mongocryptd_port}",

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -89,6 +89,12 @@ module Utils
       if name == 'autoEncryptOpts'
         opts.merge!(
           auto_encryption_options: convert_auto_encryption_client_options(value)
+            .merge(
+              extra_options: {
+                mongocryptd_spawn_args: ["--port=#{SpecConfig.instance.mongocryptd_port}"],
+                mongocryptd_uri: "mongodb://localhost:#{SpecConfig.instance.mongocryptd_port}",
+              }
+            )
         )
       else
         uri.send(:add_uri_option, name, value.to_s, opts)


### PR DESCRIPTION
This PR allows a developer to specify a non-default port on which to run mongocryptd through an environment variable. Evergreen has mongocryptd listening on port 27090, allowing us to run tests on sharded clusters. This option could eventually be replaced with a URI option.