### PR TITLE
RUBY-2525 Expose the Reason an Operation Fails Document Validation

### DIFF
--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -55,6 +55,21 @@ module Mongo
 
       private
 
+      # Generates an error message when there are multiple write errors.
+      # The message is generated as follows:
+      #
+      # col has validation { 'validator' => { 'x' => { '$type' => 'string' } } }
+      # col.insert_many([{_id: 1}, {_id: 2}], ordered: false)
+      #
+      # Multiple errors:
+      #   [121]: Document failed validation --
+      #     {"failingDocumentId":1,"details":{"operatorName":"$type",
+      #     "specifiedAs":{"x":{"$type":"string"}},"reason":"field was
+      #     missing"}};
+      #   [121]: Document failed validation --
+      #     {"failingDocumentId":2, "details":{"operatorName":"$type",
+      #     "specifiedAs":{"x":{"$type":"string"}}, "reason":"field was
+      #     missing"}}
       def build_message
         errors = @result['writeErrors']
         return nil unless errors

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -324,7 +324,6 @@ module Mongo
       # @return [ Hash | nil ] the details extracted from the document
       def retrieve_details(document)
         return nil unless document
-        details = nil
         if document['writeConcernError'] && document['writeConcernError']['errInfo']
           details = document['writeConcernError']['errInfo']
         elsif document['writeErrors'] && document['writeErrors'][0] && document['writeErrors'][0]['errInfo']

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -224,6 +224,13 @@ module Mongo
       # @since 2.10.0
       attr_reader :write_concern_error_code_name
 
+      # @return [ String | nil ] The details of the error. For WriteConcernErrors
+      #   this is `document['writeConcernError']['errInfo']`. For WriteErrors this
+      #   is `document['writeErrors'][0]['errInfo']`.
+      #
+      # @since 2.11.0
+      attr_reader :details
+
       # @return [ BSON::Document | nil ] The server-returned error document.
       #
       # @api experimental
@@ -273,6 +280,12 @@ module Mongo
         @wtimeout = !!options[:wtimeout]
         @document = options[:document]
         @server_message = options[:server_message]
+
+        if @document['writeConcernError'] && @document['writeConcernError']['errInfo']
+          @details = @document['writeConcernError']['errInfo']
+        elsif @document['writeErrors'] && @document['writeErrors'][0] && @document['writeErrors'][0]['errInfo']
+          @details = @document['writeErrors'][0]['errInfo']
+        end
       end
 
       # Whether the error is a write concern timeout.

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -324,12 +324,11 @@ module Mongo
       # @return [ Hash | nil ] the details extracted from the document
       def retrieve_details(document)
         return nil unless document
-        if document['writeConcernError'] && document['writeConcernError']['errInfo']
-          details = document['writeConcernError']['errInfo']
-        elsif document['writeErrors'] && document['writeErrors'][0] && document['writeErrors'][0]['errInfo']
-          details = document['writeErrors'][0]['errInfo']
+        if document['writeConcernError']
+          return document['writeConcernError']['errInfo']
+        elsif document['writeErrors'] && document['writeErrors'][0]
+          return document['writeErrors'][0]['errInfo']
         end
-        details
       end
 
       # Append the details to the message

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -224,9 +224,10 @@ module Mongo
       # @since 2.10.0
       attr_reader :write_concern_error_code_name
 
-      # @return [ String | nil ] The details of the error. For WriteConcernErrors
-      #   this is `document['writeConcernError']['errInfo']`. For WriteErrors this
-      #   is `document['writeErrors'][0]['errInfo']`.
+      # @return [ String | nil ] The details of the error.
+      #   For WriteConcernErrors this is `document['writeConcernError']['errInfo']`.
+      #   For WriteErrors this is `document['writeErrors'][0]['errInfo']`.
+      #   For all other errors this is nil.
       #
       # @since 2.11.0
       attr_reader :details

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -326,7 +326,7 @@ module Mongo
         return nil unless document
         if document['writeConcernError']
           return document['writeConcernError']['errInfo']
-        elsif document['writeErrors'] && document['writeErrors'][0]
+        elsif document['writeErrors']&.first
           return document['writeErrors'][0]['errInfo']
         end
       end

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -228,8 +228,6 @@ module Mongo
       #   For WriteConcernErrors this is `document['writeConcernError']['errInfo']`.
       #   For WriteErrors this is `document['writeErrors'][0]['errInfo']`.
       #   For all other errors this is nil.
-      #
-      # @since 2.11.0
       attr_reader :details
 
       # @return [ BSON::Document | nil ] The server-returned error document.
@@ -266,8 +264,6 @@ module Mongo
       # @option options [ Array<String> ] :labels The set of labels associated
       #   with the error.
       # @option options [ true | false ] :wtimeout Whether the error is a wtimeout.
-      #
-      # @since 2.5.0, options added in 2.6.0
       def initialize(message = nil, result = nil, options = {})
         @details = retrieve_details(options[:document])
         super(append_details(message, @details))
@@ -324,10 +320,10 @@ module Mongo
       # @return [ Hash | nil ] the details extracted from the document
       def retrieve_details(document)
         return nil unless document
-        if document['writeConcernError']
-          return document['writeConcernError']['errInfo']
-        elsif document['writeErrors']&.first
-          return document['writeErrors'][0]['errInfo']
+        if wce = document['writeConcernError']
+          return wce['errInfo']
+        elsif we = document['writeErrors']&.first
+          return we['errInfo']
         end
       end
 

--- a/spec/integration/bulk_write_error_message_spec.rb
+++ b/spec/integration/bulk_write_error_message_spec.rb
@@ -38,4 +38,33 @@ describe 'BulkWriteError message' do
       end
     end
   end
+
+  context 'a bulk write with validation errors' do
+
+    let(:collection_name) { 'bulk_write_error_validation_message_spec' }
+
+    let(:collection) do
+      client[:collection_name].drop
+      client[:collection_name,
+      {
+        'validator' => {
+          'x' => { '$type' => 'string' },
+        }
+      }].create
+      client[:collection_name]
+    end
+
+    it 'reports code name, code, message, and details' do
+      begin
+        collection.insert_one({_id:1, x:"1"})
+        collection.insert_many([
+          {_id: 1, x:"1"},
+          {_id: 2, x:1},
+        ], ordered: false)
+        fail('Should have raised')
+      rescue Mongo::Error::BulkWriteError => e
+        e.message.should =~ %r,\AMultiple errors: \[11000\]: (insertDocument :: caused by :: 11000 )?E11000 duplicate key error (collection|index):.*\; \[121\]: Document failed validation -- .*,
+      end
+    end
+  end
 end

--- a/spec/integration/bulk_write_error_message_spec.rb
+++ b/spec/integration/bulk_write_error_message_spec.rb
@@ -63,10 +63,10 @@ describe 'BulkWriteError message' do
         ], ordered: false)
         fail('Should have raised')
       rescue Mongo::Error::BulkWriteError => e
-        e.message.should =~ %r,\AMultiple errors: \[11000\]: (insertDocument :: caused by :: 11000 )?E11000 duplicate key error (collection|index):.*\; \[121\]: Document failed validation -- .*,
+        e.message.should =~ %r,\AMultiple errors: \[11000\]: (insertDocument :: caused by :: 11000 )?E11000 duplicate key error (collection|index):.*\; \[121\]: Document failed validation( -- .*)?,
         # The duplicate key error should not print details because it's not a
         # WriteError or a WriteConcernError
-        expect(e.message.scan(/ -- /).length).to eq 1
+        e.message.scan(/ -- /).length.should be < 1
       end
     end
   end

--- a/spec/integration/bulk_write_error_message_spec.rb
+++ b/spec/integration/bulk_write_error_message_spec.rb
@@ -66,7 +66,7 @@ describe 'BulkWriteError message' do
         e.message.should =~ %r,\AMultiple errors: \[11000\]: (insertDocument :: caused by :: 11000 )?E11000 duplicate key error (collection|index):.*\; \[121\]: Document failed validation( -- .*)?,
         # The duplicate key error should not print details because it's not a
         # WriteError or a WriteConcernError
-        e.message.scan(/ -- /).length.should be < 1
+        e.message.scan(/ -- /).length.should be <= 1
       end
     end
   end

--- a/spec/integration/bulk_write_error_message_spec.rb
+++ b/spec/integration/bulk_write_error_message_spec.rb
@@ -64,6 +64,9 @@ describe 'BulkWriteError message' do
         fail('Should have raised')
       rescue Mongo::Error::BulkWriteError => e
         e.message.should =~ %r,\AMultiple errors: \[11000\]: (insertDocument :: caused by :: 11000 )?E11000 duplicate key error (collection|index):.*\; \[121\]: Document failed validation -- .*,
+        # The duplicate key error should not print details because it's not a
+        # WriteError or a WriteConcernError
+        expect(e.message.scan(/ -- /).length).to eq 1
       end
     end
   end

--- a/spec/mongo/error/operation_failure_heavy_spec.rb
+++ b/spec/mongo/error/operation_failure_heavy_spec.rb
@@ -40,6 +40,9 @@ describe Mongo::Error::OperationFailure do
       begin
         authorized_client['foo'].insert_one(test: 1)
       rescue Mongo::Error::OperationFailure => exc
+        expect(exc.details).to eq(exc.document['writeConcernError']['errInfo'])
+        expect(exc.server_message).to eq(exc.document['writeConcernError']['errmsg'])
+        expect(exc.code).to eq(exc.document['writeConcernError']['code'])
       else
         fail 'Expected an OperationFailure'
       end
@@ -56,6 +59,52 @@ describe Mongo::Error::OperationFailure do
           },
         },
       }
+    end
+  end
+
+  describe 'WriteError details' do
+    min_server_fcv '5.0'
+
+    let(:subscriber) { Mrss::EventSubscriber.new }
+
+    let(:subscribed_client) do
+      authorized_client.tap do |client|
+        client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+      end
+    end
+
+    let(:collection_name) { 'write_error_prose_spec' }
+
+    let(:collection) do
+      subscribed_client[:collection_name].drop
+      subscribed_client[:collection_name,
+      {
+        'validator' => {
+          'x' => { '$type' => 'string' },
+        }
+      }].create
+      subscribed_client[:collection_name]
+    end
+
+    context 'when there is a write error' do
+      it 'succeeds and prints the error' do
+        begin
+          collection.insert_one({x: 1})
+        rescue Mongo::Error => e
+          insert_events = subscriber.succeeded_events.select { |e| e.command_name == "insert" }
+          expect(insert_events.length).to eq 1
+          expect(e.message).to match(/\[#{e.code}\].+ -- .+/)
+
+          expect(e.details).to eq(e.document['writeErrors'][0]['errInfo'])
+          expect(e.server_message).to eq(e.document['writeErrors'][0]['errmsg'])
+          expect(e.code).to eq(e.document['writeErrors'][0]['code'])
+
+          expect(e.code).to eq 121
+          expect(e.details).to eq(insert_events[0].reply['writeErrors'][0]['errInfo'])
+        else
+          fail 'Expected an OperationFailure'
+        end
+      end
     end
   end
 end

--- a/spec/mongo/error/operation_failure_heavy_spec.rb
+++ b/spec/mongo/error/operation_failure_heavy_spec.rb
@@ -93,7 +93,7 @@ describe Mongo::Error::OperationFailure do
         rescue Mongo::Error => e
           insert_events = subscriber.succeeded_events.select { |e| e.command_name == "insert" }
           expect(insert_events.length).to eq 1
-          expect(e.message).to match(/\[#{e.code}\].+ -- .+/)
+          expect(e.message).to match(/\[#{e.code}(:.*)?\].+ -- .+/)
 
           expect(e.details).to eq(e.document['writeErrors'][0]['errInfo'])
           expect(e.server_message).to eq(e.document['writeErrors'][0]['errmsg'])

--- a/spec/mongo/error/operation_failure_heavy_spec.rb
+++ b/spec/mongo/error/operation_failure_heavy_spec.rb
@@ -90,7 +90,7 @@ describe Mongo::Error::OperationFailure do
       it 'succeeds and prints the error' do
         begin
           collection.insert_one({x: 1})
-        rescue Mongo::Error => e
+        rescue Mongo::Error::OperationFailure => e
           insert_events = subscriber.succeeded_events.select { |e| e.command_name == "insert" }
           expect(insert_events.length).to eq 1
           expect(e.message).to match(/\[#{e.code}(:.*)?\].+ -- .+/)


### PR DESCRIPTION
I decided to add a details property to the `OperationFailure` class to better conform with the crud spec. 
This attribute is defined as follows:

- For WriteConcernErrors this is `document['writeConcernError']['errInfo']`.
- For WriteErrors this is `document['writeErrors'][0]['errInfo']`.
- For all other errors this is `nil`.

Now, this makes a lot of sense for the OperationFailure class, but for BulkWriteError it doesn't quite make sense. The problem is that BulkWriteError can have multiple writeErrors inside it. This is troublesome because I'm not sure what to do with the `details` now. Should it be a list of the `errInfo`s of each `writeError`? This didn't seem to make sense, so I just left the details off the `BulkWriteError` class. If the user wants to find that information, they can get there from the `results` `attr_reader`.

[Evergreen Patch](https://spruce.mongodb.com/version/61b0c81f3e8e862ec357dc60/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)