### PR TITLE
RUBY-2371: Use monotonic clock for measuring time

### DIFF
--- a/lib/mongo/background_thread.rb
+++ b/lib/mongo/background_thread.rb
@@ -129,7 +129,7 @@ module Mongo
       # However, we do not want to wait indefinitely because in theory
       # a background thread could be performing, say, network I/O and if
       # the network is no longer available that could take a long time.
-      start_time = Time.now
+      start_time = Utils.monotonic_time
       ([0.1, 0.15] + [0.2] * 5 + [0.3] * 20).each do |interval|
         begin
           Timeout.timeout(interval) do
@@ -143,7 +143,7 @@ module Mongo
       # Some driver objects can be reconnected, for backwards compatibiilty
       # reasons. Clear the thread instance variable to support this cleanly.
       if @thread.alive?
-        log_warn("Failed to stop the background thread in #{self} in #{(Time.now - start_time).to_i} seconds: #{@thread.inspect} (thread status: #{@thread.status})")
+        log_warn("Failed to stop the background thread in #{self} in #{(Utils.monotonic_time - start_time).to_i} seconds: #{@thread.inspect} (thread status: #{@thread.status})")
         # On JRuby the thread may be stuck in aborting state
         # seemingly indefinitely. If the thread is aborting, consider it dead
         # for our purposes (we will create a new thread if needed, and

--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -213,8 +213,7 @@ module Mongo
       end
 
       # Need to record start time prior to starting monitoring
-      start_time = Time.now
-      start_time_monotonic = Utils.monotonic_time
+      start_monotime = Utils.monotonic_time
 
       servers.each do |server|
         server.start_monitoring
@@ -230,7 +229,7 @@ module Mongo
         if server_selection_timeout < 3
           server_selection_timeout = 3
         end
-        deadline = start_time_monotonic + server_selection_timeout
+        deadline = start_monotime + server_selection_timeout
         # Wait for the first scan of each server to complete, for
         # backwards compatibility.
         # If any servers are discovered during this SDAM round we are going to
@@ -241,7 +240,7 @@ module Mongo
           servers = @sdam_flow_lock.synchronize do
             servers_list.dup
           end
-          if servers.all? { |server| server.last_scan && server.last_scan >= start_time }
+          if servers.all? { |server| server.last_scan_monotime && server.last_scan_monotime >= start_monotime }
             break
           end
           if (time_remaining = deadline - Utils.monotonic_time) <= 0

--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -214,6 +214,7 @@ module Mongo
 
       # Need to record start time prior to starting monitoring
       start_time = Time.now
+      start_time_monotonic = Utils.monotonic_time
 
       servers.each do |server|
         server.start_monitoring
@@ -229,7 +230,7 @@ module Mongo
         if server_selection_timeout < 3
           server_selection_timeout = 3
         end
-        deadline = start_time + server_selection_timeout
+        deadline = start_time_monotonic + server_selection_timeout
         # Wait for the first scan of each server to complete, for
         # backwards compatibility.
         # If any servers are discovered during this SDAM round we are going to
@@ -243,7 +244,7 @@ module Mongo
           if servers.all? { |server| server.last_scan && server.last_scan >= start_time }
             break
           end
-          if (time_remaining = deadline - Time.now) <= 0
+          if (time_remaining = deadline - Utils.monotonic_time) <= 0
             break
           end
           log_debug("Waiting for up to #{'%.2f' % time_remaining} seconds for servers to be scanned: #{summary}")

--- a/lib/mongo/monitoring.rb
+++ b/lib/mongo/monitoring.rb
@@ -324,7 +324,7 @@ module Mongo
       # message" (ismaster). This requirement does not make sense if,
       # for example, we were never able to connect to the server at all
       # and thus ismaster was never sent.
-      start_time = Time.now
+      start_time = Utils.monotonic_time
 
       begin
         result = yield
@@ -332,7 +332,7 @@ module Mongo
         if monitoring?
           event = Event::ServerHeartbeatFailed.new(
             server.address,
-            Time.now-start_time,
+            Utils.monotonic_time - start_time,
             exc,
             awaited: awaited,
             started_event: started_event,
@@ -344,7 +344,7 @@ module Mongo
         if monitoring?
           event = Event::ServerHeartbeatSucceeded.new(
             server.address,
-            Time.now-start_time,
+            Utils.monotonic_time - start_time,
             awaited: awaited,
             started_event: started_event,
           )

--- a/lib/mongo/server.rb
+++ b/lib/mongo/server.rb
@@ -71,6 +71,7 @@ module Mongo
       @round_trip_time_averager = RoundTripTimeAverager.new
       @description = Description.new(address, {})
       @last_scan = nil
+      @last_scan_monotime = nil
       unless options[:monitoring_io] == false
         @monitor = Monitor.new(self, event_listeners, monitoring,
           options.merge(
@@ -117,6 +118,18 @@ module Mongo
         @last_scan
       end
     end
+
+    # @return [ Float | nil ] last_scan_monotime The monotonic time when the last server scan
+    #   completed, or nil if the server has not been scanned yet.
+    # @api private
+    def last_scan_monotime
+      if description && !description.config.empty?
+        description.last_update_monotime
+      else
+        @last_scan_monotime
+      end
+    end
+
 
     # @deprecated
     def heartbeat_frequency
@@ -553,6 +566,7 @@ module Mongo
     # @api private
     def update_last_scan
       @last_scan = Time.now
+      @last_scan_monotime = Utils.monotonic_time
     end
   end
 end

--- a/lib/mongo/server/connection_base.rb
+++ b/lib/mongo/server/connection_base.rb
@@ -165,7 +165,7 @@ module Mongo
             connection_generation: generation,
             server_connection_id: description.server_connection_id,
           )
-          start = Time.now
+          start = Utils.monotonic_time
           result = nil
           begin
             result = add_server_diagnostics do
@@ -177,11 +177,11 @@ module Mongo
               end
             end
           rescue Exception => e
-            total_duration = Time.now - start
+            total_duration = Utils.monotonic_time - start
             command_failed(nil, address, operation_id, message.payload, e.message, total_duration)
             raise
           else
-            total_duration = Time.now - start
+            total_duration = Utils.monotonic_time - start
             command_completed(result, address, operation_id, message.payload, total_duration)
           end
           if result && context.decrypt?

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -294,7 +294,7 @@ module Mongo
           raise Error::PoolClosedError.new(@server.address, self)
         end
 
-        deadline = Time.now + wait_timeout
+        deadline = Utils.monotonic_time + wait_timeout
         pid = Process.pid
         connection = nil
         # It seems that synchronize sets up its own loop, thus a simple break
@@ -344,7 +344,7 @@ module Mongo
               end
             end
 
-            wait = deadline - Time.now
+            wait = deadline - Utils.monotonic_time
             if wait <= 0
               publish_cmap_event(
                 Monitoring::Event::Cmap::ConnectionCheckOutFailed.new(

--- a/lib/mongo/server/description.rb
+++ b/lib/mongo/server/description.rb
@@ -218,6 +218,7 @@ module Mongo
         @features = Features.new(wire_versions, me || @address.to_s)
         @average_round_trip_time = average_round_trip_time
         @last_update_time = Time.now.dup.freeze
+        @last_update_monotime = Utils.monotonic_time
 
         if Mongo::Lint.enabled?
           # prepopulate cache instance variables
@@ -764,6 +765,15 @@ module Mongo
       #
       # @since 2.7.0
       attr_reader :last_update_time
+
+      # Time when this server description was created according to monotonic clock.
+      #
+      # @see Description::last_updated_time for more detail
+      #
+      # @return [ Float ] Server description creation monotonic time.
+      #
+      # @api private
+      attr_reader :last_update_monotime
 
       # @api experimental
       def server_connection_id

--- a/lib/mongo/server/round_trip_time_averager.rb
+++ b/lib/mongo/server/round_trip_time_averager.rb
@@ -34,7 +34,7 @@ module Mongo
       attr_reader :average_round_trip_time
 
       def measure
-        start = Time.now
+        start = Utils.monotonic_time
         begin
           rv = yield
         rescue Error::SocketError, Error::SocketTimeoutError
@@ -44,7 +44,7 @@ module Mongo
         rescue Error, Error::AuthError => exc
           # For other errors, RTT is valid.
         end
-        last_round_trip_time = Time.now - start
+        last_round_trip_time = Utils.monotonic_time - start
 
         # If ismaster fails, we need to return the last round trip time
         # because it is used in the heartbeat failed SDAM event,

--- a/lib/mongo/server_selector/base.rb
+++ b/lib/mongo/server_selector/base.rb
@@ -184,7 +184,7 @@ module Mongo
           raise Error::NoServerAvailable.new(self, cluster, msg)
         end
 
-        deadline = Time.now + server_selection_timeout
+        deadline = Utils.monotonic_time + server_selection_timeout
 
         if session && session.pinned_server
           if Mongo::Lint.enabled?
@@ -202,7 +202,7 @@ module Mongo
             # This will no longer be the case once SRV polling is implemented.
 
             unless server.mongos?
-              while (time_remaining = deadline - Time.now) > 0
+              while (time_remaining = deadline - Utils.monotonic_time) > 0
                 wait_for_server_selection(cluster, time_remaining)
               end
 
@@ -255,7 +255,7 @@ module Mongo
 
           cluster.scan!(false)
 
-          time_remaining = deadline - Time.now
+          time_remaining = deadline - Utils.monotonic_time
           if time_remaining > 0
             wait_for_server_selection(cluster, time_remaining)
 

--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -272,7 +272,7 @@ module Mongo
       _timeout = timeout || self.timeout
       if _timeout
         if _timeout > 0
-          deadline = Time.now + _timeout
+          deadline = Utils.monotonic_time + _timeout
         elsif _timeout < 0
           raise Errno::ETIMEDOUT, "Negative timeout #{_timeout} given to socket"
         end
@@ -327,7 +327,7 @@ module Mongo
       # reading from a TLS socket may require writing which may raise WaitWritable
       rescue IO::WaitReadable, IO::WaitWritable => exc
         if deadline
-          select_timeout = deadline - Time.now
+          select_timeout = deadline - Utils.monotonic_time
           if select_timeout <= 0
             raise Errno::ETIMEDOUT, "Took more than #{_timeout} seconds to receive data"
           end
@@ -345,7 +345,7 @@ module Mongo
           # even though we could have retried it.
           # Check the deadline ourselves.
           if deadline
-            select_timeout = deadline - Time.now
+            select_timeout = deadline - Utils.monotonic_time
             if select_timeout <= 0
               raise Errno::ETIMEDOUT, "Took more than #{_timeout} seconds to receive data"
             end

--- a/lib/mongo/utils.rb
+++ b/lib/mongo/utils.rb
@@ -87,5 +87,20 @@ module Mongo
         end
       end
     end
+
+    # This function should be used if you need to measure time.
+    # @example Calculate elapsed time.
+    #   starting = Utils.monotonic_time
+    #   # do something time consuming
+    #   ending = Utils.monotonic_time
+    #   puts "It took #{(ending - starting).to_i} seconds"
+    #
+    # @see https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
+    #
+    # @return [Float] seconds according to monotonic clock
+    module_function def monotonic_time
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+
   end
 end

--- a/spec/mongo/cluster_spec.rb
+++ b/spec/mongo/cluster_spec.rb
@@ -296,6 +296,7 @@ describe Mongo::Cluster do
         expect(server).not_to be nil
 
         expect(server.last_scan).to be nil
+        expect(server.last_scan_monotime).to be nil
       end
     end
   end

--- a/spec/mongo/server/description_spec.rb
+++ b/spec/mongo/server/description_spec.rb
@@ -833,4 +833,22 @@ describe Mongo::Server::Description do
       end
     end
   end
+
+  describe '#last_update_monotime' do
+    context 'stub description' do
+      let(:description) { described_class.new(address) }
+
+      it 'is present' do
+        expect(description.last_update_monotime).to be_a(Float)
+      end
+    end
+
+    context 'filled out description' do
+      let(:description) { described_class.new(address, replica) }
+
+      it 'is present' do
+        expect(description.last_update_monotime).to be_a(Float)
+      end
+    end
+  end
 end

--- a/spec/mongo/session_transaction_spec.rb
+++ b/spec/mongo/session_transaction_spec.rb
@@ -116,19 +116,15 @@ describe Mongo::Session do
     context 'timeout with callback raising TransientTransactionError' do
       max_example_run_time 7
 
-      after do
-        Timecop.return
-      end
-
       it 'times out' do
-        warp = Time.now + 200
+        warp = Mongo::Utils.monotonic_time + 200
         entered = false
 
         Thread.new do
           until entered
             sleep 0.1
           end
-          Timecop.travel warp
+          allow(Mongo::Utils).to receive(:monotonic_time).and_return(warp)
         end
 
         expect do
@@ -152,24 +148,20 @@ describe Mongo::Session do
       context "timeout with commit raising with #{label}" do
         max_example_run_time 7
 
-        after do
-          Timecop.return
-        end
-
         before do
           # create collection if it does not exist
           collection.insert_one(a: 1)
         end
 
         it 'times out' do
-          warp = Time.now + 200
+          warp = Mongo::Utils.monotonic_time + 200
           entered = false
 
           Thread.new do
             until entered
               sleep 0.1
             end
-            Timecop.travel warp
+            allow(Mongo::Utils).to receive(:monotonic_time).and_return(warp)
           end
 
           exc = Mongo::Error::OperationFailure.new('timeout test')


### PR DESCRIPTION
This PR introduces usage of monotonic clock instead of wall clock for measuring time. This ensures correct calculation of elapsed times.

See https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/ for details 