### PR TITLE
RUBY-2184: Make $readPreference behave as specified

### DIFF
--- a/lib/mongo/operation/shared/sessions_supported.rb
+++ b/lib/mongo/operation/shared/sessions_supported.rb
@@ -173,10 +173,11 @@ module Mongo
           # - When mode is 'secondaryPreferred' $readPreference is only sent
           #   when a non-mode field (i.e. tag_sets) is present
           # - Otherwise $readPreference is sent
-          if read && read.to_doc[:mode] == 'secondaryPreferred'
-            sel['$readPreference'] = read.to_doc unless read.to_mongos.nil?
-          elsif read && read.to_doc[:mode] != 'primary'
-            sel['$readPreference'] = read.to_doc
+          if read
+            doc = read.to_mongos
+            if doc
+              sel['$readPreference'] = doc
+            end
           end
         elsif connection.server.cluster.single?
           # In Single topology:
@@ -194,9 +195,8 @@ module Mongo
           end
           sel['$readPreference'] = read_doc
         else
-          # In replica sets and sharded clusters, read preference is passed
-          # to the server if one is specified by the application, and there
-          # is no default.
+          # In replica sets, read preference is passed to the server if one
+          # is specified by the application, and there is no default.
           if read
             sel['$readPreference'] = read.to_doc
           end


### PR DESCRIPTION
From the [server selection spec](https://github.com/mongodb/specifications/blob/4e570fc442e0a67bcb4999c85a0afb10c0c5a8ae/source/server-selection/server-selection.rst#passing-read-preference-to-mongos):
> Therefore, when sending queries to a mongos, the following rules apply:
>
> - For mode 'primary', drivers MUST NOT set the slaveOK wire protocol flag and MUST NOT use $readPreference
> - For mode 'secondary', drivers MUST set the slaveOK wire protocol flag and MUST also use $readPreference
> - For mode 'primaryPreferred', drivers MUST set the slaveOK wire protocol flag and MUST also use $readPreference
> - For mode 'secondaryPreferred', drivers MUST set the slaveOK wire protocol flag. If the read preference contains a non-empty tag_sets parameter, maxStalenessSeconds is a positive integer, or the hedge parameter is non-empty, drivers MUST use $readPreference; otherwise, drivers MUST NOT use $readPreference
> - For mode 'nearest', drivers MUST set the slaveOK wire protocol flag and MUST also use $readPreference

Our read preference op message tests did not test for this behavior, so I have updated the tests and modified the existing code. The actual work for RUBY-2184 will be completed on top of this work.