### PR TITLE
RUBY-2419 Exclude connectionId field when checking for equality

### DIFF
--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -194,7 +194,8 @@ module Mongo
                                  LAST_WRITE,
                                  OPERATION_TIME,
                                  Operation::CLUSTER_TIME,
-                                 CONNECTION_ID ].freeze
+                                 CONNECTION_ID,
+                               ].freeze
 
       # Instantiate the new server description from the result of the ismaster
       # command.

--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -184,7 +184,7 @@ module Mongo
 
       # Constant for reading connectionId info from config.
       #
-      # @since 2.13.0
+      # @api private
       CONNECTION_ID = 'connectionId'.freeze
 
       # Fields to exclude when comparing two descriptions.

--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -182,13 +182,19 @@ module Mongo
       # @since 2.5.0
       LOGICAL_SESSION_TIMEOUT_MINUTES = 'logicalSessionTimeoutMinutes'.freeze
 
+      # Constant for reading connectionId info from config.
+      #
+      # @since 2.13.0
+      CONNECTION_ID = 'connectionId'.freeze
+
       # Fields to exclude when comparing two descriptions.
       #
       # @since 2.0.6
       EXCLUDE_FOR_COMPARISON = [ LOCAL_TIME,
                                  LAST_WRITE,
                                  OPERATION_TIME,
-                                 Operation::CLUSTER_TIME ].freeze
+                                 Operation::CLUSTER_TIME,
+                                 CONNECTION_ID ].freeze
 
       # Instantiate the new server description from the result of the ismaster
       # command.

--- a/spec/mongo/server/description_spec.rb
+++ b/spec/mongo/server/description_spec.rb
@@ -27,6 +27,7 @@ describe Mongo::Server::Description do
       'logicalSessionTimeoutMinutes' => 7,
       'operationTime' => 1,
       '$clusterTime' => 1,
+      'connectionId' => 11,
       'ok' => 1
     }
   end
@@ -750,6 +751,23 @@ describe Mongo::Server::Description do
 
       let(:other) do
         described_class.new(address, replica)
+      end
+
+      it 'returns true' do
+        expect(description == other).to be(true)
+      end
+    end
+
+    context 'when the configs match, but have different connectionId values' do
+
+      let(:description) do
+        described_class.new(address, replica)
+      end
+
+      let(:other) do
+        described_class.new(address, replica.merge(
+          'connectionId' => 12
+        ))
       end
 
       it 'returns true' do


### PR DESCRIPTION
`connectionId` does not represent state of the topology and as such should be excluded when comparing two Description objects.