### PR TITLE
RUBY-1999 improve command monitoring diagnostics

### DIFF
--- a/lib/mongo/monitoring/event/secure.rb
+++ b/lib/mongo/monitoring/event/secure.rb
@@ -50,7 +50,13 @@ module Mongo
         #
         # @since 2.1.0
         def redacted(command_name, document)
-          REDACTED_COMMANDS.include?(command_name.to_s) ? BSON::Document.new : document
+          if REDACTED_COMMANDS.include?(command_name.to_s) &&
+            !%w(1 true yes).include?(ENV['MONGO_RUBY_DRIVER_UNREDACT_EVENTS'])
+          then
+            BSON::Document.new
+          else
+            document
+          end
         end
 
         # Is compression allowed for a given command message.

--- a/lib/mongo/monitoring/event/secure.rb
+++ b/lib/mongo/monitoring/event/secure.rb
@@ -51,7 +51,7 @@ module Mongo
         # @since 2.1.0
         def redacted(command_name, document)
           if REDACTED_COMMANDS.include?(command_name.to_s) &&
-            !%w(1 true yes).include?(ENV['MONGO_RUBY_DRIVER_UNREDACT_EVENTS'])
+            !%w(1 true yes).include?(ENV['MONGO_RUBY_DRIVER_UNREDACT_EVENTS']&.downcase)
           then
             BSON::Document.new
           else

--- a/spec/README.md
+++ b/spec/README.md
@@ -488,6 +488,12 @@ This will produce additional log output pertaining to, for example, SDAM
 events and transitions performed by the driver, as well as log all
 commands sent to and responses received from the database.
 
+To debug authentication and user management commands, set the
+`MONGO_RUBY_DRIVER_UNREDACT_EVENTS` environment variable to `1`, `true` or
+`yes`. This will disable redaction of command monitoring payloads for sensitive
+commands. Normally this environment variable should be used with
+`MONGO_RUBY_DRIVER_CLIENT_DEBUG` to see the command payloads.
+
 ## Caveats
 
 ### Socket Permission Errors

--- a/spec/README.md
+++ b/spec/README.md
@@ -476,6 +476,18 @@ variable:
 
     EXTERNAL_DISABLED=true
 
+## Debug Logging
+
+The test suite is run with the driver log level set to `WARN` by default.
+This produces a fair amount of output as many tests trigger various conditions
+resulting in the driver outputting warnings. This is expected behavior.
+
+To increase the driver log level to `DEBUG`, set the
+`MONGO_RUBY_DRIVER_CLIENT_DEBUG` environment variable to `1`, `true` or `yes`.
+This will produce additional log output pertaining to, for example, SDAM
+events and transitions performed by the driver, as well as log all
+commands sent to and responses received from the database.
+
 ## Caveats
 
 ### Socket Permission Errors
@@ -514,12 +526,6 @@ In order to run some of the tests, the mongo cluster needs to have fail points
 enabled. This is accomplished by starting `mongod` with the following option:
 
     --setParameter enableTestCommands=1
-
-### Log Output
-
-The test suite is run with the driver log level set to WARN by default.
-This produces a fair amount of output as many tests trigger various conditions
-resulting in the driver outputting warnings. This is expected behavior.
 
 ## Running Individual Examples
 

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -121,7 +121,7 @@ class SpecConfig
   # Test suite configuration
 
   def client_debug?
-    %w(1 true yes).include?((ENV['MONGO_RUBY_DRIVER_CLIENT_DEBUG'] || '').downcase)
+    %w(1 true yes).include?(ENV['MONGO_RUBY_DRIVER_CLIENT_DEBUG']&.downcase)
   end
 
   def drivers_tools?

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -121,7 +121,7 @@ class SpecConfig
   # Test suite configuration
 
   def client_debug?
-    %w(1 true yes).include?((ENV['CLIENT_DEBUG'] || '').downcase)
+    %w(1 true yes).include?((ENV['MONGO_RUBY_DRIVER_CLIENT_DEBUG'] || '').downcase)
   end
 
   def drivers_tools?


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-1999

- Add MONGO_RUBY_DRIVER_UNREDACT_EVENTS environment variable to omit command event payload redaction, for assistance with e.g. auth or user management debugging
- Rename CLIENT_DEBUG to MONGO_RUBY_DRIVER_CLIENT_DEBUG for consistency with our other environment variables in the test suite
- Document MONGO_RUBY_DRIVER_CLIENT_DEBUG