### PR TITLE
RUBY-2399 Provide more descriptive error message when inserting nil documents

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -566,7 +566,7 @@ module Mongo
         end
 
         if document.nil?
-          raise ArgumentError, "Inserted document cannot be nil"
+          raise ArgumentError, "Document to be inserted cannot be nil"
         end
 
         write_with_retry(session, write_concern) do |server, txn_num|

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -565,8 +565,8 @@ module Mongo
           write_concern_with_session(session)
         end
 
-        unless document.is_a?(Hash) || document.is_a?(BSON::Document)
-          raise ArgumentError, "Inserted document must be a Hash or BSON::Document."
+        if document.nil?
+          raise ArgumentError, "Inserted document cannot be nil"
         end
 
         write_with_retry(session, write_concern) do |server, txn_num|

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -564,6 +564,11 @@ module Mongo
         else
           write_concern_with_session(session)
         end
+
+        unless document.is_a?(Hash) || document.is_a?(BSON::Document)
+          raise ArgumentError, "Inserted document must be a Hash or BSON::Document."
+        end
+
         write_with_retry(session, write_concern) do |server, txn_num|
           Operation::Insert.new(
             :documents => [ document ],

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -1853,7 +1853,7 @@ describe Mongo::Collection do
       it 'raises an ArgumentError' do
        expect {
          result
-       }.to raise_error(ArgumentError, "Inserted document cannot be nil")
+       }.to raise_error(ArgumentError, "Document to be inserted cannot be nil")
      end
     end
 

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -1845,6 +1845,28 @@ describe Mongo::Collection do
       end
     end
 
+    context 'when the document is nil' do
+      let(:result) do
+        authorized_collection.insert_one(nil)
+      end
+      it 'raises an ArgumentError' do
+       expect {
+         result
+       }.to raise_error(ArgumentError, "Inserted document must be a Hash or BSON::Document.")
+     end
+    end
+
+    context 'when the document is not a hash or BSON' do
+      let(:result) do
+        authorized_collection.insert_one("hello")
+      end
+      it 'raises an ArgumentError' do
+       expect {
+         result
+       }.to raise_error(ArgumentError, "Inserted document must be a Hash or BSON::Document.")
+     end
+    end
+
     context 'when the insert fails' do
 
       let(:result) do

--- a/spec/mongo/collection_spec.rb
+++ b/spec/mongo/collection_spec.rb
@@ -1849,21 +1849,11 @@ describe Mongo::Collection do
       let(:result) do
         authorized_collection.insert_one(nil)
       end
-      it 'raises an ArgumentError' do
-       expect {
-         result
-       }.to raise_error(ArgumentError, "Inserted document must be a Hash or BSON::Document.")
-     end
-    end
 
-    context 'when the document is not a hash or BSON' do
-      let(:result) do
-        authorized_collection.insert_one("hello")
-      end
       it 'raises an ArgumentError' do
        expect {
          result
-       }.to raise_error(ArgumentError, "Inserted document must be a Hash or BSON::Document.")
+       }.to raise_error(ArgumentError, "Inserted document cannot be nil")
      end
     end
 


### PR DESCRIPTION
I added more detailed error messages for when users insert nil or non-hash documents (as described [here](https://jira.mongodb.org/browse/RUBY-2399)) and wrote corresponding unit test cases. 