### PR TITLE
RUBY-2296: Fix app metadata spec

### DIFF
--- a/spec/mongo/server/app_metadata_shared.rb
+++ b/spec/mongo/server/app_metadata_shared.rb
@@ -11,14 +11,40 @@ shared_examples 'app metadata document' do
     document[:client][:driver][:version].should == Mongo::VERSION
   end
 
-  it 'includes operating system information' do
-    %w(linux darwin).each do |os|
-      if !!(RUBY_PLATFORM =~ /\#{os}/)
-        document[:client][:os][:type].should == os
+  context 'linux' do
+    before(:all) do
+      unless SpecConfig.instance.linux?
+        skip "Linux required, we have #{RbConfig::CONFIG['host_os']}"
       end
     end
-    document[:client][:os][:name].should == RbConfig::CONFIG['host_os']
-    document[:client][:os][:architecture].should == RbConfig::CONFIG['target_cpu']
+
+    it 'includes operating system information' do
+      document[:client][:os][:type].should == 'linux'
+      if BSON::Environment.jruby? || RUBY_VERSION >= '3.0'
+        document[:client][:os][:name].should == 'linux'
+      else
+        document[:client][:os][:name].should == 'linux-gnu'
+      end
+      document[:client][:os][:architecture].should == 'x86_64'
+    end
+  end
+
+  context 'macos' do
+    before(:all) do
+      unless SpecConfig.instance.macos?
+        skip "MacOS required, we have #{RbConfig::CONFIG['host_os']}"
+      end
+    end
+
+    it 'includes operating system information' do
+      document[:client][:os][:type].should == 'darwin'
+      if BSON::Environment.jruby?
+        document[:client][:os][:name].should == 'darwin'
+      else
+        document[:client][:os][:name].should =~ /darwin\d+/
+      end
+      document[:client][:os][:architecture].should == 'x86_64'
+    end
   end
 
   context 'mri' do

--- a/spec/mongo/server/app_metadata_shared.rb
+++ b/spec/mongo/server/app_metadata_shared.rb
@@ -12,13 +12,13 @@ shared_examples 'app metadata document' do
   end
 
   it 'includes operating system information' do
-    document[:client][:os][:type].should == 'linux'
-    if BSON::Environment.jruby? || RUBY_VERSION >= '3.0'
-      document[:client][:os][:name].should == 'linux'
-    else
-      document[:client][:os][:name].should == 'linux-gnu'
+    %w(linux darwin).each do |os|
+      if !!(RUBY_PLATFORM =~ /\#{os}/)
+        document[:client][:os][:type].should == os
+      end
     end
-    document[:client][:os][:architecture].should == 'x86_64'
+    document[:client][:os][:name].should == RbConfig::CONFIG['host_os']
+    document[:client][:os][:architecture].should == RbConfig::CONFIG['target_cpu']
   end
 
   context 'mri' do

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -124,6 +124,14 @@ class SpecConfig
     !!(RUBY_PLATFORM =~ /\bjava\b/)
   end
 
+  def linux?
+    !!(RbConfig::CONFIG['host_os'].downcase =~ /\blinux/)
+  end
+
+  def macos?
+    !!(RbConfig::CONFIG['host_os'].downcase =~ /\bdarwin/)
+  end
+
   def platform
     RUBY_PLATFORM
   end


### PR DESCRIPTION
This commit fixes an assumption that the spec is always executed on a
Linux machine.