### PR TITLE
RUBY-2119 Do not lose type information when writing documents with automatic encryption

### DIFF
--- a/lib/mongo/crypt/encryption_io.rb
+++ b/lib/mongo/crypt/encryption_io.rb
@@ -105,13 +105,17 @@ module Mongo
           raise ArgumentError, 'mark_command requires mongocryptd_client to have been passed to the constructor, but it was not'
         end
 
+        # Ensure the response from mongocryptd is deserialized with { mode: :bson }
+        # to prevent losing type information in commands
+        options = { execution_options: { deserialize_as_bson: true } }
+
         begin
-          response = @mongocryptd_client.database.command(cmd, { deserialization_mode: :bson })
+          response = @mongocryptd_client.database.command(cmd, options)
         rescue Error::NoServerAvailable => e
           raise e if @options[:mongocryptd_bypass_spawn]
 
           spawn_mongocryptd
-          response = @mongocryptd_client.database.command(cmd, { deserialization_mode: :bson })
+          response = @mongocryptd_client.database.command(cmd, options)
         end
 
         return response.first

--- a/lib/mongo/crypt/encryption_io.rb
+++ b/lib/mongo/crypt/encryption_io.rb
@@ -106,12 +106,12 @@ module Mongo
         end
 
         begin
-          response = @mongocryptd_client.database.command(cmd)
+          response = @mongocryptd_client.database.command(cmd, { deserialization_mode: :bson })
         rescue Error::NoServerAvailable => e
           raise e if @options[:mongocryptd_bypass_spawn]
 
           spawn_mongocryptd
-          response = @mongocryptd_client.database.command(cmd)
+          response = @mongocryptd_client.database.command(cmd, { deserialization_mode: :bson })
         end
 
         return response.first

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -171,19 +171,19 @@ module Mongo
     #
     # @return [ Mongo::Operation::Result ] The result of the command execution.
     def command(operation, opts = {})
-      opts_copy = opts.dup
-      execution_opts = opts_copy.delete(:execution_options) || {}
+      opts = opts.dup
+      execution_opts = opts.delete(:execution_options) || {}
 
-      txn_read_pref = if opts_copy[:session] && opts_copy[:session].in_transaction?
-        opts_copy[:session].txn_read_preference
+      txn_read_pref = if opts[:session] && opts[:session].in_transaction?
+        opts[:session].txn_read_preference
       else
         nil
       end
-      txn_read_pref ||= opts_copy[:read] || ServerSelector::PRIMARY
+      txn_read_pref ||= opts[:read] || ServerSelector::PRIMARY
       Lint.validate_underscore_read_preference(txn_read_pref)
       selector = ServerSelector.get(txn_read_pref)
 
-      client.send(:with_session, opts_copy) do |session|
+      client.send(:with_session, opts) do |session|
         server = selector.select_server(cluster, nil, session)
         op = Operation::Command.new(
           :selector => operation.dup,

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -182,7 +182,9 @@ module Mongo
           :read => selector,
           :session => session
         )
-        op.execute(server, client: client)
+
+        execution_opts = opts[:deserialization_mode] ? { deserialization_mode: opts[:deserialization_mode] } : {}
+        op.execute(server, client: client, options: execution_opts)
       end
     end
 

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -165,6 +165,9 @@ module Mongo
     # @option opts :execution_options [ Hash ] Options to pass to the code that
     #   executes this command. This is an internal option and is subject to
     #   change.
+    #   - :deserialize_as_bson [ Boolean ] Whether to deserialize the response
+    #     to this command using BSON types intead of native Ruby types wherever
+    #     possible.
     #
     # @return [ Mongo::Operation::Result ] The result of the command execution.
     def command(operation, opts = {})

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -162,9 +162,14 @@ module Mongo
     #
     # @option opts :read [ Hash ] The read preference for this command.
     # @option opts :session [ Session ] The session to use for this command.
+    # @option opts :execution_options [ Hash ] Options to pass to the code that
+    #   executes this command. This is an internal option and is subject to
+    #   change.
     #
     # @return [ Mongo::Operation::Result ] The result of the command execution.
     def command(operation, opts = {})
+      execution_opts = opts.delete(:execution_options) || {}
+
       txn_read_pref = if opts[:session] && opts[:session].in_transaction?
         opts[:session].txn_read_preference
       else
@@ -183,7 +188,6 @@ module Mongo
           :session => session
         )
 
-        execution_opts = opts[:deserialization_mode] ? { deserialization_mode: opts[:deserialization_mode] } : {}
         op.execute(server, client: client, options: execution_opts)
       end
     end

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -171,18 +171,19 @@ module Mongo
     #
     # @return [ Mongo::Operation::Result ] The result of the command execution.
     def command(operation, opts = {})
-      execution_opts = opts.delete(:execution_options) || {}
+      opts_copy = opts.dup
+      execution_opts = opts_copy.delete(:execution_options) || {}
 
-      txn_read_pref = if opts[:session] && opts[:session].in_transaction?
-        opts[:session].txn_read_preference
+      txn_read_pref = if opts_copy[:session] && opts_copy[:session].in_transaction?
+        opts_copy[:session].txn_read_preference
       else
         nil
       end
-      txn_read_pref ||= opts[:read] || ServerSelector::PRIMARY
+      txn_read_pref ||= opts_copy[:read] || ServerSelector::PRIMARY
       Lint.validate_underscore_read_preference(txn_read_pref)
       selector = ServerSelector.get(txn_read_pref)
 
-      client.send(:with_session, opts) do |session|
+      client.send(:with_session, opts_copy) do |session|
         server = selector.select_server(cluster, nil, session)
         op = Operation::Command.new(
           :selector => operation.dup,

--- a/lib/mongo/operation/insert/command.rb
+++ b/lib/mongo/operation/insert/command.rb
@@ -32,7 +32,7 @@ module Mongo
 
         private
 
-        def get_result(server, client)
+        def get_result(server, client, options = {})
           # This is a Mongo::Operation::Insert::Result
           Result.new(*dispatch_message(server, client), @ids)
         end

--- a/lib/mongo/operation/insert/legacy.rb
+++ b/lib/mongo/operation/insert/legacy.rb
@@ -30,7 +30,7 @@ module Mongo
 
         private
 
-        def get_result(server, client)
+        def get_result(server, client, options = {})
           # This is a Mongo::Operation::Insert::Result
           Result.new(*dispatch_message(server, client), @ids)
         end

--- a/lib/mongo/operation/insert/op_msg.rb
+++ b/lib/mongo/operation/insert/op_msg.rb
@@ -30,7 +30,7 @@ module Mongo
 
         private
 
-        def get_result(server, client)
+        def get_result(server, client, options = {})
           # This is a Mongo::Operation::Insert::Result
           Result.new(*dispatch_message(server, client), @ids)
         end

--- a/lib/mongo/operation/shared/op_msg_or_command.rb
+++ b/lib/mongo/operation/shared/op_msg_or_command.rb
@@ -22,9 +22,9 @@ module Mongo
     module OpMsgOrCommand
       include PolymorphicLookup
 
-      def execute(server, client:)
+      def execute(server, client:, options: {})
         operation = final_operation(server)
-        operation.execute(server, client: client)
+        operation.execute(server, client: client, options: options)
       end
 
       private

--- a/lib/mongo/protocol/bit_vector.rb
+++ b/lib/mongo/protocol/bit_vector.rb
@@ -47,6 +47,7 @@ module Mongo
         # Deserializes vector by decoding the symbol according to its mask
         #
         # @param [ String ] buffer Buffer containing the vector to be deserialized.
+        # @param [ Hash ] options This method does not currently accept any options.
         #
         # @return [ Array<Symbol> ] Flags contained in the vector
         def deserialize(buffer, options = {})

--- a/lib/mongo/protocol/bit_vector.rb
+++ b/lib/mongo/protocol/bit_vector.rb
@@ -49,7 +49,7 @@ module Mongo
         # @param [ String ] buffer Buffer containing the vector to be deserialized.
         #
         # @return [ Array<Symbol> ] Flags contained in the vector
-        def deserialize(buffer)
+        def deserialize(buffer, options = {})
           vector = buffer.get_int32
           flags = []
           @masks.each do |flag, mask|

--- a/lib/mongo/protocol/message.rb
+++ b/lib/mongo/protocol/message.rb
@@ -196,7 +196,7 @@ module Mongo
       # @param [ IO ] io Stream containing a message
       #
       # @return [ Message ] Instance of a Message class
-      def self.deserialize(io, max_message_size = MAX_MESSAGE_SIZE, expected_response_to = nil)
+      def self.deserialize(io, max_message_size = MAX_MESSAGE_SIZE, expected_response_to = nil, options = {})
         length, _request_id, response_to, _op_code = deserialize_header(BSON::ByteBuffer.new(io.read(16)))
 
         # Protection from potential DOS man-in-the-middle attacks. See
@@ -216,9 +216,9 @@ module Mongo
 
         message.send(:fields).each do |field|
           if field[:multi]
-            deserialize_array(message, buffer, field)
+            deserialize_array(message, buffer, field, options)
           else
-            deserialize_field(message, buffer, field)
+            deserialize_field(message, buffer, field, options)
           end
         end
         if message.is_a?(Msg)
@@ -364,10 +364,10 @@ module Mongo
       # @param io [IO] Stream containing the array to deserialize.
       # @param field [Hash] Hash representing a field.
       # @return [Message] Message with deserialized array.
-      def self.deserialize_array(message, io, field)
+      def self.deserialize_array(message, io, field, options)
         elements = []
         count = message.instance_variable_get(field[:multi])
-        count.times { elements << field[:type].deserialize(io) }
+        count.times { elements << field[:type].deserialize(io, options) }
         message.instance_variable_set(field[:name], elements)
       end
 
@@ -377,10 +377,10 @@ module Mongo
       # @param io [IO] Stream containing the field to deserialize.
       # @param field [Hash] Hash representing a field.
       # @return [Message] Message with deserialized field.
-      def self.deserialize_field(message, io, field)
+      def self.deserialize_field(message, io, field, options)
         message.instance_variable_set(
           field[:name],
-          field[:type].deserialize(io)
+          field[:type].deserialize(io, options)
         )
       end
 

--- a/lib/mongo/protocol/message.rb
+++ b/lib/mongo/protocol/message.rb
@@ -194,6 +194,11 @@ module Mongo
       #
       # @param [ Integer ] max_message_size The max message size.
       # @param [ IO ] io Stream containing a message
+      # @param [ Hash ] options
+      #
+      # @option options [ Boolean ] :deserialize_as_bson Whether to deserialize
+      #   this message using BSON types instead of native Ruby types wherever
+      #   possible.
       #
       # @return [ Message ] Instance of a Message class
       def self.deserialize(io, max_message_size = MAX_MESSAGE_SIZE, expected_response_to = nil, options = {})
@@ -363,6 +368,11 @@ module Mongo
       # @param message [Message] Message to contain the deserialized array.
       # @param io [IO] Stream containing the array to deserialize.
       # @param field [Hash] Hash representing a field.
+      # @param options [ Hash ]
+      #
+      # @option options [ Boolean ] :deserialize_as_bson Whether to deserialize
+      #   each of the elements in this array using BSON types wherever possible.
+      #
       # @return [Message] Message with deserialized array.
       def self.deserialize_array(message, io, field, options)
         elements = []
@@ -376,6 +386,11 @@ module Mongo
       # @param message [Message] Message to contain the deserialized field.
       # @param io [IO] Stream containing the field to deserialize.
       # @param field [Hash] Hash representing a field.
+      # @param options [ Hash ]
+      #
+      # @option options [ Boolean ] :deserialize_as_bson Whether to deserialize
+      #   this field using BSON types wherever possible.
+      #
       # @return [Message] Message with deserialized field.
       def self.deserialize_field(message, io, field, options)
         message.instance_variable_set(

--- a/lib/mongo/protocol/msg.rb
+++ b/lib/mongo/protocol/msg.rb
@@ -214,10 +214,7 @@ module Mongo
           if cmd.key?('$db') && !enc_cmd.key?('$db')
             enc_cmd['$db'] = cmd['$db']
           end
-          # This will be investigtated in RUBY-2119
-          if enc_cmd['txnNumber'].is_a?(Integer) && cmd[:txnNumber].is_a?(BSON::Int64)
-            enc_cmd['txnNumber'] = BSON::Int64.new(enc_cmd[:txnNumber])
-          end
+
           Msg.new(@flags, @options, enc_cmd)
         else
           self

--- a/lib/mongo/protocol/serializers.rb
+++ b/lib/mongo/protocol/serializers.rb
@@ -60,7 +60,7 @@ module Mongo
         #
         # @return [ Array<Fixnum> ] Array consisting of the deserialized
         #   length, request id, response id, and op code.
-        def self.deserialize(buffer)
+        def self.deserialize(buffer, options = {})
           buffer.get_bytes(16).unpack(HEADER_PACK)
         end
       end
@@ -125,7 +125,7 @@ module Mongo
         # @param [ String ] buffer Buffer containing the 32-bit integer
         #
         # @return [ Fixnum ] Deserialized Int32
-        def self.deserialize(buffer)
+        def self.deserialize(buffer, options = {})
           buffer.get_int32
         end
       end
@@ -158,7 +158,7 @@ module Mongo
         # @param [ String ] buffer Buffer containing the 64-bit integer.
         #
         # @return [Fixnum] Deserialized Int64.
-        def self.deserialize(buffer)
+        def self.deserialize(buffer, options = {})
           buffer.get_int64
         end
       end
@@ -202,15 +202,15 @@ module Mongo
         # @return [ Array<BSON::Document> ] Deserialized sections.
         #
         # @since 2.5.0
-        def self.deserialize(buffer)
+        def self.deserialize(buffer, options = {})
           end_length = (@flag_bits & Msg::FLAGS.index(:checksum_present)) == 1 ? 32 : 0
           sections = []
           until buffer.length == end_length
             case byte = buffer.get_byte
             when PayloadZero::TYPE_BYTE
-              sections << PayloadZero.deserialize(buffer)
+              sections << PayloadZero.deserialize(buffer, options)
             when PayloadOne::TYPE_BYTE
-              sections += PayloadOne.deserialize(buffer)
+              sections += PayloadOne.deserialize(buffer, options)
             else
               raise Error::UnknownPayloadType.new(byte)
             end
@@ -264,8 +264,9 @@ module Mongo
           # @return [ Array<BSON::Document> ] Deserialized section.
           #
           # @since 2.5.0
-          def self.deserialize(buffer)
-            BSON::Document.from_bson(buffer)
+          def self.deserialize(buffer, options = {})
+            opts = options[:mode] ? { mode: options[:mode] } : {}
+            BSON::Document.from_bson(buffer, **opts)
           end
         end
 
@@ -354,8 +355,9 @@ module Mongo
         # @param [ String ] buffer Buffer containing the BSON encoded document.
         #
         # @return [ Hash ] The decoded BSON document.
-        def self.deserialize(buffer)
-          BSON::Document.from_bson(buffer)
+        def self.deserialize(buffer, options = {})
+          opts = options[:mode] ? { mode: options[:mode] } : {}
+          BSON::Document.from_bson(buffer, **opts)
         end
 
         # Whether there can be a size limit on this type after serialization.
@@ -393,7 +395,7 @@ module Mongo
         # @return [ String ] The byte.
         #
         # @since 2.5.0
-        def self.deserialize(buffer)
+        def self.deserialize(buffer, options = {})
           buffer.get_byte
         end
       end

--- a/lib/mongo/protocol/serializers.rb
+++ b/lib/mongo/protocol/serializers.rb
@@ -265,8 +265,8 @@ module Mongo
           #
           # @since 2.5.0
           def self.deserialize(buffer, options = {})
-            opts = options[:mode] ? { mode: options[:mode] } : {}
-            BSON::Document.from_bson(buffer, **opts)
+            mode = options[:deserialize_as_bson] ? :bson : nil
+            BSON::Document.from_bson(buffer, **{ mode: mode })
           end
         end
 
@@ -356,8 +356,8 @@ module Mongo
         #
         # @return [ Hash ] The decoded BSON document.
         def self.deserialize(buffer, options = {})
-          opts = options[:mode] ? { mode: options[:mode] } : {}
-          BSON::Document.from_bson(buffer, **opts)
+          mode = options[:deserialize_as_bson] ? :bson : nil
+          BSON::Document.from_bson(buffer, **{ mode: mode })
         end
 
         # Whether there can be a size limit on this type after serialization.

--- a/lib/mongo/protocol/serializers.rb
+++ b/lib/mongo/protocol/serializers.rb
@@ -57,6 +57,7 @@ module Mongo
         # Deserializes the header value from the IO stream
         #
         # @param [ String ] buffer Buffer containing the message header.
+        # @param [ Hash ] options This method currently accepts no options.
         #
         # @return [ Array<Fixnum> ] Array consisting of the deserialized
         #   length, request id, response id, and op code.
@@ -123,6 +124,7 @@ module Mongo
         # Deserializes a 32-bit Fixnum from the IO stream
         #
         # @param [ String ] buffer Buffer containing the 32-bit integer
+        # @param [ Hash ] options This method currently accepts no options.
         #
         # @return [ Fixnum ] Deserialized Int32
         def self.deserialize(buffer, options = {})
@@ -156,6 +158,7 @@ module Mongo
         # Deserializes a 64-bit Fixnum from the IO stream
         #
         # @param [ String ] buffer Buffer containing the 64-bit integer.
+        # @param [ Hash ] options This method currently accepts no options.
         #
         # @return [Fixnum] Deserialized Int64.
         def self.deserialize(buffer, options = {})
@@ -198,6 +201,11 @@ module Mongo
         # Deserializes a section of an OP_MSG from the IO stream.
         #
         # @param [ BSON::ByteBuffer ] buffer Buffer containing the sections.
+        # @param [ Hash ] options
+        #
+        # @option options [ Boolean ] :deserialize_as_bson Whether to perform
+        #   section deserialization using BSON types instead of native Ruby types
+        #   wherever possible.
         #
         # @return [ Array<BSON::Document> ] Deserialized sections.
         #
@@ -260,6 +268,11 @@ module Mongo
           # Deserializes a section of payload type 0 of an OP_MSG from the IO stream.
           #
           # @param [ BSON::ByteBuffer ] buffer Buffer containing the sections.
+          # @param [ Hash ] options
+          #
+          # @option options [ Boolean ] :deserialize_as_bson Whether to perform
+          #   section deserialization using BSON types instead of native Ruby types
+          #   wherever possible.
           #
           # @return [ Array<BSON::Document> ] Deserialized section.
           #
@@ -353,6 +366,11 @@ module Mongo
         # Deserializes a document from the IO stream
         #
         # @param [ String ] buffer Buffer containing the BSON encoded document.
+        # @param [ Hash ] options
+        #
+        # @option options [ Boolean ] :deserialize_as_bson Whether to perform
+        #   section deserialization using BSON types instead of native Ruby types
+        #   wherever possible.
         #
         # @return [ Hash ] The decoded BSON document.
         def self.deserialize(buffer, options = {})
@@ -391,6 +409,7 @@ module Mongo
         # Deserializes a byte from the byte buffer.
         #
         # @param [ BSON::ByteBuffer ] buffer Buffer containing the value to read.
+        # @param [ Hash ] options This method currently accepts no options.
         #
         # @return [ String ] The byte.
         #

--- a/lib/mongo/server/connection.rb
+++ b/lib/mongo/server/connection.rb
@@ -405,7 +405,7 @@ module Mongo
         @auth_mechanism || (@server.features.scram_sha_1_enabled? ? :scram : :mongodb_cr)
       end
 
-      def deliver(message, client)
+      def deliver(message, client, options = {})
         begin
           super
         # Important: timeout errors are not handled here

--- a/lib/mongo/server/connection_base.rb
+++ b/lib/mongo/server/connection_base.rb
@@ -146,8 +146,7 @@ module Mongo
           begin
             socket.write(buffer.to_s)
             result = if message.replyable?
-              deserialization_options = options[:deserialization_mode] ? { mode: options[:deserialization_mode] } : {}
-              Protocol::Message.deserialize(socket, max_message_size, message.request_id, deserialization_options)
+              Protocol::Message.deserialize(socket, max_message_size, message.request_id, options)
             else
               nil
             end

--- a/lib/mongo/server/connection_base.rb
+++ b/lib/mongo/server/connection_base.rb
@@ -115,6 +115,11 @@ module Mongo
       # @param [ Array<Message> ] messages A one-element array containing
       #   the message to dispatch.
       # @param [ Integer ] operation_id The operation id to link messages.
+      # @param [ Hash ] options
+      #
+      # @option options [ Boolean ] :deserialize_as_bson Whether to deserialize
+      #   the response to this message using BSON objects in place of native
+      #   Ruby types wherever possible.
       #
       # @return [ Protocol::Message | nil ] The reply if needed.
       #

--- a/spec/integration/client_side_encryption/auto_encryption_mongocryptd_spawn_spec.rb
+++ b/spec/integration/client_side_encryption/auto_encryption_mongocryptd_spawn_spec.rb
@@ -54,7 +54,8 @@ describe 'Auto Encryption' do
             'documents' => kind_of(Array),
             'jsonSchema' => kind_of(Hash),
             'isRemoteSchema' => false,
-          )
+          ),
+          { execution_options: { deserialize_as_bson: true } },
         )
         .and_raise(Mongo::Error::NoServerAvailable.new(server_selector, cluster))
     end

--- a/spec/integration/crud_spec.rb
+++ b/spec/integration/crud_spec.rb
@@ -14,7 +14,7 @@ describe 'CRUD operations' do
       end
 
       it 'is stored as the correct type' do
-        result = collection.find(int64: { '$type' => 18 }).first
+        result = collection.find(int64: { '$type' => 'long' }).first
         expect(result).not_to be_nil
         expect(result['int64']).to eq(42)
       end
@@ -26,7 +26,7 @@ describe 'CRUD operations' do
       end
 
       it 'is stored as the correct type' do
-        result = collection.find(int32: { '$type' => 16 }).first
+        result = collection.find(int32: { '$type' => 'int' }).first
         expect(result).not_to be_nil
         expect(result['int32']).to eq(42)
       end
@@ -64,7 +64,7 @@ describe 'CRUD operations' do
         end
 
         it 'is stored as the correct type' do
-          result = collection.find(int64: { '$type' => 18 }).first
+          result = collection.find(int64: { '$type' => 'long' }).first
           expect(result).not_to be_nil
           expect(result['int64']).to eq(42)
         end
@@ -76,7 +76,7 @@ describe 'CRUD operations' do
         end
 
         it 'is stored as the correct type' do
-          result = collection.find(int32: { '$type' => 16 }).first
+          result = collection.find(int32: { '$type' => 'int' }).first
           expect(result).not_to be_nil
           expect(result['int32']).to eq(42)
         end

--- a/spec/integration/crud_spec.rb
+++ b/spec/integration/crud_spec.rb
@@ -53,10 +53,10 @@ describe 'CRUD operations' do
             },
             database: 'auto_encryption'
           )
-        )['auto_encryption']
+        )['users']
       end
 
-      let(:collection) { authorized_client['auto_encryption'] }
+      let(:collection) { authorized_client.use('auto_encryption')['users'] }
 
       context 'inserting an int64' do
         before do

--- a/spec/integration/crud_spec.rb
+++ b/spec/integration/crud_spec.rb
@@ -7,6 +7,83 @@ describe 'CRUD operations' do
     collection.delete_many
   end
 
+  describe 'insert' do
+    context 'inserting a BSON::Int64 or BSON::Int32' do
+      before do
+        collection.insert_one(int64: BSON::Int64.new(42))
+      end
+
+      it 'is stored as the correct type' do
+        result = collection.find(int64: { '$type' => 18 }).first
+        expect(result).not_to be_nil
+        expect(result['int64']).to eq(42)
+      end
+    end
+
+    context 'inserting an in32' do
+      before do
+        collection.insert_one(int32: BSON::Int32.new(42))
+      end
+
+      it 'is stored as the correct type' do
+        result = collection.find(int32: { '$type' => 16 }).first
+        expect(result).not_to be_nil
+        expect(result['int32']).to eq(42)
+      end
+    end
+
+    context 'with automatic encryption' do
+      require_libmongocrypt
+      require_enterprise
+      min_server_fcv '4.2'
+
+      include_context 'define shared FLE helpers'
+      include_context 'with local kms_providers'
+
+      let(:encrypted_collection) do
+        new_local_client(
+          SpecConfig.instance.addresses,
+          SpecConfig.instance.test_options.merge(
+            auto_encryption_options: {
+              kms_providers: kms_providers,
+              key_vault_namespace: key_vault_namespace,
+              schema_map: { 'auto_encryption.users' => schema_map },
+              # Spawn mongocryptd on non-default port for sharded cluster tests
+              extra_options: extra_options,
+            },
+            database: 'auto_encryption'
+          )
+        )['auto_encryption']
+      end
+
+      let(:collection) { authorized_client['auto_encryption'] }
+
+      context 'inserting an int64' do
+        before do
+          encrypted_collection.insert_one(ssn: '123-456-7890', int64: BSON::Int64.new(42))
+        end
+
+        it 'is stored as the correct type' do
+          result = collection.find(int64: { '$type' => 18 }).first
+          expect(result).not_to be_nil
+          expect(result['int64']).to eq(42)
+        end
+      end
+
+      context 'inserting an in32' do
+        before do
+          encrypted_collection.insert_one(ssn: '123-456-7890', int32: BSON::Int32.new(42))
+        end
+
+        it 'is stored as the correct type' do
+          result = collection.find(int32: { '$type' => 16 }).first
+          expect(result).not_to be_nil
+          expect(result['int32']).to eq(42)
+        end
+      end
+    end
+  end
+
   describe 'upsert' do
     context 'with default write concern' do
       it 'upserts' do

--- a/spec/integration/crud_spec.rb
+++ b/spec/integration/crud_spec.rb
@@ -8,25 +8,31 @@ describe 'CRUD operations' do
   end
 
   describe 'insert' do
-    context 'inserting a BSON::Int64 or BSON::Int32' do
+    context 'inserting a BSON::Int64' do
       before do
         collection.insert_one(int64: BSON::Int64.new(42))
       end
 
       it 'is stored as the correct type' do
-        result = collection.find(int64: { '$type' => 'long' }).first
+        # 18 is the number that represents the Int64 type for the $type
+        # operator; string aliases in the $type operator are only supported on
+        # server versions 3.2 and newer.
+        result = collection.find(int64: { '$type' => 18 }).first
         expect(result).not_to be_nil
         expect(result['int64']).to eq(42)
       end
     end
 
-    context 'inserting an in32' do
+    context 'inserting a BSON::Int32' do
       before do
         collection.insert_one(int32: BSON::Int32.new(42))
       end
 
       it 'is stored as the correct type' do
-        result = collection.find(int32: { '$type' => 'int' }).first
+        # 16 is the number that represents the Int32 type for the $type
+        # operator; string aliases in the $type operator are only supported on
+        # server versions 3.2 and newer.
+        result = collection.find(int32: { '$type' => 16 }).first
         expect(result).not_to be_nil
         expect(result['int32']).to eq(42)
       end
@@ -58,25 +64,31 @@ describe 'CRUD operations' do
 
       let(:collection) { authorized_client.use('auto_encryption')['users'] }
 
-      context 'inserting an int64' do
+      context 'inserting a BSON::Int64' do
         before do
           encrypted_collection.insert_one(ssn: '123-456-7890', int64: BSON::Int64.new(42))
         end
 
         it 'is stored as the correct type' do
-          result = collection.find(int64: { '$type' => 'long' }).first
+          # 18 is the number that represents the Int64 type for the $type
+          # operator; string aliases in the $type operator are only supported on
+          # server versions 3.2 and newer.
+          result = collection.find(int64: { '$type' => 18 }).first
           expect(result).not_to be_nil
           expect(result['int64']).to eq(42)
         end
       end
 
-      context 'inserting an in32' do
+      context 'inserting a BSON::Int32' do
         before do
           encrypted_collection.insert_one(ssn: '123-456-7890', int32: BSON::Int32.new(42))
         end
 
         it 'is stored as the correct type' do
-          result = collection.find(int32: { '$type' => 'int' }).first
+          # 16 is the number that represents the Int32 type for the $type
+          # operator; string aliases in the $type operator are only supported on
+          # server versions 3.2 and newer.
+          result = collection.find(int32: { '$type' => 16 }).first
           expect(result).not_to be_nil
           expect(result['int32']).to eq(42)
         end


### PR DESCRIPTION
**The Problem:** During automatic encryption, commands are sent to mongocryptd to have encryption placeholders added to them. The response from mongocryptd is deserialized without the `mode: :bson` flag, causing command fields that were previously BSON types (e.g. Int64s) to be deserialized into Ruby types (e.g. Ruby integers). This means that the driver can lose type information on non-encrypted fields when writing them to the database using automatic encryption.

**The Fix:** Allow commands to pass an option called `deserialize_as_bson` to the execution code and down to the protocol layer, which will then deserialize responses from the server using the `mode: :bson` option. This isn't included on all commands because it would create a significant change in driver behavior, so it is only used on the command that is sent to mongocryptd.