### PR TITLE
RUBY-2842: Sleep 200ms before reporting failed server heartbeat back

### DIFF
--- a/lib/mongo/monitoring.rb
+++ b/lib/mongo/monitoring.rb
@@ -337,6 +337,8 @@ module Mongo
             awaited: awaited,
             started_event: started_event,
           )
+          sleep(0.5) # sleep just for a while before publishing event as it will start instantly another request
+          # and possibly cause overhead in number of threads
           failed(SERVER_HEARTBEAT, event)
         end
         raise

--- a/lib/mongo/monitoring.rb
+++ b/lib/mongo/monitoring.rb
@@ -337,7 +337,7 @@ module Mongo
             awaited: awaited,
             started_event: started_event,
           )
-          sleep(0.5) # sleep just for a while before publishing event as it will start instantly another request
+          sleep(0.2) # sleep just for a while before publishing event as it will start instantly another request
           # and possibly cause overhead in number of threads
           failed(SERVER_HEARTBEAT, event)
         end


### PR DESCRIPTION
This prevents from issuing too many requests and causing memory use spike