### PR TITLE
Remove pending status from BSON Symbol test

### DIFF
--- a/spec/integration/bson_symbol_spec.rb
+++ b/spec/integration/bson_symbol_spec.rb
@@ -25,10 +25,6 @@ describe 'Symbol encoding to BSON' do
   end
 
   it 'round-trips symbol values using the same byte buffer' do
-    if BSON::Environment.jruby?
-      pending 'https://jira.mongodb.org/browse/RUBY-2128'
-    end
-
     Hash.from_bson(hash.to_bson).should == hash
   end
 end

--- a/spec/integration/bson_symbol_spec.rb
+++ b/spec/integration/bson_symbol_spec.rb
@@ -25,6 +25,12 @@ describe 'Symbol encoding to BSON' do
   end
 
   it 'round-trips symbol values using the same byte buffer' do
+    if BSON::Environment.jruby? && BSON::VERSION < "4.11.0"
+      skip 'This test is only relevant to bson versions that increment ByteBuffer '\
+       'read and write positions separately in JRuby, as implemented in ' \
+       'bson version 4.11.0. For more information, see https://jira.mongodb.org/browse/RUBY-2128'
+    end
+
     Hash.from_bson(hash.to_bson).should == hash
   end
 end

--- a/spec/support/shared/protocol.rb
+++ b/spec/support/shared/protocol.rb
@@ -5,7 +5,8 @@ shared_examples 'message with a header' do
     describe 'length' do
       let(:field) { bytes.to_s[0..3] }
       it 'serializes the length' do
-        expect(field).to be_int32(bytes.length)
+        bytes.rewind!
+        expect(field).to be_int32(bytes.to_s.length)
       end
     end
 

--- a/spec/support/shared/protocol.rb
+++ b/spec/support/shared/protocol.rb
@@ -5,8 +5,7 @@ shared_examples 'message with a header' do
     describe 'length' do
       let(:field) { bytes.to_s[0..3] }
       it 'serializes the length' do
-        bytes.rewind! if BSON::Environment.jruby?
-        expect(field).to be_int32(bytes.to_s.length)
+        expect(field).to be_int32(bytes.length)
       end
     end
 

--- a/spec/support/shared/protocol.rb
+++ b/spec/support/shared/protocol.rb
@@ -5,7 +5,7 @@ shared_examples 'message with a header' do
     describe 'length' do
       let(:field) { bytes.to_s[0..3] }
       it 'serializes the length' do
-        bytes.rewind!
+        bytes.rewind! if BSON::Environment.jruby?
         expect(field).to be_int32(bytes.to_s.length)
       end
     end


### PR DESCRIPTION
A couple tests were broken/fixed as a result of the bson jruby 4.11.0 release.