### PR TITLE
RUBY-2367 Allow CachingCursor to cache multi-batch queries

### DIFF
--- a/lib/mongo/caching_cursor.rb
+++ b/lib/mongo/caching_cursor.rb
@@ -63,11 +63,8 @@ module Mongo
     # get_more_operation.
     def process(result)
       documents = super
-      if @cursor_id.zero? && !@after_first_batch
-        @cached_docs ||= []
-        @cached_docs.concat(documents)
-      end
-      @after_first_batch = true
+      @cached_docs ||= []
+      @cached_docs.concat(documents)
       documents
     end
   end

--- a/lib/mongo/caching_cursor.rb
+++ b/lib/mongo/caching_cursor.rb
@@ -32,9 +32,17 @@ module Mongo
     #     # ...
     #   end
     def each
-      if @cached_docs && closed?
+      if @cached_docs
         @cached_docs.each do |doc|
           yield doc
+        end
+
+        unless closed?
+          # StopIteration raised by try_next ends this loop.
+          loop do
+            document = try_next
+            yield document if document
+          end
         end
       else
         super
@@ -51,21 +59,16 @@ module Mongo
       "#<Mongo::CachingCursor:0x#{object_id} @view=#{@view.inspect}>"
     end
 
-    private
-
-    # Populates the cursor's cached documents if all of the results of the
-    # query fit in the first batch (cursor_id is zero) and the first batch
-    # of results have not been iterated yet. If the result set exceeds the
-    # batch size and a CachingCursor is iterated more than once, an error
-    # is returned.
+    # Acquires the next document for cursor iteration and then
+    # inserts that document in the @cached_docs array.
     #
-    # @return [ Array <BSON::Document> ] The documents returned by the
-    # get_more_operation.
-    def process(result)
-      documents = super
+    # @api private
+    def try_next
       @cached_docs ||= []
-      @cached_docs.concat(documents)
-      documents
+      document = super
+      @cached_docs << document
+
+      document
     end
   end
 end

--- a/lib/mongo/caching_cursor.rb
+++ b/lib/mongo/caching_cursor.rb
@@ -66,7 +66,7 @@ module Mongo
     def try_next
       @cached_docs ||= []
       document = super
-      @cached_docs << document
+      @cached_docs << document if document
 
       document
     end

--- a/lib/mongo/caching_cursor.rb
+++ b/lib/mongo/caching_cursor.rb
@@ -32,7 +32,7 @@ module Mongo
     #     # ...
     #   end
     def each
-      if @cached_docs
+      if @cached_docs && closed?
         @cached_docs.each do |doc|
           yield doc
         end

--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -38,7 +38,7 @@ module Mongo
           session = client.send(:get_session, @options)
           @cursor = select_cursor(session)
 
-          if QueryCache.enabled? && @cursor.is_a?(Mongo::CachingCursor)
+          if QueryCache.enabled?
             # No need to store the cursor in the query cache if there is
             # already a cached cursor stored at this key.
             QueryCache.set(@cursor, cache_options) unless cached_cursor
@@ -93,7 +93,7 @@ module Mongo
 
             # RUBY-2367: This will be updated to allow the query cache to
             # cache cursors with multi-batch results.
-            if QueryCache.enabled? && (result.cursor_id == 0 || result.cursor_id.nil?)
+            if QueryCache.enabled?
               CachingCursor.new(view, result, server, session: session)
             else
               Cursor.new(view, result, server, session: session)

--- a/lib/mongo/retryable.rb
+++ b/lib/mongo/retryable.rb
@@ -62,7 +62,7 @@ module Mongo
 
         # RUBY-2367: This will be updated to allow the query cache to
         # cache cursors with multi-batch results.
-        if QueryCache.enabled? && (result.cursor_id == 0 || result.cursor_id.nil?)
+        if QueryCache.enabled?
           CachingCursor.new(view, result, server, session: session)
         else
           Cursor.new(view, result, server, session: session)

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -76,14 +76,14 @@ describe 'QueryCache' do
     min_server_fcv '3.2'
 
     before do
-      101.times { |i| authorized_collection.insert_one(_id: i) }
+      102.times { |i| authorized_collection.insert_one(_id: i) }
     end
 
-    let(:expected_results) { [*0..100].map { |id| { "_id" => id } } }
+    let(:expected_results) { [*0..101].map { |id| { "_id" => id } } }
 
     it 'returns the correct result' do
       result = authorized_collection.find.to_a
-      expect(result.length).to eq(101)
+      expect(result.length).to eq(102)
       expect(result).to eq(expected_results)
     end
 
@@ -113,8 +113,8 @@ describe 'QueryCache' do
 
         result2 = authorized_collection.find.to_a
 
-        expect(result1.length).to eq(101)
-        expect(result1).to eq(expected_results)
+        expect(result2.length).to eq(102)
+        expect(result2).to eq(expected_results)
 
         expect(subscriber.command_started_events('find').length).to eq(1)
         expect(subscriber.command_started_events('getMore').length).to eq(1)

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -91,7 +91,11 @@ describe 'QueryCache' do
 
         # Verify that the driver performs the query once
         expect(subscriber.command_started_events('find').length).to eq(1)
-        expect(subscriber.command_started_events('getMore').length).to eq(0)
+        #
+        # getMore was only introduced in server version 3.2
+        if ClusterConfig.instance.fcv_ish >= "3.2"
+          expect(subscriber.command_started_events('getMore').length).to eq(0)
+        end
       end
     end
 
@@ -113,7 +117,11 @@ describe 'QueryCache' do
 
         # Verify that the driver performs the query once
         expect(subscriber.command_started_events('find').length).to eq(1)
-        expect(subscriber.command_started_events('getMore').length).to eq(1)
+
+        # getMore was only introduced in server version 3.2
+        if ClusterConfig.instance.fcv_ish >= "3.2"
+          expect(subscriber.command_started_events('getMore').length).to eq(1)
+        end
       end
     end
   end
@@ -298,14 +306,6 @@ describe 'QueryCache' do
         end
 
         context 'and two queries are performed with a larger limit' do
-          before do
-            if ClusterConfig.instance.fcv_ish <= '3.0'
-              pending 'RUBY-2367 Server versions 3.0 and older execute three' \
-                'queries in this case. This should be resolved when the query' \
-                'cache is modified to cache multi-batch queries.'
-            end
-          end
-
           it 'uses the query cache for the third query' do
             results1 = authorized_collection.find.limit(3).to_a
             results2 = authorized_collection.find.limit(3).to_a
@@ -321,14 +321,6 @@ describe 'QueryCache' do
         end
 
         context 'and the second query has a smaller limit' do
-          before do
-            if ClusterConfig.instance.fcv_ish <= '3.0'
-              pending 'RUBY-2367 Server versions 3.0 and older execute two' \
-                'queries in this case. This should be resolved when the query' \
-                'cache is modified to cache multi-batch queries.'
-            end
-          end
-
           let(:results) { authorized_collection.find.limit(1).to_a }
 
           it 'uses the cached query' do


### PR DESCRIPTION
I did this by modifying the CachingCursor so that it adds document to `@cached_docs` on `try_next` rather than `process`. This way, the cursor can iterate through the `@cached_docs` and then use `try_next` to iterate through the remaining documents, calling `get_more` if there are other batches of documents that haven't been fetched.