### PR TITLE
RUBY-2377 Cache aggregations and clear the cache when $out or $merge stages provided

### DIFF
--- a/lib/mongo/collection/view/aggregation.rb
+++ b/lib/mongo/collection/view/aggregation.rb
@@ -89,6 +89,16 @@ module Mongo
           self.class.new(view, pipeline, options.merge(explain: true)).first
         end
 
+        # Whether this aggregation will write its result to a database collection.
+        #
+        # @return [ Boolean ] Whether the aggregation will write its result
+        #   to a collection.
+        #
+        # @api private
+        def write?
+          pipeline.any? { |op| op.key?('$out') || op.key?(:$out) || op.key?('$merge') || op.key?(:$merge) }
+        end
+
         private
 
         def server_selector
@@ -112,10 +122,6 @@ module Mongo
             connection.description
           end
           description.standalone? || description.mongos? || description.primary? || secondary_ok?
-        end
-
-        def write?
-          pipeline.any? { |op| op.key?('$out') || op.key?(:$out) || op.key?('$merge') || op.key?(:$merge) }
         end
 
         def secondary_ok?

--- a/lib/mongo/collection/view/aggregation.rb
+++ b/lib/mongo/collection/view/aggregation.rb
@@ -137,15 +137,16 @@ module Mongo
           end
         end
 
+        # Skip, sort, limit, projection are specified as pipeline stages
+        # rather than as options.
         def cache_options
           {
             namespace: collection.namespace,
             selector: pipeline,
+            read_concern: view.read_concern,
+            read_preference: view.read_preference,
+            collation: options[:collation]
           }
-        end
-
-        def limit
-          nil
         end
       end
     end

--- a/lib/mongo/collection/view/aggregation.rb
+++ b/lib/mongo/collection/view/aggregation.rb
@@ -136,6 +136,17 @@ module Mongo
             raise Error::UnsupportedCollation.new
           end
         end
+
+        def cache_options
+          {
+            namespace: collection.namespace,
+            selector: pipeline,
+          }
+        end
+
+        def limit
+          nil
+        end
       end
     end
   end

--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -45,7 +45,9 @@ module Mongo
           end
 
           if block_given?
-            if limit
+            # Mongo::View::Aggregation instances do not have a limit method
+            # because aggregations take $limit as a pipeline rather than an option.
+            if respond_to?(:limit) && limit
               @cursor.to_a[0...limit].each do |doc|
                 yield doc
               end

--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -52,14 +52,14 @@ module Mongo
           if block_given?
             # Ruby versions 2.5 and older do not support arr[0..nil] syntax, so
             # this must be a separate conditional.
-            if limit_for_cached_query
-              @cursor.to_a[0...limit_for_cached_query].each do |doc|
-                yield doc
-              end
+            cursor_to_iterate = if limit_for_cached_query
+              @cursor.to_a[0...limit_for_cached_query]
             else
-              @cursor.each do |doc|
-                yield doc
-              end
+              @cursor
+            end
+
+            cursor_to_iterate.each do |doc|
+              yield doc
             end
           else
             @cursor.to_enum

--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -42,12 +42,11 @@ module Mongo
             # No need to store the cursor in the query cache if there is
             # already a cached cursor stored at this key.
             QueryCache.set(@cursor, cache_options) unless cached_cursor
-            range = limit || nil
           end
 
           if block_given?
-            if range
-              @cursor.to_a[0...range].each do |doc|
+            if limit
+              @cursor.to_a[0...limit].each do |doc|
                 yield doc
               end
             else

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -45,15 +45,13 @@ module Mongo
         #
         # @since 2.0.0
         def aggregate(pipeline, options = {})
+          aggregation = Aggregation.new(self, pipeline, options)
+
           # Because the $merge and $out pipeline stages write documents to the
           # collection, it is necessary to clear the cache when they are performed.
-          write = pipeline.any? do |op| 
-            op.key?('$out') || op.key?(:$out) ||
-              op.key?('$merge') || op.key?(:$merge)
-          end
+          Mongo::QueryCache.clear_cache if aggregation.write?
 
-          Mongo::QueryCache.clear_cache if write
-          Aggregation.new(self, pipeline, options)
+          aggregation
         end
 
         # Allows the server to write temporary data to disk while executing

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -45,6 +45,14 @@ module Mongo
         #
         # @since 2.0.0
         def aggregate(pipeline, options = {})
+          # Because the $merge and $out pipeline stages write documents to the
+          # collection, it is necessary to clear the cache when they are performed.
+          write = pipeline.any? do |op| 
+            op.key?('$out') || op.key?(:$out) ||
+              op.key?('$merge') || op.key?(:$merge)
+          end
+
+          Mongo::QueryCache.clear_cache if write
           Aggregation.new(self, pipeline, options)
         end
 


### PR DESCRIPTION
This PR does two things:
1. It allows aggregations to be cached. Previously, trying to aggregate with the QueryCache turned on would have caused an error. Now, it caches the aggregation, taking into account read concern, read preference, and collation options. (All other options are specified in the pipeline).
2. It clears the query cache when $out or $merge stages are specified in an aggregation, since those stages can write to the collection.

Documentation on aggregation caching will be provided in a later ticket.