### PR TITLE
RUBY-2340 Part 1: Refactor the query cache to implement read and write methods

### DIFF
--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -39,7 +39,7 @@ module Mongo
           @cursor = select_cursor(session)
 
           if QueryCache.enabled? && @cursor.is_a?(Mongo::CachingCursor)
-            QueryCache.write(@cursor, cache_options)
+            QueryCache.set(@cursor, cache_options)
             range = limit || nil
           end
 
@@ -104,7 +104,7 @@ module Mongo
         end
 
         def cached_cursor
-          QueryCache.read(cache_options)
+          QueryCache.get(cache_options)
         end
 
         def cache_options

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -92,6 +92,8 @@ module Mongo
       #   :limit, :projection, :collation, :read_concern, and :read_preference.
       #
       # @return [ true ] Always true.
+      #
+      # @api private
       def set(cursor, options = {})
         key = cache_key(options)
         QueryCache.cache_table[key] = cursor
@@ -108,6 +110,8 @@ module Mongo
       #
       # @return [ Mongo::CachingCursor | nil ] Returns a CachingCursor if one
       #   exists in the query cache, otherwise returns nil.
+      # 
+      # @api private
       def get(options = {})
         key = if options[:limit]
                 cache_key(options, omit_limit: true)

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -84,11 +84,30 @@ module Mongo
         Thread.current["[mongo]:query_cache"] = nil
       end
 
+      # Store a CachingCursor instance in the query cache.
+      #
+      # @param [ Mongo::CachingCursor ] cursor The CachingCursor instance to store.
+      # @param [ Hash ] options The query options that will be used to create
+      #   the cache key. Valid keys are: :namespace, :selector, :skip, :sort,
+      #   :limit, :projection, :collation, :read_concern, and :read_preference.
+      #
+      # @return [ true ] Always true.
       def write(cursor, options = {})
         key = cache_key(options)
         QueryCache.cache_table[key] = cursor
+
+        true
       end
 
+      # For the given query options, determine whether the cache has stored a
+      # CachingCursor that can be used to acquire the correct query results.
+      #
+      # @param [ Hash ] options The query options that will be used to create
+      #   the cache key. Valid keys are: :namespace, :selector, :skip, :sort,
+      #   :limit, :projection, :collation, :read_concern, and :read_preference.
+      #
+      # @return [ Mongo::CachingCursor | nil ] Returns a CachingCursor if one
+      #   exists in the query cache, otherwise returns nil.
       def read(options = {})
         key = if options[:limit]
                 cache_key(options, omit_limit: true)

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -92,7 +92,7 @@ module Mongo
       #   :limit, :projection, :collation, :read_concern, and :read_preference.
       #
       # @return [ true ] Always true.
-      def write(cursor, options = {})
+      def set(cursor, options = {})
         key = cache_key(options)
         QueryCache.cache_table[key] = cursor
 
@@ -108,7 +108,7 @@ module Mongo
       #
       # @return [ Mongo::CachingCursor | nil ] Returns a CachingCursor if one
       #   exists in the query cache, otherwise returns nil.
-      def read(options = {})
+      def get(options = {})
         key = if options[:limit]
                 cache_key(options, omit_limit: true)
               else

--- a/spec/mongo/query_cache_spec.rb
+++ b/spec/mongo/query_cache_spec.rb
@@ -102,7 +102,7 @@ describe Mongo::QueryCache do
     end
   end
 
-  describe '#write' do
+  describe '#set' do
     let(:caching_cursor) { double("Mongo::CachingCursor") }
     let(:namespace) { 'db.coll' }
     let(:selector) { { field: 'value' } }
@@ -129,12 +129,12 @@ describe Mongo::QueryCache do
     end
 
     it 'stores the cursor at the correct key' do
-      Mongo::QueryCache.write(caching_cursor, options)
+      Mongo::QueryCache.set(caching_cursor, options)
       expect(Mongo::QueryCache.cache_table[[namespace, selector, skip, sort, limit, projection, collation, read_concern, read_preference]]).to eq(caching_cursor)
     end
   end
 
-  describe '#read' do
+  describe '#get' do
     let(:view) { double("Mongo::Collection::View") }
     let(:result) { double("Mongo::Operation::Result") }
     let(:server) { double("Mongo::Server") }
@@ -154,13 +154,13 @@ describe Mongo::QueryCache do
 
     context 'when there is no entry in the cache' do
       it 'returns nil' do
-        expect(Mongo::QueryCache.read(options)).to be_nil
+        expect(Mongo::QueryCache.get(options)).to be_nil
       end
     end
 
     context 'when there is an entry in the cache' do
       before do
-        Mongo::QueryCache.write(caching_cursor, caching_cursor_options)
+        Mongo::QueryCache.set(caching_cursor, caching_cursor_options)
       end
 
       context 'when that entry has no limit' do
@@ -179,7 +179,7 @@ describe Mongo::QueryCache do
           let(:limit) { 5 }
 
           it 'returns the caching cursor' do
-            expect(Mongo::QueryCache.read(query_options)).to eq(caching_cursor)
+            expect(Mongo::QueryCache.get(query_options)).to eq(caching_cursor)
           end
         end
 
@@ -187,7 +187,7 @@ describe Mongo::QueryCache do
           let(:limit) { nil }
 
           it 'returns the caching cursor' do
-            expect(Mongo::QueryCache.read(query_options)).to eq(caching_cursor)
+            expect(Mongo::QueryCache.get(query_options)).to eq(caching_cursor)
           end
         end
       end
@@ -213,7 +213,7 @@ describe Mongo::QueryCache do
           end
 
           it 'returns the caching cursor' do
-            expect(Mongo::QueryCache.read(query_options)).to eq(caching_cursor)
+            expect(Mongo::QueryCache.get(query_options)).to eq(caching_cursor)
           end
         end
 
@@ -221,7 +221,7 @@ describe Mongo::QueryCache do
           let(:limit) { 6 }
 
           it 'returns nil' do
-            expect(Mongo::QueryCache.read(query_options)).to be_nil
+            expect(Mongo::QueryCache.get(query_options)).to be_nil
           end
         end
 
@@ -233,7 +233,7 @@ describe Mongo::QueryCache do
           end
 
           it 'returns the caching cursor' do
-            expect(Mongo::QueryCache.read(query_options)).to eq(caching_cursor)
+            expect(Mongo::QueryCache.get(query_options)).to eq(caching_cursor)
           end
         end
 
@@ -241,7 +241,7 @@ describe Mongo::QueryCache do
           let(:limit) { nil }
 
           it 'returns nil' do
-            expect(Mongo::QueryCache.read(query_options)).to be_nil
+            expect(Mongo::QueryCache.get(query_options)).to be_nil
           end
         end
       end

--- a/spec/mongo/query_cache_spec.rb
+++ b/spec/mongo/query_cache_spec.rb
@@ -101,4 +101,150 @@ describe Mongo::QueryCache do
       expect(Mongo::QueryCache.cache_table.length).to eq(0)
     end
   end
+
+  describe '#write' do
+    let(:caching_cursor) { double("Mongo::CachingCursor") }
+    let(:namespace) { 'db.coll' }
+    let(:selector) { { field: 'value' } }
+    let(:skip) { 5 }
+    let(:sort) { { field: 'asc' } }
+    let(:limit) { 5 }
+    let(:projection) { { field: 1 } }
+    let(:collation) { { locale: 'fr_CA' } }
+    let(:read_concern) { { level: :majority } }
+    let(:read_preference) { { mode: :secondary } }
+
+    let(:options) do
+      {
+        namespace: namespace,
+        selector: selector,
+        skip: skip,
+        sort: sort,
+        limit: limit,
+        projection: projection,
+        collation: collation,
+        read_concern: read_concern,
+        read_preference: read_preference,
+      }
+    end
+
+    it 'stores the cursor at the correct key' do
+      Mongo::QueryCache.write(caching_cursor, options)
+      expect(Mongo::QueryCache.cache_table[[namespace, selector, skip, sort, limit, projection, collation, read_concern, read_preference]]).to eq(caching_cursor)
+    end
+  end
+
+  describe '#read' do
+    let(:view) { double("Mongo::Collection::View") }
+    let(:result) { double("Mongo::Operation::Result") }
+    let(:server) { double("Mongo::Server") }
+    let(:caching_cursor) { Mongo::CachingCursor.new(view, result, server) }
+
+    let(:options) do
+      {
+        namespace: 'db.coll',
+        selector: { field: 'value' },
+      }
+    end
+
+    before do
+      allow(result).to receive(:cursor_id) { 0 }
+      allow(view).to receive(:limit) { limit }
+    end
+
+    context 'when there is no entry in the cache' do
+      it 'returns nil' do
+        expect(Mongo::QueryCache.read(options)).to be_nil
+      end
+    end
+
+    context 'when there is an entry in the cache' do
+      before do
+        Mongo::QueryCache.write(caching_cursor, caching_cursor_options)
+      end
+
+      context 'when that entry has no limit' do
+        let(:caching_cursor_options) do
+          {
+            namespace: 'db.coll',
+            selector: { field: 'value' },
+          }
+        end
+
+        let(:query_options) do
+          caching_cursor_options.merge(limit: limit)
+        end
+
+        context 'when the query has a limit' do
+          let(:limit) { 5 }
+
+          it 'returns the caching cursor' do
+            expect(Mongo::QueryCache.read(query_options)).to eq(caching_cursor)
+          end
+        end
+
+        context 'when the query has no limit' do
+          let(:limit) { nil }
+
+          it 'returns the caching cursor' do
+            expect(Mongo::QueryCache.read(query_options)).to eq(caching_cursor)
+          end
+        end
+      end
+
+      context 'when that entry has a limit' do
+        let(:caching_cursor_options) do
+          {
+            namespace: 'db.coll',
+            selector: { field: 'value' },
+            limit: 5,
+          }
+        end
+
+        let(:query_options) do
+          caching_cursor_options.merge(limit: limit)
+        end
+
+        context 'and the new query has a smaller limit' do
+          let(:limit) { 4 }
+
+          before do
+            pending("RUBY-2340")
+          end
+
+          it 'returns the caching cursor' do
+            expect(Mongo::QueryCache.read(query_options)).to eq(caching_cursor)
+          end
+        end
+
+        context 'and the new query has a larger limit' do
+          let(:limit) { 6 }
+
+          it 'returns nil' do
+            expect(Mongo::QueryCache.read(query_options)).to be_nil
+          end
+        end
+
+        context 'and the new query has the same limit' do
+          let(:limit) { 5 }
+
+          before do
+            pending("RUBY-2340")
+          end
+
+          it 'returns the caching cursor' do
+            expect(Mongo::QueryCache.read(query_options)).to eq(caching_cursor)
+          end
+        end
+
+        context 'and the new query has no limit' do
+          let(:limit) { nil }
+
+          it 'returns nil' do
+            expect(Mongo::QueryCache.read(query_options)).to be_nil
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR does not change any behavior but implements methods in the query cache that abstract some of the behavior of creating a cache key and reading from/writing to the cache. These methods will be used to implement efficient limits in the query cache.