### PR TITLE
RUBY-2413 Add a test and documentation for system collections with query cache

### DIFF
--- a/docs/tutorials/query-cache.txt
+++ b/docs/tutorials/query-cache.txt
@@ -211,3 +211,24 @@ The query cache also caches the results of aggregation pipelines. For example:
   Aggregation results are cleared from the cache during every write operation,
   with no exceptions.
 
+System Collections
+==================
+
+MongoDB stores system information in collections that use the ``database.system.*``
+namespace pattern.
+
+When the query cache is enabled, it will cache all system collection results.
+However, system collections are not subject to the same cache invalidation rules
+as normal collections; if your app relies on up-to-date information from
+system collections, please ensure that you are performing queries against the
+system collections with the query cache disabled, as demonstrated below.
+
+.. code-block:: ruby
+
+  Mongo::QueryCache.uncached do
+    Mongo::Client.new([ '127.0.0.1:27017' ], database: 'admin') do |client|
+      users = client['system.users'].find.to_a
+      #=> Does not return cached results
+    end
+  end
+

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -35,16 +35,16 @@ describe 'QueryCache' do
 
   let(:authorized_collection) { client['collection_spec'] }
 
+  let(:events) do
+    subscriber.command_started_events('find')
+  end
+
   describe '#cache' do
 
     before do
       Mongo::QueryCache.enabled = false
       authorized_collection.insert_one({ name: 'testing' })
       authorized_collection.find(name: 'testing').to_a
-    end
-
-    let(:events) do
-      subscriber.command_started_events('find')
     end
 
     it 'enables the query cache inside the block' do
@@ -66,10 +66,6 @@ describe 'QueryCache' do
     before do
       authorized_collection.insert_one({ name: 'testing' })
       authorized_collection.find(name: 'testing').to_a
-    end
-
-    let(:events) do
-      subscriber.command_started_events('find')
     end
 
     it 'disables the query cache inside the block' do
@@ -197,10 +193,6 @@ describe 'QueryCache' do
       authorized_client['test'].drop
     end
 
-    let(:events) do
-      subscriber.command_started_events('find')
-    end
-
     context 'when two queries have same read concern' do
       before do
         authorized_client['test', read_concern: { level: :majority }].find.to_a
@@ -228,10 +220,6 @@ describe 'QueryCache' do
     before do
       subscriber.clear_events!
       authorized_client['test'].drop
-    end
-
-    let(:events) do
-      subscriber.command_started_events('find')
     end
 
     context 'when two queries have different read preferences' do
@@ -284,10 +272,6 @@ describe 'QueryCache' do
       10.times do |i|
         authorized_collection.insert_one(test: i)
       end
-    end
-
-    let(:events) do
-      subscriber.command_started_events('find')
     end
 
     context 'when query cache is disabled' do
@@ -1030,15 +1014,10 @@ describe 'QueryCache' do
       authorized_collection.find.to_a
     end
 
-    let(:events) do
-      subscriber.command_started_events('find')
-    end
-
     it 'queries again' do
       new_collection.find.to_a
       expect(Mongo::QueryCache.send(:cache_table).length).to eq(2)
       expect(events.length).to eq(2)
     end
   end
-
 end


### PR DESCRIPTION
I have opted here not to add cache invalidation to the helpers that modify those systems collections as that would be a fairly significant project if I tried to do it exhaustively. Instead, I added a documentation section explaining that system collections use the query cache and the data will not be invalidated, so users should disable the query cache if they need up to date systems collection information.