### PR TITLE
RUBY-2176 Raise an error if an encryption client is initialized with empty string AWS credentials

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -703,7 +703,9 @@ module Mongo
             build_encrypter
           end
         elsif @options[:auto_encryption_options].nil?
-          @encrypter = nil
+          @connect_lock.synchronize do
+            @encrypter = nil
+          end
         end
 
         validate_options!
@@ -908,9 +910,9 @@ module Mongo
         @encrypter = Crypt::AutoEncrypter.new(
           @options[:auto_encryption_options].merge(client: self)
         )
-      rescue => e
-        do_close
-        raise e
+      rescue
+        @cluster.disconnect!
+        raise
       end
     end
 

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -269,15 +269,37 @@ module Mongo
         access_key_id = kms_providers[:aws][:access_key_id]
         secret_access_key = kms_providers[:aws][:secret_access_key]
 
-        valid_access_key_id = access_key_id && access_key_id.is_a?(String)
-        valid_secret_access_key = secret_access_key && secret_access_key.is_a?(String)
-
-        unless valid_access_key_id && valid_secret_access_key
+        unless kms_providers[:aws].key?(:access_key_id) && 
+            kms_providers[:aws].key?(:secret_access_key)
           raise ArgumentError.new(
             "The specified aws kms_providers option is invalid: #{kms_providers[:aws]}. " +
             "kms_providers with :aws key must be in the format: " +
             "{ aws: { access_key_id: 'YOUR-ACCESS-KEY-ID', secret_access_key: 'SECRET-ACCESS-KEY' } }"
           )
+        end
+
+        %i(access_key_id secret_access_key).each do |key|
+          value = kms_providers[:aws][key]
+          if value.nil?
+            raise ArgumentError.new(
+              "The aws #{key} option must be a String with at least one character; " \
+              "currently have nil"
+            )
+          end
+
+          unless value.is_a?(String)
+            raise ArgumentError.new(
+              "The aws #{key} option must be a String with at least one character; " \
+              "currently have #{value}"
+            )
+          end
+
+          if value.empty?
+            raise ArgumentError.new(
+              "The aws #{key} option must be a String with at least one character; " \
+              "it is currently an empty string"
+            )
+          end
         end
 
         Binding.setopt_kms_provider_aws(self, access_key_id, secret_access_key)

--- a/spec/integration/client_construction_spec.rb
+++ b/spec/integration/client_construction_spec.rb
@@ -158,12 +158,34 @@ describe 'Client construction' do
       }
     end
 
+    let(:client) do
+      ClientRegistry.instance.new_local_client([SpecConfig.instance.addresses.first], options)
+    end
+
+    context 'with AWS kms providers with empty string credentials' do
+      let(:auto_encryption_options) do
+        {
+          key_vault_namespace: key_vault_namespace,
+          kms_providers: {
+            aws: {
+              access_key_id: '',
+              secret_access_key: '',
+            }
+          },
+          # Spawn mongocryptd on non-default port for sharded cluster tests
+          extra_options: extra_options,
+        }
+      end
+
+      it 'raises an exception' do
+        expect do
+          client
+        end.to raise_error(ArgumentError, /The aws access_key_id option must be a String with at least one character; it is currently an empty string/)
+      end
+    end
+
     context 'with default key vault client' do
       let(:key_vault_client) { nil }
-
-      let(:client) do
-        ClientRegistry.instance.new_local_client([SpecConfig.instance.addresses.first], options)
-      end
 
       it 'creates a working key vault client' do
         key_vault_client = client.encrypter.key_vault_client

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -134,7 +134,7 @@ describe Mongo::Crypt::Handle do
       it 'raises an exception' do
         expect do
           handle
-        end.to raise_error(ArgumentError, /The specified aws kms_providers option is invalid/)
+        end.to raise_error(ArgumentError, /The aws access_key_id option must be a String with at least one character; currently have nil/)
       end
     end
 
@@ -151,7 +151,24 @@ describe Mongo::Crypt::Handle do
       it 'raises an exception' do
         expect do
           handle
-        end.to raise_error(ArgumentError, /The specified aws kms_providers option is invalid/)
+        end.to raise_error(ArgumentError, /The aws access_key_id option must be a String with at least one character; currently have 5/)
+      end
+    end
+
+    context 'with empty string AWS access_key_id' do
+      let(:kms_providers) {
+        {
+          aws: {
+            access_key_id: '',
+            secret_access_key: SpecConfig.instance.fle_aws_secret
+          }
+        }
+      }
+
+      it 'raises an exception' do
+        expect do
+          handle
+        end.to raise_error(ArgumentError, /The aws access_key_id option must be a String with at least one character; it is currently an empty string/)
       end
     end
 
@@ -169,7 +186,7 @@ describe Mongo::Crypt::Handle do
       it 'raises an exception' do
         expect do
           handle
-        end.to raise_error(ArgumentError, /The specified aws kms_providers option is invalid/)
+        end.to raise_error(ArgumentError, /The aws secret_access_key option must be a String with at least one character; currently have nil/)
       end
     end
 
@@ -186,7 +203,24 @@ describe Mongo::Crypt::Handle do
       it 'raises an exception' do
         expect do
           handle
-        end.to raise_error(ArgumentError, /The specified aws kms_providers option is invalid/)
+        end.to raise_error(ArgumentError, /The aws secret_access_key option must be a String with at least one character; currently have 5/)
+      end
+    end
+
+    context 'with empty string AWS secret_access_key' do
+      let(:kms_providers) {
+        {
+          aws: {
+            access_key_id: SpecConfig.instance.fle_aws_key,
+            secret_access_key: ''
+          }
+        }
+      }
+
+      it 'raises an exception' do
+        expect do
+          handle
+        end.to raise_error(ArgumentError, /The aws secret_access_key option must be a String with at least one character; it is currently an empty string/)
       end
     end
 


### PR DESCRIPTION
When testing this change, I realized that the client would leak background threads if it raised an error while building the encrypter, so I added a fix and tests for that as well.