### PR TITLE
RUBY-2349 Raise error when estimated_document_count is called with filters

### DIFF
--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -226,6 +226,10 @@ module Mongo
         #
         # @since 2.6.0
         def estimated_document_count(opts = {})
+          unless view.filter.empty?
+            raise ArgumentError, "Cannot call estimated_document_count when querying with a filter"
+          end
+
           cmd = { count: collection.name }
           cmd[:maxTimeMS] = opts[:max_time_ms] if opts[:max_time_ms]
           if read_concern

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -631,6 +631,7 @@ describe Mongo::Collection::View::Readable do
     end
 
     context 'when no selector is provided' do
+
       it 'returns the estimated count of matching documents' do
         expect(view.estimated_document_count).to eq(10)
       end

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -305,6 +305,7 @@ describe Mongo::Collection::View::Readable do
     end
 
     context 'when incorporating read concern' do
+
       let(:result) do
         new_view.count(options)
       end
@@ -328,6 +329,7 @@ describe Mongo::Collection::View::Readable do
     end
 
     context 'when no selector is provided' do
+
       it 'returns the count of matching documents' do
         expect(view.count).to eq(10)
       end

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -305,7 +305,6 @@ describe Mongo::Collection::View::Readable do
     end
 
     context 'when incorporating read concern' do
-
       let(:result) do
         new_view.count(options)
       end
@@ -329,7 +328,6 @@ describe Mongo::Collection::View::Readable do
     end
 
     context 'when no selector is provided' do
-
       it 'returns the count of matching documents' do
         expect(view.count).to eq(10)
       end
@@ -598,6 +596,41 @@ describe Mongo::Collection::View::Readable do
             }.to raise_exception(Mongo::Error::UnsupportedCollation)
           end
         end
+      end
+    end
+  end
+
+  describe "#estimated_document_count" do
+
+   let(:documents) do
+      (1..10).map{ |i| { field: "test#{i}" }}
+   end
+
+   before do
+    authorized_collection.delete_many
+    authorized_collection.insert_many(documents)
+   end
+
+    let(:result) do
+      view.estimated_document_count(options)
+    end
+
+    context 'when a selector is provided' do
+
+      let(:selector) do
+        { field: 'test1' }
+      end
+
+      it 'raises an error' do
+        expect {
+          result
+        }.to raise_error(ArgumentError, "Cannot call estimated_document_count when querying with a filter")
+      end
+    end
+
+    context 'when no selector is provided' do
+      it 'returns the estimated count of matching documents' do
+        expect(view.estimated_document_count).to eq(10)
       end
     end
   end


### PR DESCRIPTION
I added a check in estimated_document_count to raise an error if the filter hash is non-empty (as discussed [here](https://jira.mongodb.org/browse/RUBY-2349)), and I added corresponding unit tests.