### PR TITLE
Fix FLE tests

### DIFF
--- a/spec/mongo/client_encryption_spec.rb
+++ b/spec/mongo/client_encryption_spec.rb
@@ -268,13 +268,27 @@ describe Mongo::ClientEncryption do
         it_behaves_like 'it creates a data key'
       end
 
-      context 'with invalid endpoint' do
+      context 'with https' do
         let(:options) do
           {
             master_key: {
               key: aws_arn,
               region: aws_region,
               endpoint: "https://#{aws_endpoint_host}:#{aws_endpoint_port}"
+            }
+          }
+        end
+
+        it_behaves_like 'it creates a data key'
+      end
+
+      context 'with invalid endpoint' do
+        let(:options) do
+          {
+            master_key: {
+              key: aws_arn,
+              region: aws_region,
+              endpoint: "invalid-nonsense-endpoint.com"
             }
           }
         end

--- a/spec/mongo/client_encryption_spec.rb
+++ b/spec/mongo/client_encryption_spec.rb
@@ -293,20 +293,12 @@ describe Mongo::ClientEncryption do
           }
         end
 
-        let(:expected_message) do
+        it 'raises an exception' do
           # RUBY-2129: This error message could be more specific and inform the user
           # that there is a problem with their KMS endpoint
-          if BSON::Environment.jruby?
-            /getservbyname.* failed/
-          else
-            /SocketError/
-          end
-        end
-
-        it 'raises an exception' do
           expect do
             data_key_id
-          end.to raise_error(Mongo::Error::KmsError, expected_message)
+          end.to raise_error(Mongo::Error::KmsError, /SocketError/)
         end
       end
 

--- a/spec/mongo/crypt/data_key_context_spec.rb
+++ b/spec/mongo/crypt/data_key_context_spec.rb
@@ -188,7 +188,7 @@ describe Mongo::Crypt::DataKeyContext do
       end
 
       context 'with valid endpoint' do
-        let(:options) { { master_key: { region: 'us-east-2', key: 'arn', endpoint: 'endpoint/to/kms' } } }
+        let(:options) { { master_key: { region: 'us-east-2', key: 'arn', endpoint: 'kms.us-east-2.amazonaws.com:443' } } }
 
         it 'does not raise an exception' do
           expect do


### PR DESCRIPTION
It looks like libmongocrypt has changed some of its KMS endpoint validation behavior -- now calling the Amazon KMS endpoint via https is valid, and the data key context object also performs some endpoint validation. This does not impact the user experience with FLE.