### PR TITLE
RUBY-1999 Evergreen/Docker tooling changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,4 +2,4 @@
 /yard-docs
 Gemfile.lock
 gemfiles/*.lock
-.env.private
+.env.private*

--- a/.evergreen/Dockerfile.erb
+++ b/.evergreen/Dockerfile.erb
@@ -118,15 +118,13 @@ RUN echo 2
 
   WORKDIR /app
 
-  RUN curl --retry 3 -fL <%= server_download_url %> -o <%= File.basename(server_download_url) %>
-  RUN tar xfz <%= File.basename(server_download_url) %>
+  RUN curl --retry 3 -fL <%= server_download_url %> |tar xzf -
   RUN mv mongo*/ /opt/mongodb
   ENV USE_OPT_MONGODB=1
   
   <% unless ruby_head? %>
     
-    RUN curl --retry 3 -fL <%= ruby_toolchain_url %> -o ruby-toolchain.tar.gz
-    RUN tar -xC /opt -zf ruby-toolchain.tar.gz
+    RUN curl --retry 3 -fL <%= ruby_toolchain_url %> |tar -xC /opt -zf -
     ENV PATH=/opt/rubies/<%= ruby %>/bin:$PATH
     #ENV PATH=/opt/rubies/python/3/bin:$PATH
     ENV USE_OPT_TOOLCHAIN=1

--- a/.evergreen/Dockerfile.erb
+++ b/.evergreen/Dockerfile.erb
@@ -69,7 +69,7 @@ RUN echo 2
   # Ruby runtime dependencies: libyaml-0-2
   # Compiling ruby libraries: gcc make
   # JRuby: openjdk-8-jre
-  # Server dependencies: libsnmp30 libcurl3
+  # Server dependencies: libsnmp30 libcurl3/libcurl4
   # Determining OS we are running on: lsb-release
   # Kerberos testing: krb5-user
   # Installing mlaunch from git: git
@@ -91,9 +91,16 @@ RUN echo 2
   <% else %>
     RUN apt-get install -y libsnmp30
   <% end %>
-
+  
   # ubuntu1204, ubuntu1404, ubuntu1604: libcurl3
-  RUN apt-get install -y libyaml-0-2 gcc make git lsb-release libcurl3 \
+  # ubuntu1804: libcurl4
+  <% if distro =~ /ubuntu1804/ %>
+    RUN apt-get install -y libcurl4
+  <% else %>
+    RUN apt-get install -y libcurl3
+  <% end %>
+
+  RUN apt-get install -y libyaml-0-2 gcc make git lsb-release \
     krb5-user bzip2 libgmp-dev python-pip
 
 <% else %>

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -120,10 +120,7 @@ elif test "$AUTH" = x509; then
       {
         createUser: "C=US,ST=New York,L=New York City,O=MongoDB,OU=x509,CN=localhost",
         roles: [
-             { role: "dbAdminAnyDatabase", db: "admin" },
-             { role: "readWriteAnyDatabase", db: "admin" },
-             { role: "userAdminAnyDatabase", db: "admin" },
-             { role: "clusterAdmin", db: "admin" },
+             { role: "root", db: "admin" },
         ],
         writeConcern: { w: "majority" , wtimeout: 5000 },
       }

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -55,8 +55,7 @@ if test -n "$MMAPV1"; then
 fi
 if test "$AUTH" = auth; then
   args="$args --auth --username bob --password pwd123"
-fi
-if test "$AUTH" = x509; then
+elif test "$AUTH" = x509; then
   args="$args --auth --username bootstrap --password bootstrap"
 fi
 if test "$SSL" = ssl; then
@@ -115,9 +114,7 @@ fi
 
 if test "$AUTH" = auth; then
   hosts="bob:pwd123@$hosts"
-fi
-
-if test "$AUTH" = x509; then
+elif test "$AUTH" = x509; then
   create_user_cmd="`cat <<'EOT'
     db.getSiblingDB("$external").runCommand(
       {
@@ -139,9 +136,7 @@ EOT
     --tlsCertificateKeyFile spec/support/certificates/client-x509.pem \
     -u bootstrap -p bootstrap \
     --eval "$create_user_cmd"
-fi
-
-if test "$AUTH" = kerberos; then
+elif test "$AUTH" = kerberos; then
   export MONGO_RUBY_DRIVER_KERBEROS=1
 fi
 

--- a/.evergreen/tools.rb
+++ b/.evergreen/tools.rb
@@ -36,7 +36,10 @@ class ServerVersionRegistry
           exit 2
         end
       end
-      dl = version['downloads'].detect { |dl| dl['archive']['url'].index("enterprise-#{arch}") }
+      dl = version['downloads'].detect do |dl|
+        dl['archive']['url'].index("enterprise-#{arch}") &&
+        dl['arch'] == 'x86_64'
+      end
       unless dl
         STDERR.puts "Error: no download for #{arch} for #{version['version']}"
         exit 2

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ tmp
 sandbox/*
 .byebug_history
 gemfiles/*.gemfile.lock
-.env.private
+.env.private*


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-1999

- Improve efficiency of docker provisioning by eliminating redundant stores of toolchain and server tarballs
- Exclude all files beginning with .env.private from git and docker
- Support ubuntu1804 in Docker
