### PR TITLE
RUBY-1262 added tests for closing session after block

### DIFF
--- a/docs/tutorials/ruby-driver-authentication.txt
+++ b/docs/tutorials/ruby-driver-authentication.txt
@@ -470,7 +470,7 @@ MONGODB-CR
 ``````````
 
 *Deprecated:* MONGODB-CR mechanism is deprecated as of MongoDB 3.6 and
-removed as of MongoDB 4.0. Please use `SCRAM authentication <scram>`_ instead.
+removed as of MongoDB 4.0. Please use `SCRAM authentication <#scram>`_ instead.
 
 MONGODB-CR was the default authentication mechanism for MongoDB through
 version 2.6.

--- a/docs/tutorials/ruby-driver-sessions.txt
+++ b/docs/tutorials/ruby-driver-sessions.txt
@@ -92,7 +92,7 @@ A session can be created by calling the ``start_session`` method on a client:
 
   session = client.start_session
 
-When ``start_session`` is used without passing a block to it, the driver does not automatically clean up the session which can result in an accumulation of sessions on the server. Use `end_session<#end-a-session>` to manually end the session created. The server will automatically clean up old sessions after a timeout but the application should end sessions when the sessions are no longer needed.
+When ``start_session`` is used without passing a block to it, the driver does not automatically clean up the session which can result in an accumulation of sessions on the server. Use `end_session <#end-a-session>`_ to manually end the session created. The server will automatically clean up old sessions after a timeout but the application should end sessions when the sessions are no longer needed.
 
 Unacknowledged Writes
 =====================
@@ -141,5 +141,5 @@ The Ruby driver will then add the id for the corresponding server session to a p
 When a client is closed, the driver will send a command to the server to end all sessions it has cached
 in its server session pool. You may see this command in your logs when a client is closed.
 
-Note that when using the `block syntax<#creating-a-session-from-a-mongo-client>` for ``start_session`` the session is automatically ended after
+Note that when using the `block syntax <#creating-a-session-from-a-mongo-client>`_ for ``start_session`` the session is automatically ended after
 the block finishes executing.

--- a/docs/tutorials/ruby-driver-sessions.txt
+++ b/docs/tutorials/ruby-driver-sessions.txt
@@ -90,12 +90,6 @@ A session can be created by calling the ``start_session`` method on a client:
 
   session = client.start_session
 
-Keep in mind that when starting a session this way you must remember to end it as well:
-
-.. code-block:: ruby
-
-  session.end_session
-
 Unacknowledged Writes
 =====================
 

--- a/docs/tutorials/ruby-driver-sessions.txt
+++ b/docs/tutorials/ruby-driver-sessions.txt
@@ -20,6 +20,8 @@ and passed to operation methods that should be executed in the context of that s
 
 Please note that session objects are not thread safe. They must only be used by one thread at a time.
 
+.. _create-session:
+
 Creating a session from a ``Mongo::Client``
 ===========================================
 
@@ -92,7 +94,7 @@ A session can be created by calling the ``start_session`` method on a client:
 
   session = client.start_session
 
-When ``start_session`` is used without passing a block to it, the driver does not automatically clean up the session which can result in an accumulation of sessions on the server. Use `end_session <#end-a-session>`_ to manually end the session created. The server will automatically clean up old sessions after a timeout but the application should end sessions when the sessions are no longer needed.
+When ``start_session`` is used without passing a block to it, the driver does not automatically clean up the session which can result in an accumulation of sessions on the server. Use `end_session <end-session>`_ to manually end the session created. The server will automatically clean up old sessions after a timeout but the application should end sessions when the sessions are no longer needed.
 
 Unacknowledged Writes
 =====================
@@ -129,6 +131,8 @@ consistent reads are not causally consistent with unacknowledged writes.
 Note that if you set the causal_consistency option to nil as in ``(causal_consistency: nil)``, it will be interpreted
 as false.
 
+.. _end-session:
+
 End a session
 =============
 To end a session, call the ``end_session`` method:
@@ -141,5 +145,5 @@ The Ruby driver will then add the id for the corresponding server session to a p
 When a client is closed, the driver will send a command to the server to end all sessions it has cached
 in its server session pool. You may see this command in your logs when a client is closed.
 
-Note that when using the `block syntax <#creating-a-session-from-a-mongo-client>`_ for ``start_session`` the session is automatically ended after
+Note that when using the `block syntax <create-session>`_ for ``start_session`` the session is automatically ended after
 the block finishes executing.

--- a/docs/tutorials/ruby-driver-sessions.txt
+++ b/docs/tutorials/ruby-driver-sessions.txt
@@ -94,7 +94,7 @@ A session can be created by calling the ``start_session`` method on a client:
 
   session = client.start_session
 
-When ``start_session`` is used without passing a block to it, the driver does not automatically clean up the session which can result in an accumulation of sessions on the server. Use `end_session <end-session>`_ to manually end the session created. The server will automatically clean up old sessions after a timeout but the application should end sessions when the sessions are no longer needed.
+When ``start_session`` is used without passing a block to it, the driver does not automatically clean up the session which can result in an accumulation of sessions on the server. Use `end_session <#end-a-session>`_ to manually end the session created. The server will automatically clean up old sessions after a timeout but the application should end sessions when the sessions are no longer needed.
 
 Unacknowledged Writes
 =====================
@@ -145,5 +145,5 @@ The Ruby driver will then add the id for the corresponding server session to a p
 When a client is closed, the driver will send a command to the server to end all sessions it has cached
 in its server session pool. You may see this command in your logs when a client is closed.
 
-Note that when using the `block syntax <create-session>`_ for ``start_session`` the session is automatically ended after
+Note that when using the `block syntax <#creating-a-session-from-a-mongo-client>`_ for ``start_session`` the session is automatically ended after
 the block finishes executing.

--- a/docs/tutorials/ruby-driver-sessions.txt
+++ b/docs/tutorials/ruby-driver-sessions.txt
@@ -136,3 +136,6 @@ To end a session, call the ``end_session`` method:
 The Ruby driver will then add the id for the corresponding server session to a pool for reuse.
 When a client is closed, the driver will send a command to the server to end all sessions it has cached
 in its server session pool. You may see this command in your logs when a client is closed.
+
+Note that when using the block syntax for ``start_session`` the session is automatically ended after
+the block finishes executing.

--- a/docs/tutorials/ruby-driver-sessions.txt
+++ b/docs/tutorials/ruby-driver-sessions.txt
@@ -92,7 +92,7 @@ A session can be created by calling the ``start_session`` method on a client:
 
   session = client.start_session
 
-When ``start_session`` is used without passing a block to it, the driver does not automatically clean up the session which can result in an accumulation of sessions on the server. Use :ref:`end_session<End a session>` to manually end the session created. The server will automatically clean up old sessions after a timeout but the application should end sessions when the sessions are no longer needed.
+When ``start_session`` is used without passing a block to it, the driver does not automatically clean up the session which can result in an accumulation of sessions on the server. Use `end_session<#end-a-session>` to manually end the session created. The server will automatically clean up old sessions after a timeout but the application should end sessions when the sessions are no longer needed.
 
 Unacknowledged Writes
 =====================
@@ -141,5 +141,5 @@ The Ruby driver will then add the id for the corresponding server session to a p
 When a client is closed, the driver will send a command to the server to end all sessions it has cached
 in its server session pool. You may see this command in your logs when a client is closed.
 
-Note that when using the :ref:`block syntax<Creating a session from a ``Mongo::Client``>` for ``start_session`` the session is automatically ended after
+Note that when using the `block syntax<#creating-a-session-from-a-mongo-client>` for ``start_session`` the session is automatically ended after
 the block finishes executing.

--- a/docs/tutorials/ruby-driver-sessions.txt
+++ b/docs/tutorials/ruby-driver-sessions.txt
@@ -23,12 +23,13 @@ Please note that session objects are not thread safe. They must only be used by 
 Creating a session from a ``Mongo::Client``
 ===========================================
 
-A session can be created by calling the ``start_session`` method on a client:
+A session can be created by calling the ``start_session`` method on a client and passing it a block:
 
 .. code-block:: ruby
 
-  session = client.start_session
+  client.start_session do |session| 
 
+  end
 
 It is valid to call ``start_session`` with no options set. This will result in a
 session that has no effect on the operations performed in the context of that session,
@@ -43,6 +44,7 @@ Be aware that if the application calls ``#start_session`` on a client and waits 
 the session, it risks getting errors due to the session going stale before it is used.
 
 
+
 Using a session
 ===============
 A session object can be passed to most driver methods so that the operation can be executed in the
@@ -52,28 +54,41 @@ Create a session and execute an insert, then a find using that session:
 
 .. code-block:: ruby
 
-  session = client.start_session
-  client[:artists].insert_one({ :name => 'FKA Twigs' }, session: session)
-  client[:artists].find({ :name => 'FKA Twigs' }, limit: 1, session: session).first
+  client.start_session do |session|
+    client[:artists].insert_one({ :name => 'FKA Twigs' }, session: session)
+    client[:artists].find({ :name => 'FKA Twigs' }, limit: 1, session: session).first
+  end
 
 If you like to call methods on a ``Mongo::Collection::View`` in the context of a particular session, you can create the
 ``Mongo::Collection::View`` with the session and then call methods on it:
 
 .. code-block:: ruby
 
-  session = client.start_session(causal_consistency: true)
-  view = client[:artists].find({ :name => 'FKA Twigs' }, session: session)
-  view.count # will use the session
+  client.start_session(causal_consistency: true) do |session| 
+    view = client[:artists].find({ :name => 'FKA Twigs' }, session: session)
+    view.count # will use the session
+  end
 
 You can also pass the session option to the methods directly. This session will override any session associated with
 the ``Mongo::Collection::View``:
 
 .. code-block:: ruby
 
+  client.start_session do |session|
+    client.start_session do |second_session|
+      view = client[:artists].find({ :name => 'FKA Twigs' }, session: session)
+      view.count(session: second_session) # will use the second_session
+    end
+  end
+
+Alternative way to create a session
+===================================
+
+A session can be created by calling the ``start_session`` method on a client:
+
+.. code-block:: ruby
+
   session = client.start_session
-  second_session = client.start_session
-  view = client[:artists].find({ :name => 'FKA Twigs' }, session: session)
-  view.count(session: second_session) # will use the second_session
 
 
 Unacknowledged Writes

--- a/docs/tutorials/ruby-driver-sessions.txt
+++ b/docs/tutorials/ruby-driver-sessions.txt
@@ -28,7 +28,7 @@ A session can be created by calling the ``start_session`` method on a client and
 .. code-block:: ruby
 
   client.start_session do |session| 
-
+    # work with session
   end
 
 It is valid to call ``start_session`` with no options set. This will result in a
@@ -90,6 +90,11 @@ A session can be created by calling the ``start_session`` method on a client:
 
   session = client.start_session
 
+Keep in mind that when starting a session this way you must remember to end it as well:
+
+.. code-block:: ruby
+
+  session.end_session
 
 Unacknowledged Writes
 =====================

--- a/docs/tutorials/ruby-driver-sessions.txt
+++ b/docs/tutorials/ruby-driver-sessions.txt
@@ -28,8 +28,10 @@ A session can be created by calling the ``start_session`` method on a client and
 .. code-block:: ruby
 
   client.start_session do |session| 
-    # work with session
+    # work with the session
   end
+
+When using the block form, the session will be automatically ended by the driver after the block finishes executing.
 
 It is valid to call ``start_session`` with no options set. This will result in a
 session that has no effect on the operations performed in the context of that session,
@@ -90,6 +92,8 @@ A session can be created by calling the ``start_session`` method on a client:
 
   session = client.start_session
 
+When ``start_session`` is used without passing a block to it, the driver does not automatically clean up the session which can result in an accumulation of sessions on the server. Use :ref:`end_session<End a session>` to manually end the session created. The server will automatically clean up old sessions after a timeout but the application should end sessions when the sessions are no longer needed.
+
 Unacknowledged Writes
 =====================
 
@@ -137,5 +141,5 @@ The Ruby driver will then add the id for the corresponding server session to a p
 When a client is closed, the driver will send a command to the server to end all sessions it has cached
 in its server session pool. You may see this command in your logs when a client is closed.
 
-Note that when using the block syntax for ``start_session`` the session is automatically ended after
+Note that when using the :ref:`block syntax<Creating a session from a ``Mongo::Client``>` for ``start_session`` the session is automatically ended after
 the block finishes executing.

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -872,8 +872,17 @@ module Mongo
     #
     # @since 2.5.0
     def start_session(options = {})
-      get_session(options.merge(implicit: false)) or
+      session = get_session(options.merge(implicit: false)) or
         raise Error::InvalidSession.new(Session::SESSIONS_NOT_SUPPORTED)
+      if block_given?
+        begin 
+          yield session
+        ensure
+          session.end_session
+        end
+      else
+        session
+      end
     end
 
     # As of version 3.6 of the MongoDB server, a ``$changeStream`` pipeline stage is supported

--- a/spec/mongo/session_spec.rb
+++ b/spec/mongo/session_spec.rb
@@ -331,5 +331,14 @@ describe Mongo::Session do
         expect(block_session.ended?).to be true
       end
     end
+
+    context 'when block returns value' do
+      it 'is returned by the function' do
+        res = authorized_client.start_session do |session| 
+          4
+        end
+        expect(res).to be 4
+      end
+    end
   end
 end

--- a/spec/mongo/session_spec.rb
+++ b/spec/mongo/session_spec.rb
@@ -307,4 +307,27 @@ describe Mongo::Session do
       end
     end
   end
+
+  describe '#with_session' do
+    context 'when block doesn\'t raise an error' do 
+      it 'closes the session after the block' do 
+        block_session = nil
+        authorized_client.with_session do |session| 
+          block_session = session 
+        end
+        expect(block_session.ended?).to be true
+      end
+    end
+
+    context 'when block raises an error' do
+      it 'closes the session after the block' do
+        block_session = nil
+        authorized_client.with_session do |session|
+          block_session = session
+          raise 'This is an error!'
+        end
+        expect(block_session.ended?).to be true
+      end
+    end
+  end
 end

--- a/spec/mongo/session_spec.rb
+++ b/spec/mongo/session_spec.rb
@@ -313,6 +313,7 @@ describe Mongo::Session do
       it 'closes the session after the block' do 
         block_session = nil
         authorized_client.start_session do |session| 
+          expect(session.ended?).to be false
           block_session = session 
         end
         expect(block_session.ended?).to be true

--- a/spec/mongo/session_spec.rb
+++ b/spec/mongo/session_spec.rb
@@ -308,11 +308,11 @@ describe Mongo::Session do
     end
   end
 
-  describe '#with_session' do
+  describe '#start_session' do
     context 'when block doesn\'t raise an error' do 
       it 'closes the session after the block' do 
         block_session = nil
-        authorized_client.with_session do |session| 
+        authorized_client.start_session do |session| 
           block_session = session 
         end
         expect(block_session.ended?).to be true
@@ -322,10 +322,12 @@ describe Mongo::Session do
     context 'when block raises an error' do
       it 'closes the session after the block' do
         block_session = nil
-        authorized_client.with_session do |session|
-          block_session = session
-          raise 'This is an error!'
-        end
+        expect do 
+          authorized_client.start_session do |session|
+            block_session = session
+            raise 'This is an error!'
+          end
+        end.to raise_error(StandardError, 'This is an error!')
         expect(block_session.ended?).to be true
       end
     end


### PR DESCRIPTION
It seems like the with_session function on the client already closes the session on completion of the block. All I did was add some tests to make sure it works...

Some notes:
- I did this in `session_spec.rb` but perhaps it should have been in `client_spec.rb`
- When there is an error inside the `with_session` block, it is rescued and never re-raised.