### PR TITLE
RUBY-2196 Move Kerberos auth mechanism and conversation to driver

### DIFF
--- a/.evergreen/Dockerfile.erb
+++ b/.evergreen/Dockerfile.erb
@@ -28,7 +28,7 @@ FROM <%= base_image %>
   # increment the counter to force apt-get update to run.
   # zsh is not required for any scripts but it is a better interactive shell
   # than bash.
-  RUN echo 2 && \
+  RUN echo 3 && \
     apt-get update && \
     apt-get install -y curl zsh
 
@@ -84,7 +84,8 @@ FROM <%= base_image %>
   <% end %>
 
   RUN apt-get install -y libsnmp30 libyaml-0-2 gcc make git lsb-release \
-    krb5-user krb5-kdc krb5-admin-server bzip2 libgmp-dev python-pip python2.7-dev
+    krb5-user krb5-kdc krb5-admin-server libsasl2-dev libsasl2-modules-gssapi-mit \
+    bzip2 libgmp-dev python-pip python2.7-dev
 
 <% else %>
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -897,7 +897,7 @@ buildvariants:
   - matrix_name: "kerberos-integration-ubuntu"
     matrix_spec:
       # Other Rubies segfault
-      ruby: [ruby-2.5, ruby-2.4, jruby-9.2]
+      ruby: [ruby-2.5, ruby-2.4]
     display_name: "Kerberos integration Ubuntu ${ruby}"
     run_on:
       - ubuntu1604-test
@@ -907,7 +907,7 @@ buildvariants:
   - matrix_name: "kerberos-integration-rhel"
     matrix_spec:
       # Other Rubies segfault
-      ruby: [ruby-2.7, ruby-2.3, jruby-9.2]
+      ruby: [ruby-2.7, ruby-2.3]
       os: rhel70
     display_name: "Kerberos integration RHEL ${ruby} ${os}"
     tasks:

--- a/.evergreen/run-tests-kerberos-integration.sh
+++ b/.evergreen/run-tests-kerberos-integration.sh
@@ -56,6 +56,7 @@ configure_kerberos_ip_addr
 echo "Install dependencies"
 export BUNDLE_GEMFILE=gemfiles/mongo_kerberos.gemfile
 bundle_install
+bundle list
 
 export MONGO_RUBY_DRIVER_KERBEROS=1
 export MONGO_RUBY_DRIVER_KERBEROS_INTEGRATION=1

--- a/gemfiles/mongo_kerberos.gemfile
+++ b/gemfiles/mongo_kerberos.gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 gemspec path: '..'
 
-gem 'mongo_kerberos'
+gem 'mongo_kerberos', git: 'https://github.com/mongodb/mongo-ruby-kerberos', branch: 'master'
 
 require_relative './standard'
 

--- a/lib/mongo/auth/aws.rb
+++ b/lib/mongo/auth/aws.rb
@@ -17,13 +17,10 @@ module Mongo
     class Aws < Base
       MECHANISM = 'MONGODB-AWS'.freeze
 
-      # Log the user in on the given connection.
-      #
-      # @param [ Mongo::Connection ] connection The connection to log into.
+      # Log the user in on the current connection.
       #
       # @return [ BSON::Document ] The document of the authentication response.
-      def login(connection)
-        conversation = Conversation.new(user)
+      def login
         converse_2_step(connection, conversation)
       end
 

--- a/lib/mongo/auth/base.rb
+++ b/lib/mongo/auth/base.rb
@@ -17,23 +17,30 @@ module Mongo
 
     # Base class for authenticators.
     #
+    # Each authenticator is instantiated for authentication over a particular
+    # connection.
+    #
     # @api private
     class Base
 
       # @return [ Mongo::Auth::User ] The user to authenticate.
       attr_reader :user
 
-      # Instantiate a new authenticator.
+      # @return [ Mongo::Connection ] The connection to authenticate over.
+      attr_reader :connection
+
+      # Initializes the authenticator.
       #
-      # @param [ Mongo::Auth::User ] user The user to authenticate.
-      #
-      # @since 2.0.0
-      def initialize(user)
+      # @param [ Auth::User ] user The user to authenticate.
+      # @param [ Mongo::Connection ] connection The connection to authenticate
+      #   over.
+      def initialize(user, connection, **opts)
         @user = user
+        @connection = connection
       end
 
       def conversation
-        @conversation ||= self.class.const_get(:Conversation).new(user)
+        @conversation ||= self.class.const_get(:Conversation).new(user, connection)
       end
 
       private

--- a/lib/mongo/auth/conversation_base.rb
+++ b/lib/mongo/auth/conversation_base.rb
@@ -23,13 +23,19 @@ module Mongo
 
       # Create the new conversation.
       #
-      # @param [ Auth::User ] user The user to converse about.
-      def initialize(user)
+      # @param [ Auth::User ] user The user to authenticate.
+      # @param [ Mongo::Connection ] connection The connection to authenticate
+      #   over.
+      def initialize(user, connection, **opts)
         @user = user
+        @connection = connection
       end
 
       # @return [ Auth::User ] user The user for the conversation.
       attr_reader :user
+
+      # @return [ Mongo::Connection ] The connection to authenticate over.
+      attr_reader :connection
 
       # Returns the hash to provide to the server in the handshake
       # as value of the speculativeAuthenticate key.

--- a/lib/mongo/auth/cr.rb
+++ b/lib/mongo/auth/cr.rb
@@ -29,14 +29,10 @@ module Mongo
       # @since 2.0.0
       MECHANISM = 'MONGODB-CR'.freeze
 
-      # Log the user in on the given connection.
-      #
-      # @param [ Mongo::Connection ] connection The connection to log into.
+      # Log the user in on the current connection.
       #
       # @return [ BSON::Document ] The document of the authentication response.
-      #
-      # @since 2.0.0
-      def login(connection)
+      def login
         converse_2_step(connection, conversation)
       end
     end

--- a/lib/mongo/auth/gssapi.rb
+++ b/lib/mongo/auth/gssapi.rb
@@ -1,10 +1,10 @@
-# Copyright (C) 2014-2020 MongoDB Inc.
+# Copyright (C) 2014-2020 MongoDB, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+# http://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -15,25 +15,24 @@
 module Mongo
   module Auth
 
-    # Defines behavior for LDAP Proxy authentication.
+    # Defines behavior for Kerberos authentication.
     #
-    # @since 2.0.0
     # @api private
-    class LDAP < Base
+    class Gssapi < Base
 
       # The authentication mechanism string.
       #
       # @since 2.0.0
-      MECHANISM = 'PLAIN'.freeze
+      MECHANISM = 'GSSAPI'.freeze
 
       # Log the user in on the current connection.
       #
       # @return [ BSON::Document ] The document of the authentication response.
       def login
-        converse_1_step(connection, conversation)
+        converse_multi_step(connection, conversation)
       end
     end
   end
 end
 
-require 'mongo/auth/ldap/conversation'
+require 'mongo/auth/gssapi/conversation'

--- a/lib/mongo/auth/gssapi/conversation.rb
+++ b/lib/mongo/auth/gssapi/conversation.rb
@@ -1,0 +1,107 @@
+# Copyright (C) 2015-2020 MongoDB Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module Mongo
+  module Auth
+    class Gssapi
+
+      # Defines behaviour around a single Kerberos conversation between the
+      # client and the server.
+      #
+      # @api private
+      class Conversation < SaslConversationBase
+
+        # The base client first message.
+        START_MESSAGE = { saslStart: 1, autoAuthorize: 1 }.freeze
+
+        # The base client continue message.
+        CONTINUE_MESSAGE = { saslContinue: 1 }.freeze
+
+        # Create the new conversation.
+        #
+        # @example Create the new conversation.
+        #   Conversation.new(user, 'test.example.com')
+        #
+        # @param [ Auth::User ] user The user to converse about.
+        # @param [ String ] host The host to talk to.
+        #
+        # @since 2.0.0
+        def initialize(user, connection, **opts)
+          super
+          host = connection.address.host
+          unless defined?(Mongo::GssapiNative)
+            require 'mongo_kerberos'
+          end
+          @authenticator = Mongo::GssapiNative::Authenticator.new(
+            user.name,
+            host,
+            user.auth_mech_properties[:service_name] || 'mongodb',
+            user.auth_mech_properties[:canonicalize_host_name] || false,
+          )
+        end
+
+        # @return [ Authenticator ] authenticator The native SASL authenticator.
+        attr_reader :authenticator
+
+        # Get the id of the conversation.
+        #
+        # @return [ Integer ] The conversation id.
+        attr_reader :id
+
+        def client_first_document
+          start_token = authenticator.initialize_challenge
+          START_MESSAGE.merge(mechanism: Gssapi::MECHANISM, payload: start_token)
+        end
+
+        # Continue the conversation.
+        #
+        # @param [ BSON::Document ] reply_document The reply document of the
+        #   previous message.
+        #
+        # @return [ Protocol::Query ] The next query to execute.
+        def continue(reply_document, connection)
+          @id = reply_document['conversationId']
+          payload = reply_document['payload']
+
+          continue_token = authenticator.evaluate_challenge(payload)
+          selector = CONTINUE_MESSAGE.merge(payload: continue_token, conversationId: id)
+
+          Protocol::Query.new(
+            Auth::EXTERNAL,
+            Database::COMMAND,
+            selector,
+            limit: 1,
+          )
+        end
+
+        def process_continue_response(reply_document)
+          payload = reply_document['payload']
+
+          @continue_token = authenticator.evaluate_challenge(payload)
+        end
+
+        def finalize(connection)
+          selector = CONTINUE_MESSAGE.merge(payload: @continue_token, conversationId: id)
+
+          Protocol::Query.new(
+            Auth::EXTERNAL,
+            Database::COMMAND,
+            selector,
+            limit: 1,
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/mongo/auth/x509.rb
+++ b/lib/mongo/auth/x509.rb
@@ -26,15 +26,11 @@ module Mongo
       # @since 2.0.0
       MECHANISM = 'MONGODB-X509'.freeze
 
-      # Instantiate a new authenticator.
+      # Initializes the X.509 authenticator.
       #
-      # @example Create the authenticator.
-      #   Mongo::Auth::X509.new(user)
-      #
-      # @param [ Mongo::Auth::User ] user The user to authenticate.
-      #
-      # @since 2.0.0
-      def initialize(user)
+      # @param [ Auth::User ] user The user to authenticate.
+      # @param [ Mongo::Connection ] connection The connection to authenticate over.
+      def initialize(user, connection, **opts)
         # The only valid database for X.509 authentication is $external.
         if user.auth_source != '$external'
           user_name_msg = if user.name
@@ -48,15 +44,10 @@ module Mongo
         super
       end
 
-      # Log the user in on the given connection.
-      #
-      # @param [ Mongo::Connection ] connection The connection to log into.
-      #   on.
+      # Log the user in on the current connection.
       #
       # @return [ BSON::Document ] The document of the authentication response.
-      #
-      # @since 2.0.0
-      def login(connection)
+      def login
         converse_1_step(connection, conversation)
       end
     end

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -22,7 +22,9 @@ CMAP_TESTS = Dir.glob("#{CURRENT_PATH}/spec_tests/data/cmap/*.yml").sort
 AUTH_TESTS = Dir.glob("#{CURRENT_PATH}/spec_tests/data/auth/*.yml").sort
 CLIENT_SIDE_ENCRYPTION_TESTS = Dir.glob("#{CURRENT_PATH}/spec_tests/data/client_side_encryption/*.yml").sort
 
-unless ENV['CI']
+if ENV['CI']
+  autoload :Byebug, 'byebug'
+else
   # Load debuggers before loading the driver code, so that breakpoints
   # can be placed in the driver code on file/class level.
   begin

--- a/spec/mongo/auth/cr_spec.rb
+++ b/spec/mongo/auth/cr_spec.rb
@@ -27,16 +27,16 @@ describe Mongo::Auth::CR do
       end
 
       let(:cr) do
-        described_class.new(user)
+        described_class.new(user, connection)
       end
 
       let(:login) do
-        cr.login(connection).documents[0]
+        cr.login.documents[0]
       end
 
       it 'raises an exception' do
         expect {
-          cr.login(connection)
+          cr.login
         }.to raise_error(Mongo::Auth::Unauthorized)
       end
 
@@ -47,7 +47,7 @@ describe Mongo::Auth::CR do
         it 'does not compress the message' do
           expect(Mongo::Protocol::Compressed).not_to receive(:new)
           expect {
-            cr.login(connection)
+            cr.login
           }.to raise_error(Mongo::Auth::Unauthorized)
         end
       end
@@ -62,11 +62,11 @@ describe Mongo::Auth::CR do
     end
 
     let(:cr) do
-      described_class.new(root_user)
+      described_class.new(root_user, connection)
     end
 
     let(:login) do
-      cr.login(connection)
+      cr.login
     end
 
     it 'logs the user into the connection' do

--- a/spec/mongo/auth/gssapi/conversation_spec.rb
+++ b/spec/mongo/auth/gssapi/conversation_spec.rb
@@ -1,0 +1,121 @@
+require 'spec_helper'
+
+describe Mongo::Auth::Gssapi::Conversation do
+  require_mongo_kerberos
+
+  let(:user) do
+    Mongo::Auth::User.new(user: 'test')
+  end
+
+  let(:conversation) do
+    described_class.new(user, 'test.example.com')
+  end
+
+  let(:authenticator) do
+    double('authenticator')
+  end
+
+  let(:connection) do
+    double('connection')
+  end
+
+  before do
+    expect(Mongo::Auth::Gssapi::Authenticator).to receive(:new).
+      with(user, 'test.example.com').
+      and_return(authenticator)
+  end
+
+  context 'when the user has a realm', if: RUBY_PLATFORM == 'java' do
+
+    let(:user) do
+      Mongo::Auth::User.new(user: 'user1@MYREALM.ME')
+    end
+
+    it 'includes the realm in the username as it was provided' do
+      expect(conversation.user.name).to eq(user.name)
+    end
+  end
+
+  describe '#start' do
+
+    let(:query) do
+      conversation.start(connection)
+    end
+
+    let(:selector) do
+      query.selector
+    end
+
+    before do
+      expect(authenticator).to receive(:initialize_challenge).and_return('test')
+    end
+
+    it 'sets the sasl start flag' do
+      expect(selector[:saslStart]).to eq(1)
+    end
+
+    it 'sets the auto authorize flag' do
+      expect(selector[:autoAuthorize]).to eq(1)
+    end
+
+    it 'sets the mechanism' do
+      expect(selector[:mechanism]).to eq('GSSAPI')
+    end
+
+    it 'sets the payload', unless: BSON::Environment.jruby? do
+      expect(selector[:payload]).to start_with('test')
+    end
+
+    it 'sets the payload', if: BSON::Environment.jruby? do
+      expect(selector[:payload].data).to start_with('test')
+    end
+  end
+
+  describe '#finalize' do
+
+    let(:continue_token) do
+      BSON::Environment.jruby? ? BSON::Binary.new('testing') : 'testing'
+    end
+
+    context 'when the conversation is a success' do
+
+      let(:reply_document) do
+        BSON::Document.new(
+          'conversationId' => 1,
+          'done' => false,
+          'payload' => continue_token,
+          'ok' => 1.0,
+        )
+      end
+
+      let(:query) do
+        conversation.finalize(reply_document, connection)
+      end
+
+      let(:selector) do
+        query.selector
+      end
+
+      before do
+        expect(authenticator).to receive(:evaluate_challenge).
+          with('testing').and_return(continue_token)
+      end
+
+      it 'sets the conversation id' do
+        expect(selector[:conversationId]).to eq(1)
+      end
+
+      it 'sets the payload', unless: BSON::Environment.jruby? do
+        expect(selector[:payload]).to eq(continue_token)
+      end
+
+      it 'sets the payload', if: BSON::Environment.jruby? do
+        expect(selector[:payload].data).to eq(continue_token)
+      end
+
+      it 'sets the continue flag' do
+        expect(selector[:saslContinue]).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/mongo/auth/invalid_mechanism_spec.rb
+++ b/spec/mongo/auth/invalid_mechanism_spec.rb
@@ -5,7 +5,7 @@ describe Mongo::Auth::InvalidMechanism do
     let(:exception) { described_class.new(:foo) }
 
     it 'includes all built in mechanisms' do
-      expect(exception.message).to eq(':foo is invalid, please use one of the following mechanisms: :aws, :mongodb_cr, :mongodb_x509, :plain, :scram, :scram256')
+      expect(exception.message).to eq(':foo is invalid, please use one of the following mechanisms: :aws, :gssapi, :mongodb_cr, :mongodb_x509, :plain, :scram, :scram256')
     end
   end
 end

--- a/spec/mongo/auth/ldap/conversation_spec.rb
+++ b/spec/mongo/auth/ldap/conversation_spec.rb
@@ -11,7 +11,7 @@ describe Mongo::Auth::LDAP::Conversation do
   end
 
   let(:conversation) do
-    described_class.new(user)
+    described_class.new(user, double('connection'))
   end
 
   describe '#start' do

--- a/spec/mongo/auth/ldap_spec.rb
+++ b/spec/mongo/auth/ldap_spec.rb
@@ -23,16 +23,16 @@ describe Mongo::Auth::LDAP do
     context 'when the user is not authorized for the database' do
 
       let(:cr) do
-        described_class.new(user)
+        described_class.new(user, connection)
       end
 
       let(:login) do
-        cr.login(connection).documents[0]
+        cr.login.documents[0]
       end
 
       it 'attempts to log the user into the connection' do
         expect {
-          cr.login(connection)
+          cr.login
         }.to raise_error(Mongo::Auth::Unauthorized)
       end
     end

--- a/spec/mongo/auth/scram/conversation_spec.rb
+++ b/spec/mongo/auth/scram/conversation_spec.rb
@@ -8,7 +8,7 @@ describe Mongo::Auth::Scram::Conversation do
   include_context 'scram conversation context'
 
   let(:conversation) do
-    described_class.new(user)
+    described_class.new(user, double('connection'))
   end
 
   it_behaves_like 'scram conversation'

--- a/spec/mongo/auth/scram256/conversation_spec.rb
+++ b/spec/mongo/auth/scram256/conversation_spec.rb
@@ -8,7 +8,7 @@ describe Mongo::Auth::Scram256::Conversation do
   include_context 'scram conversation context'
 
   let(:conversation) do
-    described_class.new(user)
+    described_class.new(user, double('connection'))
   end
 
   it_behaves_like 'scram conversation'

--- a/spec/mongo/auth/scram_negotiation_spec.rb
+++ b/spec/mongo/auth/scram_negotiation_spec.rb
@@ -201,11 +201,11 @@ describe 'SCRAM-SHA auth mechanism negotiation' do
             RSpec::Mocks.with_temporary_scope do
               mechanism = nil
               # With speculative auth, Auth is instantiated twice.
-              expect(Mongo::Auth).to receive(:get).at_least(:once).at_most(:twice).and_wrap_original do |m, user|
+              expect(Mongo::Auth).to receive(:get).at_least(:once).at_most(:twice).and_wrap_original do |m, user, connection|
                 # copy mechanism here rather than whole user
                 # in case something mutates mechanism later
                 mechanism = user.mechanism
-                m.call(user)
+                m.call(user, connection)
               end
 
               expect do
@@ -230,11 +230,11 @@ describe 'SCRAM-SHA auth mechanism negotiation' do
             RSpec::Mocks.with_temporary_scope do
               mechanism = nil
               # With speculative auth, Auth is instantiated twice.
-              expect(Mongo::Auth).to receive(:get).at_least(:once).at_most(:twice).and_wrap_original do |m, user|
+              expect(Mongo::Auth).to receive(:get).at_least(:once).at_most(:twice).and_wrap_original do |m, user, connection|
                 # copy mechanism here rather than whole user
                 # in case something mutates mechanism later
                 mechanism = user.mechanism
-                m.call(user)
+                m.call(user, connection)
               end
 
               expect { result }.not_to raise_error
@@ -483,11 +483,11 @@ describe 'SCRAM-SHA auth mechanism negotiation' do
             RSpec::Mocks.with_temporary_scope do
               mechanism = nil
               # With speculative auth, Auth is instantiated twice.
-              expect(Mongo::Auth).to receive(:get).at_least(:once).at_most(:twice).and_wrap_original do |m, user|
+              expect(Mongo::Auth).to receive(:get).at_least(:once).at_most(:twice).and_wrap_original do |m, user, connection|
                 # copy mechanism here rather than whole user
                 # in case something mutates mechanism later
                 mechanism = user.mechanism
-                m.call(user)
+                m.call(user, connection)
               end
 
               expect { result }.not_to raise_error
@@ -510,11 +510,11 @@ describe 'SCRAM-SHA auth mechanism negotiation' do
             RSpec::Mocks.with_temporary_scope do
               mechanism = nil
               # With speculative auth, Auth is instantiated twice.
-              expect(Mongo::Auth).to receive(:get).at_least(:once).at_most(:twice).and_wrap_original do |m, user|
+              expect(Mongo::Auth).to receive(:get).at_least(:once).at_most(:twice).and_wrap_original do |m, user, connection|
                 # copy mechanism here rather than whole user
                 # in case something mutates mechanism later
                 mechanism = user.mechanism
-                m.call(user)
+                m.call(user, connection)
               end
 
               expect { result }.not_to raise_error

--- a/spec/mongo/auth/scram_spec.rb
+++ b/spec/mongo/auth/scram_spec.rb
@@ -49,13 +49,13 @@ describe Mongo::Auth::Scram do
         end
 
         let(:authenticator) do
-          described_class.new(user)
+          described_class.new(user, connection)
         end
 
         it 'raises an exception' do
-          expect {
-            authenticator.login(connection)
-          }.to raise_error(Mongo::Auth::Unauthorized)
+          expect do
+            authenticator.login
+          end.to raise_error(Mongo::Auth::Unauthorized)
         end
 
         context 'when compression is used' do
@@ -74,11 +74,11 @@ describe Mongo::Auth::Scram do
       context 'when the user is authorized for the database' do
 
         let(:authenticator) do
-          described_class.new(test_user)
+          described_class.new(test_user, connection)
         end
 
         let(:login) do
-          authenticator.login(connection)
+          authenticator.login
         end
 
         it 'logs the user into the connection' do

--- a/spec/mongo/auth/user_spec.rb
+++ b/spec/mongo/auth/user_spec.rb
@@ -47,7 +47,7 @@ describe Mongo::Auth::User do
       it 'raises ArgumentError' do
         expect do
           user
-        end.to raise_error(Mongo::Auth::InvalidMechanism, ":invalid is invalid, please use one of the following mechanisms: :aws, :mongodb_cr, :mongodb_x509, :plain, :scram, :scram256")
+        end.to raise_error(Mongo::Auth::InvalidMechanism, ":invalid is invalid, please use one of the following mechanisms: :aws, :gssapi, :mongodb_cr, :mongodb_x509, :plain, :scram, :scram256")
       end
     end
 

--- a/spec/mongo/auth/x509/conversation_spec.rb
+++ b/spec/mongo/auth/x509/conversation_spec.rb
@@ -10,7 +10,7 @@ describe Mongo::Auth::X509::Conversation do
   end
 
   let(:conversation) do
-    described_class.new(user)
+    described_class.new(user, double('connection'))
   end
 
   describe '#start' do

--- a/spec/mongo/auth/x509_spec.rb
+++ b/spec/mongo/auth/x509_spec.rb
@@ -23,7 +23,7 @@ describe Mongo::Auth::X509 do
       end
 
       it 'works' do
-        described_class.new(user)
+        described_class.new(user, connection)
       end
     end
 
@@ -35,7 +35,7 @@ describe Mongo::Auth::X509 do
 
       it 'raises InvalidConfiguration' do
         expect do
-          described_class.new(user)
+          described_class.new(user, connection)
         end.to raise_error(Mongo::Auth::InvalidConfiguration, /User specifies auth source 'foo', but the only valid auth source for X.509 is '\$external'/)
       end
     end
@@ -53,16 +53,16 @@ describe Mongo::Auth::X509 do
       end
 
       let(:x509) do
-        described_class.new(user)
+        described_class.new(user, connection)
       end
 
       let(:login) do
-        x509.login(connection).documents[0]
+        x509.login.documents[0]
       end
 
       it 'attempts to log the user into the connection' do
         expect do
-          x509.login(connection)
+          x509.login
         end.to raise_error(Mongo::Auth::Unauthorized)
       end
     end

--- a/spec/mongo/auth_spec.rb
+++ b/spec/mongo/auth_spec.rb
@@ -11,7 +11,7 @@ describe Mongo::Auth do
       end
 
       let(:cr) do
-        described_class.get(user)
+        described_class.get(user, double('connection'))
       end
 
       it 'returns CR' do
@@ -26,7 +26,7 @@ describe Mongo::Auth do
       end
 
       let(:x509) do
-        described_class.get(user)
+        described_class.get(user, double('connection'))
       end
 
       it 'returns X509' do
@@ -41,7 +41,7 @@ describe Mongo::Auth do
       end
 
       let(:ldap) do
-        described_class.get(user)
+        described_class.get(user, double('connection'))
       end
 
       it 'returns LDAP' do
@@ -57,7 +57,7 @@ describe Mongo::Auth do
 
       it 'raises an error' do
         expect {
-          described_class.get(user)
+          described_class.get(user, double('connection'))
         }.to raise_error(Mongo::Auth::InvalidMechanism)
       end
     end


### PR DESCRIPTION
This PR removes JRuby/Kerberos configurations until the JRuby native gssapi implementation is unbroken.