### PR TITLE
RUBY-2444 remove SSL_ERROR messaging since it is often confusing in present days


### DIFF
--- a/lib/mongo/address.rb
+++ b/lib/mongo/address.rb
@@ -286,7 +286,7 @@ module Mongo
       rescue IOError, SystemCallError => e
         raise Error::SocketError, "#{e.class}: #{e} (for #{self})"
       rescue OpenSSL::SSL::SSLError => e
-        raise Error::SocketError, "#{e.class}: #{e} (for #{self}) (#{SSL_ERROR})"
+        raise Error::SocketError, "#{e.class}: #{e} (for #{self})"
       end
     end
   end

--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -30,6 +30,7 @@ module Mongo
     # Error message for TLS related exceptions.
     #
     # @since 2.0.0
+    # @deprecated
     SSL_ERROR = 'MongoDB may not be configured with TLS support'.freeze
 
     # Error message for timeouts on socket calls.
@@ -422,7 +423,7 @@ module Mongo
       rescue IOError, SystemCallError => e
         raise Error::SocketError, "#{e.class}: #{e} (for #{human_address})"
       rescue OpenSSL::SSL::SSLError => e
-        raise Error::SocketError, "#{e.class}: #{e} (for #{human_address}) (#{SSL_ERROR})"
+        raise Error::SocketError, "#{e.class}: #{e} (for #{human_address})"
       end
     end
 

--- a/spec/mongo/socket_spec.rb
+++ b/spec/mongo/socket_spec.rb
@@ -48,7 +48,7 @@ describe Mongo::Socket do
         socket.send(:map_exceptions) do
           raise OpenSSL::SSL::SSLError.new('Test error')
         end
-      end.to raise_error(Mongo::Error::SocketError, 'OpenSSL::SSL::SSLError: Test error (for fake-address) (MongoDB may not be configured with TLS support)')
+      end.to raise_error(Mongo::Error::SocketError, 'OpenSSL::SSL::SSLError: Test error (for fake-address)')
     end
   end
 


### PR DESCRIPTION
https://jira.mongodb.com/browse/RUBY-2444