### PR TITLE
RUBY-2340 Update the query cache to efficiently handle limits

### DIFF
--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -39,7 +39,9 @@ module Mongo
           @cursor = select_cursor(session)
 
           if QueryCache.enabled? && @cursor.is_a?(Mongo::CachingCursor)
-            QueryCache.set(@cursor, cache_options)
+            # No need to store the cursor in the query cache if there is
+            # already a cached cursor stored at this key.
+            QueryCache.set(@cursor, cache_options) unless cached_cursor
             range = limit || nil
           end
 

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -110,21 +110,34 @@ module Mongo
       #
       # @return [ Mongo::CachingCursor | nil ] Returns a CachingCursor if one
       #   exists in the query cache, otherwise returns nil.
-      # 
+      #
       # @api private
       def get(options = {})
-        key = if options[:limit]
-                cache_key(options, omit_limit: true)
-              else
-                cache_key(options)
-              end
+        limit = options[:limit]
+        key = cache_key(options)
 
-        QueryCache.cache_table[key]
+        caching_cursor = QueryCache.cache_table[key]
+        return nil unless caching_cursor
+
+        # If the new query has a limit
+        if limit
+          if caching_cursor.view.limit.nil? || caching_cursor.view.limit >= limit
+            caching_cursor
+          else
+            nil
+          end
+        else
+          if caching_cursor.view.limit.nil?
+            caching_cursor
+          else
+            nil
+          end
+        end
       end
 
       private
 
-      def cache_key(options, omit_limit: false)
+      def cache_key(options)
         unless options[:namespace] && options[:selector]
           raise ArgumentError.new("Cannot generate cache key without namespace or selector")
         end
@@ -134,7 +147,6 @@ module Mongo
           options[:selector],
           options[:skip],
           options[:sort],
-          omit_limit ? nil : options[:limit],
           options[:projection],
           options[:collation],
           options[:read_concern],

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -289,6 +289,14 @@ describe 'QueryCache' do
         end
 
         context 'and two queries are performed with a larger limit' do
+          before do
+            if ClusterConfig.instance.fcv_ish <= '3.0'
+              pending 'RUBY-2367 Server versions 3.0 and older execute three' \
+                'queries in this case. This should be resolved when the query' \
+                'cache is modified to cache multi-batch queries.'
+            end
+          end
+
           it 'uses the query cache for the third query' do
             results1 = authorized_collection.find.limit(3).to_a
             results2 = authorized_collection.find.limit(3).to_a

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -265,7 +265,7 @@ describe 'QueryCache' do
 
       context 'when the first query has a limit' do
         before do
-          authorized_collection.find.limit(2).to_a
+          authorized_collection.find({}, limit: 2).to_a
         end
 
         context 'and the second query has a larger limit' do
@@ -276,8 +276,16 @@ describe 'QueryCache' do
         end
 
         context 'and the second query has a smaller limit' do
+          before do
+            if ClusterConfig.instance.fcv_ish <= '3.0'
+              pending 'RUBY-2367 Server versions 3.0 and older execute two' \
+                'queries in this case. This should be resolved when the query' \
+                'cache is modified to cache multi-batch queries.'
+            end
+          end
+
           it 'uses the cached query' do
-            expect(authorized_collection.find.limit(1).to_a.count).to eq(1)
+            expect(authorized_collection.find({}, limit: 1).to_a.count).to eq(1)
             expect(events.length).to eq(1)
           end
         end

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -249,13 +249,11 @@ describe 'QueryCache' do
       end
     end
 
-    context 'when first query has no limit' do
-
-      before do
-        authorized_collection.find.to_a.count
-      end
-
-      context 'when next query has a limit' do
+    describe 'queries with limits' do
+      context 'when the first query has no limit and the second does' do
+        before do
+          authorized_collection.find.to_a.count
+        end
 
         it 'uses the cache' do
           expect(authorized_collection.find.limit(5).to_a.count).to eq(5)
@@ -264,27 +262,31 @@ describe 'QueryCache' do
           expect(events.length).to eq(1)
         end
       end
-    end
 
-    context 'when first query has a limit' do
-
-      before do
-        authorized_collection.find.limit(2).to_a
-      end
-
-      context 'when next query has a different limit' do
-
-        it 'queries again' do
-          expect(authorized_collection.find.limit(3).to_a.count).to eq(3)
-          expect(events.length).to eq(2)
+      context 'when the first query has a limit' do
+        before do
+          authorized_collection.find.limit(2).to_a
         end
-      end
 
-      context 'when next query does not have a limit' do
+        context 'and the second query has a larger limit' do
+          it 'queries again' do
+            expect(authorized_collection.find.limit(3).to_a.count).to eq(3)
+            expect(events.length).to eq(2)
+          end
+        end
 
-        it 'queries again' do
-          expect(authorized_collection.find.to_a.count).to eq(10)
-          expect(events.length).to eq(2)
+        context 'and the second query has a smaller limit' do
+          it 'uses the cached query' do
+            expect(authorized_collection.find.limit(1).to_a.count).to eq(1)
+            expect(events.length).to eq(1)
+          end
+        end
+
+        context 'and the second query has no limit' do
+          it 'queries again' do
+            expect(authorized_collection.find.to_a.count).to eq(10)
+            expect(events.length).to eq(2)
+          end
         end
       end
     end

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -288,6 +288,21 @@ describe 'QueryCache' do
           end
         end
 
+        context 'and two queries are performed with a larger limit' do
+          it 'uses the query cache for the third query' do
+            results1 = authorized_collection.find.limit(3).to_a
+            results2 = authorized_collection.find.limit(3).to_a
+
+            expect(results1.length).to eq(3)
+            expect(results1.map { |r| r["test"] }).to eq([0, 1, 2])
+
+            expect(results2.length).to eq(3)
+            expect(results2.map { |r| r["test"] }).to eq([0, 1, 2])
+
+            expect(events.length).to eq(2)
+          end
+        end
+
         context 'and the second query has a smaller limit' do
           before do
             if ClusterConfig.instance.fcv_ish <= '3.0'

--- a/spec/mongo/query_cache_spec.rb
+++ b/spec/mongo/query_cache_spec.rb
@@ -130,7 +130,7 @@ describe Mongo::QueryCache do
 
     it 'stores the cursor at the correct key' do
       Mongo::QueryCache.set(caching_cursor, options)
-      expect(Mongo::QueryCache.cache_table[[namespace, selector, skip, sort, limit, projection, collation, read_concern, read_preference]]).to eq(caching_cursor)
+      expect(Mongo::QueryCache.cache_table[[namespace, selector, skip, sort, projection, collation, read_concern, read_preference]]).to eq(caching_cursor)
     end
   end
 
@@ -149,7 +149,7 @@ describe Mongo::QueryCache do
 
     before do
       allow(result).to receive(:cursor_id) { 0 }
-      allow(view).to receive(:limit) { limit }
+      allow(view).to receive(:limit) { nil }
     end
 
     context 'when there is no entry in the cache' do
@@ -205,12 +205,12 @@ describe Mongo::QueryCache do
           caching_cursor_options.merge(limit: limit)
         end
 
+        before do
+          allow(view).to receive(:limit) { 5 }
+        end
+
         context 'and the new query has a smaller limit' do
           let(:limit) { 4 }
-
-          before do
-            pending("RUBY-2340")
-          end
 
           it 'returns the caching cursor' do
             expect(Mongo::QueryCache.get(query_options)).to eq(caching_cursor)
@@ -227,10 +227,6 @@ describe Mongo::QueryCache do
 
         context 'and the new query has the same limit' do
           let(:limit) { 5 }
-
-          before do
-            pending("RUBY-2340")
-          end
 
           it 'returns the caching cursor' do
             expect(Mongo::QueryCache.get(query_options)).to eq(caching_cursor)


### PR DESCRIPTION
The goal of this PR is to have the query cache reuse the same query results when a query with the same or a lower limit as the stored results is executed.

Here is my general design:
* Remove the limit from the cache key
* When reading from the cache, check the limit on the cursor's view. If that limit is greater than or equal to the limit of the query currently being executed, then return that cached cursor.
* The query cache does not store more than one result for the same query with different limits. It stores the result thus far with the most permissive limit (either a large number or nil).

Let me know if you think there needs to be more comments in the code!