### PR TITLE
Revert "MONGOID-4785 Test that QueryCache uses modern read retries (#…

### DIFF
--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -298,44 +298,6 @@ describe 'QueryCache' do
     end
   end
 
-  context 'when find command fails and retries' do
-    require_fail_command
-    require_no_multi_shard
-
-    before do
-      5.times do |i|
-        authorized_collection.insert_one(test: i)
-      end
-    end
-
-    before do
-      client.use('admin').command(
-        configureFailPoint: 'failCommand',
-        mode: { times: 1 },
-        data: {
-          failCommands: ['find'],
-          closeConnection: true,
-          failInternalCommands: true
-        }
-      )
-    end
-
-    let(:command_name) { 'find' }
-
-    it 'uses modern retryable reads when using query cache' do
-      expect(Mongo::QueryCache.enabled?).to be(true)
-
-      expect(Mongo::Logger.logger).to receive(:warn).once.with(/modern.*attempt 1/).and_call_original
-      authorized_collection.find(test: 1).to_a
-      expect(Mongo::QueryCache.cache_table.length).to eq(1)
-      expect(subscriber.command_started_events('find').length).to eq(2)
-
-      authorized_collection.find(test: 1).to_a
-      expect(Mongo::QueryCache.cache_table.length).to eq(1)
-      expect(subscriber.command_started_events('find').length).to eq(2)
-    end
-  end
-
   context 'when querying in a different collection' do
 
     let(:database) { client.database }


### PR DESCRIPTION
…2035)"

This reverts commit 8a066ffb61c43abaa2317892344c326dccb67f6a.