### PR TITLE
RUBY-2814 listCollectionNames should use authorizedCollections argument

### DIFF
--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -66,10 +66,7 @@ module Mongo
         @batch_size = options[:batch_size]
         session = client.send(:get_session, options)
         cursor = read_with_retry_cursor(session, ServerSelector.primary, self) do |server|
-          if server.description.server_version_gte? '4.0'
-            options.merge!(authorized_collections: true)
-          end
-          send_initial_query(server, session, options.merge(name_only: true))
+          send_initial_query(server, session, options.merge(name_only: true, authorized_collections: true))
         end
         cursor.map do |info|
           if cursor.initial_result.connection_description.features.list_collections_enabled?

--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -66,7 +66,8 @@ module Mongo
         @batch_size = options[:batch_size]
         session = client.send(:get_session, options)
         cursor = read_with_retry_cursor(session, ServerSelector.primary, self) do |server|
-          send_initial_query(server, session, options.merge(name_only: true, authorized_collections: true))
+          options[:authorized_collections] = true if !options.key?(:authorized_collections)
+          send_initial_query(server, session, options.merge(name_only: true))
         end
         cursor.map do |info|
           if cursor.initial_result.connection_description.features.list_collections_enabled?

--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -66,6 +66,9 @@ module Mongo
         @batch_size = options[:batch_size]
         session = client.send(:get_session, options)
         cursor = read_with_retry_cursor(session, ServerSelector.primary, self) do |server|
+          if server.description.server_version_gte? '4.0'
+            options.merge!(authorized_collections: true)
+          end
           send_initial_query(server, session, options.merge(name_only: true))
         end
         cursor.map do |info|

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -255,11 +255,11 @@ describe Mongo::Database do
             subscriber.command_started_events('listCollections')
           end
 
-          it 'authorized_collections not passed to server' do
+          it 'authorized_collections and name_only are passed to server' do
             expect(events.length).to eq(1)
             command = events.first.command
             expect(command['nameOnly']).to eq(true)
-            expect(command['authorizedCollections']).to be_nil
+            expect(command['authorizedCollections']).to eq(true)
           end
         end
       end
@@ -591,9 +591,9 @@ describe Mongo::Database do
           end
         end
 
-        context 'when authorized_collections are provided' do
+        context 'when authorized_collections and name_only are provided as false' do
           let(:options) do
-            { authorized_collections: false }
+            { authorized_collections: false, name_only: false }
           end
 
           let!(:result) do
@@ -604,11 +604,11 @@ describe Mongo::Database do
             subscriber.command_started_events('listCollections')
           end
 
-          it 'authorized_collections not passed to server because false' do
+          it 'is ignored and both are sent as true' do
             expect(events.length).to eq(1)
             command = events.first.command
             expect(command['nameOnly']).to eq(true)
-            expect(command['authorizedCollections']).to be_nil
+            expect(command['authorizedCollections']).to eq(true)
           end
         end
 
@@ -621,10 +621,11 @@ describe Mongo::Database do
             subscriber.command_started_events('listCollections')
           end
 
-          it 'authorized_collections not passed to server because not provided' do
+          it 'authorized_collections and name_only are passed to the server' do
             expect(events.length).to eq(1)
             command = events.first.command
-            expect(command['authorizedCollections']).to be_nil
+            expect(command['nameOnly']).to eq(true)
+            expect(command['authorizedCollections']).to eq(true)
           end
         end
       end

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -607,6 +607,7 @@ describe Mongo::Database do
           it 'does not send authorized_collections to the server' do
             expect(events.length).to eq(1)
             command = events.first.command
+            expect(command['nameOnly']).to eq(true)
             expect(command['authorizedCollections']).to be_nil
           end
         end
@@ -624,7 +625,7 @@ describe Mongo::Database do
             subscriber.command_started_events('listCollections')
           end
 
-          it 'ignores it and sets it to true' do
+          it 'is ignored and set to true' do
             expect(events.length).to eq(1)
             command = events.first.command
             expect(command['nameOnly']).to eq(true)

--- a/spec/mongo/database_spec.rb
+++ b/spec/mongo/database_spec.rb
@@ -591,9 +591,9 @@ describe Mongo::Database do
           end
         end
 
-        context 'when authorized_collections and name_only are provided as false' do
+        context 'when authorized_collections is provided' do
           let(:options) do
-            { authorized_collections: false, name_only: false }
+            { authorized_collections: false }
           end
 
           let!(:result) do
@@ -604,11 +604,30 @@ describe Mongo::Database do
             subscriber.command_started_events('listCollections')
           end
 
-          it 'is ignored and both are sent as true' do
+          it 'does not send authorized_collections to the server' do
+            expect(events.length).to eq(1)
+            command = events.first.command
+            expect(command['authorizedCollections']).to be_nil
+          end
+        end
+
+        context 'when name_only is provided' do
+          let(:options) do
+            { name_only: false }
+          end
+
+          let!(:result) do
+            database.collections(options)
+          end
+
+          let(:events) do
+            subscriber.command_started_events('listCollections')
+          end
+
+          it 'ignores it and sets it to true' do
             expect(events.length).to eq(1)
             command = events.first.command
             expect(command['nameOnly']).to eq(true)
-            expect(command['authorizedCollections']).to eq(true)
           end
         end
 


### PR DESCRIPTION
All the tests that I had to edit here are for server versions >= 4.0. Should I be adding tests specifically for < 4.0 being that nothing changed for those versions? 

UPDATE: This PR is no longer necessary as after the update of [DRIVERS-1393](https://jira.mongodb.org/browse/DRIVERS-1393), the ruby driver already fulfills it's requirements. Closing this PR.