### PR TITLE
RUBY-2410 Fix issue where same aggregation occuring on different collection returns cached result

### DIFF
--- a/lib/mongo/collection/view/aggregation.rb
+++ b/lib/mongo/collection/view/aggregation.rb
@@ -147,14 +147,14 @@ module Mongo
         # rather than as options.
         def cache_options
           {
-            # Aggregations can read documents from more than one collection,
-            # so they will be cached without a namespace and cleared on
-            # every write operation.
-            namespace: nil,
+            namespace: collection.namespace,
             selector: pipeline,
             read_concern: view.read_concern,
             read_preference: view.read_preference,
-            collation: options[:collation]
+            collation: options[:collation],
+            # Aggregations can read documents from more than one collection,
+            # so they will be cleared on every write operation.
+            multi_collection: true,
           }
         end
       end

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -125,13 +125,17 @@ module Mongo
       #   (e.g. { level: :majority }).
       # @option options [ Hash | nil ] read_preference The read preference of
       #   the query (e.g. { mode: :secondary }).
+      # @option options [ Boolean | nil ] multi_collection Whether the query
+      #   results could potentially come from multiple collections. When true,
+      #   these results will bes tored under the nil namespace key and cleared
+      #   on every write command.
       #
       # @return [ true ] Always true.
       #
       # @api private
       def set(cursor, options = {})
         key = cache_key(options)
-        namespace = options[:namespace]
+        namespace = namespace_key(options)
 
         QueryCache.cache_table[namespace] ||= {}
         QueryCache.cache_table[namespace][key] = cursor
@@ -162,6 +166,10 @@ module Mongo
       #   (e.g. { level: :majority }).
       # @option options [ Hash | nil ] read_preference The read preference of
       #   the query (e.g. { mode: :secondary }).
+      # @option options [ Boolean | nil ] multi_collection Whether the query
+      #   results could potentially come from multiple collections. When true,
+      #   these results will bes tored under the nil namespace key and cleared
+      #   on every write command.
       #
       # @return [ Mongo::CachingCursor | nil ] Returns a CachingCursor if one
       #   exists in the query cache, otherwise returns nil.
@@ -169,7 +177,7 @@ module Mongo
       # @api private
       def get(options = {})
         limit = options[:limit]
-        namespace = options[:namespace]
+        namespace = namespace_key(options)
         key = cache_key(options)
 
         namespace_hash = QueryCache.cache_table[namespace]
@@ -200,11 +208,12 @@ module Mongo
       private
 
       def cache_key(options)
-        unless options[:selector]
-          raise ArgumentError.new("Cannot generate cache key without selector")
+        unless options[:namespace] && options[:selector]
+          raise ArgumentError.new("Cannot generate cache key without namesapce or selector")
         end
 
         [
+          options[:namespace],
           options[:selector],
           options[:skip],
           options[:sort],
@@ -213,6 +222,17 @@ module Mongo
           options[:read_concern],
           options[:read_preference]
         ]
+      end
+
+      # If the cached results can come from multiple collections, store this
+      # cursor under the nil namespace to be cleared on every write operation.
+      # Otherwise, store it under the specified namespace.
+      def namespace_key(options)
+        if options[:multi_collection]
+          nil
+        else
+          options[:namespace]
+        end
       end
     end
   end

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -127,7 +127,7 @@ module Mongo
       #   the query (e.g. { mode: :secondary }).
       # @option options [ Boolean | nil ] multi_collection Whether the query
       #   results could potentially come from multiple collections. When true,
-      #   these results will bes tored under the nil namespace key and cleared
+      #   these results will be stored under the nil namespace key and cleared
       #   on every write command.
       #
       # @return [ true ] Always true.
@@ -168,7 +168,7 @@ module Mongo
       #   the query (e.g. { mode: :secondary }).
       # @option options [ Boolean | nil ] multi_collection Whether the query
       #   results could potentially come from multiple collections. When true,
-      #   these results will bes tored under the nil namespace key and cleared
+      #   these results will be stored under the nil namespace key and cleared
       #   on every write command.
       #
       # @return [ Mongo::CachingCursor | nil ] Returns a CachingCursor if one
@@ -209,7 +209,7 @@ module Mongo
 
       def cache_key(options)
         unless options[:namespace] && options[:selector]
-          raise ArgumentError.new("Cannot generate cache key without namesapce or selector")
+          raise ArgumentError.new("Cannot generate cache key without namespace or selector")
         end
 
         [

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -937,6 +937,33 @@ describe 'QueryCache' do
         expect(events.length).to eq(2)
       end
     end
+
+    context '#count_documents' do
+      context 'on same collection' do
+        it 'caches the query' do
+          expect(authorized_collection.count_documents(test: 1)).to eq(3)
+          expect(authorized_collection.count_documents(test: 1)).to eq(3)
+
+          expect(events.length).to eq(1)
+        end
+      end
+
+      context 'on different collections' do
+        let(:other_collection) { authorized_client['other_collection'] }
+
+        before do
+          other_collection.drop
+          6.times { other_collection.insert_one(test: 1) }
+        end
+
+        it 'caches the query' do
+          expect(authorized_collection.count_documents(test: 1)).to eq(3)
+          expect(other_collection.count_documents(test: 1)).to eq(6)
+
+          expect(events.length).to eq(2)
+        end
+      end
+    end
   end
 
   context 'when find command fails and retries' do

--- a/spec/mongo/query_cache_spec.rb
+++ b/spec/mongo/query_cache_spec.rb
@@ -130,7 +130,7 @@ describe Mongo::QueryCache do
 
     it 'stores the cursor at the correct key' do
       Mongo::QueryCache.set(caching_cursor, options)
-      expect(Mongo::QueryCache.cache_table[namespace][[selector, skip, sort, projection, collation, read_concern, read_preference]]).to eq(caching_cursor)
+      expect(Mongo::QueryCache.cache_table[namespace][[namespace, selector, skip, sort, projection, collation, read_concern, read_preference]]).to eq(caching_cursor)
     end
   end
 
@@ -248,12 +248,13 @@ describe Mongo::QueryCache do
     let(:caching_cursor) { double("Mongo::CachingCursor") }
     let(:namespace1) { 'db.coll' }
     let(:namespace2) { 'db.coll2' }
+    let(:namespace3) { 'db.coll3' }
     let(:selector) { { field: 'value' } }
 
     before do
       Mongo::QueryCache.set(caching_cursor, { namespace: namespace1, selector: selector })
       Mongo::QueryCache.set(caching_cursor, { namespace: namespace2, selector: selector })
-      Mongo::QueryCache.set(caching_cursor, { namespace: nil, selector: selector })
+      Mongo::QueryCache.set(caching_cursor, { namespace: namespace3, selector: selector, multi_collection: true })
     end
 
     it 'returns nil' do


### PR DESCRIPTION
I introduced a bug in the query cache by storing aggregations in the `nil` namespace -- if aggregations with the same pipeline were performed in two different namespaces, then the second one would return the cached results of the first. This PR adds namespace back to the cache key and introduces a new option (`multi_collection`) which indicates that results could come from multiple namespaces and should be stored under the `nil` namespace key.