### PR TITLE
Add support of MongoDB Extended JSON to Mongo::Crypt::Handle

### DIFF
--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -49,20 +49,19 @@ module Mongo
           Binding.method(:mongocrypt_destroy)
         )
 
-        @kms_tls_options =  kms_tls_options
+        @kms_tls_options = kms_tls_options
 
         @schema_map =
           case options[:schema_map].class
           when String
             begin
-              # Support raw JSON string
+              # Rebuild to raw JSON string as schema map implementation requires BSON variable instances
               BSON::ExtJSON.parse(options[:schema_map])
             rescue JSON::ParserError
               nil
             end
-          when Hash
-            # Rebuild to BSON as schema map implementation requires BSON variable instances
-            BSON::ExtJSON.parse options[:schema_map].to_json
+          else
+            options[:schema_map]
           end
 
         set_schema_map if @schema_map

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -52,7 +52,7 @@ module Mongo
         @kms_tls_options =  kms_tls_options
 
         # Rebuild to BSON as schema map implementation requires BSON variable instances
-        @schema_map = BSON::ExtJSON.parse options[:schema_map].to_json
+        @schema_map = BSON::ExtJSON.parse(options[:schema_map].is_a?(String) ? options[:schema_map] : options[:schema_map].to_json)
 
         set_schema_map if @schema_map
 

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -51,8 +51,19 @@ module Mongo
 
         @kms_tls_options =  kms_tls_options
 
-        # Rebuild to BSON as schema map implementation requires BSON variable instances
-        @schema_map = BSON::ExtJSON.parse(options[:schema_map].is_a?(String) ? options[:schema_map] : options[:schema_map].to_json)
+        @schema_map =
+          case options[:schema_map].class
+          when String
+            begin
+              # Support raw JSON string
+              BSON::ExtJSON.parse(options[:schema_map])
+            rescue JSON::ParserError
+              nil
+            end
+          when Hash
+            # Rebuild to BSON as schema map implementation requires BSON variable instances
+            BSON::ExtJSON.parse options[:schema_map].to_json
+          end
 
         set_schema_map if @schema_map
 

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -51,7 +51,9 @@ module Mongo
 
         @kms_tls_options =  kms_tls_options
 
-        @schema_map = options[:schema_map]
+        # Rebuild to BSON as schema map implementation requires BSON variable instances
+        @schema_map = BSON::ExtJSON.parse options[:schema_map].to_json
+
         set_schema_map if @schema_map
 
         @logger = options[:logger]

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -22,6 +22,16 @@ describe Mongo::Crypt::Handle do
         end
       end
 
+      context 'with schema map in JSON string' do
+        let(:schema_map) do
+          File.read 'spec/support/crypt/schema_maps/schema_map_local.json'
+        end
+
+        it 'does not raise an exception' do
+          expect { handle }.not_to raise_error
+        end
+      end
+
       context 'with invalid schema map' do
         let(:schema_map) { '' }
 


### PR DESCRIPTION
`keyId` in Auto-encryption schema map config is required to be in BSON::Binary type to communicate with mongocryptd, for projects that working with a static config file (like Mongoid) is unable to set keyId with MongoDB Extended JSON syntax like `$binary` or `$uuid`.

This PR add support on raw JSON string schema map and also hash object parsed by static mongoid.yml with Mongoid