### PR TITLE
RUBY-2177 Fix all API documentation warnings

### DIFF
--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -44,7 +44,7 @@ module Mongo
     #
     # @param [ String ] kms_provider The KMS provider to use. Valid values are
     #   "aws" and "local".
-    # @params [ Hash ] options
+    # @param [ Hash ] options
     #
     # @option options [ Hash ] :master_key Information about the AWS master key.
     #   Required if kms_provider is "aws".

--- a/lib/mongo/crypt/auto_decryption_context.rb
+++ b/lib/mongo/crypt/auto_decryption_context.rb
@@ -23,13 +23,11 @@ module Mongo
       # Create a new AutoEncryptionContext object
       #
       # @param [ Mongo::Crypt::Handle ] mongocrypt a Handle that
-      #   wraps a mongocrypt_t object used to create a new mongocrypt_ctx_t
+      #   wraps a mongocrypt_t object used to create a new mongocrypt_ctx_t.
       # @param [ ClientEncryption::IO ] io A instance of the IO class
       #   that implements driver I/O methods required to run the
-      #   state machine
-      # @param [ String ] db_name The name of the database against which
-      #   the command is being made
-      # @param [ Hash ] command The command to be encrypted
+      #   state machine.
+      # @param [ Hash ] command The command to be decrypted.
       def initialize(mongocrypt, io, command)
         super(mongocrypt, io)
 

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -56,55 +56,50 @@ module Mongo
           "is invalid: #{ENV['LIBMONGOCRYPT_PATH']}\n\n#{e.class}: #{e.message}"
       end
 
-      # Returns the version string of the libmongocrypt library
-      #
-      # @param [ FFI::Pointer | nil ] len (out param) An optional pointer to a
-      #   uint8 that will reference the length of the returned string.
-      #
-      # @return [ String ] A version string for libmongocrypt
+      # @!method mongocrypt_version(len)
+      #   Returns the version string of the libmongocrypt library.
+      #   @param [ FFI::Pointer | nil ] len (out param) An optional pointer to a
+      #     uint8 that will reference the length of the returned string.
+      #   @return [ String ] A version string for libmongocrypt.
       attach_function :mongocrypt_version, [:pointer], :string
 
-      # Create a new mongocrypt_binary_t object (a non-owning view of a byte
-      # array)
-      #
-      # @return [ FFI::Pointer ] A pointer to the newly-created
-      #   mongocrypt_binary_t object
+      # @!method mongocrypt_binary_new
+      #   Creates a new mongocrypt_binary_t object (a non-owning view of a byte
+      #     array).
+      #   @return [ FFI::Pointer ] A pointer to the newly-created
+      #     mongocrypt_binary_t object.
       attach_function :mongocrypt_binary_new, [], :pointer
 
-      # Create a new mongocrypt_binary_t object that maintains a pointer to
-      # the specified byte array.
-      #
-      # @param [ FFI::Pointer ] data A pointer to an array of bytes; the data
-      #   is not copied and must outlive the mongocrypt_binary_t object
-      # @param [ Integer ] len The length of the array argument
-      #
-      # @return [ FFI::Pointer ] A pointer to the newly-created
-      #   mongocrypt_binary_t object
+      # @!method mongocrypt_binary_new_from_data(data, len)
+      #   Create a new mongocrypt_binary_t object that maintains a pointer to
+      #     the specified byte array.
+      #   @param [ FFI::Pointer ] data A pointer to an array of bytes; the data
+      #     is not copied and must outlive the mongocrypt_binary_t object.
+      #   @param [ Integer ] len The length of the array argument.
+      #   @return [ FFI::Pointer ] A pointer to the newly-created
+      #     mongocrypt_binary_t object.
       attach_function(
         :mongocrypt_binary_new_from_data,
         [:pointer, :int],
         :pointer
       )
 
-      # Get the pointer to the underlying data for the mongocrypt_binary_t
-      #
-      # @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t object
-      #
-      # @return [ FFI::Pointer ] A pointer to the data array
+      # @!method mongocrypt_binary_data(binary)
+      #   Get the pointer to the underlying data for the mongocrypt_binary_t.
+      #   @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t object.
+      #   @return [ FFI::Pointer ] A pointer to the data array.
       attach_function :mongocrypt_binary_data, [:pointer], :pointer
 
-      # Get the length of the underlying data array
-      #
-      # @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t object
-      #
-      # @return [ Integer ] The length of the data array
+      # @!method mongocrypt_binary_len(binary)
+      #   Get the length of the underlying data array.
+      #   @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t object.
+      #   @return [ Integer ] The length of the data array.
       attach_function :mongocrypt_binary_len, [:pointer], :int
 
-      # Destroy the mongocrypt_binary_t object
-      #
-      # @param [ FFI::Pointer ] A pointer to a mongocrypt_binary_t object
-      #
-      # @return [ nil ] Always nil
+      # @!method mongocrypt_binary_destroy(binary)
+      #   Destroy the mongocrypt_binary_t object.
+      #   @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t object.
+      #   @return [ nil ] Always nil.
       attach_function :mongocrypt_binary_destroy, [:pointer], :void
 
       # Enum labeling different status types
@@ -114,63 +109,57 @@ module Mongo
         :error_kms,     2,
       ]
 
-      # Create a new mongocrypt_status_t object
-      #
-      # @return [ FFI::Pointer ] A pointer to the new mongocrypt_status_ts
+      # @!method mongocrypt_status_new
+      #   Create a new mongocrypt_status_t object.
+      #   @return [ FFI::Pointer ] A pointer to the new mongocrypt_status_ts.
       attach_function :mongocrypt_status_new, [], :pointer
 
-      # Set a message, type, and code on an existing status
-      #
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      # @param [ Symbol ] type The status type; possible values are defined
-      #   by the status_type enum
-      # @param [ Integer ] code The status code
-      # @param [ String ] message The status message
-      # @param [ Integer ] len The length of the message argument (or -1 for a
-      #   null-terminated string)
-      #
-      # @return [ nil ] Always nil
+      # @!method mongocrypt_status_set(status, type, code, message, len)
+      #   Set a message, type, and code on an existing status.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
+      #   @param [ Symbol ] type The status type; possible values are defined
+      #     by the status_type enum.
+      #   @param [ Integer ] code The status code.
+      #   @param [ String ] message The status message.
+      #   @param [ Integer ] len The length of the message argument (or -1 for a
+      #     null-terminated string).
+      #   @return [ nil ] Always nil.
       attach_function(
         :mongocrypt_status_set,
         [:pointer, :status_type, :int, :string, :int],
         :void
       )
 
-      # Indicates the status type
-      #
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      #
-      # @return [ Symbol ] The status type (as defined by the status_type enum)
+      # @!method mongocrypt_status_type(status)
+      #   Indicates the status type.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
+      #   @return [ Symbol ] The status type (as defined by the status_type enum).
       attach_function :mongocrypt_status_type, [:pointer], :status_type
 
-      # Return the status error code
-      #
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      #
-      # @return [ Integer ] The status code
+      # @!method mongocrypt_status_code(status)
+      #   Return the status error code.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
+      #   @return [ Integer ] The status code.
       attach_function :mongocrypt_status_code, [:pointer], :int
 
-      # Returns the status message
-      #
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      # @param [ FFI::Pointer | nil ] len (out param) An optional pointer to a
-      #   uint32, where the length of the retun string will be written
-      #
-      # @return [ String ] The status message
+      # @!method mongocrypt_status_message(status, len=nil)
+      #   Returns the status message.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
+      #   @param [ FFI::Pointer | nil ] len (out param) An optional pointer to a
+      #     uint32, where the length of the retun string will be written.
+      #   @return [ String ] The status message.
       attach_function :mongocrypt_status_message, [:pointer, :pointer], :string
 
-      # Returns whether the status is ok or an error
-      #
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      #
-      # @return [ Boolean ] Whether the status is ok
+      # @!method mongocrypt_status_ok(status)
+      #   Returns whether the status is ok or an error.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
+      #   @return [ Boolean ] Whether the status is ok.
       attach_function :mongocrypt_status_ok, [:pointer], :bool
 
-      # Destroys the reference to the mongocrypt_status_t object
-      #
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      #
-      # @return [ nil ] Always nil
+      # @!method mongocrypt_status_destroy(status)
+      #   Destroys the reference to the mongocrypt_status_t object.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
+      #   @return [ nil ] Always nil.
       attach_function :mongocrypt_status_destroy, [:pointer], :void
 
       # Enum labeling the various log levels
@@ -185,31 +174,30 @@ module Mongo
       # A callback to the mongocrypt log function
       # Set a custom log callback with the mongocrypt_setopt_log_handler method
       #
-      # @param [ Symbol ] level The log level; possible values defined by the
+      # param [ Symbol ] level The log level; possible values defined by the
       #   log_level enum
-      # @param [ String ] message The log message
-      # @param [ Integer ] len The length of the message param, or -1 if the
+      # param [ String ] message The log message
+      # param [ Integer ] len The length of the message param, or -1 if the
       #   string is null terminated
-      # @param [ FFI::Pointer | nil ] ctx An optional pointer to a context
+      # param [ FFI::Pointer | nil ] ctx An optional pointer to a context
       #   object when this callback was set
       #
-      # @return [ nil ] Always nil.
+      # return [ nil ] Always nil.
       callback :mongocrypt_log_fn_t, [:log_level, :string, :int, :pointer], :void
 
-      # Creates a new mongocrypt_t object
-      #
-      # @return [ FFI::Pointer ] A pointer to a new mongocrypt_t object
+      # @!method mongocrypt_new
+      #   Creates a new mongocrypt_t object.
+      #   @return [ FFI::Pointer ] A pointer to a new mongocrypt_t object.
       attach_function :mongocrypt_new, [], :pointer
 
-      # Set the handler on the mongocrypt_t object to be called every time
-      #   libmongocrypt logs a message
-      #
-      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object
-      # @param [ Method ] log_fn A logging callback method
-      # @param [ FFI::Pointer | nil ] log_ctx An optional pointer to a context
-      #   to be passed into the log callback on every invocation.
-      #
-      # @return [ Boolean ] Whether setting the callback was successful
+      # @!method mongocrypt_setopt_log_handler(crypt, log_fn, log_ctx=nil)
+      #   Set the handler on the mongocrypt_t object to be called every time
+      #     libmongocrypt logs a message.
+      #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      #   @param [ Method ] log_fn A logging callback method.
+      #   @param [ FFI::Pointer | nil ] log_ctx An optional pointer to a context
+      #     to be passed into the log callback on every invocation.
+      #   @return [ Boolean ] Whether setting the callback was successful.
       attach_function(
         :mongocrypt_setopt_log_handler,
         [:pointer, :mongocrypt_log_fn_t, :pointer],
@@ -228,17 +216,16 @@ module Mongo
         end
       end
 
-      # Configure mongocrypt_t object with AWS KMS provider options
-      #
-      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object
-      # @param [ String ] aws_access_key_id The AWS access key id
-      # @param [ Integer ] aws_access_key_id_len The length of the AWS access
-      #   key string (or -1 for a null-terminated string)
-      # @param [ String ] aws_secret_access_key The AWS secret access key
-      # @param [ Integer ] aws_secret_access_key_len The length of the AWS
-      #   secret access key (or -1 for a null-terminated string)
-      #
-      # @return [ Boolean ] Returns whether the option was set successfully
+      # @!method mongocrypt_setopt_kms_provider_aws(crypt, aws_access_key_id, aws_access_key_id_len, aws_secret_access_key, aws_secret_access_key_len)
+      #   Configure mongocrypt_t object with AWS KMS provider options.
+      #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      #   @param [ String ] aws_access_key_id The AWS access key id.
+      #   @param [ Integer ] aws_access_key_id_len The length of the AWS access
+      #     key string (or -1 for a null-terminated string).
+      #   @param [ String ] aws_secret_access_key The AWS secret access key.
+      #   @param [ Integer ] aws_secret_access_key_len The length of the AWS
+      #     secret access key (or -1 for a null-terminated string).
+      #   @return [ Boolean ] Returns whether the option was set successfully.
       attach_function(
         :mongocrypt_setopt_kms_provider_aws,
         [:pointer, :string, :int, :string, :int],
@@ -266,13 +253,12 @@ module Mongo
         end
       end
 
-      # Configure mongocrypt_t object to take local KSM provider options
-      #
-      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object
-      # @param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
-      #   that references the 96-byte local master key
-      #
-      # @return [ Boolean ] Returns whether the option was set successfully
+      # @!method mongocrypt_setopt_kms_provider_local(crypt, key)
+      #   Configure mongocrypt_t object to take local KSM provider options.
+      #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      #   @param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
+      #     that references the 96-byte local master key.
+      #   @return [ Boolean ] Returns whether the option was set successfully.
       attach_function(
         :mongocrypt_setopt_kms_provider_local,
         [:pointer, :pointer],
@@ -293,13 +279,12 @@ module Mongo
         end
       end
 
-      # Sets a local schema map for encryption
-      #
-      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object
-      # @param [ FFI::Pointer ] schema_map A pointer to a mongocrypt_binary_t
-      #   object that references the schema map as a BSON binary string
-      #
-      # @return [ Boolean ] Returns whether the option was set successfully
+      # @!method mongocrypt_setopt_schema_map(crypt, schema_map)
+      #   Sets a local schema map for encryption.
+      #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      #   @param [ FFI::Pointer ] schema_map A pointer to a mongocrypt_binary_t.
+      #     object that references the schema map as a BSON binary string.
+      #   @return [ Boolean ] Returns whether the option was set successfully.
       attach_function :mongocrypt_setopt_schema_map, [:pointer, :pointer], :bool
 
       # Set schema map on the Mongo::Crypt::Handle object
@@ -319,11 +304,10 @@ module Mongo
         end
       end
 
-      # Initialize the mongocrypt_t object
-      #
-      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object
-      #
-      # @return [ Boolean ] Returns whether the crypt was initialized successfully
+      # @!method mongocrypt_init(crypt)
+      #   Initialize the mongocrypt_t object.
+      #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      #   @return [ Boolean ] Returns whether the crypt was initialized successfully.
       attach_function :mongocrypt_init, [:pointer], :bool
 
       # Initialize the Mongo::Crypt::Handle object
@@ -337,47 +321,42 @@ module Mongo
         end
       end
 
-      # Set the status information from the mongocrypt_t object on the
-      # mongocrypt_status_t object
-      #
-      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t object
-      #
-      # @return [ Boolean ] Whether the status was successfully set
+      # @!method mongocrypt_status(crypt, status)
+      #   Set the status information from the mongocrypt_t object on the
+      #     mongocrypt_status_t object.
+      #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t object.
+      #   @return [ Boolean ] Whether the status was successfully set.
       attach_function :mongocrypt_status, [:pointer, :pointer], :bool
 
-      # Destroy the reference the mongocrypt_t object
-      #
-      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object
-      #
-      # @return [ nil ] Always nil
+      # @!method mongocrypt_destroy(crypt)
+      #   Destroy the reference the mongocrypt_t object.
+      #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      #   @return [ nil ] Always nil.
       attach_function :mongocrypt_destroy, [:pointer], :void
 
-      # Create a new mongocrypt_ctx_t object (a wrapper for the libmongocrypt
-      #   state machine)
-      #
-      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object
-      #
-      # @return [ FFI::Pointer ] A new mongocrypt_ctx_t object
+      # @!method mongocrypt_ctx_new(crypt)
+      #   Create a new mongocrypt_ctx_t object (a wrapper for the libmongocrypt
+      #     state machine).
+      #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      #   @return [ FFI::Pointer ] A new mongocrypt_ctx_t object.
       attach_function :mongocrypt_ctx_new, [:pointer], :pointer
 
-      # Set the status information from the mongocrypt_ctx_t object on the
-      # mongocrypt_status_t object
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t object
-      #
-      # @return [ Boolean ] Whether the status was successfully set
+      # @!method mongocrypt_ctx_status(ctx, status)
+      #   Set the status information from the mongocrypt_ctx_t object on the
+      #     mongocrypt_status_t object.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t object.
+      #   @return [ Boolean ] Whether the status was successfully set.
       attach_function :mongocrypt_ctx_status, [:pointer, :pointer], :bool
 
-      # Set the key id used for explicit encryption
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ FFI::Pointer ] key_id A pointer to a mongocrypt_binary_t object
-      #   that references the 16-byte key-id
-      #
-      # @note Do not initialize ctx before calling this method
-      # @return [ Boolean ] Whether the option was successfully set
+      # @!method mongocrypt_ctx_setopt_key_id(ctx, key_id)
+      #   Set the key id used for explicit encryption.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] key_id A pointer to a mongocrypt_binary_t object
+      #     that references the 16-byte key-id.
+      #   @note Do not initialize ctx before calling this method.
+      #   @return [ Boolean ] Whether the option was successfully set.
       attach_function :mongocrypt_ctx_setopt_key_id, [:pointer, :pointer], :bool
 
       # Sets the key id option on an explicit encryption context.
@@ -394,18 +373,16 @@ module Mongo
         end
       end
 
-      # When creating a data key, set an alternate name on that key. When
-      # performing explicit encryption, specifying which data key to use for
-      # encryption based on its keyAltName field.
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t
-      #   object that references a BSON document in the format
-      #   { "keyAltName": <BSON UTF8 value> }
-      #
-      # @return [ Boolean ] Whether the alternative name was successfully set
-      #
-      # @note Do not initialize ctx before calling this method
+      # @!method mongocrypt_ctx_setopt_key_alt_name(ctx, binary)
+      #   When creating a data key, set an alternate name on that key. When
+      #     performing explicit encryption, specifying which data key to use for
+      #     encryption based on its keyAltName field.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t
+      #     object that references a BSON document in the format
+      #     { "keyAltName": <BSON UTF8 value> }.
+      #   @return [ Boolean ] Whether the alternative name was successfully set.
+      #   @note Do not initialize ctx before calling this method.
       attach_function(
         :mongocrypt_ctx_setopt_key_alt_name,
         [:pointer, :pointer],
@@ -431,16 +408,15 @@ module Mongo
         end
       end
 
-      # Set the algorithm used for explicit encryption
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ String ] algorithm The algorithm name. Valid values are:
-      #   - "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
-      #   - "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
-      # @param [ Integer ] len The length of the algorithm string
-      #
-      # @note Do not initialize ctx before calling this method
-      # @return [ Boolean ] Whether the option was successfully set
+      # @!method mongocrypt_ctx_setopt_algorithm(ctx, algorithm, len)
+      #   Set the algorithm used for explicit encryption.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ String ] algorithm The algorithm name. Valid values are:
+      #     - "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+      #     - "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
+      #   @param [ Integer ] len The length of the algorithm string.
+      #   @note Do not initialize ctx before calling this method.
+      #   @return [ Boolean ] Whether the option was successfully set.
       attach_function(
         :mongocrypt_ctx_setopt_algorithm,
         [:pointer, :string, :int],
@@ -461,17 +437,16 @@ module Mongo
         end
       end
 
-      # Configure the ctx to take a master key from AWS
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_object
-      # @param [ String ] region The AWS region
-      # @param [ Integer ] region_len The length of the region string (or -1
-      #   for a null-terminated string)
-      # @param [ String ] arn The Amazon Resource Name (ARN) of the mater key
-      # @param [ Integer ] arn_len The length of the ARN (or -1 for a
-      #   null-terminated string)
-      #
-      # @return [ Boolean ] Returns whether the option was set successfully
+      # @!method mongocrypt_ctx_setopt_masterkey_aws(ctx, region, region_len, arn, arn_len)
+      #   Configure the ctx to take a master key from AWS.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_object.
+      #   @param [ String ] region The AWS region.
+      #   @param [ Integer ] region_len The length of the region string (or -1
+      #     for a null-terminated string).
+      #   @param [ String ] arn The Amazon Resource Name (ARN) of the mater key.
+      #   @param [ Integer ] arn_len The length of the ARN (or -1 for a
+      #     null-terminated string).
+      #   @return [ Boolean ] Returns whether the option was set successfully.
       attach_function(
         :mongocrypt_ctx_setopt_masterkey_aws,
         [:pointer, :string, :int, :string, :int],
@@ -497,14 +472,13 @@ module Mongo
         end
       end
 
-      # Set a custom endpoint at which to fetch the AWS master key
-      #
-      # @param [ FFI::Pointer ] ctx
-      # @param [ String ] endpoint The custom endpoint
-      # @param [ Integer ] endpoint_len The length of the endpoint string (or
-      #   -1 for a null-terminated string)
-      #
-      # @return [ Boolean ] Returns whether the option was set successfully
+      # @!method mongocrypt_ctx_setopt_masterkey_aws_endpoint(ctx, endpoint, endpoint_len)
+      #   Set a custom endpoint at which to fetch the AWS master key
+      #   @param [ FFI::Pointer ] ctx
+      #   @param [ String ] endpoint The custom endpoint.
+      #   @param [ Integer ] endpoint_len The length of the endpoint string (or
+      #     -1 for a null-terminated string).
+      #   @return [ Boolean ] Returns whether the option was set successfully.
       attach_function(
         :mongocrypt_ctx_setopt_masterkey_aws_endpoint,
         [:pointer, :string, :int],
@@ -527,12 +501,11 @@ module Mongo
         end
       end
 
-      # Set the ctx to take a local master key
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      #
-      # @note Do not initialize ctx before calling this method
-      # @return [ Boolean ] Whether the option was successfully set
+      # @!method mongocrypt_ctx_setopt_masterkey_local(ctx)
+      #   Set the ctx to take a local master key.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @note Do not initialize ctx before calling this method.
+      #   @return [ Boolean ] Whether the option was successfully set.
       attach_function(
         :mongocrypt_ctx_setopt_masterkey_local,
         [:pointer],
@@ -550,16 +523,14 @@ module Mongo
         end
       end
 
-      # Initializes the ctx to create a data key
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      #
-      # @note Before calling this method, master key options must be set.
-      #   Set AWS master key by calling mongocrypt_ctx_setopt_masterkey_aws
-      #   and mongocrypt_ctx_setopt_masterkey_aws_endpoint. Set local master
-      #   key by calling mongocrypt_ctx_setopt_masterkey_local.
-      #
-      # @return [ Boolean ] Whether the initialization was successful
+      # @!method mongocrypt_ctx_datakey_init(ctx)
+      #   Initializes the ctx to create a data key.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @note Before calling this method, master key options must be set.
+      #     Set AWS master key by calling mongocrypt_ctx_setopt_masterkey_aws
+      #     and mongocrypt_ctx_setopt_masterkey_aws_endpoint. Set local master
+      #     key by calling mongocrypt_ctx_setopt_masterkey_local.
+      #   @return [ Boolean ] Whether the initialization was successful.
       attach_function :mongocrypt_ctx_datakey_init, [:pointer], :bool
 
       # Initialize the Context to create a data key
@@ -573,19 +544,17 @@ module Mongo
         end
       end
 
-      # Initializes the ctx for auto-encryption
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ String ] db The database name
-      # @param [ Integer ] db_len The length of the database name argument (or
-      #   -1 for a null-terminated string)
-      # @param [ FFI::Pointer ] cmd A pointer to a mongocrypt_binary_t object
-      #   that references the database command as a binary string
-      #
-      # @note This method expects the passed-in BSON to be in the format:
-      #   { "v": BSON value to decrypt }
-      #
-      # @return [ Boolean ] Whether the initialization was successful
+      # @!method mongocrypt_ctx_encrypt_init(ctx, db, db_len, cmd)
+      #   Initializes the ctx for auto-encryption.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ String ] db The database name.
+      #   @param [ Integer ] db_len The length of the database name argument
+      #     (or -1 for a null-terminated string).
+      #   @param [ FFI::Pointer ] cmd A pointer to a mongocrypt_binary_t object
+      #     that references the database command as a binary string.
+      #   @note This method expects the passed-in BSON to be in the format:
+      #     { "v": BSON value to decrypt }.
+      #   @return [ Boolean ] Whether the initialization was successful.
       attach_function(
         :mongocrypt_ctx_encrypt_init,
         [:pointer, :string, :int, :pointer],
@@ -610,18 +579,16 @@ module Mongo
         end
       end
 
-      # Initializes the ctx for explicit encryption
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ FFI::Pointer ] msg A pointer to a mongocrypt_binary_t object
-      #   that references the message to be encrypted as a binary string
-      #
-      # @note Before calling this method, set a key_id, key_alt_name (optional),
-      #   and encryption algorithm using the following methods:
-      #   mongocrypt_ctx_setopt_key_id, mongocrypt_ctx_setopt_key_alt_name,
-      #   and mongocrypt_ctx_setopt_algorithm
-      #
-      # @return [ Boolean ] Whether the initialization was successful
+      # @!method mongocrypt_ctx_explicit_encrypt_init(ctx, msg)
+      #   Initializes the ctx for explicit encryption.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] msg A pointer to a mongocrypt_binary_t object
+      #     that references the message to be encrypted as a binary string.
+      #   @note Before calling this method, set a key_id, key_alt_name (optional),
+      #     and encryption algorithm using the following methods:
+      #     mongocrypt_ctx_setopt_key_id, mongocrypt_ctx_setopt_key_alt_name,
+      #     and mongocrypt_ctx_setopt_algorithm.
+      #   @return [ Boolean ] Whether the initialization was successful.
       attach_function(
         :mongocrypt_ctx_explicit_encrypt_init,
         [:pointer, :pointer],
@@ -631,7 +598,7 @@ module Mongo
       # Initialize the Context for explicit encryption
       #
       # @param [ Mongo::Crypt::Context ] context
-      # @param [ Hash ] A BSON document to encrypt
+      # @param [ Hash ] doc A BSON document to encrypt
       #
       # @raise [ Mongo::Error::CryptError ] If initialization fails
       def self.ctx_explicit_encrypt_init(context, doc)
@@ -644,19 +611,18 @@ module Mongo
         end
       end
 
-      # Initializes the ctx for auto-decryption
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ FFI::Pointer ] doc A pointer to a mongocrypt_binary_t object
-      #   that references the document to be decrypted as a BSON binary string
-      #
-      # @return [ Boolean ] Whether the initialization was successful
+      # @!method mongocrypt_ctx_decrypt_init(ctx, doc)
+      #   Initializes the ctx for auto-decryption.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] doc A pointer to a mongocrypt_binary_t object
+      #     that references the document to be decrypted as a BSON binary string.
+      #   @return [ Boolean ] Whether the initialization was successful.
       attach_function :mongocrypt_ctx_decrypt_init, [:pointer, :pointer], :bool
 
       # Initialize the Context for auto-decryption
       #
       # @param [ Mongo::Crypt::Context ] context
-      # @param [ BSON::Document ] A BSON document to decrypt
+      # @param [ BSON::Document ] command A BSON document to decrypt
       #
       # @raise [ Mongo::Error::CryptError ] If initialization fails
       def self.ctx_decrypt_init(context, command)
@@ -669,13 +635,12 @@ module Mongo
         end
       end
 
-      # Initializes the ctx for explicit decryption
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ FFI::Pointer ] msg A pointer to a mongocrypt_binary_t object
-      #   that references the message to be decrypted as a BSON binary string
-      #
-      # @return [ Boolean ] Whether the initialization was successful
+      # @!method mongocrypt_ctx_explicit_decrypt_init(ctx, msg)
+      #   Initializes the ctx for explicit decryption.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] msg A pointer to a mongocrypt_binary_t object
+      #     that references the message to be decrypted as a BSON binary string.
+      #   @return [ Boolean ] Whether the initialization was successful.
       attach_function(
         :mongocrypt_ctx_explicit_decrypt_init,
         [:pointer, :pointer],
@@ -685,7 +650,7 @@ module Mongo
       # Initialize the Context for explicit decryption
       #
       # @param [ Mongo::Crypt::Context ] context
-      # @param [ Hash ] A BSON document to decrypt
+      # @param [ Hash ] doc A BSON document to decrypt
       #
       # @raise [ Mongo::Error::CryptError ] If initialization fails
       def self.ctx_explicit_decrypt_init(context, doc)
@@ -709,23 +674,21 @@ module Mongo
         :done,                6,
       ]
 
-      # Get the current state of the ctx
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      #
-      # @return [ Symbol ] The current state, will be one of the values defined
-      #   by the mongocrypt_ctx_state enum
+      # @!method mongocrypt_ctx_state(ctx)
+      #   Get the current state of the ctx.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @return [ Symbol ] The current state, will be one of the values defined
+      #     by the mongocrypt_ctx_state enum.
       attach_function :mongocrypt_ctx_state, [:pointer], :mongocrypt_ctx_state
 
-      # Get a BSON operation for the driver to run against the MongoDB
-      # collection, the key vault database, or mongocryptd.
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ FFI::Pointer ] op_bson (out param) A pointer to a
-      #   mongocrypt_binary_t object that will have a reference to the
-      #   BSON operation written to it by libmongocrypt
-      #
-      # @return [ Boolean ] A boolean indicating the success of the operation
+      # @!method mongocrypt_ctx_mongo_op(ctx, op_bson)
+      #   Get a BSON operation for the driver to run against the MongoDB
+      #     collection, the key vault database, or mongocryptd.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] op_bson (out param) A pointer to a
+      #     mongocrypt_binary_t object that will have a reference to the
+      #     BSON operation written to it by libmongocrypt.
+      #   @return [ Boolean ] A boolean indicating the success of the operation.
       attach_function :mongocrypt_ctx_mongo_op, [:pointer, :pointer], :bool
 
       # Returns a BSON::Document representing an operation that the
@@ -750,13 +713,12 @@ module Mongo
         BSON::Document.from_bson(BSON::ByteBuffer.new(binary.to_s), mode: :bson)
       end
 
-      # Feed a BSON reply to libmongocrypt
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ FFI::Pointer ] reply A mongocrypt_binary_t object that
-      #   references the BSON reply to feed to libmongocrypt
-      #
-      # @return [ Boolean ] A boolean indicating the success of the operation
+      # @!method mongocrypt_ctx_mongo_feed(ctx, reply)
+      #   Feed a BSON reply to libmongocrypt.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] reply A mongocrypt_binary_t object that
+      #     references the BSON reply to feed to libmongocrypt.
+      #   @return [ Boolean ] A boolean indicating the success of the operation.
       attach_function :mongocrypt_ctx_mongo_feed, [:pointer, :pointer], :bool
 
       # Feed a response from the driver back to libmongocrypt
@@ -775,18 +737,16 @@ module Mongo
         end
       end
 
-      # Indicate to libmongocrypt that the driver is done feeding replies
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      #
-      # @return [ Boolean ] A boolean indicating the success of the operation
+      # @!method mongocrypt_ctx_mongo_done(ctx)
+      #   Indicate to libmongocrypt that the driver is done feeding replies.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @return [ Boolean ] A boolean indicating the success of the operation.
       attach_function :mongocrypt_ctx_mongo_done, [:pointer], :bool
 
-      # Return a pointer to a mongocrypt_kms_ctx_t object or NULL.
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      #
-      # @return [ FFI::Pointer ] A pointer to a mongocrypt_kms_ctx_t object
+      # @!method mongocrypt_ctx_mongo_next_kms_ctx(ctx)
+      #   Return a pointer to a mongocrypt_kms_ctx_t object or NULL.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @return [ FFI::Pointer ] A pointer to a mongocrypt_kms_ctx_t object.
       attach_function :mongocrypt_ctx_next_kms_ctx, [:pointer], :pointer
 
       # Return a new KmsContext object needed by a Context object.
@@ -805,14 +765,13 @@ module Mongo
         end
       end
 
-      # Get the message needed to fetch the AWS KMS master key.
-      #
-      # @param [ FFI::Pointer ] kms Pointer to the mongocrypt_kms_ctx_t object
-      # @param [ FFI::Pointer ] msg (outparam) Pointer to a mongocrypt_binary_t
-      #   object that will have the location of the message written to it by
-      #   libmongocrypt
-      #
-      # @return [ Boolean ] Whether the operation is successful
+      # @!method mongocrypt_kms_ctx_message(kms, msg)
+      #   Get the message needed to fetch the AWS KMS master key.
+      #   @param [ FFI::Pointer ] kms Pointer to the mongocrypt_kms_ctx_t object
+      #   @param [ FFI::Pointer ] msg (outparam) Pointer to a mongocrypt_binary_t
+      #     object that will have the location of the message written to it by
+      #     libmongocrypt.
+      #   @return [ Boolean ] Whether the operation is successful.
       attach_function :mongocrypt_kms_ctx_message, [:pointer, :pointer], :bool
 
       # Get the HTTP message needed to fetch the AWS KMS master key from a
@@ -833,14 +792,13 @@ module Mongo
         return binary.to_s
       end
 
-      # Get the hostname with which to connect over TLS to get information about
-      # the AWS master key.
-      #
-      # @param [ FFI::Pointer ] kms A pointer to a mongocrypt_kms_ctx_t object
-      # @param [ FFI::Pointer ] endpoint (out param) A pointer to which the
-      #   endpoint string will be written by libmongocrypt
-      #
-      # @return [ Boolean ] Whether the operation was successful
+      # @!method mongocrypt_kms_ctx_endpoint(kms, endpoint)
+      #   Get the hostname with which to connect over TLS to get information about
+      #     the AWS master key.
+      #   @param [ FFI::Pointer ] kms A pointer to a mongocrypt_kms_ctx_t object.
+      #   @param [ FFI::Pointer ] endpoint (out param) A pointer to which the
+      #     endpoint string will be written by libmongocrypt.
+      #   @return [ Boolean ] Whether the operation was successful.
       attach_function :mongocrypt_kms_ctx_endpoint, [:pointer, :pointer], :bool
 
       # Get the hostname with which to connect over TLS to get information
@@ -862,11 +820,10 @@ module Mongo
         str_ptr.null? ? nil : str_ptr.read_string.force_encoding('UTF-8')
       end
 
-      # Get the number of bytes needed by the KMS context.
-      #
-      # @param [ FFI::Pointer ] kms The mongocrypt_kms_ctx_t object
-      #
-      # @return [ Integer ] The number of bytes needed
+      # @!method mongocrypt_kms_ctx_bytes_needed(kms)
+      #   Get the number of bytes needed by the KMS context.
+      #   @param [ FFI::Pointer ] kms The mongocrypt_kms_ctx_t object.
+      #   @return [ Integer ] The number of bytes needed.
       attach_function :mongocrypt_kms_ctx_bytes_needed, [:pointer], :int
 
       # Get the number of bytes needed by the KmsContext.
@@ -878,19 +835,18 @@ module Mongo
         mongocrypt_kms_ctx_bytes_needed(kms_context.kms_ctx_p)
       end
 
-      # Feed replies from the KMS back to libmongocrypt.
-      #
-      # @param [ FFI::Pointer ] kms A pointer to the mongocrypt_kms_ctx_t object
-      # @param [ FFI::Pointer ] bytes A pointer to a mongocrypt_binary_t
-      #   object that references the response from the KMS
-      #
-      # @return [ Boolean ] Whether the operation was successful
+      # @!method mongocrypt_kms_ctx_feed(kms, bytes)
+      #   Feed replies from the KMS back to libmongocrypt.
+      #   @param [ FFI::Pointer ] kms A pointer to the mongocrypt_kms_ctx_t object.
+      #   @param [ FFI::Pointer ] bytes A pointer to a mongocrypt_binary_t
+      #     object that references the response from the KMS.
+      #   @return [ Boolean ] Whether the operation was successful.
       attach_function :mongocrypt_kms_ctx_feed, [:pointer, :pointer], :bool
 
       # Feed replies from the KMS back to libmongocrypt.
       #
       # @param [ Mongo::Crypt::KmsContext ] kms_context
-      # @oaram [ String ] data The data to feed to libmongocrypt
+      # @param [ String ] bytes The data to feed to libmongocrypt
       #
       # @raise [ Mongo::Error::CryptError ] If the response is not fed successfully
       def self.kms_ctx_feed(kms_context, bytes)
@@ -901,13 +857,12 @@ module Mongo
         end
       end
 
-      # Write status information about the mongocrypt_kms_ctx_t object
-      # to the mongocrypt_status_t object.
-      #
-      # @param [ FFI::Pointer ] kms A pointer to the mongocrypt_kms_ctx_t object
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t object
-      #
-      # @return [ Boolean ] Whether the operation was successful
+      # @!method mongocrypt_kms_ctx_status(kms, status)
+      #   Write status information about the mongocrypt_kms_ctx_t object
+      #     to the mongocrypt_status_t object.
+      #   @param [ FFI::Pointer ] kms A pointer to the mongocrypt_kms_ctx_t object.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t object.
+      #   @return [ Boolean ] Whether the operation was successful.
       attach_function :mongocrypt_kms_ctx_status, [:pointer, :pointer], :bool
 
       # If the provided block returns false, raise a CryptError with the
@@ -925,12 +880,11 @@ module Mongo
         end
       end
 
-      # Indicate to libmongocrypt that it will receive no more replies from
-      # mongocrypt_kms_ctx_t objects.
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      #
-      # @return [ Boolean ] Whether the operation was successful
+      # @!method mongocrypt_kms_ctx_done(ctx)
+      #   Indicate to libmongocrypt that it will receive no more replies from
+      #     mongocrypt_kms_ctx_t objects.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @return [ Boolean ] Whether the operation was successful.
       attach_function :mongocrypt_ctx_kms_done, [:pointer], :bool
 
       # Indicate to libmongocrypt that it will receive no more KMS replies.
@@ -944,14 +898,13 @@ module Mongo
         end
       end
 
-      # Perform the final encryption or decryption and return a BSON document
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      # @param [ FFI::Pointer ] op_bson (out param) A pointer to a
-      #   mongocrypt_binary_t object that will have a reference to the
-      #   final encrypted BSON document
-      #
-      # @return [ Boolean ] A boolean indicating the success of the operation
+      # @!method mongocrypt_ctx_finalize(ctx, op_bson)
+      #   Perform the final encryption or decryption and return a BSON document.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] op_bson (out param) A pointer to a
+      #     mongocrypt_binary_t object that will have a reference to the
+      #     final encrypted BSON document.
+      #   @return [ Boolean ] A boolean indicating the success of the operation.
       attach_function :mongocrypt_ctx_finalize, [:pointer, :pointer], :void
 
       # Finalize the state machine represented by the Context
@@ -973,30 +926,29 @@ module Mongo
         BSON::Document.from_bson(BSON::ByteBuffer.new(binary.to_s), mode: :bson)
       end
 
-      # Destroy the reference to the mongocrypt_ctx_t object
-      #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object
-      #
-      # @return [ nil ] Always nil
+      # @!method mongocrypt_ctx_destroy(ctx)
+      #   Destroy the reference to the mongocrypt_ctx_t object.
+      #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      #   @return [ nil ] Always nil.
       attach_function :mongocrypt_ctx_destroy, [:pointer], :void
 
       # A callback to a function that performs AES encryption or decryption
       #
-      # @param [ FFI::Pointer | nil] ctx An optional pointer to a context object
+      # param [ FFI::Pointer | nil] ctx An optional pointer to a context object
       #   that may have been set when hooks were enabled.
-      # @param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
+      # param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
       #   that references the 32-byte AES encryption key
-      # @param [ FFI::Pointer ] iv A pointer to a mongocrypt_binary_t object
+      # param [ FFI::Pointer ] iv A pointer to a mongocrypt_binary_t object
       #   that references the 16-byte AES IV
-      # @param [ FFI::Pointer ] in A pointer to a mongocrypt_binary_t object
+      # param [ FFI::Pointer ] in A pointer to a mongocrypt_binary_t object
       #   that references the value to be encrypted/decrypted
-      # @param [ FFI::Pointer ] out (out param) A pointer to a
+      # param [ FFI::Pointer ] out (out param) A pointer to a
       #   mongocrypt_binary_t object will have a reference to the encrypted/
       #   decrypted value written to it by libmongocrypt
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
+      # param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
       #   object to which an error message will be written if encryption fails
       #
-      # @return [ Bool ] Whether encryption/decryption was successful
+      # return [ Bool ] Whether encryption/decryption was successful
       callback(
         :mongocrypt_crypto_fn,
         [:pointer, :pointer, :pointer, :pointer, :pointer, :pointer, :pointer],
@@ -1005,19 +957,19 @@ module Mongo
 
       # A callback to a function that performs HMAC SHA-512 or SHA-256
       #
-      # @param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
+      # param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
       #   that may have been set when hooks were enabled.
-      # @param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
+      # param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
       #   that references the 32-byte HMAC SHA encryption key
-      # @param [ FFI::Pointer ] in A pointer to a mongocrypt_binary_t object
+      # param [ FFI::Pointer ] in A pointer to a mongocrypt_binary_t object
       #   that references the input value
-      # @param [ FFI::Pointer ] out (out param) A pointer to a
+      # param [ FFI::Pointer ] out (out param) A pointer to a
       #   mongocrypt_binary_t object will have a reference to the output value
       #   written to it by libmongocrypt
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
+      # param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
       #   object to which an error message will be written if encryption fails
       #
-      # @return [ Bool ] Whether HMAC-SHA was successful
+      # return [ Bool ] Whether HMAC-SHA was successful
       callback(
         :mongocrypt_hmac_fn,
         [:pointer, :pointer, :pointer, :pointer, :pointer],
@@ -1026,46 +978,45 @@ module Mongo
 
       # A callback to a SHA-256 hash function
       #
-      # @param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
+      # param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
       #   that may have been set when hooks were enabled.
-      # @param [ FFI::Pointer ] in A pointer to a mongocrypt_binary_t object
+      # param [ FFI::Pointer ] in A pointer to a mongocrypt_binary_t object
       #   that references the value to be hashed
-      # @param [ FFI::Pointer ] out (out param) A pointer to a
+      # param [ FFI::Pointer ] out (out param) A pointer to a
       #   mongocrypt_binary_t object will have a reference to the output value
       #   written to it by libmongocrypt
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
+      # param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
       #   object to which an error message will be written if encryption fails
       #
-      # @return [ Bool ] Whether hashing was successful
+      # return [ Bool ] Whether hashing was successful
       callback :mongocrypt_hash_fn, [:pointer, :pointer, :pointer, :pointer], :bool
 
       # A callback to a crypto secure random function
       #
-      # @param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
+      # param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
       #   that may have been set when hooks were enabled.
-      # @param [ FFI::Pointer ] out (out param) A pointer to a
+      # param [ FFI::Pointer ] out (out param) A pointer to a
       #   mongocrypt_binary_t object will have a reference to the output value
       #   written to it by libmongocrypt
-      # @param [ Integer ] count The number of random bytes to return
-      # @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
+      # param [ Integer ] count The number of random bytes to return
+      # param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
       #   object to which an error message will be written if encryption fails
       #
-      # @return [ Bool ] Whether hashing was successful
+      # return [ Bool ] Whether hashing was successful
       callback :mongocrypt_random_fn, [:pointer, :pointer, :int, :pointer], :bool
 
-      # Set crypto hooks on the provided mongocrypt object
-      #
-      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object
-      # @param [ Proc ] An AES encryption method
-      # @param [ Proc ] An AES decryption method
-      # @param [ Proc ] A random method
-      # @param [ Proc ] A HMAC SHA-512 method
-      # @param [ Proc ] A HMAC SHA-256 method
-      # @param [ Proc ] A SHA-256 hash method
-      # @param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
-      #   that may have been set when hooks were enabled.
-      #
-      # @return [ Boolean ] Whether setting this option succeeded
+      # @!method mongocrypt_setopt_crypto_hooks(crypt, aes_enc_fn, aes_dec_fn, random_fn, sha_512_fn, sha_256_fn, hash_fn, ctx=nil)
+      #   Set crypto hooks on the provided mongocrypt object.
+      #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      #   @param [ Proc ] aes_enc_fn An AES encryption method.
+      #   @param [ Proc ] aes_dec_fn An AES decryption method.
+      #   @param [ Proc ] random_fn A random method.
+      #   @param [ Proc ] sha_512_fn A HMAC SHA-512 method.
+      #   @param [ Proc ] sha_256_fn A HMAC SHA-256 method.
+      #   @param [ Proc ] hash_fn A SHA-256 hash method.
+      #   @param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
+      #     that may have been set when hooks were enabled.
+      #   @return [ Boolean ] Whether setting this option succeeded.
       attach_function(
         :mongocrypt_setopt_crypto_hooks,
         [

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -56,21 +56,27 @@ module Mongo
           "is invalid: #{ENV['LIBMONGOCRYPT_PATH']}\n\n#{e.class}: #{e.message}"
       end
 
-      # @!method mongocrypt_version(len)
+      # @!method self.mongocrypt_version(len)
+      #   @api private
+      #
       #   Returns the version string of the libmongocrypt library.
       #   @param [ FFI::Pointer | nil ] len (out param) An optional pointer to a
       #     uint8 that will reference the length of the returned string.
       #   @return [ String ] A version string for libmongocrypt.
       attach_function :mongocrypt_version, [:pointer], :string
 
-      # @!method mongocrypt_binary_new
+      # @!method self.mongocrypt_binary_new
+      #   @api private
+      #
       #   Creates a new mongocrypt_binary_t object (a non-owning view of a byte
       #     array).
       #   @return [ FFI::Pointer ] A pointer to the newly-created
       #     mongocrypt_binary_t object.
       attach_function :mongocrypt_binary_new, [], :pointer
 
-      # @!method mongocrypt_binary_new_from_data(data, len)
+      # @!method self.mongocrypt_binary_new_from_data(data, len)
+      #   @api private
+      #
       #   Create a new mongocrypt_binary_t object that maintains a pointer to
       #     the specified byte array.
       #   @param [ FFI::Pointer ] data A pointer to an array of bytes; the data
@@ -84,19 +90,25 @@ module Mongo
         :pointer
       )
 
-      # @!method mongocrypt_binary_data(binary)
+      # @!method self.mongocrypt_binary_data(binary)
+      #   @api private
+      #
       #   Get the pointer to the underlying data for the mongocrypt_binary_t.
       #   @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t object.
       #   @return [ FFI::Pointer ] A pointer to the data array.
       attach_function :mongocrypt_binary_data, [:pointer], :pointer
 
-      # @!method mongocrypt_binary_len(binary)
+      # @!method self.mongocrypt_binary_len(binary)
+      #   @api private
+      #
       #   Get the length of the underlying data array.
       #   @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t object.
       #   @return [ Integer ] The length of the data array.
       attach_function :mongocrypt_binary_len, [:pointer], :int
 
-      # @!method mongocrypt_binary_destroy(binary)
+      # @!method self.mongocrypt_binary_destroy(binary)
+      #   @api private
+      #
       #   Destroy the mongocrypt_binary_t object.
       #   @param [ FFI::Pointer ] binary A pointer to a mongocrypt_binary_t object.
       #   @return [ nil ] Always nil.
@@ -109,12 +121,16 @@ module Mongo
         :error_kms,     2,
       ]
 
-      # @!method mongocrypt_status_new
+      # @!method self.mongocrypt_status_new
+      #   @api private
+      #
       #   Create a new mongocrypt_status_t object.
       #   @return [ FFI::Pointer ] A pointer to the new mongocrypt_status_ts.
       attach_function :mongocrypt_status_new, [], :pointer
 
-      # @!method mongocrypt_status_set(status, type, code, message, len)
+      # @!method self.mongocrypt_status_set(status, type, code, message, len)
+      #   @api private
+      #
       #   Set a message, type, and code on an existing status.
       #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
       #   @param [ Symbol ] type The status type; possible values are defined
@@ -130,19 +146,25 @@ module Mongo
         :void
       )
 
-      # @!method mongocrypt_status_type(status)
+      # @!method self.mongocrypt_status_type(status)
+      #   @api private
+      #
       #   Indicates the status type.
       #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
       #   @return [ Symbol ] The status type (as defined by the status_type enum).
       attach_function :mongocrypt_status_type, [:pointer], :status_type
 
-      # @!method mongocrypt_status_code(status)
+      # @!method self.mongocrypt_status_code(status)
+      #   @api private
+      #
       #   Return the status error code.
       #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
       #   @return [ Integer ] The status code.
       attach_function :mongocrypt_status_code, [:pointer], :int
 
-      # @!method mongocrypt_status_message(status, len=nil)
+      # @!method self.mongocrypt_status_message(status, len=nil)
+      #   @api private
+      #
       #   Returns the status message.
       #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
       #   @param [ FFI::Pointer | nil ] len (out param) An optional pointer to a
@@ -150,13 +172,17 @@ module Mongo
       #   @return [ String ] The status message.
       attach_function :mongocrypt_status_message, [:pointer, :pointer], :string
 
-      # @!method mongocrypt_status_ok(status)
+      # @!method self.mongocrypt_status_ok(status)
+      #   @api private
+      #
       #   Returns whether the status is ok or an error.
       #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
       #   @return [ Boolean ] Whether the status is ok.
       attach_function :mongocrypt_status_ok, [:pointer], :bool
 
-      # @!method mongocrypt_status_destroy(status)
+      # @!method self.mongocrypt_status_destroy(status)
+      #   @api private
+      #
       #   Destroys the reference to the mongocrypt_status_t object.
       #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t.
       #   @return [ nil ] Always nil.
@@ -171,26 +197,34 @@ module Mongo
         :debug,   4,
       ]
 
-      # A callback to the mongocrypt log function
-      # Set a custom log callback with the mongocrypt_setopt_log_handler method
+      # @!method mongocrypt_log_fn_t(level, message, len, ctx)
+      #   @api private
       #
-      # param [ Symbol ] level The log level; possible values defined by the
-      #   log_level enum
-      # param [ String ] message The log message
-      # param [ Integer ] len The length of the message param, or -1 if the
-      #   string is null terminated
-      # param [ FFI::Pointer | nil ] ctx An optional pointer to a context
-      #   object when this callback was set
+      #   A callback to the mongocrypt log function. Set a custom log callback
+      #     with the mongocrypt_setopt_log_handler method
+      #   @param [ Symbol ] level The log level; possible values defined by the
+      #     log_level enum
+      #   @param [ String ] message The log message
+      #   @param [ Integer ] len The length of the message param, or -1 if the
+      #     string is null terminated
+      #   @param [ FFI::Pointer | nil ] ctx An optional pointer to a context
+      #     object when this callback was set
+      #   @return [ nil ] Always nil.
       #
-      # return [ nil ] Always nil.
+      #   @note This defines a method signature for an FFI callback; it is not
+      #     an instance method on the Binding class.
       callback :mongocrypt_log_fn_t, [:log_level, :string, :int, :pointer], :void
 
-      # @!method mongocrypt_new
+      # @!method self.ongocrypt_new
+      #   @api private
+      #
       #   Creates a new mongocrypt_t object.
       #   @return [ FFI::Pointer ] A pointer to a new mongocrypt_t object.
       attach_function :mongocrypt_new, [], :pointer
 
-      # @!method mongocrypt_setopt_log_handler(crypt, log_fn, log_ctx=nil)
+      # @!method self.mongocrypt_setopt_log_handler(crypt, log_fn, log_ctx=nil)
+      #   @api private
+      #
       #   Set the handler on the mongocrypt_t object to be called every time
       #     libmongocrypt logs a message.
       #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
@@ -216,7 +250,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_setopt_kms_provider_aws(crypt, aws_access_key_id, aws_access_key_id_len, aws_secret_access_key, aws_secret_access_key_len)
+      # @!method self.mongocrypt_setopt_kms_provider_aws(crypt, aws_access_key_id, aws_access_key_id_len, aws_secret_access_key, aws_secret_access_key_len)
+      #   @api private
+      #
       #   Configure mongocrypt_t object with AWS KMS provider options.
       #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
       #   @param [ String ] aws_access_key_id The AWS access key id.
@@ -253,7 +289,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_setopt_kms_provider_local(crypt, key)
+      # @!method self.mongocrypt_setopt_kms_provider_local(crypt, key)
+      #   @api private
+      #
       #   Configure mongocrypt_t object to take local KSM provider options.
       #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
       #   @param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
@@ -279,7 +317,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_setopt_schema_map(crypt, schema_map)
+      # @!method self.mongocrypt_setopt_schema_map(crypt, schema_map)
+      #   @api private
+      #
       #   Sets a local schema map for encryption.
       #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
       #   @param [ FFI::Pointer ] schema_map A pointer to a mongocrypt_binary_t.
@@ -304,7 +344,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_init(crypt)
+      # @!method self.mongocrypt_init(crypt)
+      #   @api private
+      #
       #   Initialize the mongocrypt_t object.
       #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
       #   @return [ Boolean ] Returns whether the crypt was initialized successfully.
@@ -321,7 +363,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_status(crypt, status)
+      # @!method self.mongocrypt_status(crypt, status)
+      #   @api private
+      #
       #   Set the status information from the mongocrypt_t object on the
       #     mongocrypt_status_t object.
       #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
@@ -329,20 +373,26 @@ module Mongo
       #   @return [ Boolean ] Whether the status was successfully set.
       attach_function :mongocrypt_status, [:pointer, :pointer], :bool
 
-      # @!method mongocrypt_destroy(crypt)
+      # @!method self.mongocrypt_destroy(crypt)
+      #   @api private
+      #
       #   Destroy the reference the mongocrypt_t object.
       #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
       #   @return [ nil ] Always nil.
       attach_function :mongocrypt_destroy, [:pointer], :void
 
-      # @!method mongocrypt_ctx_new(crypt)
+      # @!method self.mongocrypt_ctx_new(crypt)
+      #   @api private
+      #
       #   Create a new mongocrypt_ctx_t object (a wrapper for the libmongocrypt
       #     state machine).
       #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
       #   @return [ FFI::Pointer ] A new mongocrypt_ctx_t object.
       attach_function :mongocrypt_ctx_new, [:pointer], :pointer
 
-      # @!method mongocrypt_ctx_status(ctx, status)
+      # @!method self.mongocrypt_ctx_status(ctx, status)
+      #   @api private
+      #
       #   Set the status information from the mongocrypt_ctx_t object on the
       #     mongocrypt_status_t object.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
@@ -350,7 +400,9 @@ module Mongo
       #   @return [ Boolean ] Whether the status was successfully set.
       attach_function :mongocrypt_ctx_status, [:pointer, :pointer], :bool
 
-      # @!method mongocrypt_ctx_setopt_key_id(ctx, key_id)
+      # @!method self.mongocrypt_ctx_setopt_key_id(ctx, key_id)
+      #   @api private
+      #
       #   Set the key id used for explicit encryption.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @param [ FFI::Pointer ] key_id A pointer to a mongocrypt_binary_t object
@@ -373,7 +425,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_setopt_key_alt_name(ctx, binary)
+      # @!method self.mongocrypt_ctx_setopt_key_alt_name(ctx, binary)
+      #   @api private
+      #
       #   When creating a data key, set an alternate name on that key. When
       #     performing explicit encryption, specifying which data key to use for
       #     encryption based on its keyAltName field.
@@ -408,7 +462,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_setopt_algorithm(ctx, algorithm, len)
+      # @!method self.mongocrypt_ctx_setopt_algorithm(ctx, algorithm, len)
+      #   @api private
+      #
       #   Set the algorithm used for explicit encryption.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @param [ String ] algorithm The algorithm name. Valid values are:
@@ -437,7 +493,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_setopt_masterkey_aws(ctx, region, region_len, arn, arn_len)
+      # @!method self.mongocrypt_ctx_setopt_masterkey_aws(ctx, region, region_len, arn, arn_len)
+      #   @api private
+      #
       #   Configure the ctx to take a master key from AWS.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_object.
       #   @param [ String ] region The AWS region.
@@ -472,7 +530,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_setopt_masterkey_aws_endpoint(ctx, endpoint, endpoint_len)
+      # @!method self.mongocrypt_ctx_setopt_masterkey_aws_endpoint(ctx, endpoint, endpoint_len)
+      #   @api private
+      #
       #   Set a custom endpoint at which to fetch the AWS master key
       #   @param [ FFI::Pointer ] ctx
       #   @param [ String ] endpoint The custom endpoint.
@@ -501,7 +561,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_setopt_masterkey_local(ctx)
+      # @!method self.mongocrypt_ctx_setopt_masterkey_local(ctx)
+      #   @api private
+      #
       #   Set the ctx to take a local master key.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @note Do not initialize ctx before calling this method.
@@ -523,7 +585,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_datakey_init(ctx)
+      # @!method self.mongocrypt_ctx_datakey_init(ctx)
+      #   @api private
+      #
       #   Initializes the ctx to create a data key.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @note Before calling this method, master key options must be set.
@@ -544,7 +608,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_encrypt_init(ctx, db, db_len, cmd)
+      # @!method self.mongocrypt_ctx_encrypt_init(ctx, db, db_len, cmd)
+      #   @api private
+      #
       #   Initializes the ctx for auto-encryption.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @param [ String ] db The database name.
@@ -579,7 +645,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_explicit_encrypt_init(ctx, msg)
+      # @!method self.mongocrypt_ctx_explicit_encrypt_init(ctx, msg)
+      #   @api private
+      #
       #   Initializes the ctx for explicit encryption.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @param [ FFI::Pointer ] msg A pointer to a mongocrypt_binary_t object
@@ -611,7 +679,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_decrypt_init(ctx, doc)
+      # @!method self.mongocrypt_ctx_decrypt_init(ctx, doc)
+      #   @api private
+      #
       #   Initializes the ctx for auto-decryption.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @param [ FFI::Pointer ] doc A pointer to a mongocrypt_binary_t object
@@ -635,7 +705,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_explicit_decrypt_init(ctx, msg)
+      # @!method self.mongocrypt_ctx_explicit_decrypt_init(ctx, msg)
+      #   @api private
+      #
       #   Initializes the ctx for explicit decryption.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @param [ FFI::Pointer ] msg A pointer to a mongocrypt_binary_t object
@@ -674,14 +746,18 @@ module Mongo
         :done,                6,
       ]
 
-      # @!method mongocrypt_ctx_state(ctx)
+      # @!method self.mongocrypt_ctx_state(ctx)
+      #   @api private
+      #
       #   Get the current state of the ctx.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @return [ Symbol ] The current state, will be one of the values defined
       #     by the mongocrypt_ctx_state enum.
       attach_function :mongocrypt_ctx_state, [:pointer], :mongocrypt_ctx_state
 
-      # @!method mongocrypt_ctx_mongo_op(ctx, op_bson)
+      # @!method self.mongocrypt_ctx_mongo_op(ctx, op_bson)
+      #   @api private
+      #
       #   Get a BSON operation for the driver to run against the MongoDB
       #     collection, the key vault database, or mongocryptd.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
@@ -713,7 +789,9 @@ module Mongo
         BSON::Document.from_bson(BSON::ByteBuffer.new(binary.to_s), mode: :bson)
       end
 
-      # @!method mongocrypt_ctx_mongo_feed(ctx, reply)
+      # @!method self.mongocrypt_ctx_mongo_feed(ctx, reply)
+      #   @api private
+      #
       #   Feed a BSON reply to libmongocrypt.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @param [ FFI::Pointer ] reply A mongocrypt_binary_t object that
@@ -737,13 +815,17 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_mongo_done(ctx)
+      # @!method self.mongocrypt_ctx_mongo_done(ctx)
+      #   @api private
+      #
       #   Indicate to libmongocrypt that the driver is done feeding replies.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @return [ Boolean ] A boolean indicating the success of the operation.
       attach_function :mongocrypt_ctx_mongo_done, [:pointer], :bool
 
-      # @!method mongocrypt_ctx_mongo_next_kms_ctx(ctx)
+      # @!method self.mongocrypt_ctx_mongo_next_kms_ctx(ctx)
+      #   @api private
+      #
       #   Return a pointer to a mongocrypt_kms_ctx_t object or NULL.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @return [ FFI::Pointer ] A pointer to a mongocrypt_kms_ctx_t object.
@@ -765,7 +847,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_kms_ctx_message(kms, msg)
+      # @!method self.mongocrypt_kms_ctx_message(kms, msg)
+      #   @api private
+      #
       #   Get the message needed to fetch the AWS KMS master key.
       #   @param [ FFI::Pointer ] kms Pointer to the mongocrypt_kms_ctx_t object
       #   @param [ FFI::Pointer ] msg (outparam) Pointer to a mongocrypt_binary_t
@@ -792,7 +876,9 @@ module Mongo
         return binary.to_s
       end
 
-      # @!method mongocrypt_kms_ctx_endpoint(kms, endpoint)
+      # @!method self.mongocrypt_kms_ctx_endpoint(kms, endpoint)
+      #   @api private
+      #
       #   Get the hostname with which to connect over TLS to get information about
       #     the AWS master key.
       #   @param [ FFI::Pointer ] kms A pointer to a mongocrypt_kms_ctx_t object.
@@ -820,7 +906,9 @@ module Mongo
         str_ptr.null? ? nil : str_ptr.read_string.force_encoding('UTF-8')
       end
 
-      # @!method mongocrypt_kms_ctx_bytes_needed(kms)
+      # @!method self.mongocrypt_kms_ctx_bytes_needed(kms)
+      #   @api private
+      #
       #   Get the number of bytes needed by the KMS context.
       #   @param [ FFI::Pointer ] kms The mongocrypt_kms_ctx_t object.
       #   @return [ Integer ] The number of bytes needed.
@@ -835,7 +923,9 @@ module Mongo
         mongocrypt_kms_ctx_bytes_needed(kms_context.kms_ctx_p)
       end
 
-      # @!method mongocrypt_kms_ctx_feed(kms, bytes)
+      # @!method self.mongocrypt_kms_ctx_feed(kms, bytes)
+      #   @api private
+      #
       #   Feed replies from the KMS back to libmongocrypt.
       #   @param [ FFI::Pointer ] kms A pointer to the mongocrypt_kms_ctx_t object.
       #   @param [ FFI::Pointer ] bytes A pointer to a mongocrypt_binary_t
@@ -857,7 +947,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_kms_ctx_status(kms, status)
+      # @!method self.mongocrypt_kms_ctx_status(kms, status)
+      #   @api private
+      #
       #   Write status information about the mongocrypt_kms_ctx_t object
       #     to the mongocrypt_status_t object.
       #   @param [ FFI::Pointer ] kms A pointer to the mongocrypt_kms_ctx_t object.
@@ -880,7 +972,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_kms_ctx_done(ctx)
+      # @!method self.mongocrypt_kms_ctx_done(ctx)
+      #   @api private
+      #
       #   Indicate to libmongocrypt that it will receive no more replies from
       #     mongocrypt_kms_ctx_t objects.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
@@ -898,7 +992,9 @@ module Mongo
         end
       end
 
-      # @!method mongocrypt_ctx_finalize(ctx, op_bson)
+      # @!method self.mongocrypt_ctx_finalize(ctx, op_bson)
+      #   @api private
+      #
       #   Perform the final encryption or decryption and return a BSON document.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @param [ FFI::Pointer ] op_bson (out param) A pointer to a
@@ -926,86 +1022,106 @@ module Mongo
         BSON::Document.from_bson(BSON::ByteBuffer.new(binary.to_s), mode: :bson)
       end
 
-      # @!method mongocrypt_ctx_destroy(ctx)
+      # @!method self.mongocrypt_ctx_destroy(ctx)
+      #   @api private
+      #
       #   Destroy the reference to the mongocrypt_ctx_t object.
       #   @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
       #   @return [ nil ] Always nil.
       attach_function :mongocrypt_ctx_destroy, [:pointer], :void
 
-      # A callback to a function that performs AES encryption or decryption
+      # @!method mongocrypt_crypto_fn(ctx, key, iv, input, output, status)
+      #   @api private
       #
-      # param [ FFI::Pointer | nil] ctx An optional pointer to a context object
-      #   that may have been set when hooks were enabled.
-      # param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
-      #   that references the 32-byte AES encryption key
-      # param [ FFI::Pointer ] iv A pointer to a mongocrypt_binary_t object
-      #   that references the 16-byte AES IV
-      # param [ FFI::Pointer ] in A pointer to a mongocrypt_binary_t object
-      #   that references the value to be encrypted/decrypted
-      # param [ FFI::Pointer ] out (out param) A pointer to a
-      #   mongocrypt_binary_t object will have a reference to the encrypted/
-      #   decrypted value written to it by libmongocrypt
-      # param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      #   object to which an error message will be written if encryption fails
+      #   A callback to a function that performs AES encryption or decryption.
+      #   @param [ FFI::Pointer | nil] ctx An optional pointer to a context object
+      #     that may have been set when hooks were enabled.
+      #   @param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
+      #     that references the 32-byte AES encryption key.
+      #   @param [ FFI::Pointer ] iv A pointer to a mongocrypt_binary_t object
+      #     that references the 16-byte AES IV.
+      #   @param [ FFI::Pointer ] input A pointer to a mongocrypt_binary_t object
+      #     that references the value to be encrypted/decrypted.
+      #   @param [ FFI::Pointer ] output (out param) A pointer to a
+      #     mongocrypt_binary_t object will have a reference to the encrypted/
+      #     decrypted value written to it by libmongocrypt.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
+      #     object to which an error message will be written if encryption fails.
+      #   @return [ Bool ] Whether encryption/decryption was successful.
       #
-      # return [ Bool ] Whether encryption/decryption was successful
+      #   @note This defines a method signature for an FFI callback; it is not
+      #     an instance method on the Binding class.
       callback(
         :mongocrypt_crypto_fn,
         [:pointer, :pointer, :pointer, :pointer, :pointer, :pointer, :pointer],
         :bool
       )
 
-      # A callback to a function that performs HMAC SHA-512 or SHA-256
+      # @!method mongocrypt_hmac_fn(ctx, key, input, output, status)
+      #   @api private
       #
-      # param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
-      #   that may have been set when hooks were enabled.
-      # param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
-      #   that references the 32-byte HMAC SHA encryption key
-      # param [ FFI::Pointer ] in A pointer to a mongocrypt_binary_t object
-      #   that references the input value
-      # param [ FFI::Pointer ] out (out param) A pointer to a
-      #   mongocrypt_binary_t object will have a reference to the output value
-      #   written to it by libmongocrypt
-      # param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      #   object to which an error message will be written if encryption fails
+      #   A callback to a function that performs HMAC SHA-512 or SHA-256.
+      #   @param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
+      #     that may have been set when hooks were enabled.
+      #   @param [ FFI::Pointer ] key A pointer to a mongocrypt_binary_t object
+      #     that references the 32-byte HMAC SHA encryption key.
+      #   @param [ FFI::Pointer ] input A pointer to a mongocrypt_binary_t object
+      #     that references the input value.
+      #   @param [ FFI::Pointer ] output (out param) A pointer to a
+      #     mongocrypt_binary_t object will have a reference to the output value
+      #     written to it by libmongocrypt.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
+      #     object to which an error message will be written if encryption fails.
+      #   @return [ Bool ] Whether HMAC-SHA was successful.
       #
-      # return [ Bool ] Whether HMAC-SHA was successful
+      #   @note This defines a method signature for an FFI callback; it is not
+      #     an instance method on the Binding class.
       callback(
         :mongocrypt_hmac_fn,
         [:pointer, :pointer, :pointer, :pointer, :pointer],
         :bool
       )
 
-      # A callback to a SHA-256 hash function
+      # @!method mongocrypt_hash_fn(ctx, input, output, status)
+      #   @api private
       #
-      # param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
-      #   that may have been set when hooks were enabled.
-      # param [ FFI::Pointer ] in A pointer to a mongocrypt_binary_t object
-      #   that references the value to be hashed
-      # param [ FFI::Pointer ] out (out param) A pointer to a
-      #   mongocrypt_binary_t object will have a reference to the output value
-      #   written to it by libmongocrypt
-      # param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      #   object to which an error message will be written if encryption fails
+      #   A callback to a SHA-256 hash function.
+      #   @param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
+      #     that may have been set when hooks were enabled.
+      #   @param [ FFI::Pointer ] input A pointer to a mongocrypt_binary_t object
+      #     that references the value to be hashed.
+      #   @param [ FFI::Pointer ] output (out param) A pointer to a
+      #     mongocrypt_binary_t object will have a reference to the output value
+      #     written to it by libmongocrypt.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
+      #     object to which an error message will be written if encryption fails.
+      #   @return [ Bool ] Whether hashing was successful.
       #
-      # return [ Bool ] Whether hashing was successful
+      #   @note This defines a method signature for an FFI callback; it is not
+      #     an instance method on the Binding class.
       callback :mongocrypt_hash_fn, [:pointer, :pointer, :pointer, :pointer], :bool
 
-      # A callback to a crypto secure random function
+      # @!method mongocrypt_random_fn(ctx, output, count, status)
+      #   @api private
       #
-      # param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
-      #   that may have been set when hooks were enabled.
-      # param [ FFI::Pointer ] out (out param) A pointer to a
-      #   mongocrypt_binary_t object will have a reference to the output value
-      #   written to it by libmongocrypt
-      # param [ Integer ] count The number of random bytes to return
-      # param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
-      #   object to which an error message will be written if encryption fails
+      #   A callback to a crypto secure random function.
+      #   @param [ FFI::Pointer | nil ] ctx An optional pointer to a context object
+      #     that may have been set when hooks were enabled.
+      #   @param [ FFI::Pointer ] output (out param) A pointer to a
+      #     mongocrypt_binary_t object will have a reference to the output value
+      #     written to it by libmongocrypt.
+      #   @param [ Integer ] count The number of random bytes to return.
+      #   @param [ FFI::Pointer ] status A pointer to a mongocrypt_status_t
+      #     object to which an error message will be written if encryption fails.
+      #   @return [ Bool ] Whether hashing was successful.
       #
-      # return [ Bool ] Whether hashing was successful
+      #   @note This defines a method signature for an FFI callback; it is not
+      #     an instance method on the Binding class.
       callback :mongocrypt_random_fn, [:pointer, :pointer, :int, :pointer], :bool
 
-      # @!method mongocrypt_setopt_crypto_hooks(crypt, aes_enc_fn, aes_dec_fn, random_fn, sha_512_fn, sha_256_fn, hash_fn, ctx=nil)
+      # @!method self.mongocrypt_setopt_crypto_hooks(crypt, aes_enc_fn, aes_dec_fn, random_fn, sha_512_fn, sha_256_fn, hash_fn, ctx=nil)
+      #   @api private
+      #
       #   Set crypto hooks on the provided mongocrypt object.
       #   @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
       #   @param [ Proc ] aes_enc_fn An AES encryption method.

--- a/lib/mongo/crypt/context.rb
+++ b/lib/mongo/crypt/context.rb
@@ -26,11 +26,11 @@ module Mongo
     class Context
       #  Create a new Context object
       #
-      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_t object
-      #   used to create a new mongocrypt_ctx_t
-      # @param [ ClientEncryption::IO ] A instance of the IO class
+      # @param [ Mongo::Crypt::Handle ] mongocrypt_handle A handle to libmongocrypt
+      #   used to create a new context object.
+      # @param [ ClientEncryption::IO ] io An instance of the IO class
       #   that implements driver I/O methods required to run the
-      #   state machine
+      #   state machine.
       def initialize(mongocrypt_handle, io)
         # Ideally, this level of the API wouldn't be passing around pointer
         # references between objects, so this method signature is subject to change.

--- a/lib/mongo/crypt/encryption_io.rb
+++ b/lib/mongo/crypt/encryption_io.rb
@@ -29,15 +29,15 @@ module Mongo
       # Creates a new EncryptionIO object with information about how to connect
       # to the key vault.
       #
-      # @param [ Mongo::Client ] client: The client used to connect to the collection
+      # @param [ Mongo::Client ] client The client used to connect to the collection
       #   that stores the encrypted documents, defaults to nil.
-      # @param [ Mongo::Client ] mongocryptd_client: The client connected to mongocryptd,
+      # @param [ Mongo::Client ] mongocryptd_client The client connected to mongocryptd,
       #   defaults to nil.
-      # @param [ Mongo::Client ] key_vault_client: The client connected to the
+      # @param [ Mongo::Client ] key_vault_client The client connected to the
       #   key vault collection.
-      # @param [ String ] key_vault_namespace: The key vault namespace in the format
+      # @param [ String ] key_vault_namespace The key vault namespace in the format
       #   db_name.collection_name.
-      # @param [ Hash ] mongocryptd_options: Options related to mongocryptd.
+      # @param [ Hash ] mongocryptd_options Options related to mongocryptd.
       #
       # @option mongocryptd_options [ Boolean ] :mongocryptd_bypass_spawn
       # @option mongocryptd_options [ String ] :mongocryptd_spawn_path
@@ -234,8 +234,9 @@ module Mongo
 
       # Provide an SSL socket to be used for KMS calls in a block API
       #
-      # @param [ String ] endpoint The URI at which to connect the SSL socket
-      # @param [ Proc ] block The block to execute
+      # @param [ String ] endpoint The URI at which to connect the SSL socket.
+      # @yieldparam [ OpenSSL::SSL::SSLSocket ] ssl_socket Yields an SSL socket
+      #   connected to the specified endpoint.
       #
       # @raise [ Mongo::Error::KmsError ] If the socket times out or raises
       #   an exception

--- a/lib/mongo/crypt/explicit_encrypter.rb
+++ b/lib/mongo/crypt/explicit_encrypter.rb
@@ -22,9 +22,9 @@ module Mongo
     class ExplicitEncrypter
       # Create a new ExplicitEncrypter object.
       #
-      # @params [ Mongo::Client ] key_vault_client An instance of Mongo::Client
+      # @param [ Mongo::Client ] key_vault_client An instance of Mongo::Client
       #   to connect to the key vault collection.
-      # @params [ String ] key_vault_namespace The namespace of the key vault
+      # @param [ String ] key_vault_namespace The namespace of the key vault
       #   collection in the format "db_name.collection_name".
       # @option options [ Hash ] :kms_providers A hash of key management service
       #   configuration information. Valid hash keys are :local or :aws. There
@@ -44,7 +44,7 @@ module Mongo
       #
       # @param [ String ] kms_provider The KMS provider to use. Valid values are
       #   "aws" and "local".
-      # @params [ Hash ] options
+      # @param [ Hash ] options
       #
       # @option options [ Hash ] :master_key Information about the AWS master key. Required
       #   if kms_provider is "aws".

--- a/lib/mongo/crypt/explicit_encryption_context.rb
+++ b/lib/mongo/crypt/explicit_encryption_context.rb
@@ -38,7 +38,7 @@ module Mongo
       #   value. Valid algorithms are "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
       #   or "AEAD_AES_256_CBC_HMAC_SHA_512-Random"
       #
-      # @raises [ ArgumentError|Mongo::Error::CryptError ] If invalid options are provided
+      # @raise [ ArgumentError|Mongo::Error::CryptError ] If invalid options are provided
       def initialize(mongocrypt, io, doc, options={})
         super(mongocrypt, io)
 

--- a/lib/mongo/crypt/hooks.rb
+++ b/lib/mongo/crypt/hooks.rb
@@ -62,7 +62,7 @@ module Mongo
 
       # An HMAC SHA-512 or SHA-256 function
       #
-      # @param [ String ] The name of the digest, either "SHA256" or "SHA512"
+      # @param [ String ] digest_name The name of the digest, either "SHA256" or "SHA512"
       # @param [ String ] key The 32-byte AES encryption key
       # @param [ String ] input The data to be tagged
       #

--- a/lib/mongo/error/parser.rb
+++ b/lib/mongo/error/parser.rb
@@ -76,7 +76,7 @@ module Mongo
       # examined because the status (ok: 1) is not part of the document and
       # there is no way to distinguish successful from failed responses using
       # the document itself, and a successful response may legitimately have
-      # {code: 123, codeName: 'foo'} as the contents of a user-inserted
+      # { code: 123, codeName: 'foo' } as the contents of a user-inserted
       # document. The legacy server versions do not fill out code nor codeName
       # thus not reading them does not lose information.
       #

--- a/lib/mongo/grid/file/info.rb
+++ b/lib/mongo/grid/file/info.rb
@@ -204,7 +204,7 @@ module Mongo
         # @note This method is transitional and is provided for backwards compatibility.
         # It will be removed when md5 support is deprecated entirely.
         #
-        # @param [ String ] The bytes to use to update the digest.
+        # @param [ String ] bytes The bytes to use to update the digest.
         #
         # @return [ Digest::MD5 ] The md5 hash object.
         #

--- a/lib/mongo/monitoring/event/cmap/connection_check_out_failed.rb
+++ b/lib/mongo/monitoring/event/cmap/connection_check_out_failed.rb
@@ -57,7 +57,7 @@ module Mongo
           # Create the event.
           #
           # @param [ Address ] address
-          # @param [ Symbol ] symbol
+          # @param [ Symbol ] reason
           #
           # @since 2.9.0
           # @api private

--- a/lib/mongo/operation/shared/response_handling.rb
+++ b/lib/mongo/operation/shared/response_handling.rb
@@ -68,7 +68,7 @@ module Mongo
       #   is included in BulkWrite which does not store the session in the
       #   receiver (despite Specifiable doing so).
       #
-      # @param [ Session | nil ] Session to consider.
+      # @param [ Session | nil ] session Session to consider.
       def unpin_maybe(session)
         yield
       rescue Mongo::Error => e

--- a/lib/mongo/protocol/msg.rb
+++ b/lib/mongo/protocol/msg.rb
@@ -161,7 +161,7 @@ module Mongo
       end
 
       # Reverse-populates the instance variables after deserialization sets
-      # the sections instance variable to the list of documents.
+      # the @sections instance variable to the list of documents.
       #
       # TODO fix deserialization so that this method is not needed.
       #

--- a/lib/mongo/protocol/msg.rb
+++ b/lib/mongo/protocol/msg.rb
@@ -161,7 +161,7 @@ module Mongo
       end
 
       # Reverse-populates the instance variables after deserialization sets
-      # @sections to the list of documents.
+      # the sections instance variable to the list of documents.
       #
       # TODO fix deserialization so that this method is not needed.
       #

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -144,7 +144,7 @@ module Mongo
     # @note This only retries read operations on socket errors.
     #
     # @param [ Hash ] options Options.
-    # @yield [] Calls the provided block with no arguments
+    # @yield Calls the provided block with no arguments
     #
     # @option options [ String ] :retry_message Message to log when retrying.
     #

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -144,7 +144,7 @@ module Mongo
     # @note This only retries read operations on socket errors.
     #
     # @param [ Hash ] options Options.
-    # @param [ Proc ] block The block to execute.
+    # @yield [] Calls the provided block with no arguments
     #
     # @option options [ String ] :retry_message Message to log when retrying.
     #

--- a/lib/mongo/server/connection_pool/populator.rb
+++ b/lib/mongo/server/connection_pool/populator.rb
@@ -21,7 +21,7 @@ module Mongo
     class Populator
       include BackgroundThread
 
-      # @param [ Server::ConnectionPool ] The connection pool.
+      # @param [ Server::ConnectionPool ] pool The connection pool.
       # @param [ Hash ] options The options.
       #
       # @option options [ Logger ] :logger A custom logger to use.

--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -697,7 +697,7 @@ module Mongo
     # The exception instance should already have all of the labels set on it
     # (both client- and server-side generated ones).
     #
-    # @param [ Error ] The exception instance to process.
+    # @param [ Error ] error The exception instance to process.
     #
     # @api private
     def unpin_maybe(error)

--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -216,7 +216,7 @@ module Mongo
     #   URI.get(string)
     #
     # @param [ String ] string The URI to parse.
-    # @param [ Hash ] options The options.
+    # @param [ Hash ] opts The options.
     #
     # @option options [ Logger ] :logger A custom logger to use.
     #

--- a/lib/mongo/uri/srv_protocol.rb
+++ b/lib/mongo/uri/srv_protocol.rb
@@ -17,7 +17,7 @@ module Mongo
   class URI
 
     # Parser for a URI using the mongodb+srv protocol, which specifies a DNS to query for SRV records.
-    # The driver will query the DNS server for SRV records on {hostname}.{domainname},
+    # The driver will query the DNS server for SRV records on <hostname>.<domainname>,
     # prefixed with _mongodb._tcp
     # The SRV records can then be used as the seedlist for a Mongo::Client.
     # The driver also queries for a TXT record providing default connection string options.


### PR DESCRIPTION
The culprit was mostly lib/mongo/crypt/binding.rb. Because most of the methods in that file are metaprogrammed, I had to use the `@!method` tag, which I hadn't known about before!