### PR TITLE
RUBY-2238 remove ElectionInProgress from resumable change stream error list

### DIFF
--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -143,7 +143,6 @@ module Mongo
         {code_name: 'StaleShardVersion', code: 63},
         {code_name: 'FailedToSatisfyReadPreference', code: 133},
         {code_name: 'StaleEpoch', code: 150},
-        {code_name: 'ElectionInProgress', code: 216},
         {code_name: 'RetryChangeStream', code: 234},
         {code_name: 'StaleConfig', code: 13388},
       ].freeze

--- a/spec/integration/change_stream_spec.rb
+++ b/spec/integration/change_stream_spec.rb
@@ -148,6 +148,14 @@ describe 'Change stream integration', retry: 4 do
 
           it_behaves_like 'raises an exception'
         end
+
+        context 'when the error is ElectionInProgress' do
+          let(:error_code) { 216 }
+
+          let(:error_labels) { [] }
+
+          it_behaves_like 'raises an exception'
+        end
       end
 
       context 'error on a getMore other than first' do


### PR DESCRIPTION
[RUBY-2238](https://jira.mongodb.org/browse/RUBY-2238)

I believe we never ended up syncing the spec tests that tested whether ElectionInProgress was a resumable change stream error, so the spec tests are already up to date. I added an integration test just to sanity check that this change actually did something.