### PR TITLE
RUBY-2044 Part I: Modify existing retryable writes functionality to use the RetryableWriteError label

### DIFF
--- a/lib/mongo/bulk_write.rb
+++ b/lib/mongo/bulk_write.rb
@@ -183,7 +183,7 @@ module Mongo
         else
           result = send(name, values, server, operation_id, session, txn_num)
 
-          add_error_labels(client) do
+          add_error_labels(client, session) do
             result_combiner.combine!(result, values.size)
           end
         end
@@ -233,10 +233,6 @@ module Mongo
     end
 
     private
-
-    def session
-      nil
-    end
 
     def validate_collation!(server)
       features = server.with_connection { |connection| connection.features }

--- a/lib/mongo/bulk_write.rb
+++ b/lib/mongo/bulk_write.rb
@@ -182,7 +182,10 @@ module Mongo
           split_execute(name, values, server, operation_id, result_combiner, session, txn_num)
         else
           result = send(name, values, server, operation_id, session, txn_num)
-          result_combiner.combine!(result, values.size)
+
+          add_error_labels(client) do
+            result_combiner.combine!(result, values.size)
+          end
         end
       end
     rescue Error::MaxBSONSize, Error::MaxMessageSize => e
@@ -230,6 +233,10 @@ module Mongo
     end
 
     private
+
+    def session
+      nil
+    end
 
     def validate_collation!(server)
       features = server.with_connection { |connection| connection.features }

--- a/lib/mongo/operation/shared/executable.rb
+++ b/lib/mongo/operation/shared/executable.rb
@@ -24,7 +24,7 @@ module Mongo
 
       def do_execute(connection, client, options = {})
         unpin_maybe(session) do
-          add_error_labels(client) do
+          add_error_labels(client, session) do
             add_server_diagnostics(connection.server) do
               get_result(connection, client, options).tap do |result|
                 process_result(result, connection.server)

--- a/lib/mongo/operation/shared/executable.rb
+++ b/lib/mongo/operation/shared/executable.rb
@@ -24,7 +24,7 @@ module Mongo
 
       def do_execute(connection, client, options = {})
         unpin_maybe(session) do
-          add_error_labels do
+          add_error_labels(client) do
             add_server_diagnostics(connection.server) do
               get_result(connection, client, options).tap do |result|
                 process_result(result, connection.server)
@@ -42,7 +42,7 @@ module Mongo
         end
 
         do_execute(connection, client, options).tap do |result|
-          validate_result(result, connection.server)
+          validate_result(result, client, connection.server)
         end
       end
 

--- a/lib/mongo/operation/shared/response_handling.rb
+++ b/lib/mongo/operation/shared/response_handling.rb
@@ -48,12 +48,12 @@ module Mongo
           if session && session.committing_transaction?
             e.add_label('UnknownTransactionCommitResult')
           end
-          if (!within_transaction? && retry_writes?(client)) || session.ending_transaction?
+          if (!within_transaction? && retry_writes?(client)) || ending_transaction?
             e.add_label('RetryableWriteError')
           end
           raise e
         rescue Mongo::Error::SocketTimeoutError => e
-          if (!within_transaction? && retry_writes?(client)) || session.ending_transaction?
+          if (!within_transaction? && retry_writes?(client)) || ending_transaction?
             e.add_label('RetryableWriteError')
           end
           raise e
@@ -65,7 +65,7 @@ module Mongo
               e.add_label('UnknownTransactionCommitResult')
             end
           end
-          if ((!within_transaction? && retry_writes?(client)) || session.ending_transaction?) &&
+          if ((!within_transaction? && retry_writes?(client)) || ending_transaction?) &&
               e.write_retryable?
             e.add_label('RetryableWriteError')
           end
@@ -76,6 +76,11 @@ module Mongo
       # TODO: documentation
       private def within_transaction?
         session && session.in_transaction? && !session.ending_transaction?
+      end
+
+      # TODO: documentation
+      private def ending_transaction?
+        session && session.ending_transaction?
       end
 
       # TODO: documentation

--- a/lib/mongo/operation/shared/response_handling.rb
+++ b/lib/mongo/operation/shared/response_handling.rb
@@ -48,7 +48,12 @@ module Mongo
           if session && session.committing_transaction?
             e.add_label('UnknownTransactionCommitResult')
           end
-          if (!within_transaction? && client.options[:retry_writes]) || session.ending_transaction? 
+          if (!within_transaction? && client.options[:retry_writes]) || session.ending_transaction?
+            e.add_label('RetryableWriteError')
+          end
+          raise e
+        rescue Mongo::Error::SocketTimeoutError => e
+          if (!within_transaction? && client.options[:retry_writes]) || session.ending_transaction?
             e.add_label('RetryableWriteError')
           end
           raise e

--- a/lib/mongo/operation/shared/response_handling.rb
+++ b/lib/mongo/operation/shared/response_handling.rb
@@ -119,6 +119,15 @@ module Mongo
       #
       # If these conditions are met, the original error will be mutated.
       # If they're not met, the error will not be changed.
+      #
+      # @param [ Mongo::Error ] error The error to which to add the label.
+      # @param [ Mongo::Client | nil ] client The client that is performing
+      #   the operation.
+      # @param [ Mongo::Session ] session The operation's session.
+      #
+      # @note The client argument is optional because some operations, such as
+      #   end_session, do not pass the client as an argument to the execute
+      #   method.
       def maybe_add_retryable_write_error_label!(error, client, session)
         in_transaction = session && session.in_transaction?
         committing_transaction = in_transaction && session.committing_transaction?

--- a/lib/mongo/operation/shared/write.rb
+++ b/lib/mongo/operation/shared/write.rb
@@ -49,7 +49,7 @@ module Mongo
           op.execute(connection, client: client)
         end
 
-        validate_result(result, server)
+        validate_result(result, client, server)
       end
 
       # Execute the bulk write operation.

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -298,7 +298,7 @@ module Mongo
         if attempt > client.max_write_retries
           raise e
         end
-        if e.label?('RetryableWriteError')
+        if e.write_retryable? && !(session && session.in_transaction?)
           log_retry(e, message: 'Legacy write retry')
           cluster.scan!(false)
           retry

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -221,7 +221,7 @@ module Mongo
       rescue Error::SocketError, Error::SocketTimeoutError => e
         e.add_note('modern retry')
         e.add_note("attempt 1")
-        if session.in_transaction? && !ending_transaction
+        if !e.label?('RetryableWriteError')
           raise e
         end
         retry_write(e, session, txn_num, &block)
@@ -230,7 +230,7 @@ module Mongo
         e.add_note("attempt 1")
         if e.unsupported_retryable_write?
           raise_unsupported_error(e)
-        elsif (session.in_transaction? && !ending_transaction) || !e.write_retryable?
+        elsif !e.label?('RetryableWriteError')
           raise e
         end
 
@@ -298,7 +298,7 @@ module Mongo
         if attempt > client.max_write_retries
           raise e
         end
-        if e.write_retryable? && !(session && session.in_transaction?)
+        if e.label?('RetryableWriteError')
           log_retry(e, message: 'Legacy write retry')
           cluster.scan!(false)
           retry

--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -625,7 +625,6 @@ module Mongo
               txn_num: txn_num
             ).execute(server, client: @client)
           end
-          @aborting_transaction = false
         end
 
         @state = TRANSACTION_ABORTED_STATE
@@ -636,6 +635,8 @@ module Mongo
       rescue Exception
         @state = TRANSACTION_ABORTED_STATE
         raise
+      ensure
+        @aborting_transaction = false
       end
 
       # No official return value, but return true so that in interactive

--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -676,14 +676,6 @@ module Mongo
       !!@aborting_transaction
     end
 
-    # @return [ true | false ] Whether the session is currently aborting a
-    #   transaction by committing or aborting it.
-    #
-    # @api private
-    def ending_transaction?
-      committing_transaction? || aborting_transaction?
-    end
-
     # Pins this session to the specified server, which should be a mongos.
     #
     # @param [ Server ] server The server to pin this session to.

--- a/spec/integration/retryable_bulk_write_spec.rb
+++ b/spec/integration/retryable_bulk_write_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe 'Bulk writes with retryable errors' do
+  require_topology :replica_set, :sharded
+
+  let(:subscriber) { EventSubscriber.new }
+
+  let(:client) do
+    new_local_client(
+      SpecConfig.instance.addresses,
+      SpecConfig.instance.test_options.merge(retry_writes: true)
+    ).tap do |client|
+      client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+    end
+  end
+
+  before do
+    client['test'].drop
+
+    client.use('admin').command(
+      configureFailPoint: 'failCommand',
+      mode: { times: 1 },
+      data: { failCommands: ['insert'], errorCode: 91 }
+    )
+  end
+
+  let(:bulk_write) do
+    Mongo::BulkWrite.new(
+      client['test'],
+      [
+        { insert_one: { _id: 1 } },
+        { insert_one: { _id: 2 } },
+        { update_one: { filter: { _id: 1 }, update: { text: 'hello world!' } } }
+      ],
+      {}
+    )
+  end
+
+  let(:insert_events) do
+    subscriber.started_events.select do |event|
+      event.command_name == 'insert'
+    end
+  end
+
+  let(:update_events) do
+    subscriber.started_events.select do |event|
+      event.command_name == 'update'
+    end
+  end
+
+  it 'retries the combined insert operation' do
+    bulk_write.execute
+
+    expect(insert_events.length).to eq(2)
+    expect(update_events.length).to eq(1)
+
+    # insert operations are combined
+    expect(insert_events.all? { |event| event.command['documents'].length == 2 }).to be true
+  end
+
+  context 'when two operations of the same type are split' do
+    before do
+      allow_any_instance_of(Mongo::Server::Description).to receive(:max_write_batch_size).and_return(1)
+    end
+
+    it 'retries only the first operation' do
+      bulk_write.execute
+
+      expect(insert_events.length).to eq(3)
+      expect(update_events.length).to eq(1)
+
+      # insert operations are split
+      expect(insert_events.all? { |event| event.command['documents'].length == 1 }).to be true
+
+      ids = insert_events.map { |event| event.command['documents'].first['_id'] }
+      # only the first insert is retried
+      expect(ids).to eq([1, 1, 2])
+    end
+  end
+end

--- a/spec/integration/retryable_bulk_write_spec.rb
+++ b/spec/integration/retryable_bulk_write_spec.rb
@@ -8,10 +8,7 @@ describe 'Bulk writes with retryable errors' do
   let(:subscriber) { EventSubscriber.new }
 
   let(:client) do
-    new_local_client(
-      SpecConfig.instance.addresses,
-      SpecConfig.instance.test_options.merge(options)
-    ).tap do |client|
+    authorized_client.with(options).tap do |client|
       client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
     end
   end

--- a/spec/integration/retryable_bulk_write_spec.rb
+++ b/spec/integration/retryable_bulk_write_spec.rb
@@ -2,7 +2,8 @@ require 'spec_helper'
 
 describe 'Bulk writes with retryable errors' do
   require_topology :replica_set
-  min_server_fcv '3.6'
+  # 4.0 required for failCommand
+  min_server_fcv '4.0'
 
   let(:subscriber) { EventSubscriber.new }
 

--- a/spec/integration/retryable_bulk_write_spec.rb
+++ b/spec/integration/retryable_bulk_write_spec.rb
@@ -93,6 +93,10 @@ describe 'Bulk writes with retryable errors' do
   end
 
   context 'when two operations of the same type are split' do
+    # Test uses doubles for server descriptions, doubles are
+    # incompatible with freezing which linting does for descriptions
+    skip_if_linting
+
     before do
       allow_any_instance_of(Mongo::Server::Description).to receive(:max_write_batch_size).and_return(1)
     end

--- a/spec/integration/retryable_bulk_write_spec.rb
+++ b/spec/integration/retryable_bulk_write_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'Bulk writes with retryable errors' do
-  require_topology :replica_set, :sharded
+  require_topology :replica_set
   min_server_fcv '3.6'
 
   let(:subscriber) { EventSubscriber.new }

--- a/spec/integration/retryable_writes_spec.rb
+++ b/spec/integration/retryable_writes_spec.rb
@@ -67,7 +67,7 @@ describe 'Retryable writes integration tests' do
         context 'when the error is a socket timeout error' do
 
           let(:error) do
-            Mongo::Error::SocketTimeoutError.new
+            Errno::ETIMEDOUT.new
           end
 
           it 'retries writes' do
@@ -158,7 +158,7 @@ describe 'Retryable writes integration tests' do
         context 'when the error is a socket timeout error' do
 
           let(:error) do
-            Mongo::Error::SocketTimeoutError.new('first error')
+            Errno::ETIMEDOUT.new('first error')
           end
 
           it 'does not retry writes and raises the original error' do

--- a/spec/mongo/retryable_spec.rb
+++ b/spec/mongo/retryable_spec.rb
@@ -352,11 +352,13 @@ describe Mongo::Retryable do
       end
     end
 
-    context 'when a not master error occurs' do
+    context 'when an error occurs with a RetryableWriteError label' do
+      let(:error) do
+        Mongo::Error::OperationFailure.new(nil, nil, labels: ['RetryableWriteError'])
+      end
 
       before do
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::OperationFailure.new('not master')).ordered
+        expect(operation).to receive(:execute).and_raise(error).ordered
         expect(cluster).to receive(:scan!).and_return(true).ordered
         expect(operation).to receive(:execute).and_return(true).ordered
       end
@@ -364,33 +366,7 @@ describe Mongo::Retryable do
       it_behaves_like 'executes the operation twice'
     end
 
-    context 'when a node is recovering error occurs' do
-
-      before do
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::OperationFailure.new('node is recovering')).ordered
-        expect(cluster).to receive(:scan!).and_return(true).ordered
-        expect(operation).to receive(:execute).and_return(true).ordered
-      end
-
-      it_behaves_like 'executes the operation twice'
-    end
-
-    context 'when a retryable error occurs with a code' do
-
-      before do
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::OperationFailure.new('message missing', nil,
-            :code => 91, :code_name => 'ShutdownInProgress')).ordered
-        expect(cluster).to receive(:scan!).and_return(true).ordered
-        expect(operation).to receive(:execute).and_return(true).ordered
-      end
-
-      it_behaves_like 'executes the operation twice'
-    end
-
-    context 'when a normal operation failure occurs' do
-
+    context 'when an operation failure occurs without a RetryableWriteError label' do
       before do
         expect(operation).to receive(:execute).and_raise(Mongo::Error::OperationFailure).ordered
       end
@@ -402,11 +378,15 @@ describe Mongo::Retryable do
       end
     end
 
-    context 'when a socket error occurs' do
+    context 'when a socket error occurs with a RetryableWriteError label' do
+      let(:error) do
+        error = Mongo::Error::SocketError.new(nil)
+        error.add_label('RetryableWriteError')
+        error
+      end
 
       before do
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::SocketError.new('socket error')).ordered
+        expect(operation).to receive(:execute).and_raise(error).ordered
       end
 
       it 'raises an exception' do
@@ -416,11 +396,15 @@ describe Mongo::Retryable do
       end
     end
 
-    context 'when a socket timeout occurs' do
+    context 'when a socket timeout occurs with a RetryableWriteError label' do
+      let(:error) do
+        error = Mongo::Error::SocketTimeoutError.new(nil)
+        error.add_label('RetryableWriteError')
+        error
+      end
 
       before do
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::SocketTimeoutError.new('socket timeout')).ordered
+        expect(operation).to receive(:execute).and_raise(error).ordered
       end
 
       it 'raises an exception' do
@@ -431,7 +415,6 @@ describe Mongo::Retryable do
     end
 
     context 'when a non-retryable exception occurs' do
-
       before do
         expect(operation).to receive(:execute).and_raise(
           Mongo::Error::UnsupportedCollation.new('unsupported collation')).ordered
@@ -443,7 +426,6 @@ describe Mongo::Retryable do
         }.to raise_error(Mongo::Error::UnsupportedCollation)
       end
     end
-
   end
 
   describe '#write_with_retry - modern' do
@@ -477,45 +459,21 @@ describe Mongo::Retryable do
       end
     end
 
-    context 'when a not master error occurs' do
+    context 'when an operation failure error occurs with a RetryableWriteError label' do
+      let(:error) do
+        Mongo::Error::OperationFailure.new(nil, nil, labels: ['RetryableWriteError'])
+      end
 
       before do
         server = cluster.next_primary
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::OperationFailure.new('not master')).ordered
+        expect(operation).to receive(:execute).and_raise(error).ordered
         expect(operation).to receive(:execute).and_return(true).ordered
       end
 
       it_behaves_like 'executes the operation twice'
     end
 
-    context 'when a node is recovering error occurs' do
-
-      before do
-        server = cluster.next_primary
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::OperationFailure.new('node is recovering')).ordered
-        expect(operation).to receive(:execute).and_return(true).ordered
-      end
-
-      it_behaves_like 'executes the operation twice'
-    end
-
-    context 'when a retryable error occurs with a code' do
-
-      before do
-        server = cluster.next_primary
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::OperationFailure.new('message missing', nil,
-            :code => 91, :code_name => 'ShutdownInProgress')).ordered
-        expect(operation).to receive(:execute).and_return(true).ordered
-      end
-
-      it_behaves_like 'executes the operation twice'
-    end
-
-    context 'when a normal operation failure occurs' do
-
+    context 'when an operation failure error occurs without a RetryableWriteError label' do
       before do
         expect(operation).to receive(:execute).and_raise(Mongo::Error::OperationFailure).ordered
       end
@@ -527,11 +485,15 @@ describe Mongo::Retryable do
       end
     end
 
-    context 'when a socket error occurs' do
+    context 'when a socket error occurs with a RetryableWriteError label' do
+      let(:error) do
+        error = Mongo::Error::SocketError.new('socket error')
+        error.add_label('RetryableWriteError')
+        error
+      end
 
       before do
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::SocketError.new('socket error')).ordered
+        expect(operation).to receive(:execute).and_raise(error).ordered
         # This is where the server would be marked unknown, but since
         # we are not tracking which server the operation was sent to,
         # we are not able to assert this.
@@ -542,11 +504,31 @@ describe Mongo::Retryable do
       it_behaves_like 'executes the operation twice'
     end
 
-    context 'when a socket timeout occurs' do
+    context 'when a socket error occurs without a RetryableWriteError label' do
+      let(:error) do
+        Mongo::Error::SocketError.new('socket error')
+      end
 
       before do
-        expect(operation).to receive(:execute).and_raise(
-          Mongo::Error::SocketTimeoutError.new('socket timeout')).ordered
+        expect(operation).to receive(:execute).and_raise(error).ordered
+      end
+
+      it 'raises an exception' do
+        expect {
+          retryable.write
+        }.to raise_error(Mongo::Error::SocketError)
+      end
+    end
+
+    context 'when a socket timeout occurs with a RetryableWriteError label' do
+      let(:error) do
+        error = Mongo::Error::SocketTimeoutError.new('socket timeout error')
+        error.add_label('RetryableWriteError')
+        error
+      end
+
+      before do
+        expect(operation).to receive(:execute).and_raise(error).ordered
         # This is where the server would be marked unknown, but since
         # we are not tracking which server the operation was sent to,
         # we are not able to assert this.
@@ -556,6 +538,22 @@ describe Mongo::Retryable do
       end
 
       it_behaves_like 'executes the operation twice'
+    end
+
+    context 'when a socket timeout occurs without a RetryableWriteError label' do
+      let(:error) do
+        Mongo::Error::SocketTimeoutError.new('socket timeout error')
+      end
+
+      before do
+        expect(operation).to receive(:execute).and_raise(error).ordered
+      end
+
+      it 'raises an exception' do
+        expect {
+          retryable.write
+        }.to raise_error(Mongo::Error::SocketTimeoutError)
+      end
     end
 
     context 'when a non-retryable exception occurs' do


### PR DESCRIPTION
This PR should not modify existing retryable writes functionality at all. It only changes the implementation to use the RetryableWriteError label. I will create a follow-up PR to add functionality specific to server version 4.4.