### PR TITLE
RUBY-1524 Test that driver session pool is cleared after forking

### DIFF
--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -727,6 +727,13 @@ describe Mongo::Client do
       expect(new_id).not_to eql(old_id)
     end
 
+    it 'replaces the session pool' do
+      old_id = client.cluster.session_pool.object_id
+      client.reconnect
+      new_id = client.cluster.session_pool.object_id
+      expect(new_id).not_to eql(old_id)
+    end
+
     it 'returns true' do
       expect(client.reconnect).to be(true)
     end


### PR DESCRIPTION
I wrote the tests given in the spec change [here](https://github.com/mongodb/specifications/commit/6a31988385f54e4ec9daddfbf21344a2a96e2656) and they pass on our current implementation.