### PR TITLE
Try removing symlink

### DIFF
--- a/spec/support/ocsp
+++ b/spec/support/ocsp
@@ -1,1 +1,0 @@
-../../.mod/drivers-evergreen-tools/.evergreen/ocsp


### PR DESCRIPTION
The `spec/support/ocsp` symlink is packaged as part of the gem at release and since its target is not packaged, it shows up as a broken symlink when installed using gem/bundler.

I can't seem to figure out how to run the tests on my machine to see if this change passes them, but I'll start by just removing the symlink in case it is not needed.