### PR TITLE
Remove deadlink to api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Documentation
 High level documentation and usage examples are located
 [here](http://docs.mongodb.org/ecosystem/drivers/ruby/).
 
-API documentation can be found [here](https://api.mongodb.org/ruby/).
-
 
 Support
 -------


### PR DESCRIPTION
<img width="970" alt="スクリーンショット 2021-02-21 0 33 36" src="https://user-images.githubusercontent.com/1180335/108600950-47881780-73dd-11eb-9a52-1314e85002e6.png">

Moved ? or Temporarily Unavailable ?