### PR TITLE
RUBY-2189 Restart srv monitor when using the deprecated cluster reconnect method


### DIFF
--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -497,6 +497,11 @@ module Mongo
         server.reconnect!
       end
       @periodic_executor.restart!
+      @srv_monitor_lock.synchronize do
+        if @srv_monitor
+          @srv_monitor.run!
+        end
+      end
       @connecting = false
       @connected = true
     end


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-2189