### PR TITLE
RUBY-2375 More efficient query cache invalidation

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -556,8 +556,7 @@ module Mongo
     #
     # @since 2.0.0
     def insert_one(document, opts = {})
-      Mongo::QueryCache.clear_namespace("#{database.name}.#{name}")
-      Mongo::QueryCache.clear_namespace(nil)
+      Mongo::QueryCache.clear_namespace(namespace)
 
       client.send(:with_session, opts) do |session|
         write_concern = if opts[:write_concern]
@@ -595,8 +594,7 @@ module Mongo
     #
     # @since 2.0.0
     def insert_many(documents, options = {})
-      Mongo::QueryCache.clear_namespace("#{database.name}.#{name}")
-      Mongo::QueryCache.clear_namespace(nil)
+      Mongo::QueryCache.clear_namespace(namespace)
 
       inserts = documents.map{ |doc| { :insert_one => doc }}
       bulk_write(inserts, options)

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -556,7 +556,8 @@ module Mongo
     #
     # @since 2.0.0
     def insert_one(document, opts = {})
-      Mongo::QueryCache.clear_cache
+      Mongo::QueryCache.clear_namespace("#{database.name}.#{name}")
+
       client.send(:with_session, opts) do |session|
         write_concern = if opts[:write_concern]
           WriteConcern.get(opts[:write_concern])

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -557,6 +557,7 @@ module Mongo
     # @since 2.0.0
     def insert_one(document, opts = {})
       Mongo::QueryCache.clear_namespace("#{database.name}.#{name}")
+      Mongo::QueryCache.clear_namespace(nil)
 
       client.send(:with_session, opts) do |session|
         write_concern = if opts[:write_concern]
@@ -594,7 +595,9 @@ module Mongo
     #
     # @since 2.0.0
     def insert_many(documents, options = {})
-      Mongo::QueryCache.clear_cache
+      Mongo::QueryCache.clear_namespace("#{database.name}.#{name}")
+      Mongo::QueryCache.clear_namespace(nil)
+
       inserts = documents.map{ |doc| { :insert_one => doc }}
       bulk_write(inserts, options)
     end

--- a/lib/mongo/collection/view/aggregation.rb
+++ b/lib/mongo/collection/view/aggregation.rb
@@ -147,7 +147,10 @@ module Mongo
         # rather than as options.
         def cache_options
           {
-            namespace: collection.namespace,
+            # Aggregations can read documents from more than one collection,
+            # so they will be cached without a namespace and cleared on
+            # every write operation.
+            namespace: nil,
             selector: pipeline,
             read_concern: view.read_concern,
             read_preference: view.read_preference,

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -49,6 +49,10 @@ module Mongo
 
           # Because the $merge and $out pipeline stages write documents to the
           # collection, it is necessary to clear the cache when they are performed.
+          #
+          # Opt to clear the entire cache rather than one namespace because
+          # the $out and $merge stages do not have to write to the same namespace
+          # on which the aggregation is performed.
           Mongo::QueryCache.clear_cache if aggregation.write?
 
           aggregation

--- a/lib/mongo/collection/view/writable.rb
+++ b/lib/mongo/collection/view/writable.rb
@@ -48,7 +48,7 @@ module Mongo
         #
         # @since 2.0.0
         def find_one_and_delete(opts = {})
-          clear_query_cache_namespace
+          QueryCache.clear_namespace(collection.namespace)
 
           cmd = { :findAndModify => collection.name, :query => filter, :remove => true }
           cmd[:fields] = projection if projection
@@ -129,7 +129,7 @@ module Mongo
         #
         # @since 2.0.0
         def find_one_and_update(document, opts = {})
-          clear_query_cache_namespace
+          QueryCache.clear_namespace(collection.namespace)
 
           cmd = { :findAndModify => collection.name, :query => filter }
           cmd[:update] = document
@@ -179,7 +179,7 @@ module Mongo
         #
         # @since 2.0.0
         def delete_many(opts = {})
-          clear_query_cache_namespace
+          QueryCache.clear_namespace(collection.namespace)
 
           delete_doc = { Operation::Q => filter, Operation::LIMIT => 0 }
           with_session(opts) do |session|
@@ -222,7 +222,7 @@ module Mongo
         #
         # @since 2.0.0
         def delete_one(opts = {})
-          clear_query_cache_namespace
+          QueryCache.clear_namespace(collection.namespace)
 
           delete_doc = { Operation::Q => filter, Operation::LIMIT => 1 }
           with_session(opts) do |session|
@@ -271,7 +271,7 @@ module Mongo
         #
         # @since 2.0.0
         def replace_one(replacement, opts = {})
-          clear_query_cache_namespace
+          QueryCache.clear_namespace(collection.namespace)
 
           update_doc = { Operation::Q => filter,
                          Operation::U => replacement,
@@ -329,7 +329,7 @@ module Mongo
         #
         # @since 2.0.0
         def update_many(spec, opts = {})
-          clear_query_cache_namespace
+          QueryCache.clear_namespace(collection.namespace)
 
           update_doc = { Operation::Q => filter,
                          Operation::U => spec,
@@ -386,7 +386,7 @@ module Mongo
         #
         # @since 2.0.0
         def update_one(spec, opts = {})
-          clear_query_cache_namespace
+          QueryCache.clear_namespace(collection.namespace)
 
           update_doc = { Operation::Q => filter,
                          Operation::U => spec,
@@ -464,13 +464,6 @@ module Mongo
           else
             write_concern_with_session(session)
           end
-        end
-
-        def clear_query_cache_namespace
-          Mongo::QueryCache.clear_namespace(
-            "#{collection.database.name}.#{collection.name}"
-          )
-          Mongo::QueryCache.clear_namespace(nil)
         end
       end
     end

--- a/lib/mongo/collection/view/writable.rb
+++ b/lib/mongo/collection/view/writable.rb
@@ -48,7 +48,8 @@ module Mongo
         #
         # @since 2.0.0
         def find_one_and_delete(opts = {})
-          Mongo::QueryCache.clear_cache
+          clear_query_cache_namespace
+
           cmd = { :findAndModify => collection.name, :query => filter, :remove => true }
           cmd[:fields] = projection if projection
           cmd[:sort] = sort if sort
@@ -128,7 +129,8 @@ module Mongo
         #
         # @since 2.0.0
         def find_one_and_update(document, opts = {})
-          Mongo::QueryCache.clear_cache
+          clear_query_cache_namespace
+
           cmd = { :findAndModify => collection.name, :query => filter }
           cmd[:update] = document
           cmd[:fields] = projection if projection
@@ -177,9 +179,7 @@ module Mongo
         #
         # @since 2.0.0
         def delete_many(opts = {})
-          Mongo::QueryCache.clear_namespace(
-            "#{collection.database.name}.#{collection.name}"
-          )
+          clear_query_cache_namespace
 
           delete_doc = { Operation::Q => filter, Operation::LIMIT => 0 }
           with_session(opts) do |session|
@@ -222,7 +222,8 @@ module Mongo
         #
         # @since 2.0.0
         def delete_one(opts = {})
-          Mongo::QueryCache.clear_cache
+          clear_query_cache_namespace
+
           delete_doc = { Operation::Q => filter, Operation::LIMIT => 1 }
           with_session(opts) do |session|
             write_concern = if opts[:write_concern]
@@ -270,7 +271,8 @@ module Mongo
         #
         # @since 2.0.0
         def replace_one(replacement, opts = {})
-          Mongo::QueryCache.clear_cache
+          clear_query_cache_namespace
+
           update_doc = { Operation::Q => filter,
                          Operation::U => replacement,
                         }
@@ -327,7 +329,8 @@ module Mongo
         #
         # @since 2.0.0
         def update_many(spec, opts = {})
-          Mongo::QueryCache.clear_cache
+          clear_query_cache_namespace
+
           update_doc = { Operation::Q => filter,
                          Operation::U => spec,
                          Operation::MULTI => true,
@@ -383,7 +386,8 @@ module Mongo
         #
         # @since 2.0.0
         def update_one(spec, opts = {})
-          Mongo::QueryCache.clear_cache
+          clear_query_cache_namespace
+
           update_doc = { Operation::Q => filter,
                          Operation::U => spec,
                          }
@@ -460,6 +464,12 @@ module Mongo
           else
             write_concern_with_session(session)
           end
+        end
+
+        def clear_query_cache_namespace
+          Mongo::QueryCache.clear_namespace(
+            "#{collection.database.name}.#{collection.name}"
+          )
         end
       end
     end

--- a/lib/mongo/collection/view/writable.rb
+++ b/lib/mongo/collection/view/writable.rb
@@ -177,7 +177,10 @@ module Mongo
         #
         # @since 2.0.0
         def delete_many(opts = {})
-          Mongo::QueryCache.clear_cache
+          Mongo::QueryCache.clear_namespace(
+            "#{collection.database.name}.#{collection.name}"
+          )
+
           delete_doc = { Operation::Q => filter, Operation::LIMIT => 0 }
           with_session(opts) do |session|
             write_concern = if opts[:write_concern]

--- a/lib/mongo/collection/view/writable.rb
+++ b/lib/mongo/collection/view/writable.rb
@@ -470,6 +470,7 @@ module Mongo
           Mongo::QueryCache.clear_namespace(
             "#{collection.database.name}.#{collection.name}"
           )
+          Mongo::QueryCache.clear_namespace(nil)
         end
       end
     end

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -117,9 +117,13 @@ module Mongo
       # @api private
       def get(options = {})
         limit = options[:limit]
+        namespace = options[:namespace]
         key = cache_key(options)
 
-        caching_cursor = QueryCache.cache_table[key]
+        namespace_hash = QueryCache.cache_table[namespace]
+        return nil unless namespace_hash
+
+        caching_cursor = namespace_hash[key]
         return nil unless caching_cursor
 
         caching_cursor_limit = caching_cursor.view.limit

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -161,8 +161,8 @@ module Mongo
       private
 
       def cache_key(options)
-        unless options[:namespace] && options[:selector]
-          raise ArgumentError.new("Cannot generate cache key without namespace or selector")
+        unless options[:selector]
+          raise ArgumentError.new("Cannot generate cache key without selector")
         end
 
         [

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -94,20 +94,37 @@ module Mongo
       #
       # @api private
       def clear_namespace(namespace)
-        cache_table[namespace] = nil if cache_table[namespace]
-
+        cache_table.delete(namespace)
         # The nil key is where cursors are stored that could potentially read from
         # multiple collections. This key should be cleared on every write operation
         # to prevent returning stale data.
-        cache_table[nil] = nil if cache_table[nil]
+        cache_table.delete(nil)
+        nil
       end
 
       # Store a CachingCursor instance in the query cache.
       #
       # @param [ Mongo::CachingCursor ] cursor The CachingCursor instance to store.
       # @param [ Hash ] options The query options that will be used to create
-      #   the cache key. Valid keys are: :namespace, :selector, :skip, :sort,
-      #   :limit, :projection, :collation, :read_concern, and :read_preference.
+      #   the cache key.
+      #
+      # @option options [ String | nil ] namespace The namespace of the query,
+      #   in the format "database_name.collection_name".
+      # @option options [ Array, Hash ] selector The selector passed to the query.
+      #   For most queries, this will be a Hash, but for aggregations, this
+      #   will be an Array representing the aggregation pipeline. May not be nil.
+      # @option options [ Integer | nil ] skip The skip value of the query.
+      # @option options [ Hash | nil ] sort The order of the query results
+      #   (e.g. { name: -1 }).
+      # @option options [ Integer | nil ] limit The limit value of the query.
+      # @option options [ Hash | nil ] projection The projection of the query
+      #   results (e.g. { name: 1 }).
+      # @option options [ Hash | nil ] collation The collation of the query
+      #   (e.g. { "locale" => "fr_CA" }).
+      # @option options [ Hash | nil ] read_concern The read concern of the query
+      #   (e.g. { level: :majority }).
+      # @option options [ Hash | nil ] read_preference The read preference of
+      #   the query (e.g. { mode: :secondary }).
       #
       # @return [ true ] Always true.
       #
@@ -126,8 +143,25 @@ module Mongo
       # CachingCursor that can be used to acquire the correct query results.
       #
       # @param [ Hash ] options The query options that will be used to create
-      #   the cache key. Valid keys are: :namespace, :selector, :skip, :sort,
-      #   :limit, :projection, :collation, :read_concern, and :read_preference.
+      #   the cache key.
+      #
+      # @option options [ String | nil ] namespace The namespace of the query,
+      #   in the format "database_name.collection_name".
+      # @option options [ Array, Hash ] selector The selector passed to the query.
+      #   For most queries, this will be a Hash, but for aggregations, this
+      #   will be an Array representing the aggregation pipeline. May not be nil.
+      # @option options [ Integer | nil ] skip The skip value of the query.
+      # @option options [ Hash | nil ] sort The order of the query results
+      #   (e.g. { name: -1 }).
+      # @option options [ Integer | nil ] limit The limit value of the query.
+      # @option options [ Hash | nil ] projection The projection of the query
+      #   results (e.g. { name: 1 }).
+      # @option options [ Hash | nil ] collation The collation of the query
+      #   (e.g. { "locale" => "fr_CA" }).
+      # @option options [ Hash | nil ] read_concern The read concern of the query
+      #   (e.g. { level: :majority }).
+      # @option options [ Hash | nil ] read_preference The read preference of
+      #   the query (e.g. { mode: :secondary }).
       #
       # @return [ Mongo::CachingCursor | nil ] Returns a CachingCursor if one
       #   exists in the query cache, otherwise returns nil.

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -96,7 +96,10 @@ module Mongo
       # @api private
       def set(cursor, options = {})
         key = cache_key(options)
-        QueryCache.cache_table[key] = cursor
+        namespace = options[:namespace]
+
+        QueryCache.cache_table[namespace] ||= {}
+        QueryCache.cache_table[namespace][key] = cursor
 
         true
       end
@@ -146,7 +149,6 @@ module Mongo
         end
 
         [
-          options[:namespace],
           options[:selector],
           options[:skip],
           options[:sort],

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -84,6 +84,19 @@ module Mongo
         Thread.current["[mongo]:query_cache"] = nil
       end
 
+      # Clear the section of the query cache storing cursors with results
+      # from this namespace.
+      #
+      # @param [ String ] namespace The namespace to be cleared, in the format
+      #   "database.collection".
+      #
+      # @return [ nil ] Always nil.
+      #
+      # @api private
+      def clear_namespace(namespace)
+        cache_table[namespace] = nil
+      end
+
       # Store a CachingCursor instance in the query cache.
       #
       # @param [ Mongo::CachingCursor ] cursor The CachingCursor instance to store.

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -94,7 +94,7 @@ module Mongo
       #
       # @api private
       def clear_namespace(namespace)
-        cache_table[namespace] = nil
+        cache_table[namespace] = nil if cache_table[namespace]
       end
 
       # Store a CachingCursor instance in the query cache.

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -95,6 +95,11 @@ module Mongo
       # @api private
       def clear_namespace(namespace)
         cache_table[namespace] = nil if cache_table[namespace]
+
+        # The nil key is where cursors are stored that could potentially read from
+        # multiple collections. This key should be cleared on every write operation
+        # to prevent returning stale data.
+        cache_table[nil] = nil if cache_table[nil]
       end
 
       # Store a CachingCursor instance in the query cache.

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -479,30 +479,38 @@ describe 'QueryCache' do
     end
 
     context 'when inserting new documents' do
-
       before do
         authorized_collection.find.to_a
+        # Perform a query in another namespace to test that this method only
+        # clears the cache for its own namespace.
+        authorized_client['other_collection'].find.to_a
         authorized_collection.insert_one({ name: "bob" })
       end
 
-      it 'queries again' do
-        expect(Mongo::QueryCache.cache_table.length).to eq(0)
+      it 'queries again and clears part of the query cache' do
+        expect(Mongo::QueryCache.cache_table['ruby-driver.collection_spec']).to be_nil
+        expect(Mongo::QueryCache.cache_table['ruby-driver.other_collection']).not_to be_empty
+
         authorized_collection.find.to_a
-        expect(events.length).to eq(2)
+        expect(events.length).to eq(3)
       end
     end
 
     context 'when deleting documents' do
-
       before do
         authorized_collection.find.to_a
+        # Perform a query in another namespace to test that this method only
+        # clears the cache for its own namespace.
+        authorized_client['other_collection'].find.to_a
         authorized_collection.delete_many
       end
 
-      it 'queries again' do
-        expect(Mongo::QueryCache.cache_table.length).to eq(0)
+      it 'queries again and clears part of the query cache' do
+        expect(Mongo::QueryCache.cache_table['ruby-driver.collection_spec']).to be_nil
+        expect(Mongo::QueryCache.cache_table['ruby-driver.other_collection']).not_to be_empty
+
         authorized_collection.find.to_a
-        expect(events.length).to eq(2)
+        expect(events.length).to eq(3)
       end
     end
 

--- a/spec/mongo/query_cache_spec.rb
+++ b/spec/mongo/query_cache_spec.rb
@@ -243,4 +243,30 @@ describe Mongo::QueryCache do
       end
     end
   end
+
+  describe '#clear_namespace' do
+    let(:caching_cursor) { double("Mongo::CachingCursor") }
+    let(:namespace1) { 'db.coll' }
+    let(:namespace2) { 'db.coll2' }
+    let(:selector) { { field: 'value' } }
+
+    before do
+      Mongo::QueryCache.set(caching_cursor, { namespace: namespace1, selector: selector })
+      Mongo::QueryCache.set(caching_cursor, { namespace: namespace2, selector: selector })
+    end
+
+    it 'returns nil' do
+      expect(Mongo::QueryCache.clear_namespace(namespace1)).to be_nil
+    end
+
+    it 'clears the specified namespace in the query cache' do
+      Mongo::QueryCache.clear_namespace(namespace1)
+      expect(Mongo::QueryCache.cache_table[namespace1]).to be_nil
+    end
+
+    it 'does not clear other namespaces in the query cache' do
+      Mongo::QueryCache.clear_namespace(namespace1)
+      expect(Mongo::QueryCache.cache_table[namespace2]).not_to be_nil
+    end
+  end
 end

--- a/spec/mongo/query_cache_spec.rb
+++ b/spec/mongo/query_cache_spec.rb
@@ -253,6 +253,7 @@ describe Mongo::QueryCache do
     before do
       Mongo::QueryCache.set(caching_cursor, { namespace: namespace1, selector: selector })
       Mongo::QueryCache.set(caching_cursor, { namespace: namespace2, selector: selector })
+      Mongo::QueryCache.set(caching_cursor, { namespace: nil, selector: selector })
     end
 
     it 'returns nil' do
@@ -267,6 +268,11 @@ describe Mongo::QueryCache do
     it 'does not clear other namespaces in the query cache' do
       Mongo::QueryCache.clear_namespace(namespace1)
       expect(Mongo::QueryCache.cache_table[namespace2]).not_to be_nil
+    end
+
+    it 'clears the nil namespace' do
+      Mongo::QueryCache.clear_namespace(namespace1)
+      expect(Mongo::QueryCache.cache_table[nil]).to be_nil
     end
   end
 end

--- a/spec/mongo/query_cache_spec.rb
+++ b/spec/mongo/query_cache_spec.rb
@@ -130,7 +130,7 @@ describe Mongo::QueryCache do
 
     it 'stores the cursor at the correct key' do
       Mongo::QueryCache.set(caching_cursor, options)
-      expect(Mongo::QueryCache.cache_table[[namespace, selector, skip, sort, projection, collation, read_concern, read_preference]]).to eq(caching_cursor)
+      expect(Mongo::QueryCache.cache_table[namespace][[selector, skip, sort, projection, collation, read_concern, read_preference]]).to eq(caching_cursor)
     end
   end
 


### PR DESCRIPTION
Currently, the query cache completely clears on every write operation. However, most write operations only impact one database and collection, so it doesn't make sense to clear every single cursor from the cache.

This PR introduces the following changes:
* The cache is now structured in two levels: the first-level key is the namespace (database.collection), and every value is a Hash containing CachingCursors.
* Instead of clearing the whole query cache, most write operations only clear the namespace that they're modifying.
* Aggregation results are cached at the `nil` namespace because aggregation pipelines can read data from multiple namespaces.
* Aggregation operations that write to a collection ($out and $merge stages) clear the entire cache.