### PR TITLE
RUBY-2132 remove monitoring connection retries

### DIFF
--- a/spec/integration/heartbeat_events_spec.rb
+++ b/spec/integration/heartbeat_events_spec.rb
@@ -62,7 +62,7 @@ describe 'Heartbeat events' do
 
   it 'notifies on failed heartbeats' do
     exc = HeartbeatEventsSpecTestException.new
-    expect_any_instance_of(Mongo::Server::Monitor::Connection).to receive(:ismaster).at_least(:once).and_raise(exc)
+    expect_any_instance_of(Mongo::Server::Monitor).to receive(:ismaster).at_least(:once).and_raise(exc)
 
     expect do
       client.database.command(ismaster: 1)

--- a/spec/integration/sdam_error_handling_spec.rb
+++ b/spec/integration/sdam_error_handling_spec.rb
@@ -199,7 +199,7 @@ describe 'SDAM error handling' do
       expect(server.monitor.connection).not_to be nil
       set_subscribers
       RSpec::Mocks.with_temporary_scope do
-        expect(server.monitor.connection).to receive(:ismaster).and_raise(exception)
+        expect(server.monitor).to receive(:ismaster).and_raise(exception)
         server.monitor.scan!
       end
       expect_server_state_change


### PR DESCRIPTION
Instead of retrying once on a failing ismaster:

- Immediately mark the server unknown on ismaster failure
- If server was previously known, schedule another check immediately
  (bypassing minimum interval)

This PR also uses the response from the initial handshake to perform the first sdam round.