### PR TITLE
JRuby failure debugging

### DIFF
--- a/.evergreen/Dockerfile.erb
+++ b/.evergreen/Dockerfile.erb
@@ -36,12 +36,12 @@ FROM <%= base_image %>
   
     # ubuntu1204 comes with python 2.7.3.
     # Install a more recent one from deadsnakes ppa so that pip works.
-    RUN apt-get install -y python-software-properties
-    # https://github.com/deadsnakes/issues/issues/53
-    RUN apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5BB92C09DB82666C
-    RUN add-apt-repository ppa:fkrull/deadsnakes-python2.7
-    RUN apt-get update
-    RUN apt-get install -y python2.7-dev
+    # See also: https://github.com/deadsnakes/issues/issues/53
+    RUN apt-get install -y python-software-properties && \
+      apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 5BB92C09DB82666C && \
+      add-apt-repository ppa:fkrull/deadsnakes-python2.7 && \
+      apt-get update && \
+      apt-get install -y python2.7-dev
 
   <% end %>
 
@@ -125,16 +125,16 @@ FROM <%= base_image %>
 
   WORKDIR /app
 
-  RUN curl --retry 3 -fL <%= server_download_url %> |tar xzf -
-  RUN mv mongo*/ /opt/mongodb
+  RUN curl --retry 3 -fL <%= server_download_url %> |tar xzf - && \
+    mv mongo*/ /opt/mongodb
   ENV USE_OPT_MONGODB=1
   
   <% unless ruby_head? %>
     
     RUN curl --retry 3 -fL <%= ruby_toolchain_url %> |tar -xC /opt -zf -
-    ENV PATH=/opt/rubies/<%= ruby %>/bin:$PATH
+    ENV PATH=/opt/rubies/<%= ruby %>/bin:$PATH \
+      USE_OPT_TOOLCHAIN=1
     #ENV PATH=/opt/rubies/python/3/bin:$PATH
-    ENV USE_OPT_TOOLCHAIN=1
   
   <% end %>
   
@@ -148,9 +148,8 @@ FROM <%= base_image %>
   
   <% end %>
 
-  RUN pip --version
-  
-  RUN pip install mtools-legacy[mlaunch]
+  RUN pip --version && \
+    pip install mtools-legacy[mlaunch]
 
 <% end %>
 

--- a/.evergreen/Dockerfile.erb
+++ b/.evergreen/Dockerfile.erb
@@ -21,16 +21,16 @@ ruby_toolchain_url = "https://s3.amazonaws.com//mciuploads/mongo-ruby-toolchain/
 
 FROM <%= base_image %>
 
-# increment to force apt-get update to run
-RUN echo 2
-
 <% if debian? %>
 
   ENV DEBIAN_FRONTEND=noninteractive
 
-  RUN apt-get update
-
-  RUN apt-get install -y curl
+  # increment the counter to force apt-get update to run.
+  # zsh is not required for any scripts but it is a better interactive shell
+  # than bash.
+  RUN echo 1 && \
+    apt-get update && \
+    apt-get install -y curl zsh
 
   <% if preload? && distro =~ /ubuntu1204/ %>
   

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -740,7 +740,7 @@ buildvariants:
       ruby: "jruby-9.2"
       mongodb-version: "4.2"
       topology: "*"
-      os: ubuntu1604
+      os: rhel70
     display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
     tasks:
       - name: "test-mlaunch"
@@ -751,7 +751,7 @@ buildvariants:
       ruby: "jruby-9.2"
       mongodb-version: "2.6"
       topology: "*"
-      os: ubuntu1204
+      os: rhel70
     display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
     tasks:
       - name: "test-mlaunch"
@@ -808,7 +808,7 @@ buildvariants:
       mongodb-version: '4.2'
       topology: replica-set
       bson: "*"
-      os: ubuntu1604
+      os: rhel70
     display_name: "AS ${mongodb-version} ${topology} ${ruby} ${bson}"
     tasks:
       - name: "test-mlaunch"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -484,8 +484,11 @@ axes:
         display_name: "Ubuntu 12.04"
         run_on: ubuntu1204-test
       - id: rhel70
-        display_name: "RHEL 7.0"
+        display_name: "RHEL 7"
         run_on: rhel70-small
+      - id: rhel62
+        display_name: "RHEL 6"
+        run_on: rhel62-small
 
   - id: "compressor"
     display_name: Compressor
@@ -751,7 +754,7 @@ buildvariants:
       ruby: "jruby-9.2"
       mongodb-version: "2.6"
       topology: "*"
-      os: rhel70
+      os: rhel62
     display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
     tasks:
       - name: "test-mlaunch"

--- a/.evergreen/functions.sh
+++ b/.evergreen/functions.sh
@@ -109,7 +109,7 @@ set_env_vars() {
   export CI=evergreen
 
   # JRUBY_OPTS were initially set for Mongoid
-  export JRUBY_OPTS="--server -J-Xms512m -J-Xmx2G"
+  export JRUBY_OPTS="--server -J-Xms512m -J-Xmx1G"
 
   if test "$BSON" = min; then
     export BUNDLE_GEMFILE=gemfiles/bson_min.gemfile

--- a/.evergreen/functions.sh
+++ b/.evergreen/functions.sh
@@ -203,8 +203,10 @@ setup_ruby() {
 
     # Only install bundler when not using ruby-head.
     # ruby-head comes with bundler and gem complains
-    # because installing bundler would overwrite the bundler binary
-    if echo "$RVM_RUBY" |grep -q jruby; then
+    # because installing bundler would overwrite the bundler binary.
+    # We now install bundler in the toolchain, hence nothing needs to be done
+    # in the tests.
+    if false && echo "$RVM_RUBY" |grep -q jruby; then
       gem install bundler -v '<2'
     fi
   fi

--- a/.evergreen/functions.sh
+++ b/.evergreen/functions.sh
@@ -116,6 +116,11 @@ set_env_vars() {
   elif test "$BSON" = master; then
     export BUNDLE_GEMFILE=gemfiles/bson_master.gemfile
   fi
+  
+  # rhel62 ships with Python 2.6
+  if test -d /opt/python/2.7/bin; then
+    export PATH=/opt/python/2.7/bin:$PATH
+  fi
 }
 
 setup_ruby() {

--- a/.evergreen/functions.sh
+++ b/.evergreen/functions.sh
@@ -109,7 +109,7 @@ set_env_vars() {
   export CI=evergreen
 
   # JRUBY_OPTS were initially set for Mongoid
-  export JRUBY_OPTS="--server -J-Xms512m -J-Xmx1G"
+  export JRUBY_OPTS="--server -J-Xms512m -J-Xmx1536M"
 
   if test "$BSON" = min; then
     export BUNDLE_GEMFILE=gemfiles/bson_min.gemfile

--- a/gemfiles/standard.rb
+++ b/gemfiles/standard.rb
@@ -27,7 +27,7 @@ def standard_dependencies
     gem 'rspec-retry'
     gem 'rspec-expectations', '~> 3.0'
     gem 'rspec-mocks-diag', '~> 3.0'
-    gem 'rfc'
+    gem 'rfc', '~> 0.1.0'
     gem 'fuubar'
     gem 'timeout-interrupt', platforms: :mri
     gem 'concurrent-ruby', platforms: :jruby

--- a/gemfiles/standard.rb
+++ b/gemfiles/standard.rb
@@ -27,7 +27,7 @@ def standard_dependencies
     gem 'rspec-retry'
     gem 'rspec-expectations', '~> 3.0'
     gem 'rspec-mocks-diag', '~> 3.0'
-    gem 'rfc', '~> 0.1.0'
+    gem 'rfc', '~> 0.1.1'
     gem 'fuubar'
     gem 'timeout-interrupt', platforms: :mri
     gem 'concurrent-ruby', platforms: :jruby

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -126,10 +126,11 @@ RSpec.configure do |config|
   end
 
   if SpecConfig.instance.ci?
-    unless BSON::Environment.jruby?
-      if defined?(Rfc)
+    if defined?(Rfc)
+      unless BSON::Environment.jruby?
         Rfc::Rif.output_object_space_stats = true
       end
+      Rfc::Rif.output_system_load = true
     end
   end
 

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -130,7 +130,11 @@ RSpec.configure do |config|
       unless BSON::Environment.jruby?
         Rfc::Rif.output_object_space_stats = true
       end
-      Rfc::Rif.output_system_load = true
+
+      # Uncomment this line to log memory and CPU statistics during
+      # test suite execution to diagnose issues potentially related to
+      # system resource exhaustion.
+      #Rfc::Rif.output_system_load = true
     end
   end
 

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -35,6 +35,13 @@ end
 require 'mongo'
 require 'pp'
 
+if BSON::Environment.jruby?
+  # Autoloading appears to not work in some environments without these
+  # gem calls. May have to do with rubygems version?
+  gem 'ice_nine'
+  gem 'timecop'
+end
+
 autoload :Benchmark, 'benchmark'
 autoload :IceNine, 'ice_nine'
 autoload :Timecop, 'timecop'


### PR DESCRIPTION
- Add tooling to show memory/cpu use by test suite
- Reduce heap size hard limit for jruby from 2g to 1.5g
- Stop installing bundler on jruby, it is now installed in the toolchain
- Fix autoloads not autoloading
- Use rhel instead of ubuntu which fixes the tests