### PR TITLE
Fix .evergreen/config.yml line which should be commented

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1230,7 +1230,7 @@ buildvariants:
 #      os: ubuntu1604
 #    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
 #    tasks:
-      - name: "test-mlaunch"
+#      - name: "test-mlaunch"
 
   - matrix_name: "zstd-auth"
     matrix_spec:

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -843,6 +843,14 @@ axes:
           API_VERSION_REQUIRED: 1
       - id: no
         display_name: No
+# Note that:
+# - MongoDB 2.6 and 3.0 are tested on ubuntu1604.
+#   This is because the Python that ships with ubuntu1404 is ancient and
+#   is no longer usable with the current Python infrastructure (pip, etc.).
+#   There are no ubuntu1604 builds for 2.6 and 3.0 servers however - they
+#   are only built for ubuntu1204 and ubuntu1404. We use the ubuntu1404
+#   builds on ubuntu1604 and the dependencies are satisfied.
+
 
 buildvariants:
   - matrix_name: "docker"
@@ -1327,6 +1335,8 @@ buildvariants:
     matrix_spec:
       # Other Rubies segfault
       ruby: [ruby-2.5, ruby-2.4]
+      mongodb-version: '4.4'
+      topology: standalone
     display_name: "Kerberos integration Ubuntu ${ruby}"
     run_on:
       - ubuntu1604-small

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1335,8 +1335,6 @@ buildvariants:
     matrix_spec:
       # Other Rubies segfault
       ruby: [ruby-2.5, ruby-2.4]
-      mongodb-version: '4.4'
-      topology: standalone
     display_name: "Kerberos integration Ubuntu ${ruby}"
     run_on:
       - ubuntu1604-small

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -394,7 +394,7 @@ buildvariants:
 #      os: ubuntu1604
 #    display_name: "${compressor} ${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
 #    tasks:
-      - name: "test-mlaunch"
+#      - name: "test-mlaunch"
 
   - matrix_name: "zstd-auth"
     matrix_spec:
@@ -491,6 +491,8 @@ buildvariants:
     matrix_spec:
       # Other Rubies segfault
       ruby: [ruby-2.5, ruby-2.4]
+      mongodb-version: '4.4'
+      topology: standalone
     display_name: "Kerberos integration Ubuntu ${ruby}"
     run_on:
       - ubuntu1604-small

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -491,8 +491,6 @@ buildvariants:
     matrix_spec:
       # Other Rubies segfault
       ruby: [ruby-2.5, ruby-2.4]
-      mongodb-version: '4.4'
-      topology: standalone
     display_name: "Kerberos integration Ubuntu ${ruby}"
     run_on:
       - ubuntu1604-small


### PR DESCRIPTION
In addition, the buildvariant `kerberos-integration-ubuntu` is missing fields `mongodb-version` and `topology`. All other nodes have those fields, so you might want to check it.