### PR TITLE
RUBY-2869 Do not use mutexes in finalizers

### DIFF
--- a/lib/mongo/cluster/reapers/cursor_reaper.rb
+++ b/lib/mongo/cluster/reapers/cursor_reaper.rb
@@ -112,13 +112,14 @@ module Mongo
       #
       # @api private
       def read_scheduled_kill_specs
-        while !@kill_spec_queue.empty?
-          kill_spec = @kill_spec_queue.pop
+        while kill_spec = @kill_spec_queue.pop(true)
           if @active_cursor_ids.include?(kill_spec.cursor_id)
             @to_kill[kill_spec.server_seed] ||= Set.new
             @to_kill[kill_spec.server_seed] << kill_spec
           end
         end
+      rescue ThreadError
+        # Empty queue, nothing to do.
       end
 
       # Execute all pending kill cursors operations.

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -84,9 +84,8 @@ module Mongo
       @session = @options[:session]
       unless closed?
         register
-        ObjectSpace.define_finalizer(self, self.class.finalize(kill_spec,
+        ObjectSpace.define_finalizer(self, self.class.finalize(kill_spec(server),
           cluster,
-          server,
           @session))
       end
     end
@@ -107,12 +106,12 @@ module Mongo
     # @return [ Proc ] The Finalizer.
     #
     # @api private
-    def self.finalize(kill_spec, cluster, server, session)
+    def self.finalize(kill_spec, cluster, session)
       unless KillSpec === kill_spec
         raise ArgumentError, "First argument must be a KillSpec: #{kill_spec.inspect}"
       end
       proc do
-        cluster.schedule_kill_cursor(kill_spec, server)
+        cluster.schedule_kill_cursor(kill_spec)
         session.end_session if session && session.implicit?
       end
     end
@@ -367,12 +366,13 @@ module Mongo
     end
 
     # @api private
-    def kill_spec
+    def kill_spec(server)
       KillSpec.new(
         cursor_id: id,
         coll_name: collection_name,
         db_name: database.name,
         service_id: initial_result.connection_description.service_id,
+        server_seed: server.address.seed,
       )
     end
 

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -372,7 +372,7 @@ module Mongo
         coll_name: collection_name,
         db_name: database.name,
         service_id: initial_result.connection_description.service_id,
-        server_seed: server.address.seed,
+        server_address: server.address,
       )
     end
 

--- a/lib/mongo/cursor/kill_spec.rb
+++ b/lib/mongo/cursor/kill_spec.rb
@@ -25,17 +25,22 @@ module Mongo
     # @api private
     class KillSpec
 
-      def initialize(cursor_id:, coll_name:, db_name:, service_id:)
+      def initialize(cursor_id:, coll_name:, db_name:, service_id:, server_seed:)
         @cursor_id = cursor_id
         @coll_name = coll_name
         @db_name = db_name
         @service_id = service_id
+        @server_seed = server_seed
       end
 
-      attr_reader :cursor_id, :coll_name, :db_name, :service_id
+      attr_reader :cursor_id, :coll_name, :db_name, :service_id, :server_seed
 
       def ==(other)
-        cursor_id == other.cursor_id && coll_name == other.coll_name && db_name == other.db_name && service_id == other.service_id
+        cursor_id == other.cursor_id &&
+          coll_name == other.coll_name &&
+          db_name == other.db_name &&
+          service_id == other.service_id &&
+          server_seed == other.server_seed
       end
 
       def eql?(other)
@@ -43,7 +48,7 @@ module Mongo
       end
 
       def hash
-        [cursor_id, coll_name, db_name, service_id].compact.hash
+        [cursor_id, coll_name, db_name, service_id, server_seed].compact.hash
       end
     end
   end

--- a/lib/mongo/cursor/kill_spec.rb
+++ b/lib/mongo/cursor/kill_spec.rb
@@ -33,6 +33,18 @@ module Mongo
       end
 
       attr_reader :cursor_id, :coll_name, :db_name, :service_id
+
+      def ==(other)
+        cursor_id == other.cursor_id && coll_name == other.coll_name && db_name == other.db_name && service_id == other.service_id
+      end
+
+      def eql?(other)
+        self.==(other)
+      end
+
+      def hash
+        [cursor_id, coll_name, db_name, service_id].compact.hash
+      end
     end
   end
 end

--- a/lib/mongo/cursor/kill_spec.rb
+++ b/lib/mongo/cursor/kill_spec.rb
@@ -25,22 +25,22 @@ module Mongo
     # @api private
     class KillSpec
 
-      def initialize(cursor_id:, coll_name:, db_name:, service_id:, server_seed:)
+      def initialize(cursor_id:, coll_name:, db_name:, service_id:, server_address:)
         @cursor_id = cursor_id
         @coll_name = coll_name
         @db_name = db_name
         @service_id = service_id
-        @server_seed = server_seed
+        @server_address = server_address
       end
 
-      attr_reader :cursor_id, :coll_name, :db_name, :service_id, :server_seed
+      attr_reader :cursor_id, :coll_name, :db_name, :service_id, :server_address
 
       def ==(other)
         cursor_id == other.cursor_id &&
           coll_name == other.coll_name &&
           db_name == other.db_name &&
           service_id == other.service_id &&
-          server_seed == other.server_seed
+          server_address == other.server_address
       end
 
       def eql?(other)
@@ -48,7 +48,7 @@ module Mongo
       end
 
       def hash
-        [cursor_id, coll_name, db_name, service_id, server_seed].compact.hash
+        [cursor_id, coll_name, db_name, service_id, server_address].compact.hash
       end
     end
   end

--- a/spec/mongo/cluster/cursor_reaper_spec.rb
+++ b/spec/mongo/cluster/cursor_reaper_spec.rb
@@ -41,12 +41,12 @@ describe Mongo::Cluster::CursorReaper do
     let(:cursor_id) { 1 }
     let(:cursor_kill_spec_1) do
       Mongo::Cursor::KillSpec.new(
-        cursor_id: cursor_id, coll_name: 'c', db_name: 'd', service_id: nil, server_seed: address.seed
+        cursor_id: cursor_id, coll_name: 'c', db_name: 'd', service_id: nil, server_address: address
       )
     end
     let(:cursor_kill_spec_2) do
       Mongo::Cursor::KillSpec.new(
-        cursor_id: cursor_id, coll_name: 'c', db_name: 'q', service_id: nil, server_seed: address.seed
+        cursor_id: cursor_id, coll_name: 'c', db_name: 'q', service_id: nil, server_address: address
       )
     end
     let(:to_kill) { reaper.instance_variable_get(:@to_kill)}
@@ -65,8 +65,8 @@ describe Mongo::Cluster::CursorReaper do
         end
 
         it 'initializes the list of op specs to a set' do
-          expect(to_kill.keys).to eq([ address.seed ])
-          expect(to_kill[address.seed]).to contain_exactly(cursor_kill_spec_1)
+          expect(to_kill.keys).to eq([ address ])
+          expect(to_kill[address]).to contain_exactly(cursor_kill_spec_1)
         end
       end
 
@@ -80,8 +80,8 @@ describe Mongo::Cluster::CursorReaper do
         end
 
         it 'adds the op to the server list' do
-          expect(to_kill.keys).to eq([ address.seed ])
-          expect(to_kill[address.seed]).to contain_exactly(cursor_kill_spec_1, cursor_kill_spec_2)
+          expect(to_kill.keys).to eq([ address ])
+          expect(to_kill[address]).to contain_exactly(cursor_kill_spec_1, cursor_kill_spec_2)
         end
 
         context 'when the same op is added more than once' do
@@ -92,8 +92,8 @@ describe Mongo::Cluster::CursorReaper do
           end
 
           it 'does not allow duplicates ops for a server' do
-            expect(to_kill.keys).to eq([ address.seed ])
-            expect(to_kill[address.seed]).to contain_exactly(cursor_kill_spec_1, cursor_kill_spec_2)
+            expect(to_kill.keys).to eq([ address ])
+            expect(to_kill[address]).to contain_exactly(cursor_kill_spec_1, cursor_kill_spec_2)
           end
         end
       end

--- a/spec/mongo/cluster/cursor_reaper_spec.rb
+++ b/spec/mongo/cluster/cursor_reaper_spec.rb
@@ -61,11 +61,12 @@ describe Mongo::Cluster::CursorReaper do
 
         before do
           reaper.schedule_kill_cursor(cursor_kill_spec_1, server)
+          reaper.read_scheduled_kill_specs
         end
 
         it 'initializes the list of op specs to a set' do
           expect(to_kill.keys).to eq([ address.seed ])
-          expect(to_kill[address.seed]).to eq(Set.new([cursor_kill_spec_1]))
+          expect(to_kill[address.seed]).to contain_exactly(cursor_kill_spec_1)
         end
       end
 
@@ -73,7 +74,9 @@ describe Mongo::Cluster::CursorReaper do
 
         before do
           reaper.schedule_kill_cursor(cursor_kill_spec_1, server)
+          reaper.read_scheduled_kill_specs
           reaper.schedule_kill_cursor(cursor_kill_spec_2, server)
+          reaper.read_scheduled_kill_specs
         end
 
         it 'adds the op to the server list' do
@@ -85,6 +88,7 @@ describe Mongo::Cluster::CursorReaper do
 
           before do
             reaper.schedule_kill_cursor(cursor_kill_spec_2, server)
+            reaper.read_scheduled_kill_specs
           end
 
           it 'does not allow duplicates ops for a server' do

--- a/spec/mongo/cursor_spec.rb
+++ b/spec/mongo/cursor_spec.rb
@@ -331,8 +331,9 @@ describe Mongo::Cursor do
 
       before do
         authorized_collection.insert_many(documents)
-        cluster.schedule_kill_cursor(cursor.kill_spec,
-                                     cursor.instance_variable_get(:@server))
+        cluster.schedule_kill_cursor(
+          cursor.kill_spec(cursor.instance_variable_get(:@server))
+        )
       end
 
       let(:view) do


### PR DESCRIPTION
Finalizers are called from signal trap, so mutexes do not work there (see https://github.com/ruby/ruby/blob/master/thread_sync.c#L288).
