### PR TITLE
RUBY-1700 Ignore errors when killing change stream cursors when resuming

### DIFF
--- a/lib/mongo/collection/view/change_stream.rb
+++ b/lib/mongo/collection/view/change_stream.rb
@@ -206,7 +206,7 @@ module Mongo
           unless closed?
             begin
               @cursor.close
-            rescue Error::OperationFailure
+            rescue Error::OperationFailure, Error::SocketError, Error::SocketTimeoutError
               # ignore
             end
             @cursor = nil

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -268,6 +268,7 @@ module Mongo
     # @return [ nil ] Always nil.
     #
     # @raise [ Error::OperationFailure ] If the server cursor close fails.
+    # @raise [ Error::SocketError | Error::SocketTimeoutError ] When there is a network error.
     def close
       return if closed?
 

--- a/lib/mongo/server/connection_base.rb
+++ b/lib/mongo/server/connection_base.rb
@@ -136,6 +136,8 @@ module Mongo
       #
       # @return [ Protocol::Message | nil ] The reply if needed.
       #
+      # @raise [ Error::SocketError | Error::SocketTimeoutError ] When there is a network error.
+      #
       # @since 2.0.0
       def dispatch(messages, context, options = {})
         # The monitoring code does not correctly handle multiple messages,
@@ -153,6 +155,7 @@ module Mongo
 
       private
 
+      # @raise [ Error::SocketError | Error::SocketTimeoutError ] When there is a network error.
       def deliver(message, context, options = {})
         if Lint.enabled? && !@socket
           raise Error::LintError, "Trying to deliver a message over a disconnected connection (to #{address})"

--- a/lib/mongo/socket.rb
+++ b/lib/mongo/socket.rb
@@ -236,6 +236,8 @@ module Mongo
     #
     # @return [ Integer ] The length of bytes written to the socket.
     #
+    # @raise [ Error::SocketError | Error::SocketTimeoutError ] When there is a network error during the write.
+    #
     # @since 2.0.0
     def write(*args)
       map_exceptions do

--- a/spec/mongo/collection/view/change_stream_spec.rb
+++ b/spec/mongo/collection/view/change_stream_spec.rb
@@ -372,6 +372,19 @@ describe Mongo::Collection::View::ChangeStream do
 
   describe '#close' do
 
+    context 'ignores any exceptions or errors' do
+      [
+        Mongo::Error::OperationFailure,
+        Mongo::Error::SocketError,
+        Mongo::Error::SocketTimeoutError
+      ].each do |err|
+        it "ignores #{err}" do
+          expect(cursor).to receive(:close).and_raise(err)
+          change_stream.close
+        end
+      end
+    end
+
     context 'when documents have not been retrieved and the stream is closed' do
 
       before do


### PR DESCRIPTION
For details see https://github.com/mongodb/specifications/blob/master/source/change-streams/change-streams.rst#resume-process