### PR TITLE
RUBY-2031 fails when protocol is included in host array; added tests

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -443,7 +443,12 @@ module Mongo
         @srv_records = uri.srv_records
       else
         addresses = addresses_or_uri
-        @srv_records = nil
+        if addresses.any? { |addr| addr =~ /mongodb(\+srv)?:\/\// }
+          raise "Protocol should not be included in host list. Did you mean to not use an array?"
+        else
+          @srv_records = nil
+        end
+   
       end
 
       # Special handling for sdam_proc as it is only used during client

--- a/spec/mongo/client_construction_spec.rb
+++ b/spec/mongo/client_construction_spec.rb
@@ -1277,6 +1277,26 @@ describe Mongo::Client do
           expect(block_client_raise.cluster.connected?).to eq(false)
         end
       end
+
+      context 'when the hosts given include the protocol' do
+        it 'raises an error on mongodb://' do
+          expect do 
+            Mongo::Client.new(['mongodb://127.0.0.1:27017/test'])
+          end.to raise_error(StandardError, "Protocol should not be included in host list. Did you mean to not use an array?")
+        end
+
+        it 'raises an error on mongodb+srv://' do
+          expect do 
+            Mongo::Client.new(['mongodb+srv://127.0.0.1:27017/test'])
+          end.to raise_error(StandardError, "Protocol should not be included in host list. Did you mean to not use an array?")
+        end
+
+        it 'raises an error on multiple items' do
+          expect do 
+            Mongo::Client.new(['127.0.0.1:27017', 'mongodb+srv://127.0.0.1:27017/test'])
+          end.to raise_error(StandardError, "Protocol should not be included in host list. Did you mean to not use an array?")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Accomplished using a Regex to check for protocol. 

I wasn't sure what kind of error to raise here so I just raised a StandardError and included an error message that describes and tries to help diagnose the problem.