### PR TITLE
RUBY-2219 make server arguments required

### DIFF
--- a/lib/mongo/operation/drop/command.rb
+++ b/lib/mongo/operation/drop/command.rb
@@ -30,7 +30,7 @@ module Mongo
         private
 
         def message(server)
-          Protocol::Query.new(db_name, Database::COMMAND, command(server), options)
+          Protocol::Query.new(db_name, Database::COMMAND, command(server), options(server))
         end
       end
     end

--- a/lib/mongo/operation/drop_database/command.rb
+++ b/lib/mongo/operation/drop_database/command.rb
@@ -30,7 +30,7 @@ module Mongo
         private
 
         def message(server)
-          Protocol::Query.new(db_name, Database::COMMAND, command(server), options)
+          Protocol::Query.new(db_name, Database::COMMAND, command(server), options(server))
         end
       end
     end

--- a/lib/mongo/operation/drop_index/command.rb
+++ b/lib/mongo/operation/drop_index/command.rb
@@ -29,7 +29,7 @@ module Mongo
 
         private
 
-        def selector(server = nil)
+        def selector(server)
           { :dropIndexes => coll_name, :index => index_name }
         end
 

--- a/lib/mongo/operation/insert.rb
+++ b/lib/mongo/operation/insert.rb
@@ -34,7 +34,8 @@ module Mongo
 
       IDENTIFIER = 'documents'.freeze
 
-      def validate!;end
+      def validate!(server)
+      end
     end
   end
 end

--- a/lib/mongo/operation/insert/command.rb
+++ b/lib/mongo/operation/insert/command.rb
@@ -43,12 +43,12 @@ module Mongo
             ordered: ordered? }
         end
 
-        def options
+        def options(server)
           super.merge(validating_keys: true)
         end
 
         def message(server)
-          Protocol::Query.new(db_name, Database::COMMAND, command(server), options)
+          Protocol::Query.new(db_name, Database::COMMAND, command(server), options(server))
         end
       end
     end

--- a/lib/mongo/operation/insert/legacy.rb
+++ b/lib/mongo/operation/insert/legacy.rb
@@ -40,7 +40,11 @@ module Mongo
         end
 
         def message(server)
-          opts = !!options[:continue_on_error] ? { :flags => [:continue_on_error] } : {}
+          opts = if options(server)[:continue_on_error]
+            { :flags => [:continue_on_error] }
+          else
+            {}
+          end
           Protocol::Insert.new(db_name, coll_name, documents, opts)
         end
 

--- a/lib/mongo/operation/kill_cursors/command.rb
+++ b/lib/mongo/operation/kill_cursors/command.rb
@@ -29,7 +29,7 @@ module Mongo
         private
 
         def message(server)
-          Protocol::Query.new(db_name, Database::COMMAND, selector(server), options)
+          Protocol::Query.new(db_name, Database::COMMAND, selector(server), options(server))
         end
       end
     end

--- a/lib/mongo/operation/op_msg_base.rb
+++ b/lib/mongo/operation/op_msg_base.rb
@@ -23,7 +23,7 @@ module Mongo
       private
 
       def message(server)
-        Protocol::Msg.new(flags, options, command(server))
+        Protocol::Msg.new(flags, options(server), command(server))
       end
     end
   end

--- a/lib/mongo/operation/shared/limited.rb
+++ b/lib/mongo/operation/shared/limited.rb
@@ -22,7 +22,15 @@ module Mongo
 
       private
 
-      def options(server = nil)
+      # Get the options for executing the operation on a particular server.
+      #
+      # @param [ Server ] server The server that the operation will be
+      #   executed on.
+      #
+      # @return [ Hash ] The options.
+      #
+      # @since 2.0.0
+      def options(server)
         super.merge(limit: -1)
       end
     end

--- a/lib/mongo/operation/shared/specifiable.rb
+++ b/lib/mongo/operation/shared/specifiable.rb
@@ -325,15 +325,15 @@ module Mongo
         spec[OPERATION_ID]
       end
 
-      # Get the options for the operation.
+      # Get the options for executing the operation on a particular server.
       #
-      # @example Get the options.
-      #   specifiable.options
+      # @param [ Server ] server The server that the operation will be
+      #   executed on.
       #
       # @return [ Hash ] The options.
       #
       # @since 2.0.0
-      def options(server = nil)
+      def options(server)
         spec[OPTIONS] || {}
       end
 
@@ -387,15 +387,15 @@ module Mongo
         send(self.class::IDENTIFIER).first[COLLATION]
       end
 
-      # The selector for from the specification.
+      # The selector from the specification for execution on a particular server.
       #
-      # @example Get a selector specification.
-      #   specifiable.selector.
+      # @param [ Server ] server The server that the operation will be
+      #   executed on.
       #
       # @return [ Hash ] The selector spec.
       #
       # @since 2.0.0
-      def selector(server = nil)
+      def selector(server)
         spec[SELECTOR]
       end
 
@@ -543,14 +543,15 @@ module Mongo
 
       # The array filters.
       #
-      # @example Get the array filters.
-      #   specifiable.array_filters
+      # @param [ Server ] server The server that the operation will be
+      #   executed on.
       #
-      # @return [ Hash ] The array filters.
+      # @return [ Hash | nil ] The array filters.
       #
       # @since 2.5.2
-      def array_filters
-        selector[Operation::ARRAY_FILTERS] if selector
+      def array_filters(server)
+        sel = selector(server)
+        sel[Operation::ARRAY_FILTERS] if sel
       end
 
       # Does the operation have an acknowledged write concern.

--- a/lib/mongo/operation/shared/write.rb
+++ b/lib/mongo/operation/shared/write.rb
@@ -36,7 +36,7 @@ module Mongo
       #
       # @since 2.5.2
       def execute(server, client:)
-        validate!
+        validate!(server)
         op = if server.features.op_msg_enabled?
             self.class::OpMsg.new(spec)
           elsif !acknowledged_write?
@@ -73,13 +73,13 @@ module Mongo
 
       private
 
-      def validate!
+      def validate!(server)
         if !acknowledged_write?
           if collation
             raise Error::UnsupportedCollation.new(
                 Error::UnsupportedCollation::UNACKNOWLEDGED_WRITES_MESSAGE)
           end
-          if array_filters
+          if array_filters(server)
             raise Error::UnsupportedArrayFilters.new(
                 Error::UnsupportedArrayFilters::UNACKNOWLEDGED_WRITES_MESSAGE)
           end

--- a/lib/mongo/operation/update/command.rb
+++ b/lib/mongo/operation/update/command.rb
@@ -39,7 +39,7 @@ module Mongo
         end
 
         def message(server)
-          Protocol::Query.new(db_name, Database::COMMAND, command(server), options)
+          Protocol::Query.new(db_name, Database::COMMAND, command(server), options(server))
         end
       end
     end

--- a/lib/mongo/operation/update_user/command.rb
+++ b/lib/mongo/operation/update_user/command.rb
@@ -34,7 +34,7 @@ module Mongo
         end
 
         def message(server)
-          Protocol::Query.new(db_name, Database::COMMAND, command(server), options)
+          Protocol::Query.new(db_name, Database::COMMAND, command(server), options(server))
         end
       end
     end

--- a/spec/mongo/operation/limited_spec.rb
+++ b/spec/mongo/operation/limited_spec.rb
@@ -11,6 +11,8 @@ describe Mongo::Operation::Limited do
       end.new({ :options => spec })
     end
 
+    let(:server) { double('server') }
+
     context 'when no limit is provided' do
 
       let(:spec) do
@@ -18,7 +20,7 @@ describe Mongo::Operation::Limited do
       end
 
       it 'returns a limit of -1' do
-        expect(limited.send(:options)).to eq({ :skip => 5, :limit => -1 })
+        expect(limited.send(:options, server)).to eq({ :skip => 5, :limit => -1 })
       end
     end
 
@@ -31,7 +33,7 @@ describe Mongo::Operation::Limited do
         end
 
         it 'returns a limit of -1' do
-          expect(limited.send(:options)).to eq({ :skip => 5, :limit => -1 })
+          expect(limited.send(:options, server)).to eq({ :skip => 5, :limit => -1 })
         end
       end
 
@@ -42,7 +44,7 @@ describe Mongo::Operation::Limited do
         end
 
         it 'returns a limit of -1' do
-          expect(limited.send(:options)).to eq({ :skip => 5, :limit => -1 })
+          expect(limited.send(:options, server)).to eq({ :skip => 5, :limit => -1 })
         end
       end
     end


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-2219

Read preference code in the operation layer expects a server to be provided, but some of the methods involved defaulted their server argument to nil which didn't make sense. Make the server argument required everywhere along the call chain to the methods that calculate the read preference.