### PR TITLE
RUBY-1682: Add Zstandard (zstd) network compression support

### DIFF
--- a/.evergreen/config-atlas.yml
+++ b/.evergreen/config-atlas.yml
@@ -37,7 +37,7 @@ functions:
         working_dir: "src"
         script: |
           set -ex
-
+          
           git submodule update --init --recursive
 
   "fetch egos":
@@ -46,15 +46,15 @@ functions:
         working_dir: "src"
         script: |
           set -e
-
+          
           # Python version:
           #curl -sfLo egos https://raw.githubusercontent.com/p-mongo/egos/master/egos
-
+          
           # C version:
           curl --retry 3 -sfLo egos.c https://raw.githubusercontent.com/p-mongo/egos/master/egos.c
           gcc -O2 -g -oegos -lrt egos.c
 
-
+  
   "create expansions":
     # Make an evergreen expansion file with dynamic values
     - command: shell.exec
@@ -108,7 +108,7 @@ functions:
           EOT
           # See what we've done
           cat expansion.yml
-
+  
 
     # Load the expansion file to make an evergreen variable with the current
     # unique version
@@ -372,11 +372,11 @@ post:
 
 tasks:
 
-
+  
   - name: "test-atlas"
     commands:
       - func: "run Atlas tests"
-
+  
 axes:
 
   - id: preload
@@ -710,32 +710,32 @@ axes:
   - id: ocsp-connectivity
     display_name: OCSP Connectivity
     values:
-
+      
       - id: pass
         display_name: pass
         variables:
           OCSP_CONNECTIVITY: pass
-
+      
       - id: fail
         display_name: fail
         variables:
           OCSP_CONNECTIVITY: fail
-
+      
 
   - id: extra-uri-options
     display_name: extra URI options
     values:
       - id: none
         display_name: None
-
+      
       - id: "tlsInsecure=true"
         variables:
           EXTRA_URI_OPTIONS: "tlsInsecure=true"
-
+      
       - id: "tlsAllowInvalidCertificates=true"
         variables:
           EXTRA_URI_OPTIONS: "tlsAllowInvalidCertificates=true"
-
+      
 buildvariants:
   - matrix_name: "all"
     matrix_spec: { ruby: '*' }

--- a/.evergreen/config-atlas.yml
+++ b/.evergreen/config-atlas.yml
@@ -37,7 +37,7 @@ functions:
         working_dir: "src"
         script: |
           set -ex
-          
+
           git submodule update --init --recursive
 
   "fetch egos":
@@ -46,15 +46,15 @@ functions:
         working_dir: "src"
         script: |
           set -e
-          
+
           # Python version:
           #curl -sfLo egos https://raw.githubusercontent.com/p-mongo/egos/master/egos
-          
+
           # C version:
           curl --retry 3 -sfLo egos.c https://raw.githubusercontent.com/p-mongo/egos/master/egos.c
           gcc -O2 -g -oegos -lrt egos.c
 
-  
+
   "create expansions":
     # Make an evergreen expansion file with dynamic values
     - command: shell.exec
@@ -108,7 +108,7 @@ functions:
           EOT
           # See what we've done
           cat expansion.yml
-  
+
 
     # Load the expansion file to make an evergreen variable with the current
     # unique version
@@ -372,11 +372,11 @@ post:
 
 tasks:
 
-  
+
   - name: "test-atlas"
     commands:
       - func: "run Atlas tests"
-  
+
 axes:
 
   - id: preload
@@ -567,6 +567,10 @@ axes:
         display_name: Snappy
         variables:
           COMPRESSOR: "snappy"
+      - id: "zstd"
+        display_name: Zstd
+        variables:
+          COMPRESSOR: "zstd"
 
   - id: retry-reads
     display_name: Retry Reads
@@ -706,32 +710,32 @@ axes:
   - id: ocsp-connectivity
     display_name: OCSP Connectivity
     values:
-      
+
       - id: pass
         display_name: pass
         variables:
           OCSP_CONNECTIVITY: pass
-      
+
       - id: fail
         display_name: fail
         variables:
           OCSP_CONNECTIVITY: fail
-      
+
 
   - id: extra-uri-options
     display_name: extra URI options
     values:
       - id: none
         display_name: None
-      
+
       - id: "tlsInsecure=true"
         variables:
           EXTRA_URI_OPTIONS: "tlsInsecure=true"
-      
+
       - id: "tlsAllowInvalidCertificates=true"
         variables:
           EXTRA_URI_OPTIONS: "tlsAllowInvalidCertificates=true"
-      
+
 buildvariants:
   - matrix_name: "all"
     matrix_spec: { ruby: '*' }

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -37,7 +37,7 @@ functions:
         working_dir: "src"
         script: |
           set -ex
-
+          
           git submodule update --init --recursive
 
   "fetch egos":
@@ -46,15 +46,15 @@ functions:
         working_dir: "src"
         script: |
           set -e
-
+          
           # Python version:
           #curl -sfLo egos https://raw.githubusercontent.com/p-mongo/egos/master/egos
-
+          
           # C version:
           curl --retry 3 -sfLo egos.c https://raw.githubusercontent.com/p-mongo/egos/master/egos.c
           gcc -O2 -g -oegos -lrt egos.c
 
-
+  
   "create expansions":
     # Make an evergreen expansion file with dynamic values
     - command: shell.exec
@@ -130,7 +130,7 @@ functions:
 
           # See what we've done
           cat expansion.yml
-
+  
 
     # Load the expansion file to make an evergreen variable with the current
     # unique version
@@ -394,7 +394,7 @@ post:
 
 tasks:
 
-
+  
   - name: "test-docker"
     commands:
       - func: "build and test docker image"
@@ -416,7 +416,7 @@ tasks:
     commands:
       - func: "export AWS auth credentials"
       - func: "run AWS auth tests"
-
+  
 axes:
 
   - id: preload
@@ -750,32 +750,32 @@ axes:
   - id: ocsp-connectivity
     display_name: OCSP Connectivity
     values:
-
+      
       - id: pass
         display_name: pass
         variables:
           OCSP_CONNECTIVITY: pass
-
+      
       - id: fail
         display_name: fail
         variables:
           OCSP_CONNECTIVITY: fail
-
+      
 
   - id: extra-uri-options
     display_name: extra URI options
     values:
       - id: none
         display_name: None
-
+      
       - id: "tlsInsecure=true"
         variables:
           EXTRA_URI_OPTIONS: "tlsInsecure=true"
-
+      
       - id: "tlsAllowInvalidCertificates=true"
         variables:
           EXTRA_URI_OPTIONS: "tlsAllowInvalidCertificates=true"
-
+      
 buildvariants:
   - matrix_name: "docker"
     matrix_spec:
@@ -1095,7 +1095,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: "noauth-and-nossl"
       ruby: "ruby-2.3"
-      mongodb-version: "3.6"
+      mongodb-version: "4.2"
       topology: replica-set
       compressor: 'zstd'
       os: ubuntu1604
@@ -1104,15 +1104,15 @@ buildvariants:
       - name: "test-mlaunch"
 
 #  - matrix_name: "zstd-jruby"
-#     matrix_spec:
-#       ruby: jruby-9.2
-#       mongodb-version: "4.4"
+#    matrix_spec:
+#      ruby: jruby-9.2
+#      mongodb-version: "4.4"
 #      topology: replica-set
-#       compressor: 'zstd'
-#       os: ubuntu1604
+#      compressor: 'zstd'
+#      os: ubuntu1604
 #    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-#     tasks:
-#       - name: "test-mlaunch"
+#    tasks:
+#      - name: "test-mlaunch"
 
 #   - matrix_name: "ruby-head"
 #     matrix_spec:
@@ -1289,7 +1289,7 @@ buildvariants:
     tasks:
       - name: test-mlaunch
 
-
+  
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1304,7 +1304,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-
+  
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1319,7 +1319,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-
+  
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1334,7 +1334,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-
+  
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1349,7 +1349,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-
+  
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1364,7 +1364,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-
+  
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1379,7 +1379,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-
+  
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1394,7 +1394,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-
+  
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1409,7 +1409,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-
+  
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1424,7 +1424,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-
+  
 
   - matrix_name: ocsp-connectivity-jruby
     matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -37,7 +37,7 @@ functions:
         working_dir: "src"
         script: |
           set -ex
-          
+
           git submodule update --init --recursive
 
   "fetch egos":
@@ -46,15 +46,15 @@ functions:
         working_dir: "src"
         script: |
           set -e
-          
+
           # Python version:
           #curl -sfLo egos https://raw.githubusercontent.com/p-mongo/egos/master/egos
-          
+
           # C version:
           curl --retry 3 -sfLo egos.c https://raw.githubusercontent.com/p-mongo/egos/master/egos.c
           gcc -O2 -g -oegos -lrt egos.c
 
-  
+
   "create expansions":
     # Make an evergreen expansion file with dynamic values
     - command: shell.exec
@@ -130,7 +130,7 @@ functions:
 
           # See what we've done
           cat expansion.yml
-  
+
 
     # Load the expansion file to make an evergreen variable with the current
     # unique version
@@ -394,7 +394,7 @@ post:
 
 tasks:
 
-  
+
   - name: "test-docker"
     commands:
       - func: "build and test docker image"
@@ -416,7 +416,7 @@ tasks:
     commands:
       - func: "export AWS auth credentials"
       - func: "run AWS auth tests"
-  
+
 axes:
 
   - id: preload
@@ -607,6 +607,10 @@ axes:
         display_name: Snappy
         variables:
           COMPRESSOR: "snappy"
+      - id: "zstd"
+        display_name: Zstd
+        variables:
+          COMPRESSOR: "zstd"
 
   - id: retry-reads
     display_name: Retry Reads
@@ -746,32 +750,32 @@ axes:
   - id: ocsp-connectivity
     display_name: OCSP Connectivity
     values:
-      
+
       - id: pass
         display_name: pass
         variables:
           OCSP_CONNECTIVITY: pass
-      
+
       - id: fail
         display_name: fail
         variables:
           OCSP_CONNECTIVITY: fail
-      
+
 
   - id: extra-uri-options
     display_name: extra URI options
     values:
       - id: none
         display_name: None
-      
+
       - id: "tlsInsecure=true"
         variables:
           EXTRA_URI_OPTIONS: "tlsInsecure=true"
-      
+
       - id: "tlsAllowInvalidCertificates=true"
         variables:
           EXTRA_URI_OPTIONS: "tlsAllowInvalidCertificates=true"
-      
+
 buildvariants:
   - matrix_name: "docker"
     matrix_spec:
@@ -783,7 +787,7 @@ buildvariants:
     display_name: "Docker ${os} ${mongodb-version} ${topology} ${ruby} ${preload}"
     tasks:
       - name: "test-docker"
-  
+
   - matrix_name: "docker"
     matrix_spec:
       ruby: "ruby-2.7"
@@ -1075,6 +1079,41 @@ buildvariants:
     tasks:
       - name: "test-mlaunch"
 
+  - matrix_name: "zstd-auth"
+    matrix_spec:
+      auth-and-ssl: "auth-and-ssl"
+      ruby: "ruby-2.7"
+      mongodb-version: "4.2"
+      topology: "*"
+      compressor: 'zstd'
+      os: ubuntu1604
+    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+    tasks:
+      - name: "test-mlaunch"
+
+  - matrix_name: "zstd-noauth"
+    matrix_spec:
+      auth-and-ssl: "noauth-and-nossl"
+      ruby: "ruby-2.3"
+      mongodb-version: "3.6"
+      topology: replica-set
+      compressor: 'zstd'
+      os: ubuntu1604
+    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+    tasks:
+      - name: "test-mlaunch"
+
+  - matrix_name: "zstd-jruby"
+    matrix_spec:
+      ruby: jruby-9.2
+      mongodb-version: "4.4"
+      topology: replica-set
+      compressor: 'zstd'
+      os: ubuntu1604
+    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+    tasks:
+      - name: "test-mlaunch"
+
 #   - matrix_name: "ruby-head"
 #     matrix_spec:
 #       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
@@ -1250,7 +1289,7 @@ buildvariants:
     tasks:
       - name: test-mlaunch
 
-  
+
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1265,7 +1304,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-  
+
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1280,7 +1319,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-  
+
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1295,7 +1334,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-  
+
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1310,7 +1349,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-  
+
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1325,7 +1364,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-  
+
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1340,7 +1379,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-  
+
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1355,7 +1394,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-  
+
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1370,7 +1409,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-  
+
   - matrix_name: ocsp-connectivity
     matrix_spec:
       ocsp-algorithm: '*'
@@ -1385,7 +1424,7 @@ buildvariants:
     display_name: "OCSP connectivity: ${ocsp-algorithm} ${ocsp-status} ${ocsp-delegate} ${extra-uri-options} ${mongodb-version} ${ruby}"
     tasks:
       - name: test-mlaunch
-  
+
 
   - matrix_name: ocsp-connectivity-jruby
     matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1103,16 +1103,16 @@ buildvariants:
     tasks:
       - name: "test-mlaunch"
 
-  - matrix_name: "zstd-jruby"
-    matrix_spec:
-      ruby: jruby-9.2
-      mongodb-version: "4.4"
-      topology: replica-set
-      compressor: 'zstd'
-      os: ubuntu1604
-    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-    tasks:
-      - name: "test-mlaunch"
+#  - matrix_name: "zstd-jruby"
+#     matrix_spec:
+#       ruby: jruby-9.2
+#       mongodb-version: "4.4"
+#      topology: replica-set
+#       compressor: 'zstd'
+#       os: ubuntu1604
+#    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#     tasks:
+#       - name: "test-mlaunch"
 
 #   - matrix_name: "ruby-head"
 #     matrix_spec:

--- a/.evergreen/config/axes.yml.erb
+++ b/.evergreen/config/axes.yml.erb
@@ -188,6 +188,10 @@ axes:
         display_name: Snappy
         variables:
           COMPRESSOR: "snappy"
+      - id: "zstd"
+        display_name: Zstd
+        variables:
+          COMPRESSOR: "zstd"
 
   - id: retry-reads
     display_name: Retry Reads

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -9,7 +9,7 @@ buildvariants:
     display_name: "Docker ${os} ${mongodb-version} ${topology} ${ruby} ${preload}"
     tasks:
       - name: "test-docker"
-  
+
   - matrix_name: "docker"
     matrix_spec:
       ruby: "ruby-2.7"
@@ -301,6 +301,41 @@ buildvariants:
     tasks:
       - name: "test-mlaunch"
 
+  - matrix_name: "zstd-auth"
+    matrix_spec:
+      auth-and-ssl: "auth-and-ssl"
+      ruby: "ruby-2.7"
+      mongodb-version: "4.2"
+      topology: "*"
+      compressor: 'zstd'
+      os: ubuntu1604
+    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+    tasks:
+      - name: "test-mlaunch"
+
+  - matrix_name: "zstd-noauth"
+    matrix_spec:
+      auth-and-ssl: "noauth-and-nossl"
+      ruby: "ruby-2.3"
+      mongodb-version: "3.6"
+      topology: replica-set
+      compressor: 'zstd'
+      os: ubuntu1604
+    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+    tasks:
+      - name: "test-mlaunch"
+
+  - matrix_name: "zstd-jruby"
+    matrix_spec:
+      ruby: jruby-9.2
+      mongodb-version: "4.4"
+      topology: replica-set
+      compressor: 'zstd'
+      os: ubuntu1604
+    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+    tasks:
+      - name: "test-mlaunch"
+
 #   - matrix_name: "ruby-head"
 #     matrix_spec:
 #       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
@@ -480,11 +515,11 @@ buildvariants:
     %w(valid none pass),
     %w(unknown none pass),
     %w(revoked none fail),
-    
+
     %w(valid tlsInsecure=true pass),
     %w(unknown tlsInsecure=true pass),
     %w(revoked tlsInsecure=true pass),
-    
+
     %w(valid tlsAllowInvalidCertificates=true pass),
     %w(unknown tlsAllowInvalidCertificates=true pass),
     %w(revoked tlsAllowInvalidCertificates=true pass),

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -317,7 +317,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: "noauth-and-nossl"
       ruby: "ruby-2.3"
-      mongodb-version: "3.6"
+      mongodb-version: "4.2"
       topology: replica-set
       compressor: 'zstd'
       os: ubuntu1604

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -325,16 +325,16 @@ buildvariants:
     tasks:
       - name: "test-mlaunch"
 
-  - matrix_name: "zstd-jruby"
-    matrix_spec:
-      ruby: jruby-9.2
-      mongodb-version: "4.4"
-      topology: replica-set
-      compressor: 'zstd'
-      os: ubuntu1604
-    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-    tasks:
-      - name: "test-mlaunch"
+#  - matrix_name: "zstd-jruby"
+#    matrix_spec:
+#      ruby: jruby-9.2
+#      mongodb-version: "4.4"
+#      topology: replica-set
+#      compressor: 'zstd'
+#      os: ubuntu1604
+#    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+#    tasks:
+#      - name: "test-mlaunch"
 
 #   - matrix_name: "ruby-head"
 #     matrix_spec:

--- a/.evergreen/functions.sh
+++ b/.evergreen/functions.sh
@@ -46,6 +46,8 @@ set_env_vars() {
     export BUNDLE_GEMFILE=gemfiles/bson_master.gemfile
   elif test "$COMPRESSOR" = snappy; then
     export BUNDLE_GEMFILE=gemfiles/snappy_compression.gemfile
+  elif test "$COMPRESSOR" = zstd; then
+    export BUNDLE_GEMFILE=gemfiles/zstd_compression.gemfile
   fi
 
   # rhel62 ships with Python 2.6

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -183,6 +183,11 @@ if test "$COMPRESSOR" = snappy; then
   add_uri_option compressors=snappy
 fi
 
+if test "$COMPRESSOR" = zstd; then
+  add_uri_option compressors=zstd
+fi
+
+
 echo "Running tests"
 set +e
 if test -n "$TEST_CMD"; then

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -319,9 +319,8 @@ Ruby Options
      - none
 
    * - ``:compressors``
-     - A list of potential compressors to use, in order of preference. The driver chooses the first
-       compressor that is also supported by the server. Currently the driver only supports 'zstd',
-       'snappy' and 'zlib'.
+     - A list of potential compressors to use, in order of preference.
+       Please see below for details on how the driver implements compression.
      - ``Array<String>``
      - none
 
@@ -740,23 +739,9 @@ URI options are explained in detail in the :manual:`Connection URI reference
    * - compressors=Strings
      - ``:compressors => Array<String>``
 
-       Specified as an ordered, comma-separated list. The Ruby driver currently supports zstd, snappy
-       and zlib compression algorithms; the first algorithm in the list that the server
-       also supports will be used. Compression must be explicitly enabled by
-       specifying the desired compression algorithm; use "zstd,snappy,zlib" for maximum server
-       compatibility.
-
-       Snappy compression requires separate installation of the
-       snappy Ruby library; if the snappy Ruby library is not available,
-       the driver raises an error during ``Mongo::Client`` creation.
-       When using MongoDB 4.0 and earlier, zlib compression is supported by the
-       server but must be manually enabled; if zlib is the only compression algorithm
-       requested (or available due to missing snappy Ruby library), 4.0 and
-       earlier servers must be configured to explicitly enable zlib compression.
-
-       Zstd compression was introduced with Server 4.2 and requires a separate installation of the
-       zstd-ruby Ruby library. If the zstd-ruby Ruby library is not available,
-       the driver raises an error during ``Mongo::Client`` creation.
+       A comma-separated list of potential compressors to use, in order of
+       preference. Please see below for details on how the driver implements
+       compression.
 
    * - connect=String
      - ``:connect => Symbol``
@@ -1669,6 +1654,39 @@ option to the client instance.
 .. code-block:: ruby
 
   Mongo::Client.new([ '127.0.0.1:27017' ], :database => 'test', :truncate_logs => false )
+
+
+Compression
+===========
+
+To use wire protocol compression, at least one compressor must be explicitly
+requested using either the ``:compressors`` Ruby option or the ``compressors``
+URI option. If no compressors are explicitly requested, the driver will not
+use compression, even if the required dependencies for one or more compressors
+are present on the system.
+
+The driver chooses the first compressor of the ones requested that is also
+supported by the server. The driver currently supports ``zstd``, ``snappy`` and
+``zlib`` compressors. ``zstd`` compressor is recommended as it produces
+the highest compression at the same CPU consumption compared to the other
+compressors. For maximum server compatibility all three compressors can be
+specified, e.g. as ``compressors: ["zstd", "snappy", "zlib"]``.
+
+``zstd`` compressor requires the 
+`zstd-ruby <https://rubygems.org/gems/zstd-ruby>`_ library to be installed.
+``snappy`` compressor requires the
+`snappy <https://rubygems.org/gems/snappy>`_ library to be installed.
+If ``zstd`` or ``snappy`` compression is requested, and the respective
+library is not loadable, the driver will raise an error during
+``Mongo::Client`` creation. ``zlib`` compression requires the ``zlib``
+standard library extension to be present.
+
+The server support for various compressors is as follows:
+
+- ``zstd`` requires and is enabled by default in MongoDB 4.2 or higher.
+- ``snappy`` requires and is enabled by default in MongoDB 3.6 or higher.
+- ``zlib`` requires MongoDB 3.6 or higher and is enabled by default in
+  MongoDB 4.2 and higher.
 
 
 Development Configuration

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -1684,7 +1684,8 @@ standard library extension to be present.
 The server support for various compressors is as follows:
 
 - ``zstd`` requires and is enabled by default in MongoDB 4.2 or higher.
-- ``snappy`` requires and is enabled by default in MongoDB 3.6 or higher.
+- ``snappy`` requires MongoDB 3.4 or higher and is enabled by default in
+  MongoDB 3.6 or higher.
 - ``zlib`` requires MongoDB 3.6 or higher and is enabled by default in
   MongoDB 4.2 and higher.
 

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -320,8 +320,8 @@ Ruby Options
 
    * - ``:compressors``
      - A list of potential compressors to use, in order of preference. The driver chooses the first
-       compressor that is also supported by the server. Currently the driver only supports 'snappy'
-       and 'zlib'.
+       compressor that is also supported by the server. Currently the driver only supports 'snappy',
+       'zstd' and 'zlib'.
      - ``Array<String>``
      - none
 
@@ -740,17 +740,23 @@ URI options are explained in detail in the :manual:`Connection URI reference
    * - compressors=Strings
      - ``:compressors => Array<String>``
 
-       Specified as a comma-separated list. The Ruby driver currently supports snappy
+       Specified as a comma-separated list. The Ruby driver currently supports snappy, zstd
        and zlib compression algorithms; the first algorithm in the list that the server
        also supports will be used. Compression must be explicitly enabled by
-       specifying the desired compression algorithm; use "snappy,zlib" for maximum server
-       compatibility. Snappy compression requires separate installation of the
+       specifying the desired compression algorithm; use "snappy,zlib,zstd" for maximum server
+       compatibility.
+
+       Snappy compression requires separate installation of the
        snappy Ruby library; if the snappy Ruby library is not available,
        the driver raises an error during ``Mongo::Client`` creation.
        When using MongoDB 4.0 and earlier, zlib compression is supported by the
        server but must be manually enabled; if zlib is the only compression algorithm
        requested (or available due to missing snappy Ruby library), 4.0 and
        earlier servers must be configured to explicitly enable zlib compression.
+
+       Zstd compression was introduced with Server 4.2 and requires a separate installation of the
+       zstd-ruby Ruby library. If the zstd-ruby Ruby library is not available,
+       the driver raises an error during ``Mongo::Client`` creation.
 
    * - connect=String
      - ``:connect => Symbol``

--- a/docs/tutorials/ruby-driver-create-client.txt
+++ b/docs/tutorials/ruby-driver-create-client.txt
@@ -320,8 +320,8 @@ Ruby Options
 
    * - ``:compressors``
      - A list of potential compressors to use, in order of preference. The driver chooses the first
-       compressor that is also supported by the server. Currently the driver only supports 'snappy',
-       'zstd' and 'zlib'.
+       compressor that is also supported by the server. Currently the driver only supports 'zstd',
+       'snappy' and 'zlib'.
      - ``Array<String>``
      - none
 
@@ -740,10 +740,10 @@ URI options are explained in detail in the :manual:`Connection URI reference
    * - compressors=Strings
      - ``:compressors => Array<String>``
 
-       Specified as a comma-separated list. The Ruby driver currently supports snappy, zstd
+       Specified as an ordered, comma-separated list. The Ruby driver currently supports zstd, snappy
        and zlib compression algorithms; the first algorithm in the list that the server
        also supports will be used. Compression must be explicitly enabled by
-       specifying the desired compression algorithm; use "snappy,zlib,zstd" for maximum server
+       specifying the desired compression algorithm; use "zstd,snappy,zlib" for maximum server
        compatibility.
 
        Snappy compression requires separate installation of the

--- a/gemfiles/zstd_compression.gemfile
+++ b/gemfiles/zstd_compression.gemfile
@@ -1,0 +1,8 @@
+source "https://rubygems.org"
+gemspec path: '..'
+
+gem 'zstd-ruby'
+
+require_relative './standard'
+
+standard_dependencies

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -115,9 +115,9 @@ module Mongo
     #
     # @since 2.5.0
     VALID_COMPRESSORS = [
+      Mongo::Protocol::Compressed::ZSTD,
       Mongo::Protocol::Compressed::SNAPPY,
-      Mongo::Protocol::Compressed::ZLIB,
-      Mongo::Protocol::Compressed::ZSTD
+      Mongo::Protocol::Compressed::ZLIB
     ].freeze
 
     # @return [ Mongo::Cluster ] cluster The cluster of servers for the client.
@@ -227,7 +227,7 @@ module Mongo
     # @option options [ Array<String> ] :compressors A list of potential
     #   compressors to use, in order of preference. The driver chooses the
     #   first compressor that is also supported by the server. Currently the
-    #   driver only supports 'snappy', 'zstd' and 'zlib'.
+    #   driver only supports 'zstd, 'snappy' and 'zlib'.
     # @option options [ true | false ] :direct_connection Whether to connect
     #   directly to the specified seed, bypassing topology discovery. Exactly
     #   one seed must be provided.

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -116,7 +116,8 @@ module Mongo
     # @since 2.5.0
     VALID_COMPRESSORS = [
       Mongo::Protocol::Compressed::SNAPPY,
-      Mongo::Protocol::Compressed::ZLIB
+      Mongo::Protocol::Compressed::ZLIB,
+      Mongo::Protocol::Compressed::ZSTD
     ].freeze
 
     # @return [ Mongo::Cluster ] cluster The cluster of servers for the client.
@@ -226,7 +227,7 @@ module Mongo
     # @option options [ Array<String> ] :compressors A list of potential
     #   compressors to use, in order of preference. The driver chooses the
     #   first compressor that is also supported by the server. Currently the
-    #   driver only supports 'snappy' and 'zlib'.
+    #   driver only supports 'snappy', 'zstd' and 'zlib'.
     # @option options [ true | false ] :direct_connection Whether to connect
     #   directly to the specified seed, bypassing topology discovery. Exactly
     #   one seed must be provided.
@@ -1163,6 +1164,10 @@ module Mongo
               validate_snappy_compression!
             end
 
+            if compressors.include?('zstd')
+              validate_zstd_compression!
+            end
+
             _options[key] = compressors unless compressors.empty?
           else
             _options[key] = v
@@ -1331,6 +1336,15 @@ module Mongo
     rescue LoadError => e
       raise Error::UnmetDependency, "Cannot enable snappy compression because the snappy gem " \
         "has not been installed. Add \"gem 'snappy'\" to your Gemfile and run " \
+        "\"bundle install\" to install the gem. (#{e.class}: #{e})"
+    end
+
+    def validate_zstd_compression!
+      return if defined?(Zstd)
+      require 'zstd-ruby'
+    rescue LoadError => e
+      raise Error::UnmetDependency, "Cannot enable zstd compression because the zstd-ruby gem " \
+        "has not been installed. Add \"gem 'zstd-ruby'\" to your Gemfile and run " \
         "\"bundle install\" to install the gem. (#{e.class}: #{e})"
     end
 

--- a/lib/mongo/protocol/compressed.rb
+++ b/lib/mongo/protocol/compressed.rb
@@ -18,6 +18,7 @@ module Mongo
     # MongoDB Wire protocol Compressed message.
     #
     # This is a bi-directional message that compresses another opcode.
+    # See https://github.com/mongodb/specifications/blob/master/source/compression/OP_COMPRESSED.rst
     #
     # @api semipublic
     #
@@ -46,11 +47,18 @@ module Mongo
       # @since 2.5.0
       ZLIB = 'zlib'.freeze
 
+      # The zstd compressor identifier.
+      ZSTD = 'zstd'.freeze
+
+      # The byte signaling that the message has been compressed with zstd.
+      ZSTD_BYTE = 3.chr.force_encoding(BSON::BINARY).freeze
+
       # The compressor identifier to byte map.
       #
       # @since 2.5.0
       COMPRESSOR_ID_MAP = {
         SNAPPY => SNAPPY_BYTE,
+        ZSTD => ZSTD_BYTE,
         ZLIB => ZLIB_BYTE
       }.freeze
 
@@ -149,6 +157,10 @@ module Mongo
           Zlib::Deflate.deflate(buffer.to_s, @zlib_compression_level).force_encoding(BSON::BINARY)
         elsif @compressor_id == SNAPPY_BYTE
           Snappy.deflate(buffer.to_s).force_encoding(BSON::BINARY)
+        elsif @compressor_id == ZSTD_BYTE
+          # Use compression level of 3 by default as this is what the Java driver does
+          # DRIVERS-600 will allow this to be configurable in the future
+          Zstd.compress(buffer.to_s, 3).force_encoding(BSON::BINARY)
         end
       end
 
@@ -159,6 +171,8 @@ module Mongo
           BSON::ByteBuffer.new(Zlib::Inflate.inflate(compressed_message))
         elsif @compressor_id == SNAPPY_BYTE
           BSON::ByteBuffer.new(Snappy.inflate(compressed_message))
+        elsif @compressor_id == ZSTD_BYTE
+          BSON::ByteBuffer.new(Zstd.decompress(compressed_message))
         end
       end
 

--- a/lib/mongo/protocol/compressed.rb
+++ b/lib/mongo/protocol/compressed.rb
@@ -158,7 +158,8 @@ module Mongo
         elsif @compressor_id == SNAPPY_BYTE
           Snappy.deflate(buffer.to_s).force_encoding(BSON::BINARY)
         elsif @compressor_id == ZSTD_BYTE
-          # Use compression level of 3 by default as this is what the Java driver does
+          # Use compression level of 3 as this is defined in zstd.h for ZSTD_CLEVEL_DEFAULT
+          # see https://github.com/facebook/zstd/commit/e34c000e44444b9f8bd62e5af0a355ee186eb21f
           # DRIVERS-600 will allow this to be configurable in the future
           Zstd.compress(buffer.to_s, 3).force_encoding(BSON::BINARY)
         end

--- a/lib/mongo/protocol/compressed.rb
+++ b/lib/mongo/protocol/compressed.rb
@@ -158,10 +158,8 @@ module Mongo
         elsif @compressor_id == SNAPPY_BYTE
           Snappy.deflate(buffer.to_s).force_encoding(BSON::BINARY)
         elsif @compressor_id == ZSTD_BYTE
-          # Use compression level of 3 as this is defined in zstd.h for ZSTD_CLEVEL_DEFAULT
-          # see https://github.com/facebook/zstd/commit/e34c000e44444b9f8bd62e5af0a355ee186eb21f
           # DRIVERS-600 will allow this to be configurable in the future
-          Zstd.compress(buffer.to_s, 3).force_encoding(BSON::BINARY)
+          Zstd.compress(buffer.to_s).force_encoding(BSON::BINARY)
         end
       end
 

--- a/lib/mongo/server/app_metadata.rb
+++ b/lib/mongo/server/app_metadata.rb
@@ -65,7 +65,7 @@ module Mongo
       # @option options [ Array<String> ] :compressors A list of potential
       #   compressors to use, in order of preference. The driver chooses the
       #   first compressor that is also supported by the server. Currently the
-      #   driver only supports 'snappy' and 'zlib'.
+      #   driver only supports 'snappy', 'zstd' and 'zlib'.
       # @option options [ String ] :platform Platform information to include in
       #   the metadata printed to the mongod logs upon establishing a connection
       #   in server versions >= 3.4.

--- a/lib/mongo/server/app_metadata.rb
+++ b/lib/mongo/server/app_metadata.rb
@@ -65,7 +65,7 @@ module Mongo
       # @option options [ Array<String> ] :compressors A list of potential
       #   compressors to use, in order of preference. The driver chooses the
       #   first compressor that is also supported by the server. Currently the
-      #   driver only supports 'snappy', 'zstd' and 'zlib'.
+      #   driver only supports 'zstd', 'snappy' and 'zlib'.
       # @option options [ String ] :platform Platform information to include in
       #   the metadata printed to the mongod logs upon establishing a connection
       #   in server versions >= 3.4.

--- a/lib/mongo/server/monitor/connection.rb
+++ b/lib/mongo/server/monitor/connection.rb
@@ -83,7 +83,7 @@ module Mongo
         # @option options [ Array<String> ] :compressors A list of potential
         #   compressors to use, in order of preference. The driver chooses the
         #   first compressor that is also supported by the server. Currently the
-        #   driver only supports 'snappy', 'zstd' and 'zlib'.
+        #   driver only supports 'zstd', 'snappy' and 'zlib'.
         # @option options [ Float ] :connect_timeout The timeout, in seconds,
         #   to use for network operations. This timeout is used for all
         #   socket operations rather than connect calls only, contrary to

--- a/lib/mongo/server/monitor/connection.rb
+++ b/lib/mongo/server/monitor/connection.rb
@@ -83,7 +83,7 @@ module Mongo
         # @option options [ Array<String> ] :compressors A list of potential
         #   compressors to use, in order of preference. The driver chooses the
         #   first compressor that is also supported by the server. Currently the
-        #   driver only supports 'snappy' and 'zlib'.
+        #   driver only supports 'snappy', 'zstd' and 'zlib'.
         # @option options [ Float ] :connect_timeout The timeout, in seconds,
         #   to use for network operations. This timeout is used for all
         #   socket operations rather than connect calls only, contrary to

--- a/spec/README.md
+++ b/spec/README.md
@@ -513,9 +513,10 @@ To test compression, set the `compressors` URI option:
     MONGODB_URI="mongodb://localhost:27017/?compressors=zlib" rake
 
 Note that as of this writing, the driver supports
-[zlib](https://docs.mongodb.com/manual/reference/glossary/#term-zlib),
-[ztsd](https://docs.mongodb.com/manual/reference/glossary/#term-zstd) and
-[snappy](https://docs.mongodb.com/manual/reference/glossary/#term-snappy) compression.
+[ztsd](https://docs.mongodb.com/manual/reference/glossary/#term-zstd),
+[snappy](https://docs.mongodb.com/manual/reference/glossary/#term-snappy)
+and [zlib](https://docs.mongodb.com/manual/reference/glossary/#term-zlib)
+compression.
 
 Servers 4.2+ enable zlib by default; to test older servers, explicitly enable
 zlib compression when launching the server:

--- a/spec/README.md
+++ b/spec/README.md
@@ -512,7 +512,11 @@ To test compression, set the `compressors` URI option:
 
     MONGODB_URI="mongodb://localhost:27017/?compressors=zlib" rake
 
-Note that as of this writing, the driver only supports zlib compression.
+Note that as of this writing, the driver supports
+[zlib](https://docs.mongodb.com/manual/reference/glossary/#term-zlib),
+[ztsd](https://docs.mongodb.com/manual/reference/glossary/#term-zstd) and
+[snappy](https://docs.mongodb.com/manual/reference/glossary/#term-snappy) compression.
+
 Servers 4.2+ enable zlib by default; to test older servers, explicitly enable
 zlib compression when launching the server:
 

--- a/spec/integration/zstd_compression_spec.rb
+++ b/spec/integration/zstd_compression_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe 'Zstd compression' do
+  require_zstd_compression
+
+  before do
+    authorized_client['test'].drop
+  end
+
+  context 'when client has snappy compressor option enabled' do
+    it 'compresses the message to the server' do
+      # Double check that the client has zstd compression enabled
+      expect(authorized_client.options[:compressors]).to include('zstd')
+
+      expect(Mongo::Protocol::Compressed).to receive(:new).twice.and_call_original
+      expect(Zstd).to receive(:compress).twice.and_call_original
+      expect(Zstd).to receive(:decompress).twice.and_call_original
+
+      authorized_client['test'].insert_one(_id: 1, text: 'hello world')
+      document = authorized_client['test'].find(_id: 1).first
+
+      expect(document['text']).to eq('hello world')
+    end
+  end
+end

--- a/spec/integration/zstd_compression_spec.rb
+++ b/spec/integration/zstd_compression_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'Zstd compression' do
+  min_server_version '4.2'
   require_zstd_compression
 
   before do

--- a/spec/mongo/client_construction_spec.rb
+++ b/spec/mongo/client_construction_spec.rb
@@ -568,6 +568,32 @@ describe Mongo::Client do
             end
           end
         end
+
+        context 'when zstd compression is requested and supported by the server' do
+          min_server_version '4.2'
+
+          let(:options) do
+            { compressors: ['zstd'] }
+          end
+
+          context 'when zstd gem is installed' do
+            require_zstd_compression
+
+            it 'creates the client' do
+              expect(client.options['compressors']).to eq(['zstd'])
+            end
+          end
+
+          context 'when zstd gem is not installed' do
+            require_no_zstd_compression
+
+            it 'raises an exception' do
+              expect do
+                client
+              end.to raise_error(Mongo::Error::UnmetDependency, /Cannot enable zstd compression/)
+            end
+          end
+        end
       end
 
       context 'when compressors are not provided' do

--- a/spec/mongo/protocol/compressed_spec.rb
+++ b/spec/mongo/protocol/compressed_spec.rb
@@ -32,8 +32,8 @@ describe Mongo::Protocol::Compressed do
       require_zstd_compression
       let(:compressor) { 'zstd' }
 
-      it "uses zstd with default compression level of 3" do
-        expect(Zstd).to receive(:compress).with(original_message_bytes, 3).and_call_original
+      it "uses zstd with default compression level" do
+        expect(Zstd).to receive(:compress).with(original_message_bytes).and_call_original
         message.serialize
       end
     end

--- a/spec/mongo/protocol/compressed_spec.rb
+++ b/spec/mongo/protocol/compressed_spec.rb
@@ -28,6 +28,16 @@ describe Mongo::Protocol::Compressed do
       end
     end
 
+    context "when using the zstd compressor" do
+      require_zstd_compression
+      let(:compressor) { 'zstd' }
+
+      it "uses zstd with default compression level of 3" do
+        expect(Zstd).to receive(:compress).with(original_message_bytes, 3).and_call_original
+        message.serialize
+      end
+    end
+
     context 'when zlib compression level is not provided' do
 
       it 'does not set a compression level' do

--- a/spec/spec_tests/uri_options_spec.rb
+++ b/spec/spec_tests/uri_options_spec.rb
@@ -58,6 +58,14 @@ describe 'URI options' do
                 end
               end
 
+              if test.options['compressors'] && test.options['compressors'].include?('zstd')
+                before do
+                  unless ENV.fetch('BUNDLE_GEMFILE', '') =~ /zstd/
+                    skip "This test requires zstd compression"
+                  end
+                end
+              end
+
               it 'creates a client with the correct options' do
                 mapped = Mongo::URI::OptionsMapper.new.ruby_to_smc(test.client.options)
                 expected = Mongo::ConnectionString.adjust_expected_mongo_client_options(


### PR DESCRIPTION
Add support for zstd network compression (per DRIVERS-600) to the Ruby driver.

Note that this PR depends on https://github.com/mongodb-labs/mongo-ruby-spec-shared/pull/6 being merged for the specs to run.