### PR TITLE
RUBY-2376 Query cache documentation

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -78,6 +78,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mong
       /tutorials/ruby-driver-geospatial-search
       /tutorials/ruby-driver-gridfs
       /tutorials/client-side-encryption
+      /tutorials/query-cache
       bson-tutorials
       API <http://api.mongodb.com/ruby/current/>
       /reference/driver-compatibility

--- a/docs/ruby-driver-tutorials.txt
+++ b/docs/ruby-driver-tutorials.txt
@@ -11,7 +11,7 @@ Tutorials
 The tutorials in this section provide examples of some frequently used
 operations. This section is not meant to be an exhaustive list of all
 operations available in the Ruby driver.
-    
+
 .. toctree::
    :titlesonly:
 
@@ -32,3 +32,4 @@ operations available in the Ruby driver.
    /tutorials/ruby-driver-text-search
    /tutorials/ruby-driver-geospatial-search
    /tutorials/ruby-driver-gridfs
+   /tutorials/query-cache

--- a/docs/ruby-driver-tutorials.txt
+++ b/docs/ruby-driver-tutorials.txt
@@ -32,4 +32,3 @@ operations available in the Ruby driver.
    /tutorials/ruby-driver-text-search
    /tutorials/ruby-driver-geospatial-search
    /tutorials/ruby-driver-gridfs
-   /tutorials/query-cache

--- a/docs/tutorials/query-cache.txt
+++ b/docs/tutorials/query-cache.txt
@@ -1,0 +1,177 @@
+***********
+Query Cache
+***********
+
+.. default-domain:: mongodb
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 1
+   :class: singlecol
+
+The MongoDB Ruby driver provides a built-in query cache. When enabled, the
+query cache saves the results of previously-executed find and aggregation
+queries and returns those cached results when the same queries are executed
+to prevent unnecessary round trips to the database.
+
+Usage
+=====
+
+The query cache is disabled by default. It cache can be enabled on a gobal
+scope as well as within the context of a specific block.
+
+To enable the query cache globally:
+
+.. code-block:: ruby
+
+  Mongo::QueryCache.enabled = true
+
+Similarly, to disable it globally:
+
+.. code-block:: ruby
+
+  Mongo::QueryCache.enabled = false
+
+To enable the query cache within the context of a block:
+
+.. code-block:: ruby
+
+  Mongo::QueryCache.cache do
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
+    client[:artists].find(:name => 'Flying Lotus').first
+    #=> Queries the database and caches the result
+    client[:artists].find(:name => 'Flying Lotus').first
+    #=> Returns the previously cached result
+  end
+
+And to disable the query cache in the context of a block:
+
+.. code-block:: ruby
+
+  Mongo::QueryCache.uncached do
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
+    client[:artists].find(:name => 'Flying Lotus').first
+    #=> Sends the query to the database; does NOT cache the result
+    client[:artists].find(:name => 'Flying Lotus').first
+    #=> Queries the database again
+  end
+
+You may check whether the query cache is enabled at any time by calling
+``Mongo::QueryCache.enabled?``, which will return ``true`` or ``false``.
+
+Limits
+======
+
+When performing a query with a limit, the query cache will reuse an existing
+cached query with a larger limit if one exists. For example:
+
+.. code-block:: ruby
+
+  Mongo::QueryCache.cache do
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
+
+    client[:artists].find(genre: 'Rock', limit: 10)
+    #=> Queries the database and caches the result
+
+    client[:artists].find(genre: 'Rock', limit: 5)
+    #=> Returns the first 5 results from the previous query
+
+    client[:artists].find(genre: 'Rock', limit: 20)
+    #=> Queries the database again and replaces the previously cached query results
+  end
+
+Cache Invalidation
+==================
+
+The query cache is cleared in part or in full on every write operation. Most
+write operations will clear any queries that have occurred on the same
+collection that is being written to. Some operations will clear the entire
+query cache.
+
+The following operations will clear cached queries on the same database and
+collection (including during bulk writes):
+
+* ``insert_one``
+* ``update_one``
+* ``replace_one``
+* ``update_many``
+* ``delete_one``
+* ``delete_many``
+* ``find_one_and_delete``
+* ``find_one_and_update``
+* ``find_one_and_replace``
+
+The following operations will clear the entire query cache:
+
+* aggregation with ``$merge`` or ``$out`` pipeline stages
+* ``commit_transaction``
+* ``abort_transaction``
+
+Manual Cache Invalidation
+=========================
+
+You may clear the query cache at any time with the following code snippet:
+
+.. code-block:: ruby
+
+  Mongo::QueryCache.clear
+
+This will remove all cached query results; any subsequent queries must query
+the database.
+
+Transactions
+============
+
+Queries will be cached within the context of a transaction, but the entire
+cache will be cleared when the transaction is committed or aborted.
+
+.. code-block:: ruby
+
+  Mongo::QueryCache.cache do
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
+    session = client.start_session
+
+    session.with_transaction do
+      client['artists'].insert_one({ name: 'Fleet Foxes' }, session: session)
+
+      client['artists'].find({}, session: session).first
+      #=> { name: 'Fleet Foxes' }
+      # (This query is sent to the database and the results are cached)
+
+      client['artists'].find({}, session: session).first
+      #=> { name: 'Fleet Foxes' }
+      # (Results are taken from the query cache)
+
+      session.abort_transaction
+    end
+
+    client['artists'].find.first
+    #=> nil
+    # (The query cache was cleared on abort_transaction)
+  end
+
+Aggregations
+============
+
+The query cache also caches the results of aggregation pipelines. For example:
+
+.. code-block:: ruby
+
+  Mongo::QueryCache.cache do
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
+
+    client['artists'].aggregate([ { '$match' => { name: 'Fleet Foxes' } } ]).first
+    #=> { name: 'Fleet Foxes' }
+    #=> This query is sent to the database and the results are cached
+
+    client['artists'].aggregate([ { '$match' => { name: 'Fleet Foxes' } } ]).first
+    #=> { name: 'Fleet Foxes' }
+    #=> The results are taken from the cached query
+  end
+
+.. note::
+
+  Aggregation results are cleared from the cache during every write operation,
+  with no exceptions.
+

--- a/docs/tutorials/query-cache.txt
+++ b/docs/tutorials/query-cache.txt
@@ -10,10 +10,12 @@ Query Cache
    :depth: 1
    :class: singlecol
 
+.. _query-cache:
+
 The MongoDB Ruby driver provides a built-in query cache. When enabled, the
 query cache saves the results of previously-executed find and aggregation
-queries and returns those cached results when the same queries are executed
-to prevent unnecessary round trips to the database.
+queries. When those same queries are performed again, the driver returns
+the cached reuslts to prevent unnecessary round trips to the database.
 
 Usage
 =====
@@ -38,10 +40,12 @@ To enable the query cache within the context of a block:
 .. code-block:: ruby
 
   Mongo::QueryCache.cache do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
-    client[:artists].find(:name => 'Flying Lotus').first
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
+
+    client['artists'].find(name: 'Flying Lotus').first
     #=> Queries the database and caches the result
-    client[:artists].find(:name => 'Flying Lotus').first
+
+    client['artists'].find(name: 'Flying Lotus').first
     #=> Returns the previously cached result
   end
 
@@ -50,10 +54,12 @@ And to disable the query cache in the context of a block:
 .. code-block:: ruby
 
   Mongo::QueryCache.uncached do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
-    client[:artists].find(:name => 'Flying Lotus').first
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
+
+    client['artists'].find(name: 'Flying Lotus').first
     #=> Sends the query to the database; does NOT cache the result
-    client[:artists].find(:name => 'Flying Lotus').first
+
+    client['artists'].find(name: 'Flying Lotus').first
     #=> Queries the database again
   end
 
@@ -69,15 +75,15 @@ cached query with a larger limit if one exists. For example:
 .. code-block:: ruby
 
   Mongo::QueryCache.cache do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
 
-    client[:artists].find(genre: 'Rock', limit: 10)
+    client['artists'].find(genre: 'Rock', limit: 10)
     #=> Queries the database and caches the result
 
-    client[:artists].find(genre: 'Rock', limit: 5)
-    #=> Returns the first 5 results from the previous query
+    client['artists'].find(genre: 'Rock', limit: 5)
+    #=> Returns the first 5 results from the cached query
 
-    client[:artists].find(genre: 'Rock', limit: 20)
+    client['artists'].find(genre: 'Rock', limit: 20)
     #=> Queries the database again and replaces the previously cached query results
   end
 
@@ -85,7 +91,7 @@ Cache Invalidation
 ==================
 
 The query cache is cleared in part or in full on every write operation. Most
-write operations will clear any queries that have occurred on the same
+write operations will clear any queries were performed on the same
 collection that is being written to. Some operations will clear the entire
 query cache.
 
@@ -111,25 +117,24 @@ The following operations will clear the entire query cache:
 Manual Cache Invalidation
 =========================
 
-You may clear the query cache at any time with the following code snippet:
+You may clear the query cache at any time with the following method:
 
 .. code-block:: ruby
 
   Mongo::QueryCache.clear
 
-This will remove all cached query results; any subsequent queries must query
-the database.
+This will remove all cached query results.
 
 Transactions
 ============
 
-Queries will be cached within the context of a transaction, but the entire
+Queries are cached within the context of a transaction, but the entire
 cache will be cleared when the transaction is committed or aborted.
 
 .. code-block:: ruby
 
   Mongo::QueryCache.cache do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
     session = client.start_session
 
     session.with_transaction do
@@ -137,18 +142,18 @@ cache will be cleared when the transaction is committed or aborted.
 
       client['artists'].find({}, session: session).first
       #=> { name: 'Fleet Foxes' }
-      # (This query is sent to the database and the results are cached)
+      #=> Queries the database and caches the result
 
       client['artists'].find({}, session: session).first
       #=> { name: 'Fleet Foxes' }
-      # (Results are taken from the query cache)
+      #=> Returns the previously cached result
 
       session.abort_transaction
     end
 
     client['artists'].find.first
     #=> nil
-    # (The query cache was cleared on abort_transaction)
+    # The query cache was cleared on abort_transaction
   end
 
 Aggregations
@@ -159,15 +164,13 @@ The query cache also caches the results of aggregation pipelines. For example:
 .. code-block:: ruby
 
   Mongo::QueryCache.cache do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'music')
+    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
 
     client['artists'].aggregate([ { '$match' => { name: 'Fleet Foxes' } } ]).first
-    #=> { name: 'Fleet Foxes' }
-    #=> This query is sent to the database and the results are cached
+    #=> Queries the database and caches the result
 
     client['artists'].aggregate([ { '$match' => { name: 'Fleet Foxes' } } ]).first
-    #=> { name: 'Fleet Foxes' }
-    #=> The results are taken from the cached query
+    #=> Returns the previously cached result
   end
 
 .. note::

--- a/docs/tutorials/query-cache.txt
+++ b/docs/tutorials/query-cache.txt
@@ -66,6 +66,27 @@ And to disable the query cache in the context of a block:
 You may check whether the query cache is enabled at any time by calling
 ``Mongo::QueryCache.enabled?``, which will return ``true`` or ``false``.
 
+Query Matching
+==============
+
+A query is eligible to use cached results if it matches a query that was
+previously run and whose results have been cached. Two queries are considered
+matching if they are identical in the following values (with some exceptions):
+
+* Namespace (the database and collection on which the query was performed)
+* Selector (for aggregations, the aggregation pipeline stages)
+* Skip
+* Sort
+* Limit (in certain cases; read more in the :ref:`limit section <limits>`)
+* Projection
+* Collation
+* Read Concern
+* Read Preference
+
+For example, if you perform one query, and then perform a mostly identical query
+with a different sort order, those queries will not be considered matching,
+and the second query will not use the cached results of the first.
+
 Limits
 ======
 
@@ -156,6 +177,16 @@ cache will be cleared when the transaction is committed or aborted.
       # The query cache was cleared on abort_transaction
     end
   end
+
+.. note::
+
+  Transactions are often performed with a "snapshot" read concern level. Keep
+  in mind that a query with a "snapshot" read concern cannot return cached
+  results from a query without the "snapshot" read concern, so it is possible
+  that a transaction may not use previously cached queries.
+
+  To understand when a query will use a cached result, see the
+  :ref:`Query Matching <query_matching>` section.
 
 Aggregations
 ============

--- a/docs/tutorials/query-cache.txt
+++ b/docs/tutorials/query-cache.txt
@@ -66,6 +66,8 @@ And to disable the query cache in the context of a block:
 You may check whether the query cache is enabled at any time by calling
 ``Mongo::QueryCache.enabled?``, which will return ``true`` or ``false``.
 
+.. _query-cache-matching:
+
 Query Matching
 ==============
 
@@ -77,7 +79,7 @@ matching if they are identical in the following values (with some exceptions):
 * Selector (for aggregations, the aggregation pipeline stages)
 * Skip
 * Sort
-* Limit (in certain cases; read more in the :ref:`limit section <limits>`)
+* Limit (in certain cases; read more in the :ref:`Limits section <query-cache-limits>`)
 * Projection
 * Collation
 * Read Concern
@@ -86,6 +88,8 @@ matching if they are identical in the following values (with some exceptions):
 For example, if you perform one query, and then perform a mostly identical query
 with a different sort order, those queries will not be considered matching,
 and the second query will not use the cached results of the first.
+
+.. _query-cache-limits:
 
 Limits
 ======
@@ -186,7 +190,7 @@ cache will be cleared when the transaction is committed or aborted.
   that a transaction may not use previously cached queries.
 
   To understand when a query will use a cached result, see the
-  :ref:`Query Matching <query_matching>` section.
+  :ref:`Query Matching <query-cache-matching>` section.
 
 Aggregations
 ============

--- a/docs/tutorials/query-cache.txt
+++ b/docs/tutorials/query-cache.txt
@@ -7,7 +7,7 @@ Query Cache
 .. contents:: On this page
    :local:
    :backlinks: none
-   :depth: 1
+   :depth: 2
    :class: singlecol
 
 .. _query-cache:
@@ -15,12 +15,12 @@ Query Cache
 The MongoDB Ruby driver provides a built-in query cache. When enabled, the
 query cache saves the results of previously-executed find and aggregation
 queries. When those same queries are performed again, the driver returns
-the cached reuslts to prevent unnecessary round trips to the database.
+the cached reuslts to prevent unnecessary roundtrips to the database.
 
 Usage
 =====
 
-The query cache is disabled by default. It cache can be enabled on a gobal
+The query cache is disabled by default. It cache can be enabled on the global
 scope as well as within the context of a specific block.
 
 To enable the query cache globally:
@@ -40,13 +40,13 @@ To enable the query cache within the context of a block:
 .. code-block:: ruby
 
   Mongo::QueryCache.cache do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
+    Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music') do |client|
+      client['artists'].find(name: 'Flying Lotus').first
+      #=> Queries the database and caches the result
 
-    client['artists'].find(name: 'Flying Lotus').first
-    #=> Queries the database and caches the result
-
-    client['artists'].find(name: 'Flying Lotus').first
-    #=> Returns the previously cached result
+      client['artists'].find(name: 'Flying Lotus').first
+      #=> Returns the previously cached result
+    end
   end
 
 And to disable the query cache in the context of a block:
@@ -54,13 +54,13 @@ And to disable the query cache in the context of a block:
 .. code-block:: ruby
 
   Mongo::QueryCache.uncached do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
+    Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music') do |client|
+      client['artists'].find(name: 'Flying Lotus').first
+      #=> Sends the query to the database; does NOT cache the result
 
-    client['artists'].find(name: 'Flying Lotus').first
-    #=> Sends the query to the database; does NOT cache the result
-
-    client['artists'].find(name: 'Flying Lotus').first
-    #=> Queries the database again
+      client['artists'].find(name: 'Flying Lotus').first
+      #=> Queries the database again
+    end
   end
 
 You may check whether the query cache is enabled at any time by calling
@@ -75,27 +75,27 @@ cached query with a larger limit if one exists. For example:
 .. code-block:: ruby
 
   Mongo::QueryCache.cache do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
+    Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music') do |client|
+      client['artists'].find(genre: 'Rock', limit: 10)
+      #=> Queries the database and caches the result
 
-    client['artists'].find(genre: 'Rock', limit: 10)
-    #=> Queries the database and caches the result
+      client['artists'].find(genre: 'Rock', limit: 5)
+      #=> Returns the first 5 results from the cached query
 
-    client['artists'].find(genre: 'Rock', limit: 5)
-    #=> Returns the first 5 results from the cached query
-
-    client['artists'].find(genre: 'Rock', limit: 20)
-    #=> Queries the database again and replaces the previously cached query results
+      client['artists'].find(genre: 'Rock', limit: 20)
+      #=> Queries the database again and replaces the previously cached query results
+    end
   end
 
 Cache Invalidation
 ==================
 
 The query cache is cleared in part or in full on every write operation. Most
-write operations will clear any queries were performed on the same
+write operations will clear the results of any queries were performed on the same
 collection that is being written to. Some operations will clear the entire
 query cache.
 
-The following operations will clear cached queries on the same database and
+The following operations will clear cached query results on the same database and
 collection (including during bulk writes):
 
 * ``insert_one``
@@ -134,26 +134,27 @@ cache will be cleared when the transaction is committed or aborted.
 .. code-block:: ruby
 
   Mongo::QueryCache.cache do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
-    session = client.start_session
+    Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music') do |client|
+      session = client.start_session
 
-    session.with_transaction do
-      client['artists'].insert_one({ name: 'Fleet Foxes' }, session: session)
+      session.with_transaction do
+        client['artists'].insert_one({ name: 'Fleet Foxes' }, session: session)
 
-      client['artists'].find({}, session: session).first
-      #=> { name: 'Fleet Foxes' }
-      #=> Queries the database and caches the result
+        client['artists'].find({}, session: session).first
+        #=> { name: 'Fleet Foxes' }
+        #=> Queries the database and caches the result
 
-      client['artists'].find({}, session: session).first
-      #=> { name: 'Fleet Foxes' }
-      #=> Returns the previously cached result
+        client['artists'].find({}, session: session).first
+        #=> { name: 'Fleet Foxes' }
+        #=> Returns the previously cached result
 
-      session.abort_transaction
+        session.abort_transaction
+      end
+
+      client['artists'].find.first
+      #=> nil
+      # The query cache was cleared on abort_transaction
     end
-
-    client['artists'].find.first
-    #=> nil
-    # The query cache was cleared on abort_transaction
   end
 
 Aggregations
@@ -164,13 +165,13 @@ The query cache also caches the results of aggregation pipelines. For example:
 .. code-block:: ruby
 
   Mongo::QueryCache.cache do
-    client = Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music')
+    Mongo::Client.new([ '127.0.0.1:27017' ], database: 'music') do |client|
+      client['artists'].aggregate([ { '$match' => { name: 'Fleet Foxes' } } ]).first
+      #=> Queries the database and caches the result
 
-    client['artists'].aggregate([ { '$match' => { name: 'Fleet Foxes' } } ]).first
-    #=> Queries the database and caches the result
-
-    client['artists'].aggregate([ { '$match' => { name: 'Fleet Foxes' } } ]).first
-    #=> Returns the previously cached result
+      client['artists'].aggregate([ { '$match' => { name: 'Fleet Foxes' } } ]).first
+      #=> Returns the previously cached result
+    end
   end
 
 .. note::

--- a/docs/tutorials/query-cache.txt
+++ b/docs/tutorials/query-cache.txt
@@ -71,15 +71,14 @@ You may check whether the query cache is enabled at any time by calling
 Query Matching
 ==============
 
-A query is eligible to use cached results if it matches a query that was
-previously run and whose results have been cached. Two queries are considered
-matching if they are identical in the following values (with some exceptions):
+A query is eligible to use cached results if it matches the original query
+that produced the cached results. Two queries are considered matching if they
+are identical in the following values:
 
 * Namespace (the database and collection on which the query was performed)
 * Selector (for aggregations, the aggregation pipeline stages)
 * Skip
 * Sort
-* Limit (in certain cases; read more in the :ref:`Limits section <query-cache-limits>`)
 * Projection
 * Collation
 * Read Concern
@@ -88,8 +87,6 @@ matching if they are identical in the following values (with some exceptions):
 For example, if you perform one query, and then perform a mostly identical query
 with a different sort order, those queries will not be considered matching,
 and the second query will not use the cached results of the first.
-
-.. _query-cache-limits:
 
 Limits
 ======

--- a/docs/tutorials/ruby-driver-crud-operations.txt
+++ b/docs/tutorials/ruby-driver-crud-operations.txt
@@ -136,40 +136,12 @@ object, or with ``Decimal128.from_string()``.
 Query Cache
 ===========
 
-If the Ruby driver's query cache is enabled, it will cache find queries on
-the currently executed thread and avoid sending requests to the database for
-identical queries. The QueryCache class stores CachingCursor objects which attempt
-to load documents from memory before retrieving them from the database. Performing
-any write operations such as insert, update, or delete clears the query cache. Note that
-if the number of results is too large to be returned in a single batch,
-the query cache will not be used, even if ``Mongo::QueryCache.enabled`` is true, and
-an error will be returned.
+The Ruby driver provides a query cache. When enabled, the query cache will 
+save the results of find and aggregation queries and return those saved results
+when the same queries are performed again.
 
-Similar to Mongoid's query cache, the driver's query cache implementation
-does not support using CachingCursors for queries with different limit sizes if
-the original query has a specified limit. For example, if a query with a limit of
-100 were executed, followed by a query with a limit of 10, the second query
-would still run against the database and a new CachingCursor object would be stored,
-rather than using the existing one. However, if a query does not specify a limit
-initially, then any query that is run after it with a specified limit will use
-the original CachingCursor rather than going back to the database, and will return
-the correct number of documents accordingly.
-
-To enable the query cache on a global scope:
-
-.. code-block:: ruby
-
-  Mongo::QueryCache.enabled = true
-
-The following code shows how to enable the query cache within the context of a
-specific block:
-
-.. code-block:: ruby
-
-  Mongo::QueryCache.cache do
-      # all queries within this block are cached
-  end
-
+To read more about the query cache, visit the 
+:ref:`query cache tutorial <query-cache>`.
 
 Reading
 =======

--- a/docs/tutorials/ruby-driver-crud-operations.txt
+++ b/docs/tutorials/ruby-driver-crud-operations.txt
@@ -130,17 +130,14 @@ object, or with ``Decimal128.from_string()``.
    price = BSON::Decimal128.from_string("428.79")
    # => BSON::Decimal128('428.79')
 
-
-.. _query-cache:
-
 Query Cache
 ===========
 
-The Ruby driver provides a query cache. When enabled, the query cache will 
+The Ruby driver provides a query cache. When enabled, the query cache will
 save the results of find and aggregation queries and return those saved results
 when the same queries are performed again.
 
-To read more about the query cache, visit the 
+To read more about the query cache, visit the
 :ref:`query cache tutorial <query-cache>`.
 
 Reading
@@ -265,7 +262,7 @@ Additional Query Operations
 
 ``estimated_document_count``
   Get an approximate number of documents in the collection.
-  
+
   Note that unlike ``count_documents``, ``estimated_document_count`` does not
   accept a filter.
 
@@ -278,7 +275,7 @@ Additional Query Operations
 ``count``
   Get an approximate number of documents matching a filter, or an approximate
   number of documents in the collection.
-  
+
   *Deprecated:* The ``count`` method is deprecated and does not work in
   transactions. Please use ``count_documents`` to obtain an exact count of
   documents potentially matching a filter or ``estimated_document_count``
@@ -338,11 +335,11 @@ or on the collection:
 
   client = Mongo::Client.new(['localhost:14420'], database: 'music',
     read_concern: {level: :local})
-  
+
   client['collection'].find.to_a
 
   collection = client['collection', read_concern: {level: :majority}]
-  
+
   collection.find.to_a
 
 The driver does not currently support setting read concern on an individual
@@ -359,7 +356,7 @@ part of the command:
 .. code-block:: ruby
 
   client.database.command(collstats: 'test', readConcern: {level: :majority})
-  
+
 
 .. _ruby-driver-read-preference:
 


### PR DESCRIPTION
I have moved the query cache documentation to its own page and linked to it from the CRUD page. I have gone in depth on various topics, such as cache invalidation, using the query cache with transactions and aggregations, and queries with limits.