### PR TITLE
RUBY-1131 Ensure that split bulk writes don't produce command failed event

### DIFF
--- a/lib/mongo/bulk_write.rb
+++ b/lib/mongo/bulk_write.rb
@@ -195,6 +195,13 @@ module Mongo
           end
         end
       end
+    # With OP_MSG (3.6+ servers), the size of each section in the message
+    # is independently capped at 16m and each bulk operation becomes
+    # its own section. The size of the entire bulk write is limited to 48m.
+    # With OP_QUERY (pre-3.6 servers), the entire bulk write is sent as a
+    # single document and is thus subject to the 16m document size limit.
+    # This means the splits differ between pre-3.6 and 3.6+ servers, with
+    # 3.6+ servers being able to split less.
     rescue Error::MaxBSONSize, Error::MaxMessageSize => e
       raise e if values.size <= 1
       unpin_maybe(session) do

--- a/spec/integration/bulk_write_spec.rb
+++ b/spec/integration/bulk_write_spec.rb
@@ -16,4 +16,35 @@ describe 'Bulk writes' do
       end.not_to raise_error
     end
   end
+
+  context 'when bulk write needs to be split' do
+    let(:subscriber) { EventSubscriber.new }
+
+    let(:max_bson_size) { Mongo::Server::ConnectionBase::DEFAULT_MAX_BSON_OBJECT_SIZE }
+
+    let(:insert_events) do
+      subscriber.command_started_events('insert')
+    end
+
+    let(:failed_events) do
+      subscriber.failed_events
+    end
+
+    let(:operations) do
+      [{ insert_one: { text: 'a' * (max_bson_size/2) } }] * 3
+    end
+
+    before do
+      authorized_client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+      authorized_collection.bulk_write(operations) 
+    end
+
+    it 'splits the operations' do
+      expect(insert_events.length).to eq(2)
+    end
+
+    it 'does not have a command failed event' do
+      expect(failed_events).to be_empty
+    end
+  end
 end

--- a/spec/integration/bulk_write_spec.rb
+++ b/spec/integration/bulk_write_spec.rb
@@ -31,12 +31,12 @@ describe 'Bulk writes' do
     end
 
     let(:operations) do
-      [{ insert_one: { text: 'a' * (max_bson_size/2) } }] * 3
+      [{ insert_one: { text: 'a' * (max_bson_size/2) } }] * 6
     end
 
     before do
       authorized_client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
-      authorized_collection.bulk_write(operations) 
+      authorized_collection.bulk_write(operations)
     end
 
     it 'splits the operations' do

--- a/spec/integration/bulk_write_spec.rb
+++ b/spec/integration/bulk_write_spec.rb
@@ -39,8 +39,25 @@ describe 'Bulk writes' do
       authorized_collection.bulk_write(operations)
     end
 
-    it 'splits the operations' do
-      expect(insert_events.length).to eq(2)
+    context '3.6+ server' do
+      min_server_fcv '3.6'
+
+      it 'splits the operations' do
+        # 3.6+ servers can send multiple bulk operations in one message,
+        # with the whole message being limited to 48m.
+        expect(insert_events.length).to eq(2)
+      end
+    end
+
+    context 'pre-3.6 server' do
+      max_server_version '3.4'
+
+      it 'splits the operations' do
+        # Pre-3.6 servers limit the entire message payload to the size of
+        # a single document which is 16m. Given our test data this means
+        # twice as many messages are sent.
+        expect(insert_events.length).to eq(4)
+      end
     end
 
     it 'does not have a command failed event' do


### PR DESCRIPTION
This behavior was documented in [this Google groups question](https://groups.google.com/g/mongodb-user/c/o1H5Q0PQJjs/m/jb2Vr4JDEQAJ?pli=1).