### PR TITLE
RUBY-2295 include collation option in count_documents

### DIFF
--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -193,7 +193,9 @@ module Mongo
           pipeline << { :'$limit' => opts[:limit] } if opts[:limit]
           pipeline << { :'$group' => { _id: 1, n: { :'$sum' => 1 } } }
 
-          opts.select! { |k, _| [:hint, :max_time_ms, :read, :collation, :session].include?(k) }
+          opts = opts.select { |k, _| [:hint, :max_time_ms, :read, :collation, :session].include?(k) }
+          opts[:collation] = @options[:collation] unless opts[:collation]
+
           first = aggregate(pipeline, opts).first
           return 0 unless first
           first['n'].to_i

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -194,7 +194,7 @@ module Mongo
           pipeline << { :'$group' => { _id: 1, n: { :'$sum' => 1 } } }
 
           opts = opts.select { |k, _| [:hint, :max_time_ms, :read, :collation, :session].include?(k) }
-          opts[:collation] = @options[:collation] unless opts[:collation]
+          opts[:collation] ||= collation
 
           first = aggregate(pipeline, opts).first
           return 0 unless first

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -941,6 +941,28 @@ describe Mongo::Collection do
         it_behaves_like 'a failed operation using a session'
       end
     end
+
+    context 'when collation has a strength' do 
+      let(:band_collection) do 
+        described_class.new(database, :bands)
+      end
+
+      before do
+        band_collection.delete_many({})
+        band_collection.insert_many([{ name: "Depeche Mode" }, { name: "New Order" }])
+      end
+
+      let(:options) do 
+        { collation: { locale: 'en_US', strength: 2 } }
+      end
+      let(:band_result) do 
+        band_collection.find({ name: 'DEPECHE MODE' }, options)
+      end
+
+      it 'finds Capitalize from UPPER CASE' do 
+        expect(band_result.count_documents).to eq(1)
+      end
+    end
   end
 
   describe '#drop' do

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -948,7 +948,7 @@ describe Mongo::Collection do
       end
 
       before do
-        band_collection.delete_many({})
+        band_collection.delete_many
         band_collection.insert_many([{ name: "Depeche Mode" }, { name: "New Order" }])
       end
 


### PR DESCRIPTION
Worked on this with Emily. Checked for collation option in opts and if it doesn't exist get it from @options.