### PR TITLE
RUBY-2132 improve connection reconnection after fork

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -97,7 +97,7 @@ functions:
             export MMAPV1="${MMAPV1}"
             export FLE="${FLE}"
 
-            export STRESS_SPEC=true
+            export STRESS="${STRESS}"
           EOT
 
           # See what we've done
@@ -589,6 +589,14 @@ axes:
         variables:
           LINT: '1'
 
+  - id: stress
+    display_name: Stress
+    values:
+      - id: on
+        display_name: On
+        variables:
+          STRESS: '1'
+
   - id: "as"
     display_name: ActiveSupport
     values:
@@ -790,6 +798,17 @@ buildvariants:
       topology: '*'
       os: ubuntu1604
     display_name: "${mongodb-version} ${topology} ${lint} ${ruby}"
+    tasks:
+      - name: "test-mlaunch"
+
+  - matrix_name: "stress"
+    matrix_spec:
+      stress: on
+      ruby: "ruby-2.7"
+      mongodb-version: ["4.4"]
+      topology: '*'
+      os: ubuntu1604
+    display_name: "${mongodb-version} ${topology} ${stress} ${ruby}"
     tasks:
       - name: "test-mlaunch"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -97,7 +97,7 @@ functions:
             export MMAPV1="${MMAPV1}"
             export FLE="${FLE}"
 
-            export STRESS="${STRESS}"
+            export STRESS=1
           EOT
 
           # See what we've done
@@ -597,6 +597,14 @@ axes:
         variables:
           STRESS: '1'
 
+  - id: fork
+    display_name: Fork
+    values:
+      - id: on
+        display_name: On
+        variables:
+          FORK: '1'
+
   - id: "as"
     display_name: ActiveSupport
     values:
@@ -801,9 +809,9 @@ buildvariants:
     tasks:
       - name: "test-mlaunch"
 
-  - matrix_name: "stress"
+  - matrix_name: "fork"
     matrix_spec:
-      stress: on
+      fork: on
       ruby: "ruby-2.7"
       mongodb-version: ["4.4"]
       topology: '*'

--- a/.evergreen/functions-config.sh
+++ b/.evergreen/functions-config.sh
@@ -2,7 +2,7 @@
 
 show_local_instructions() {
   echo To test this configuration locally:
-  params="MONGODB_VERSION=$MONGODB_VERSION TOPOLOGY=$TOPOLOGY RVM_RUBY=$RVM_RUBY STRESS_SPEC=true"
+  params="MONGODB_VERSION=$MONGODB_VERSION TOPOLOGY=$TOPOLOGY RVM_RUBY=$RVM_RUBY STRESS=1"
   if test -n "$AUTH"; then
     params="$params AUTH=$AUTH"
   fi

--- a/.evergreen/functions-config.sh
+++ b/.evergreen/functions-config.sh
@@ -2,7 +2,7 @@
 
 show_local_instructions() {
   echo To test this configuration locally:
-  params="MONGODB_VERSION=$MONGODB_VERSION TOPOLOGY=$TOPOLOGY RVM_RUBY=$RVM_RUBY STRESS=1"
+  params="MONGODB_VERSION=$MONGODB_VERSION TOPOLOGY=$TOPOLOGY RVM_RUBY=$RVM_RUBY"
   if test -n "$AUTH"; then
     params="$params AUTH=$AUTH"
   fi
@@ -38,6 +38,12 @@ show_local_instructions() {
   fi
   if test -n "$MMAPV1"; then
     params="$params MMAPV1=$MMAPV1"
+  fi
+  if test -n "$STRESS"; then
+    params="$params STRESS=$STRESS"
+  fi
+  if test -n "$FORK"; then
+    params="$params FORK=$FORK"
   fi
   # $0 has the current script being executed which is also the script that
   # was initially invoked EXCEPT for the AWS configurations which use the

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -219,8 +219,8 @@ export MONGODB_URI="mongodb://$hosts/?appName=test-suite$uri_options"
 echo "Running tests"
 if test -n "$TEST_CMD"; then
   eval $TEST_CMD
-elif test "$STRESS" = 1; then
-  bundle exec rspec spec/stress
+elif test "$FORK" = 1; then
+  bundle exec rspec spec/integration/fork*spec.rb spec/stress/fork*spec.rb
 else
   bundle exec rake spec:ci
 fi

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -219,6 +219,8 @@ export MONGODB_URI="mongodb://$hosts/?appName=test-suite$uri_options"
 echo "Running tests"
 if test -n "$TEST_CMD"; then
   eval $TEST_CMD
+elif test "$STRESS" = 1; then
+  bundle exec rspec spec/stress
 else
   bundle exec rake spec:ci
 fi

--- a/lib/mongo/monitoring/command_log_subscriber.rb
+++ b/lib/mongo/monitoring/command_log_subscriber.rb
@@ -54,8 +54,11 @@ module Mongo
       # @since 2.1.0
       def started(event)
         if logger.debug?
-          log_debug("#{prefix(event, connection_id: event.connection_id)} | " +
-            "STARTED | #{format_command(event.command)}")
+          _prefix = prefix(event,
+            connection_generation: event.connection_generation,
+            connection_id: event.connection_id,
+          )
+          log_debug("#{_prefix} | STARTED | #{format_command(event.command)}")
         end
       end
 
@@ -97,8 +100,12 @@ module Mongo
         end
       end
 
-      def prefix(event, connection_id: nil)
-        "[#{event.request_id}] #{event.address.to_s}#{connection_id && " ##{connection_id}"} | " +
+      def prefix(event, connection_generation: nil, connection_id: nil)
+        extra = [connection_generation, connection_id].compact.join(':')
+        if extra == ''
+          extra = nil
+        end
+        "[#{event.request_id}] #{event.address.to_s}#{extra && " ##{extra}"} | " +
           "#{event.database_name}.#{event.command_name}"
       end
 

--- a/lib/mongo/monitoring/event/command_started.rb
+++ b/lib/mongo/monitoring/event/command_started.rb
@@ -45,6 +45,9 @@ module Mongo
         # @api private
         attr_reader :socket_object_id
 
+        # @api private
+        attr_reader :connection_generation
+
         # @return [ Integer ] The ID for the connection over which the command
         #   is sent.
         #
@@ -65,7 +68,8 @@ module Mongo
         # @since 2.1.0
         # @api private
         def initialize(command_name, database_name, address, request_id,
-          operation_id, command, socket_object_id: nil, connection_id: nil
+          operation_id, command, socket_object_id: nil, connection_id: nil,
+          connection_generation: nil
         )
           @command_name = command_name.to_s
           @database_name = database_name
@@ -75,6 +79,7 @@ module Mongo
           @command = redacted(command_name, command)
           @socket_object_id = socket_object_id
           @connection_id = connection_id
+          @connection_generation = connection_generation
         end
 
         # Create the event from a wire protocol message payload.
@@ -91,7 +96,7 @@ module Mongo
         # @since 2.1.0
         # @api private
         def self.generate(address, operation_id, payload,
-          socket_object_id: nil, connection_id: nil
+          socket_object_id: nil, connection_id: nil, connection_generation: nil
         )
           new(
             payload[:command_name],
@@ -107,6 +112,7 @@ module Mongo
             payload[:command].merge('$db' => payload[:database_name]),
             socket_object_id: socket_object_id,
             connection_id: connection_id,
+            connection_generation: connection_generation,
           )
         end
 

--- a/lib/mongo/monitoring/publishable.rb
+++ b/lib/mongo/monitoring/publishable.rb
@@ -45,12 +45,13 @@ module Mongo
       private
 
       def command_started(address, operation_id, payload,
-        socket_object_id: nil, connection_id: nil
+        socket_object_id: nil, connection_id: nil, connection_generation: nil
       )
         monitoring.started(
           Monitoring::COMMAND,
           Event::CommandStarted.generate(address, operation_id, payload,
-            socket_object_id: socket_object_id, connection_id: connection_id)
+            socket_object_id: socket_object_id, connection_id: connection_id,
+            connection_generation: connection_generation)
         )
       end
 

--- a/lib/mongo/monitoring/publishable.rb
+++ b/lib/mongo/monitoring/publishable.rb
@@ -57,7 +57,7 @@ module Mongo
 
       def command_completed(result, address, operation_id, payload, duration)
         document = result ? (result.documents || []).first : nil
-        if error?(document)
+        if document && (document['ok'] && document['ok'] != 1 || document.key?('$err'))
           parser = Error::Parser.new(document)
           command_failed(document, address, operation_id, payload, parser.message, duration)
         else
@@ -87,10 +87,6 @@ module Mongo
 
       def duration(start)
         Time.now - start
-      end
-
-      def error?(document)
-        document && (document['ok'] == 0 || document.key?('$err'))
       end
 
       def monitoring?

--- a/lib/mongo/server/connection.rb
+++ b/lib/mongo/server/connection.rb
@@ -133,6 +133,11 @@ module Mongo
         !!@closed
       end
 
+      # @api private
+      def error?
+        !!@error
+      end
+
       # Establishes a network connection to the target address.
       #
       # If the connection is already established, this method does nothing.
@@ -298,9 +303,12 @@ module Mongo
       def handle_errors
         begin
           yield
-        # Important: timeout errors are not handled here
         rescue Error::SocketError => e
+          @error = e
           @server.unknown!(generation: e.generation)
+          raise
+        rescue Error::SocketTimeoutError => e
+          @error = e
           raise
         end
       end

--- a/lib/mongo/server/connection_base.rb
+++ b/lib/mongo/server/connection_base.rb
@@ -155,7 +155,8 @@ module Mongo
         ensure_connected do |socket|
           operation_id = Monitoring.next_operation_id
           command_started(address, operation_id, message.payload,
-            socket_object_id: socket.object_id, connection_id: id)
+            socket_object_id: socket.object_id, connection_id: id,
+            connection_generation: generation)
           start = Time.now
           result = nil
           begin

--- a/lib/mongo/server/connection_common.rb
+++ b/lib/mongo/server/connection_common.rb
@@ -90,7 +90,7 @@ module Mongo
         # server.
         note = "on #{address.seed}"
         if respond_to?(:id)
-          note << ", connection #{id}"
+          note << ", connection #{generation}:#{id}"
         end
         e.add_note(note)
         if respond_to?(:generation)

--- a/lib/mongo/server/connection_common.rb
+++ b/lib/mongo/server/connection_common.rb
@@ -87,7 +87,11 @@ module Mongo
         # Server::Monitor::Connection does not reference its server, but
         # knows its address. Server::Connection delegates the address to its
         # server.
-        e.add_note("on #{address.seed}")
+        note = "on #{address.seed}"
+        if respond_to?(:id)
+          note << ", connection #{id}"
+        end
+        e.add_note(note)
         if respond_to?(:generation)
           # Non-monitoring connections
           e.generation = generation

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -385,7 +385,7 @@ module Mongo
 
         if Lint.enabled?
           unless connection.connected?
-            raise Error::LintError, 'Connection pool checked out a disconnected connection'
+            raise Error::LintError, "Connection pool for #{address} checked out a disconnected connection #{connection.id}"
           end
         end
 

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -432,6 +432,11 @@ module Mongo
             Monitoring::Event::Cmap::ConnectionCheckedIn.new(@server.address, connection.id, self)
           )
 
+          if connection.error?
+            connection.disconnect!(reason: :error)
+            return
+          end
+
           if closed?
             connection.disconnect!(reason: :pool_closed)
             return

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -393,7 +393,7 @@ module Mongo
 
         if Lint.enabled?
           unless connection.connected?
-            raise Error::LintError, "Connection pool for #{address} checked out a disconnected connection #{connection.id}"
+            raise Error::LintError, "Connection pool for #{address} checked out a disconnected connection #{connection.generation}:#{connection.id}"
           end
         end
 

--- a/lib/mongo/server/monitor/connection.rb
+++ b/lib/mongo/server/monitor/connection.rb
@@ -216,6 +216,17 @@ module Mongo
         def retry_message
           "Retrying ismaster in monitor for #{address}"
         end
+
+        def ensure_connected
+          if pid != Process.pid
+            log_warn("Detected PID change - Mongo client should have been reconnected (old pid #{pid}, new pid #{Process.pid}")
+            disconnect!
+            connect!
+            @pid = Process.pid
+          end
+
+          super
+        end
       end
     end
   end

--- a/lib/mongo/server/monitor/connection.rb
+++ b/lib/mongo/server/monitor/connection.rb
@@ -136,8 +136,8 @@ module Mongo
         #
         # @since 2.2.0
         def ismaster
-          ensure_connected do |socket|
-            read_with_one_retry(retry_message: retry_message) do
+          read_with_one_retry(retry_message: retry_message) do
+            ensure_connected do |socket|
               add_server_diagnostics do
                 socket.write(ISMASTER_BYTES)
                 Protocol::Message.deserialize(socket).documents[0]

--- a/spec/README.md
+++ b/spec/README.md
@@ -490,11 +490,26 @@ set names:
 However, as noted in the caveats section, changing the database name used by
 the test suite is not supported.
 
+## Special Tests
+
 Some tests require internet connectivity, for example to test DNS seed lists
 and SRV URIs. These tests can be skipped by setting the following environment
 variable:
 
-    EXTERNAL_DISABLED=true
+    EXTERNAL_DISABLED=1
+
+Some tests are designed to validate the driver's behavior under load, or
+otherwise execute a large number of operations which may take a sizable amount
+of time. Such tests are skipped by default and can be run by setting the
+following environment variable:
+
+    STRESS=1
+
+Some tests fork the process to validate the driver's behavior when forking is
+involved. These tests are skipped by default and can be run by setting the
+following environment variable:
+
+    FORK=1
 
 ## Debug Logging
 

--- a/spec/integration/fork_reconnect_spec.rb
+++ b/spec/integration/fork_reconnect_spec.rb
@@ -4,12 +4,20 @@ describe 'fork reconnect' do
   let(:client) { authorized_client }
   let(:server) { client.cluster.next_primary }
 
-  shared_examples 'reconnects the connection' do
+  describe 'monitoring connection' do
+    let(:connection) do
+      Mongo::Server::Monitor::Connection.new(server.address, server.options)
+    end
+
+    let(:operation) do
+      connection.ismaster.should be_a(Hash)
+    end
+
     it 'reconnects' do
       connection.connect!
 
       socket = connection.send(:socket).send(:socket)
-      socket.should be_a(Socket)
+      (socket.is_a?(Socket) || socket.is_a?(OpenSSL::SSL::SSLSocket)).should be true
 
       if pid = fork
         Process.wait(pid)
@@ -40,18 +48,6 @@ describe 'fork reconnect' do
     end
   end
 
-  describe 'monitoring connection' do
-    let(:connection) do
-      Mongo::Server::Monitor::Connection.new(server.address)
-    end
-
-    let(:operation) do
-      connection.ismaster.should be_a(Hash)
-    end
-
-    it_behaves_like 'reconnects the connection'
-  end
-
   describe 'non-monitoring connection' do
     let(:connection) do
       Mongo::Server::Connection.new(server)
@@ -61,7 +57,68 @@ describe 'fork reconnect' do
       connection.ping.should be true
     end
 
-    it_behaves_like 'reconnects the connection'
+    it 'does not reconnect' do
+      connection.connect!
+
+      socket = connection.send(:socket).send(:socket)
+      (socket.is_a?(Socket) || socket.is_a?(OpenSSL::SSL::SSLSocket)).should be true
+
+      if pid = fork
+        Process.wait(pid)
+        $?.exitstatus.should == 0
+      else
+        operation
+
+        child_socket = connection.send(:socket).send(:socket)
+        # fileno of child_socket may equal to fileno of socket,
+        # as socket would've been closed first and file descriptors can be
+        # reused by the kernel.
+        child_socket.object_id.should == socket.object_id
+
+        # Exec so that we do not close any clients etc. in the child.
+        exec('/bin/true')
+      end
+
+      # Connection should remain serviceable in the parent.
+      # The operation here will be invoked again, since the earlier invocation
+      # was in the child process.
+      operation
+
+      parent_socket = connection.send(:socket).send(:socket)
+      # fileno of child_socket may equal to fileno of socket,
+      # as socket would've been closed first and file descriptors can be
+      # reused by the kernel.
+      parent_socket.object_id.should == socket.object_id
+    end
+  end
+
+  describe 'connection pool' do
+
+    it 'creates a new connection in child' do
+      conn_id = server.with_connection do |connection|
+        connection.id
+      end
+
+      if pid = fork
+        Process.wait(pid)
+        $?.exitstatus.should == 0
+      else
+        new_conn_id = server.with_connection do |connection|
+          connection.id
+        end
+
+        new_conn_id.should_not == conn_id
+
+        # Exec so that we do not close any clients etc. in the child.
+        exec('/bin/true')
+      end
+
+      parent_conn_id = server.with_connection do |connection|
+        connection.id
+      end
+
+      parent_conn_id.should == conn_id
+    end
   end
 
   describe 'client' do

--- a/spec/integration/fork_reconnect_spec.rb
+++ b/spec/integration/fork_reconnect_spec.rb
@@ -31,8 +31,8 @@ describe 'fork reconnect' do
       (socket.is_a?(Socket) || socket.is_a?(OpenSSL::SSL::SSLSocket)).should be true
 
       if pid = fork
-        Process.wait(pid)
-        $?.exitstatus.should == 0
+        pid, status = Process.wait2(pid)
+        status.exitstatus.should == 0
       else
         operation
 
@@ -72,8 +72,8 @@ describe 'fork reconnect' do
       (socket.is_a?(Socket) || socket.is_a?(OpenSSL::SSL::SSLSocket)).should be true
 
       if pid = fork
-        Process.wait(pid)
-        $?.exitstatus.should == 0
+        pid, status = Process.wait2(pid)
+        status.exitstatus.should == 0
       else
         Utils.wrap_forked_child do
           operation
@@ -99,8 +99,8 @@ describe 'fork reconnect' do
       end
 
       if pid = fork
-        Process.wait(pid)
-        $?.exitstatus.should == 0
+        pid, status = Process.wait2(pid)
+        status.exitstatus.should == 0
       else
         Utils.wrap_forked_child do
           new_conn_id = server.with_connection do |connection|
@@ -130,8 +130,8 @@ describe 'fork reconnect' do
       client['foo'].insert_one(test: 1)
 
       if pid = fork
-        Process.wait(pid)
-        $?.exitstatus.should == 0
+        pid, status = Process.wait2(pid)
+        status.exitstatus.should == 0
       else
         Utils.wrap_forked_child do
           client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)

--- a/spec/integration/fork_reconnect_spec.rb
+++ b/spec/integration/fork_reconnect_spec.rb
@@ -8,6 +8,10 @@ describe 'fork reconnect' do
   # another shard with a dead connection).
   require_no_multi_shard
 
+  # On Ruby 2.3 $?.exitstatus is sometimes nil after Process.wait returns which
+  # is not supposed to happen.
+  ruby_version_gte '2.4'
+
   let(:client) { authorized_client }
   let(:server) { client.cluster.next_primary }
 

--- a/spec/integration/fork_reconnect_spec.rb
+++ b/spec/integration/fork_reconnect_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'fork reconnect' do
+  only_mri
+
   let(:client) { authorized_client }
   let(:server) { client.cluster.next_primary }
 

--- a/spec/integration/fork_reconnect_spec.rb
+++ b/spec/integration/fork_reconnect_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe 'fork reconnect' do
   only_mri
 
+  # On multi-shard sharded clusters a succeeding write request does not
+  # guarantee that the next operation will succeed (since it could be sent to
+  # another shard with a dead connection).
+  require_no_multi_shard
+
   let(:client) { authorized_client }
   let(:server) { client.cluster.next_primary }
 

--- a/spec/integration/fork_reconnect_spec.rb
+++ b/spec/integration/fork_reconnect_spec.rb
@@ -63,4 +63,22 @@ describe 'fork reconnect' do
 
     it_behaves_like 'reconnects the connection'
   end
+
+  describe 'client' do
+    it 'works after fork' do
+      client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+
+      if pid = fork
+        Process.wait(pid)
+        $?.exitstatus.should == 0
+      else
+        client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+
+        # Exec so that we do not close any clients etc. in the child.
+        exec('/bin/true')
+      end
+
+      client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+    end
+  end
 end

--- a/spec/integration/fork_reconnect_spec.rb
+++ b/spec/integration/fork_reconnect_spec.rb
@@ -1,0 +1,66 @@
+require 'spec_helper'
+
+describe 'fork reconnect' do
+  let(:client) { authorized_client }
+  let(:server) { client.cluster.next_primary }
+
+  shared_examples 'reconnects the connection' do
+    it 'reconnects' do
+      connection.connect!
+
+      socket = connection.send(:socket).send(:socket)
+      socket.should be_a(Socket)
+
+      if pid = fork
+        Process.wait(pid)
+        $?.exitstatus.should == 0
+      else
+        operation
+
+        child_socket = connection.send(:socket).send(:socket)
+        # fileno of child_socket may equal to fileno of socket,
+        # as socket would've been closed first and file descriptors can be
+        # reused by the kernel.
+        child_socket.object_id.should_not == socket.object_id
+
+        # Exec so that we do not close any clients etc. in the child.
+        exec('/bin/true')
+      end
+
+      # Connection should remain serviceable in the parent.
+      # The operation here will be invoked again, since the earlier invocation
+      # was in the child process.
+      operation
+
+      parent_socket = connection.send(:socket).send(:socket)
+      # fileno of child_socket may equal to fileno of socket,
+      # as socket would've been closed first and file descriptors can be
+      # reused by the kernel.
+      parent_socket.object_id.should == socket.object_id
+    end
+  end
+
+  describe 'monitoring connection' do
+    let(:connection) do
+      Mongo::Server::Monitor::Connection.new(server.address)
+    end
+
+    let(:operation) do
+      connection.ismaster.should be_a(Hash)
+    end
+
+    it_behaves_like 'reconnects the connection'
+  end
+
+  describe 'non-monitoring connection' do
+    let(:connection) do
+      Mongo::Server::Connection.new(server)
+    end
+
+    let(:operation) do
+      connection.ping.should be true
+    end
+
+    it_behaves_like 'reconnects the connection'
+  end
+end

--- a/spec/integration/fork_reconnect_spec.rb
+++ b/spec/integration/fork_reconnect_spec.rb
@@ -115,6 +115,9 @@ describe 'fork reconnect' do
       # Perform a write so that we discover the current primary.
       # Previous test may have stepped down the server that authorized client
       # considers the primary.
+      # In standalone deployments there are no retries, hence execute the
+      # operation twice manually.
+      client['foo'].insert_one(test: 1) rescue nil
       client['foo'].insert_one(test: 1)
 
       if pid = fork

--- a/spec/integration/fork_reconnect_spec.rb
+++ b/spec/integration/fork_reconnect_spec.rb
@@ -112,8 +112,10 @@ describe 'fork reconnect' do
 
   describe 'client' do
     it 'works after fork' do
-      client.cluster.next_primary.pool.clear
-      client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+      # Perform a write so that we discover the current primary.
+      # Previous test may have stepped down the server that authorized client
+      # considers the primary.
+      client['foo'].insert_one(test: 1)
 
       if pid = fork
         Process.wait(pid)

--- a/spec/integration/reconnect_spec.rb
+++ b/spec/integration/reconnect_spec.rb
@@ -65,9 +65,8 @@ describe 'Client after reconnect' do
     end
 
     let(:client) do
-      ClientRegistry.instance.register_local_client(
-        Mongo::Client.new(uri, SpecConfig.instance.ssl_options.merge(
-          server_selection_timeout: 3.86, logger: logger)))
+      new_local_client(uri, SpecConfig.instance.ssl_options.merge(
+        server_selection_timeout: 3.86, logger: logger))
     end
 
     let(:wait_for_discovery) do

--- a/spec/integration/sdam_error_handling_spec.rb
+++ b/spec/integration/sdam_error_handling_spec.rb
@@ -199,8 +199,7 @@ describe 'SDAM error handling' do
       expect(server.monitor.connection).not_to be nil
       set_subscribers
       RSpec::Mocks.with_temporary_scope do
-        socket = server.monitor.connection.send(:socket)
-        expect(socket).to receive(:write).twice.and_raise(exception)
+        expect(server.monitor.connection).to receive(:ismaster).and_raise(exception)
         server.monitor.scan!
       end
       expect_server_state_change

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -14,8 +14,9 @@ describe Mongo::Cluster do
   end
 
   let(:cluster_without_io) do
-    described_class.new(SpecConfig.instance.addresses, monitoring,
-      SpecConfig.instance.test_options.merge(monitoring_io: false))
+    register_cluster(
+      described_class.new(SpecConfig.instance.addresses, monitoring,
+        SpecConfig.instance.test_options.merge(monitoring_io: false)))
   end
 
   let(:cluster) { cluster_without_io }

--- a/spec/mongo/server/connection_spec.rb
+++ b/spec/mongo/server/connection_spec.rb
@@ -971,6 +971,7 @@ describe Mongo::Server::Connection do
       end
     end
 
+=begin this is now handled by connection pool
     context 'when the process is forked' do
 
       let(:insert) do
@@ -992,6 +993,7 @@ describe Mongo::Server::Connection do
         expect(connection.send(:pid)).to eq(1)
       end
     end
+=end
   end
 
   describe '#initialize' do

--- a/spec/mongo/server/monitor/connection_spec.rb
+++ b/spec/mongo/server/monitor/connection_spec.rb
@@ -146,7 +146,8 @@ describe Mongo::Server::Monitor::Connection do
         expect([Socket, OpenSSL::SSL::SSLSocket]).to include(socket.class)
 
         expect(socket).to receive(:write).and_raise(IOError)
-        expect(socket).to receive(:write).and_call_original
+        # The retry is done on a new socket instance.
+        #expect(socket).to receive(:write).and_call_original
 
         connection.ismaster
       end

--- a/spec/spec_tests/command_monitoring_spec.rb
+++ b/spec/spec_tests/command_monitoring_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+require 'runners/crud'
 require 'runners/command_monitoring'
 
 describe 'Command Monitoring Events' do

--- a/spec/stress/connection_pool_stress_spec.rb
+++ b/spec/stress/connection_pool_stress_spec.rb
@@ -1,11 +1,7 @@
 require 'spec_helper'
 
 describe 'Connection pool stress test' do
-  before(:all) do
-    if !SpecConfig.instance.stress_spec?
-      skip 'Set STRESS=1 in environment to run stress tests'
-    end
-  end
+  require_stress
 
   let(:options) do
     { max_pool_size: 5, min_pool_size: 3 }

--- a/spec/stress/connection_pool_stress_spec.rb
+++ b/spec/stress/connection_pool_stress_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Connection pool stress test' do
   before(:all) do
     if !SpecConfig.instance.stress_spec?
-      skip 'Stress spec not enabled'
+      skip 'Set STRESS=1 in environment to run stress tests'
     end
   end
 

--- a/spec/stress/connection_pool_timing_spec.rb
+++ b/spec/stress/connection_pool_timing_spec.rb
@@ -1,13 +1,10 @@
 require 'spec_helper'
 
 describe 'Connection pool timing test' do
+  require_stress
+  clean_slate_for_all
+
   before(:all) do
-    if !SpecConfig.instance.stress_spec?
-      skip 'Set STRESS=1 in environment to run stress tests'
-    end
-
-    ClientRegistry.instance.close_all_clients
-
     # This set up is taken from the step_down_spec file. In a future PR, ClusterTools
     # may be modified so this set up is no longer necessary.
     if ClusterConfig.instance.fcv_ish >= '4.2' && ClusterConfig.instance.topology == :replica_set

--- a/spec/stress/connection_pool_timing_spec.rb
+++ b/spec/stress/connection_pool_timing_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe 'Connection pool timing test' do
   before(:all) do
     if !SpecConfig.instance.stress_spec?
-      skip 'Stress spec not enabled'
+      skip 'Set STRESS=1 in environment to run stress tests'
     end
 
     ClientRegistry.instance.close_all_clients

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -14,7 +14,7 @@ describe 'fork reconnect' do
 
   before(:all) do
     if !SpecConfig.instance.stress_spec?
-      skip 'Stress spec not enabled'
+      skip 'Set STRESS=1 in environment to run stress tests'
     end
   end
 

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -13,7 +13,10 @@ describe 'fork reconnect' do
 
   describe 'client' do
     it 'works after fork' do
-      client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+      # Perform a write so that we discover the current primary.
+      # Previous test may have stepped down the server that authorized client
+      # considers the primary.
+      client['foo'].insert_one(test: 1)
 
       pids = []
       deadline = Time.now + 5

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -1,0 +1,87 @@
+require 'spec_helper'
+
+describe 'fork reconnect' do
+  before(:all) do
+    if !SpecConfig.instance.stress_spec?
+      skip 'Stress spec not enabled'
+    end
+  end
+
+  let(:client) { authorized_client }
+
+  describe 'client' do
+    it 'works after fork' do
+      client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+
+      pids = []
+      deadline = Time.now + 5
+      1.upto(10) do
+        if pid = fork
+          pids << pid
+        else
+          while Time.now < deadline
+            client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+          end
+
+          # Exec so that we do not close any clients etc. in the child.
+          exec('/bin/true')
+        end
+      end
+
+      while Time.now < deadline
+        # Use a read which is retried in case of an error
+        client['foo'].find(test: 1).to_a
+      end
+
+      pids.each do |pid|
+        Process.wait(pid)
+        $?.exitstatus.should == 0
+      end
+    end
+
+    context 'when parent is operating on client during the fork' do
+      let(:client) { authorized_client.with(max_pool_size: 5) }
+
+      it 'works' do
+        client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+
+        threads = []
+        5.times do
+          threads << Thread.new do
+            loop do
+              client['foo'].find(test: 1).to_a
+            end
+          end
+        end
+
+        pids = []
+        deadline = Time.now + 5
+        10.times do
+          if pid = fork
+            pids << pid
+          else
+            while Time.now < deadline
+              client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+            end
+
+            # Exec so that we do not close any clients etc. in the child.
+            exec('/bin/true')
+          end
+        end
+
+        while Time.now < deadline
+          sleep 0.1
+        end
+
+        threads.map(&:kill)
+        threads.map(&:join)
+
+        pids.each do |pid|
+          Process.wait(pid)
+          $?.exitstatus.should == 0
+        end
+      end
+
+    end
+  end
+end

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -40,7 +40,8 @@ describe 'fork reconnect' do
     end
 
     context 'when parent is operating on client during the fork' do
-      let(:client) { authorized_client.with(max_pool_size: 5) }
+      let(:client) { authorized_client.with(max_pool_size: 5,
+        wait_queue_timeout: 10, socket_timeout: 2, connect_timeout: 2) }
 
       it 'works' do
         client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -50,8 +50,8 @@ describe 'fork reconnect' do
       end
 
       pids.each do |pid|
-        Process.wait(pid)
-        $?.exitstatus.should == 0
+        pid, status = Process.wait2(pid)
+        status.exitstatus.should == 0
       end
     end
 
@@ -102,8 +102,8 @@ describe 'fork reconnect' do
         threads.map(&:join)
 
         pids.each do |pid|
-          Process.wait(pid)
-          $?.exitstatus.should == 0
+          pid, status = Process.wait2(pid)
+          status.exitstatus.should == 0
         end
       end
 

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper'
 describe 'fork reconnect' do
   only_mri
 
+  # On multi-shard sharded clusters a succeeding write request does not
+  # guarantee that the next operation will succeed (since it could be sent to
+  # another shard with a dead connection).
+  require_no_multi_shard
+
   before(:all) do
     if !SpecConfig.instance.stress_spec?
       skip 'Stress spec not enabled'

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -42,7 +42,11 @@ describe 'fork reconnect' do
     end
 
     context 'when parent is operating on client during the fork' do
-      let(:client) { authorized_client.with(max_pool_size: 5,
+      # This test intermittently fails in evergreen with pool size of 5,
+      # with a number o fpending connections in the pool.
+      # The reason could be that handshaking is slow or operations are slow
+      # post handshakes.
+      let(:client) { authorized_client.with(max_pool_size: 10,
         wait_queue_timeout: 10, socket_timeout: 2, connect_timeout: 2) }
 
       it 'works' do

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -8,6 +8,10 @@ describe 'fork reconnect' do
   # another shard with a dead connection).
   require_no_multi_shard
 
+  # On Ruby 2.3 $?.exitstatus is sometimes nil after Process.wait returns which
+  # is not supposed to happen.
+  ruby_version_gte '2.4'
+
   before(:all) do
     if !SpecConfig.instance.stress_spec?
       skip 'Stress spec not enabled'

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -41,11 +41,16 @@ describe 'fork reconnect' do
       end
     end
 
-    context 'when parent is operating on client during the fork' do
+    context 'when parent is operating on client during the fork', retry: 3 do
       # This test intermittently fails in evergreen with pool size of 5,
-      # with a number o fpending connections in the pool.
+      # with a number of pending connections in the pool.
       # The reason could be that handshaking is slow or operations are slow
       # post handshakes.
+      # Sometimes it seems the monitoring connection experiences network
+      # errors (despite being a loopback connection) which causes the test
+      # to fail as then server selection fails.
+      # The retry: 3 is to deal with network errors on monitoring connection.
+
       let(:client) { authorized_client.with(max_pool_size: 10,
         wait_queue_timeout: 10, socket_timeout: 2, connect_timeout: 2) }
 

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'fork reconnect' do
+  only_mri
+
   before(:all) do
     if !SpecConfig.instance.stress_spec?
       skip 'Stress spec not enabled'

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -12,11 +12,8 @@ describe 'fork reconnect' do
   # is not supposed to happen.
   ruby_version_gte '2.4'
 
-  before(:all) do
-    if !SpecConfig.instance.stress_spec?
-      skip 'Set STRESS=1 in environment to run stress tests'
-    end
-  end
+  require_stress
+  require_fork
 
   let(:client) { authorized_client }
 

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -21,12 +21,11 @@ describe 'fork reconnect' do
         if pid = fork
           pids << pid
         else
-          while Time.now < deadline
-            client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+          Utils.wrap_forked_child do
+            while Time.now < deadline
+              client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+            end
           end
-
-          # Exec so that we do not close any clients etc. in the child.
-          exec('/bin/true')
         end
       end
 
@@ -72,12 +71,11 @@ describe 'fork reconnect' do
           if pid = fork
             pids << pid
           else
-            while Time.now < deadline
-              client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+            Utils.wrap_forked_child do
+              while Time.now < deadline
+                client.database.command(ismaster: 1).should be_a(Mongo::Operation::Result)
+              end
             end
-
-            # Exec so that we do not close any clients etc. in the child.
-            exec('/bin/true')
           end
         end
 

--- a/spec/stress/fork_reconnect_stress_spec.rb
+++ b/spec/stress/fork_reconnect_stress_spec.rb
@@ -16,6 +16,9 @@ describe 'fork reconnect' do
       # Perform a write so that we discover the current primary.
       # Previous test may have stepped down the server that authorized client
       # considers the primary.
+      # In standalone deployments there are no retries, hence execute the
+      # operation twice manually.
+      client['foo'].insert_one(test: 1) rescue nil
       client['foo'].insert_one(test: 1)
 
       pids = []

--- a/spec/support/lite_constraints.rb
+++ b/spec/support/lite_constraints.rb
@@ -122,4 +122,20 @@ module LiteConstraints
       end
     end
   end
+
+  def require_stress
+    before(:all) do
+      if !SpecConfig.instance.stress?
+        skip 'Set STRESS=1 in environment to run stress tests'
+      end
+    end
+  end
+
+  def require_fork
+    before(:all) do
+      if !SpecConfig.instance.fork?
+        skip 'Set FORK=1 in environment to run fork tests'
+      end
+    end
+  end
 end

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -115,7 +115,7 @@ class SpecConfig
   end
 
   def stress_spec?
-    !!ENV['STRESS_SPEC']
+    !!ENV['STRESS']
   end
 
   # Test suite configuration

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -114,8 +114,12 @@ class SpecConfig
     RUBY_PLATFORM
   end
 
-  def stress_spec?
-    !!ENV['STRESS']
+  def stress?
+    %w(1 true yes).include?(ENV['STRESS']&.downcase)
+  end
+
+  def fork?
+    %w(1 true yes).include?(ENV['FORK']&.downcase)
   end
 
   # Test suite configuration

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -436,4 +436,16 @@ module Utils
       sleep 3
     end
   end
+
+  module_function def wrap_forked_child
+    begin
+      yield
+    rescue => e
+      STDERR.puts "Failing process #{Process.pid} due to #{e.class}: #{e}"
+      exec('/bin/false')
+    else
+      # Exec so that we do not close any clients etc. in the child.
+      exec('/bin/true')
+    end
+  end
 end


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-2132

- Remove pid checks from non-monitoring connections and place them into connection pool. This permits the pool to close/discard connections from the parent process in the child, instead of these connections getting reconnected in place.
- When operation on connections fail with network errors, mark connections as errored and do not check them into pools.
- The monitoring connections still need the pid check for the time being, moved it into the monitoring connection from connection base.
- Add an integration test for using monitoring connection after fork (this is transparently supported for now).
- Add an integration test for using a client after fork without reconnection. This does work  but new non-monitoring connections are created for operations by the pool.
- Add a stress test where multiple forked children are performing operations on the client created in the parent, without reconnecting. This intermittently fails in evergreen due to I assume network connectivity issues in ec2. Set this test to retry twice.
- Add a stress test where the parent performs operations while forked children are also performing operations on the same client without reconnecting. Operations need to be retryable by the driver (e.g. reads) to not have any application errors.
- All of the fork tests are skipped on jruby.
- Connection generation number added to command started events for diagnostics, and to error notes for the same reason.
- Unit tests that mock two consecutive ismaster failures may need to be revisited in the future, since this no longer works naively due to ismasters being sent on different driver connections.