### PR TITLE
RUBY-2044 Part II: Update legacy retries to use RetryableWriteError label

### DIFF
--- a/lib/mongo/operation/shared/response_handling.rb
+++ b/lib/mongo/operation/shared/response_handling.rb
@@ -134,7 +134,7 @@ module Mongo
         aborting_transaction = in_transaction && session.aborting_transaction?
         modern_retry_writes = client && client.options[:retry_writes]
         legacy_retry_writes = client && !client.options[:retry_writes] &&
-          client.options[:max_write_retries] != 0
+          client.max_write_retries > 0
         retry_writes = modern_retry_writes || legacy_retry_writes
 
         if (committing_transaction || aborting_transaction ||

--- a/lib/mongo/operation/shared/response_handling.rb
+++ b/lib/mongo/operation/shared/response_handling.rb
@@ -134,7 +134,7 @@ module Mongo
         aborting_transaction = in_transaction && session.aborting_transaction?
         modern_retry_writes = client && client.options[:retry_writes]
         legacy_retry_writes = client && !client.options[:retry_writes] &&
-          client.options[:max_write_retries] > 0
+          client.options[:max_write_retries] && client.options[:max_write_retries] > 0
         retry_writes = modern_retry_writes || legacy_retry_writes
 
         if (committing_transaction || aborting_transaction ||

--- a/lib/mongo/operation/shared/response_handling.rb
+++ b/lib/mongo/operation/shared/response_handling.rb
@@ -134,7 +134,7 @@ module Mongo
         aborting_transaction = in_transaction && session.aborting_transaction?
         modern_retry_writes = client && client.options[:retry_writes]
         legacy_retry_writes = client && !client.options[:retry_writes] &&
-          client.options[:max_write_retries] && client.options[:max_write_retries] > 0
+          client.options[:max_write_retries] != 0
         retry_writes = modern_retry_writes || legacy_retry_writes
 
         if (committing_transaction || aborting_transaction ||

--- a/lib/mongo/operation/shared/response_handling.rb
+++ b/lib/mongo/operation/shared/response_handling.rb
@@ -132,7 +132,10 @@ module Mongo
         in_transaction = session && session.in_transaction?
         committing_transaction = in_transaction && session.committing_transaction?
         aborting_transaction = in_transaction && session.aborting_transaction?
-        retry_writes = client && client.options[:retry_writes]
+        modern_retry_writes = client && client.options[:retry_writes]
+        legacy_retry_writes = client && !client.options[:retry_writes] &&
+          client.options[:max_write_retries] > 0
+        retry_writes = modern_retry_writes || legacy_retry_writes
 
         if (committing_transaction || aborting_transaction ||
             (!in_transaction && retry_writes)) && error.write_retryable?

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -298,7 +298,7 @@ module Mongo
         if attempt > client.max_write_retries
           raise e
         end
-        if e.write_retryable? && !(session && session.in_transaction?)
+        if e.label?('RetryableWriteError')
           log_retry(e, message: 'Legacy write retry')
           cluster.scan!(false)
           retry

--- a/spec/integration/legacy_retryable_writes_spec.rb
+++ b/spec/integration/legacy_retryable_writes_spec.rb
@@ -54,7 +54,7 @@ describe 'legacy retryable writes integration tests' do
       end
 
       it 'retries the operation' do
-        expect(Mongo::Logger.logger).to receive(:warn).once.and_call_original
+        expect(Mongo::Logger.logger).to receive(:warn).once.with(/legacy/).and_call_original
 
         result = client['test'].insert_one(_id: 1)
         expect(result).to be_ok

--- a/spec/integration/legacy_retryable_writes_spec.rb
+++ b/spec/integration/legacy_retryable_writes_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+describe 'legacy retryable writes integration tests' do
+  include PrimarySocket
+  require_topology :replica_set
+
+  let(:client) { authorized_client.with(retry_writes: false) }
+
+  before do
+    client['test'].drop
+  end
+
+  context 'when error is an IOError' do
+    let(:error) { IOError.new('io error') }
+
+    before do
+      allow(primary_socket).to receive(:do_write).and_raise(error.dup)
+    end
+
+    # legacy retry writes do not retry socket errors
+    it 'does not retry the operation' do
+      expect do
+        client['test'].insert_one(_id: 1)
+      end.to raise_error(Mongo::Error::SocketError, /io error/)
+    end
+  end
+
+  context 'when error is an ETIMEDOUT' do
+    let(:error) { Errno::ETIMEDOUT.new('timeout') }
+
+    before do
+      allow(primary_socket).to receive(:do_write).and_raise(error.dup)
+    end
+
+    # legacy retry writes do not retry socket errors
+    it 'does not retry the operation' do
+      expect do
+        client['test'].insert_one(_id: 1)
+      end.to raise_error(Mongo::Error::SocketTimeoutError, /timeout/)
+    end
+  end
+
+  context 'when error is an operation failure' do
+    # 4.0 required for failCommand
+    min_server_fcv '4.0'
+
+    context 'with a retryable code' do
+      before do
+        client.use('admin').command(
+          configureFailPoint: 'failCommand',
+          mode: { times: 1 },
+          data: { failCommands: ['insert'], errorCode: 91 }
+        )
+      end
+
+      it 'retries the operation' do
+        expect(Mongo::Logger.logger).to receive(:warn).once.and_call_original
+
+        result = client['test'].insert_one(_id: 1)
+        expect(result).to be_ok
+      end
+    end
+
+    context 'with a non-retryable code' do
+      before do
+        client.use('admin').command(
+          configureFailPoint: 'failCommand',
+          mode: { times: 1 },
+          data: { failCommands: ['insert'], errorCode: 5 }
+        )
+      end
+
+      it 'retries the operation' do
+        expect do
+          client['test'].insert_one(_id: 1)
+        end.to raise_error(Mongo::Error::OperationFailure)
+      end
+    end
+  end
+end

--- a/spec/integration/retryable_bulk_write_spec.rb
+++ b/spec/integration/retryable_bulk_write_spec.rb
@@ -4,6 +4,7 @@ describe 'Bulk writes with retryable errors' do
   require_topology :replica_set
   # 4.0 required for failCommand
   min_server_fcv '4.0'
+  require_wired_tiger
 
   let(:subscriber) { EventSubscriber.new }
 


### PR DESCRIPTION
This PR should not change user-facing behavior. I have added an integration test for legacy retryable writes because I could not find any integration tests for that behavior.