### PR TITLE
RUBY-2296: Fix app metadata spec (#2208)

### DIFF
--- a/spec/mongo/server/app_metadata_shared.rb
+++ b/spec/mongo/server/app_metadata_shared.rb
@@ -8,14 +8,40 @@ shared_examples 'app metadata document' do
     document[:client][:driver][:version].should == Mongo::VERSION
   end
 
-  it 'includes operating system information' do
-    document[:client][:os][:type].should == 'linux'
-    if BSON::Environment.jruby? || RUBY_VERSION >= '3.0'
-      document[:client][:os][:name].should == 'linux'
-    else
-      document[:client][:os][:name].should == 'linux-gnu'
+  context 'linux' do
+    before(:all) do
+      unless SpecConfig.instance.linux?
+        skip "Linux required, we have #{RbConfig::CONFIG['host_os']}"
+      end
     end
-    document[:client][:os][:architecture].should == 'x86_64'
+
+    it 'includes operating system information' do
+      document[:client][:os][:type].should == 'linux'
+      if BSON::Environment.jruby? || RUBY_VERSION >= '3.0'
+        document[:client][:os][:name].should == 'linux'
+      else
+        document[:client][:os][:name].should == 'linux-gnu'
+      end
+      document[:client][:os][:architecture].should == 'x86_64'
+    end
+  end
+
+  context 'macos' do
+    before(:all) do
+      unless SpecConfig.instance.macos?
+        skip "MacOS required, we have #{RbConfig::CONFIG['host_os']}"
+      end
+    end
+
+    it 'includes operating system information' do
+      document[:client][:os][:type].should == 'darwin'
+      if BSON::Environment.jruby?
+        document[:client][:os][:name].should == 'darwin'
+      else
+        document[:client][:os][:name].should =~ /darwin\d+/
+      end
+      document[:client][:os][:architecture].should == 'x86_64'
+    end
   end
 
   context 'mri' do

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -110,6 +110,14 @@ class SpecConfig
     !!(RUBY_PLATFORM =~ /\bjava\b/)
   end
 
+  def linux?
+    !!(RbConfig::CONFIG['host_os'].downcase =~ /\blinux/)
+  end
+
+  def macos?
+    !!(RbConfig::CONFIG['host_os'].downcase =~ /\bdarwin/)
+  end
+
   def platform
     RUBY_PLATFORM
   end


### PR DESCRIPTION
RUBY-2296: Fix app metadata spec

This commit fixes an assumption that the spec is always executed on a
Linux machine.