### PR TITLE
Fix Ruby 2.3 Replica Set Errors

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -577,7 +577,7 @@ buildvariants:
   - matrix_name: "mongo-4.2"
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-      ruby: "ruby-2.7"
+      ruby: ["ruby-2.7", "ruby-2.3"]
       mongodb-version: ['4.2']
       topology: "*"
       os: ubuntu1604

--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -35,6 +35,7 @@ module Mongo
       # @since 2.0.0
       def initialize(result)
         @result = result
+        super
       end
 
       def to_s

--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -35,7 +35,9 @@ module Mongo
       # @since 2.0.0
       def initialize(result)
         @result = result
-        super("#{self.class}: #{build_message}")
+        # Exception constructor behaves differently for a nil argument and
+        # for no argument. Avoid passing nil explicitly.
+        super(*[build_message])
       end
 
       private

--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -35,23 +35,22 @@ module Mongo
       # @since 2.0.0
       def initialize(result)
         @result = result
-        super()
+        super("#{self.class}: #{build_message}")
       end
 
-      def to_s
-        messages = if errors = result['writeErrors']
-          frag = ': ' + errors[0..10].map do |error|
-            "#{error['errmsg']} (#{error['code']})"
-          end.join(', ')
-          if errors.length > 10
-            frag += '...'
-          else
-            frag
-          end
-        else
-          ''
-        end
-        "#{self.class}: #{messages}" + notes_tail
+      private
+
+      def build_message
+        errors = @result['writeErrors']
+        return '' unless errors
+
+        fragment = errors.first(10).map do |error|
+          "#{error['errmsg']} (#{error['code']})"
+        end.join(', ')
+
+        fragment += '...' if errors.length > 10
+
+        fragment
       end
     end
   end

--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -35,7 +35,7 @@ module Mongo
       # @since 2.0.0
       def initialize(result)
         @result = result
-        super
+        super()
       end
 
       def to_s

--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -44,7 +44,7 @@ module Mongo
 
       def build_message
         errors = @result['writeErrors']
-        return '' unless errors
+        return nil unless errors
 
         fragment = errors.first(10).map do |error|
           "#{error['errmsg']} (#{error['code']})"

--- a/lib/mongo/error/notable.rb
+++ b/lib/mongo/error/notable.rb
@@ -47,7 +47,7 @@ module Mongo
 
       # @api public
       def message
-        super + notes_tail
+        super
       end
 
       # @api public

--- a/lib/mongo/error/notable.rb
+++ b/lib/mongo/error/notable.rb
@@ -46,23 +46,8 @@ module Mongo
       end
 
       # @api public
-      def message
-        super
-      end
-
-      # @api public
       def to_s
         super + notes_tail
-      end
-
-      # @api public
-      def inspect
-        msg = super
-        if msg.end_with?('>')
-          msg[0...msg.length-1] + notes_tail + '>'
-        else
-          msg + notes_tail
-        end
       end
 
       private

--- a/spec/mongo/bulk_write/result_spec.rb
+++ b/spec/mongo/bulk_write/result_spec.rb
@@ -84,19 +84,23 @@ describe Mongo::BulkWrite::Result do
 
     context 'with top level error' do
       let(:results_document) do
-        {'writeErrors' => {
-          'ok' => 0,
-          'errmsg' => 'not master',
-          'code' => 10107,
-          'codeName' => 'NotMaster',
-        }}
+        {
+          'writeErrors' => [
+            {
+              'ok' => 0,
+              'errmsg' => 'not master',
+              'code' => 10107,
+              'codeName' => 'NotMaster',
+            }
+          ]
+        }
       end
 
       it 'raises BulkWriteError' do
         expect do
           subject.validate!
         # BulkWriteErrors don't have any messages on them
-        end.to raise_error(Mongo::Error::BulkWriteError, nil)
+        end.to raise_error(Mongo::Error::BulkWriteError, /not master/)
       end
     end
 

--- a/spec/mongo/error/bulk_write_error_spec.rb
+++ b/spec/mongo/error/bulk_write_error_spec.rb
@@ -12,14 +12,6 @@ describe Mongo::Error::BulkWriteError do
 
   let(:error) { described_class.new(result) }
 
-  let(:messages) do
-    'message1 (1), message2 (2)'
-  end
-
-  let(:notes_tail) do
-    ' (note1, note2)'
-  end
-
   before do
     error.add_note('note1')
     error.add_note('note2')

--- a/spec/mongo/error/bulk_write_error_spec.rb
+++ b/spec/mongo/error/bulk_write_error_spec.rb
@@ -1,0 +1,51 @@
+require 'lite_spec_helper'
+
+describe Mongo::Error::BulkWriteError do
+  let(:result) do
+    {
+      'writeErrors' => [
+        { 'code' => 1, 'errmsg' => 'message1' },
+        { 'code' => 2, 'errmsg' => 'message2' },
+      ]
+    }
+  end
+
+  let(:error) { described_class.new(result) }
+
+  let(:messages) do
+    'message1 (1), message2 (2)'
+  end
+
+  let(:notes_tail) do
+    ' (note1, note2)'
+  end
+
+  before do
+    error.add_note('note1')
+    error.add_note('note2')
+  end
+
+  describe '#result' do
+    it 'returns the result' do
+      expect(error.result).to eq(result)
+    end
+  end
+
+  describe '#labels' do
+    it 'returns an empty array' do
+      expect(error.labels).to eq([])
+    end
+  end
+
+  describe '#message' do
+    it 'returns the formatted message' do
+      expect(error.message).to eq("#{described_class}: #{messages}#{notes_tail}")
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the error represented as a string' do
+      expect(error.to_s).to eq("#{described_class}: #{messages}#{notes_tail}")
+    end
+  end
+end

--- a/spec/mongo/error/bulk_write_error_spec.rb
+++ b/spec/mongo/error/bulk_write_error_spec.rb
@@ -38,14 +38,20 @@ describe Mongo::Error::BulkWriteError do
   end
 
   describe '#message' do
-    it 'returns the formatted message' do
-      expect(error.message).to eq("#{described_class}: #{messages}#{notes_tail}")
+    it 'is correct' do
+      expect(error.message).to eq("message1 (1), message2 (2) (note1, note2)")
     end
   end
 
   describe '#to_s' do
-    it 'returns the error represented as a string' do
-      expect(error.to_s).to eq("#{described_class}: #{messages}#{notes_tail}")
+    it 'is correct' do
+      expect(error.to_s).to eq("message1 (1), message2 (2) (note1, note2)")
+    end
+  end
+
+  describe '#inspect' do
+    it 'is correct' do
+      expect(error.inspect).to eq("#<Mongo::Error::BulkWriteError: message1 (1), message2 (2) (note1, note2)>")
     end
   end
 end

--- a/spec/mongo/error/notable_spec.rb
+++ b/spec/mongo/error/notable_spec.rb
@@ -1,0 +1,59 @@
+require 'lite_spec_helper'
+
+describe Mongo::Error::Notable do
+  let(:exception_cls) do
+    # Since Notable is a module, we need a class that includes it for testing
+    Mongo::Error
+  end
+
+  context 'when there are no notes' do
+    let(:exception) do
+      exception_cls.new('hello world')
+    end
+
+    describe '#message' do
+      it 'is correct' do
+        exception.message.should == 'hello world'
+      end
+    end
+
+    describe '#to_s' do
+      it 'is correct' do
+        exception.to_s.should == 'hello world'
+      end
+    end
+
+    describe '#inspect' do
+      it 'is correct' do
+        exception.inspect.should == '#<Mongo::Error: hello world>'
+      end
+    end
+  end
+
+  context 'when there are notes' do
+    let(:exception) do
+      exception_cls.new('hello world').tap do |exception|
+        exception.add_note('brilliant')
+        exception.add_note('weird')
+      end
+    end
+
+    describe '#message' do
+      it 'is correct' do
+        exception.message.should == 'hello world (brilliant, weird)'
+      end
+    end
+
+    describe '#to_s' do
+      it 'is correct' do
+        exception.to_s.should == 'hello world (brilliant, weird)'
+      end
+    end
+
+    describe '#inspect' do
+      it 'is correct' do
+        exception.inspect.should == '#<Mongo::Error: hello world (brilliant, weird)>'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This error was surfacing in the FLE replica set tests, but that's just the only place we test 4.2 replica sets against ruby-2.3.