### PR TITLE
Fix RUBY-2279 AWS request mutates passed in time

### DIFF
--- a/lib/mongo/auth/aws/request.rb
+++ b/lib/mongo/auth/aws/request.rb
@@ -86,7 +86,7 @@ module Mongo
         # @return [ String ] formatted_time ISO8601-formatted time of the
         #   request, as would be used in X-Amz-Date header.
         def formatted_time
-          @formatted_time ||= @time.utc.strftime('%Y%m%dT%H%M%SZ')
+          @formatted_time ||= @time.getutc.strftime('%Y%m%dT%H%M%SZ')
         end
 
         # @return [ String ] formatted_date YYYYMMDD formatted date of the request.

--- a/spec/mongo/auth/aws/request_spec.rb
+++ b/spec/mongo/auth/aws/request_spec.rb
@@ -1,24 +1,23 @@
 require 'spec_helper'
-require 'json'
 
 describe Mongo::Auth::Aws::Request do 
 
-    describe "#formatted_time" do 
-        let(:request) do 
-            described_class.new(access_key_id: 'access_key_id', 
-                secret_access_key: 'secret_access_key', 
-                session_token: 'session_token', 
-                host: 'host', 
-                server_nonce: 'server_nonce'
-            )
-        end
-
-        it 'doesn\'t modify the time instance variable' do
-            original_time = request.time.dup
-            request.formatted_time
-            expect(request.time).to eq(original_time)
-            expect(request.time.strftime('%Z')).to eq(original_time.strftime('%Z'))
-
-        end
+  describe "#formatted_time" do 
+    let(:request) do 
+      described_class.new(access_key_id: 'access_key_id', 
+        secret_access_key: 'secret_access_key', 
+        session_token: 'session_token', 
+        host: 'host', 
+        server_nonce: 'server_nonce',
+        time: Time.now
+      )
     end
+
+    it 'doesn\'t modify the time instance variable' do
+      original_time = request.time.dup
+      request.formatted_time
+      expect(request.time).to eq(original_time)
+      expect(request.time.strftime('%Z')).to eq(original_time.strftime('%Z'))
+    end
+  end
 end

--- a/spec/mongo/auth/aws/request_spec.rb
+++ b/spec/mongo/auth/aws/request_spec.rb
@@ -3,21 +3,19 @@ require 'spec_helper'
 describe Mongo::Auth::Aws::Request do 
 
   describe "#formatted_time" do 
+    original_time = Time.now.freeze
     let(:request) do 
       described_class.new(access_key_id: 'access_key_id', 
         secret_access_key: 'secret_access_key', 
         session_token: 'session_token', 
         host: 'host', 
         server_nonce: 'server_nonce',
-        time: Time.now
+        time: original_time
       )
     end
 
     it 'doesn\'t modify the time instance variable' do
-      original_time = request.time.dup
-      request.formatted_time
-      expect(request.time).to eq(original_time)
-      expect(request.time.strftime('%Z')).to eq(original_time.strftime('%Z'))
+      expect { request.formatted_time }.to_not raise_error
     end
   end
 end

--- a/spec/mongo/auth/aws/request_spec.rb
+++ b/spec/mongo/auth/aws/request_spec.rb
@@ -3,34 +3,74 @@ require 'spec_helper'
 describe Mongo::Auth::Aws::Request do 
 
   describe "#formatted_time" do 
-    original_time = Time.now.freeze
-    let(:request) do 
-      described_class.new(access_key_id: 'access_key_id', 
-        secret_access_key: 'secret_access_key', 
-        session_token: 'session_token', 
-        host: 'host', 
-        server_nonce: 'server_nonce',
-        time: original_time
-      )
+    context "when time is provided and frozen" do 
+      let(:original_time) { Time.at(1592399523).freeze }
+      let(:request) do 
+        described_class.new(access_key_id: 'access_key_id', 
+          secret_access_key: 'secret_access_key', 
+          session_token: 'session_token', 
+          host: 'host', 
+          server_nonce: 'server_nonce',
+          time: original_time
+        )
+      end
+
+      it 'doesn\'t modify the time instance variable' do
+        expect { request.formatted_time }.to_not raise_error
+      end
+
+      it 'returns the correct formatted time' do
+        expect(request.formatted_time).to eq('20200617T131203Z')
+      end
     end
 
-    it 'doesn\'t modify the time instance variable' do
-      expect { request.formatted_time }.to_not raise_error
+    context "when time is not provided" do 
+      let(:request) do 
+        described_class.new(access_key_id: 'access_key_id', 
+          secret_access_key: 'secret_access_key', 
+          session_token: 'session_token', 
+          host: 'host', 
+          server_nonce: 'server_nonce'
+        )
+      end
+
+      it 'doesn\'t raise an error on formatted_time' do
+        expect { request.formatted_time }.to_not raise_error
+      end
     end
   end
 
   describe "#signature" do 
-    let(:request) do 
-      described_class.new(access_key_id: 'access_key_id', 
-        secret_access_key: 'secret_access_key', 
-        session_token: 'session_token', 
-        host: 'host', 
-        server_nonce: 'server_nonce',
-      )
+    context "when time is provided and frozen" do 
+      let(:original_time) { Time.at(1592399523).freeze }
+      let(:request) do 
+        described_class.new(access_key_id: 'access_key_id', 
+          secret_access_key: 'secret_access_key', 
+          session_token: 'session_token', 
+          host: 'host', 
+          server_nonce: 'server_nonce',
+          time: original_time
+        )
+      end
+  
+      it 'doesn\'t raise error on signature' do 
+        expect { request.signature }.to_not raise_error
+      end
     end
 
-    it 'doesn\'t raise exception on signature' do 
-      expect { request.signature }.to_not raise_error
-    end
+    context "when time is not provided" do 
+      let(:request) do 
+        described_class.new(access_key_id: 'access_key_id', 
+          secret_access_key: 'secret_access_key', 
+          session_token: 'session_token', 
+          host: 'host', 
+          server_nonce: 'server_nonce'
+        )
+      end
+  
+      it 'doesn\'t raise error on signature' do 
+        expect { request.signature }.to_not raise_error
+      end
+    end    
   end
 end

--- a/spec/mongo/auth/aws/request_spec.rb
+++ b/spec/mongo/auth/aws/request_spec.rb
@@ -18,4 +18,19 @@ describe Mongo::Auth::Aws::Request do
       expect { request.formatted_time }.to_not raise_error
     end
   end
+
+  describe "#signature" do 
+    let(:request) do 
+      described_class.new(access_key_id: 'access_key_id', 
+        secret_access_key: 'secret_access_key', 
+        session_token: 'session_token', 
+        host: 'host', 
+        server_nonce: 'server_nonce',
+      )
+    end
+
+    it 'doesn\'t raise exception on signature' do 
+      expect { request.signature }.to_not raise_error
+    end
+  end
 end

--- a/spec/mongo/auth/aws/request_spec.rb
+++ b/spec/mongo/auth/aws/request_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'json'
+
+describe Mongo::Auth::Aws::Request do 
+
+    describe "#formatted_time" do 
+        let(:request) do 
+            described_class.new(access_key_id: 'access_key_id', 
+                secret_access_key: 'secret_access_key', 
+                session_token: 'session_token', 
+                host: 'host', 
+                server_nonce: 'server_nonce'
+            )
+        end
+
+        it 'doesn\'t modify the time instance variable' do
+            original_time = request.time.dup
+            request.formatted_time
+            expect(request.time).to eq(original_time)
+            expect(request.time.strftime('%Z')).to eq(original_time.strftime('%Z'))
+
+        end
+    end
+end


### PR DESCRIPTION
Fixed issue where a call to formatted_time mutates the @time instance. Changed the call to utc to getutc.