### PR TITLE
RUBY-2338 Stop query cache from caching multi-batch queries

### DIFF
--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -40,11 +40,12 @@ module Mongo
 
           if QueryCache.enabled? && @cursor.is_a?(Mongo::CachingCursor)
             QueryCache.cache_table[cache_key] = @cursor
+            range = limit || nil
           end
 
           if block_given?
-            if limit
-              @cursor.to_a[0...limit].each do |doc|
+            if range
+              @cursor.to_a[0...range].each do |doc|
                 yield doc
               end
             else

--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -35,24 +35,20 @@ module Mongo
         #
         # @yieldparam [ Hash ] Each matching document.
         def each
-          @cursor = nil
           session = client.send(:get_session, @options)
-          if QueryCache.enabled?
-            unless @cursor = cached_cursor
-              @cursor = select_cursor(session)
-              QueryCache.cache_table[cache_key] = @cursor
-            end
-            range = limit || nil
-          else
-            @cursor = select_cursor(session)
+          @cursor = select_cursor(session)
+
+          if QueryCache.enabled? && @cursor.is_a?(Mongo::CachingCursor)
+            QueryCache.cache_table[cache_key] = @cursor
           end
+
           if block_given?
-            if !range
-              @cursor.each do |doc|
+            if limit
+              @cursor.to_a[0...limit].each do |doc|
                 yield doc
               end
             else
-              @cursor.to_a[0...range].each do |doc|
+              @cursor.each do |doc|
                 yield doc
               end
             end
@@ -84,10 +80,17 @@ module Mongo
         private
 
         def select_cursor(session)
+          if QueryCache.enabled?
+            return cached_cursor if cached_cursor
+          end
+
           if respond_to?(:write?, true) && write?
             server = server_selector.select_server(cluster, nil, session)
             result = send_initial_query(server, session)
-            if QueryCache.enabled?
+
+            # RUBY-2367: This will be updated to allow the query cache to
+            # cache cursors with multi-batch results.
+            if QueryCache.enabled? && (result.cursor_id == 0 || result.cursor_id.nil?)
               CachingCursor.new(view, result, server, session: session)
             else
               Cursor.new(view, result, server, session: session)

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -60,7 +60,9 @@ module Mongo
       read_with_retry(session, server_selector) do |server|
         result = yield server
 
-        if QueryCache.enabled?
+        # RUBY-2367: This will be updated to allow the query cache to
+        # cache cursors with multi-batch results.
+        if QueryCache.enabled? && (result.cursor_id == 0 || result.cursor_id.nil?)
           CachingCursor.new(view, result, server, session: session)
         else
           Cursor.new(view, result, server, session: session)

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -71,6 +71,43 @@ describe 'QueryCache' do
     end
   end
 
+  describe 'iterating cursors multiple times' do
+    before do
+      authorized_collection.drop
+      Mongo::QueryCache.enabled = true
+    end
+
+    after do
+      Mongo::QueryCache.enabled = false
+    end
+
+    context 'when query returns single batch' do
+      before do
+        authorized_collection.insert_many([{ test: 1 }] * 100)
+      end
+
+      it 'does not raise an exception' do
+        expect do
+          authorized_collection.find(test: 1).to_a
+          authorized_collection.find(test: 1).to_a
+        end.not_to raise_error
+      end
+    end
+
+    context 'when query returns single batch' do
+      before do
+        authorized_collection.insert_many([{ test: 1 }] * 2000)
+      end
+
+      it 'does not raise an exception' do
+        expect do
+          authorized_collection.find(test: 1).to_a
+          authorized_collection.find(test: 1).to_a
+        end.not_to raise_error
+      end
+    end
+  end
+
   context 'when querying in the same collection' do
 
     before do

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -255,8 +255,8 @@ describe 'QueryCache' do
       end
 
       it 'queries again' do
-        authorized_collection.find({}, {limit: 2, skip: 5}).to_a
-        expect(authorized_collection.find({}, {limit: 2, skip: 5}).to_a.count).to eq(2)
+        results = authorized_collection.find({}, {limit: 2, skip: 5}).to_a
+        expect(results.count).to eq(2)
         expect(events.length).to eq(2)
       end
     end


### PR DESCRIPTION
This code will further be modified to support caching multi-batch queries, but for now, I have eliminated the `Cannot restart iteration of a cursor which issued a getMore` exception from occurring when a user tries to iterate through a multi-batch result multiple times.