### PR TITLE
DOCSP-20373 Update links to mongodb.com/docs

### DIFF
--- a/.evergreen/functions-kerberos.sh
+++ b/.evergreen/functions-kerberos.sh
@@ -18,7 +18,7 @@ configure_for_external_kerberos() {
 
   echo "Running kinit"
   kinit -k -t ${PROJECT_DIRECTORY}/.evergreen/drivers.keytab -p "$PRINCIPAL"
-  
+
   # Realm must be uppercased.
   export SASL_REALM=`echo "$SASL_HOST" |tr a-z A-Z`
 }
@@ -32,21 +32,21 @@ configure_local_kerberos() {
     echo Local Kerberos configuration should only be done in Docker containers 1>&2
     exit 43
   fi
-  
+
   cp .evergreen/local-kerberos/krb5.conf /etc/
   mkdir -p /etc/krb5kdc
   cp .evergreen/local-kerberos/kdc.conf /etc/krb5kdc/kdc.conf
   cp .evergreen/local-kerberos/kadm5.acl /etc/krb5kdc/
-  
+
   cat .evergreen/local-kerberos/test.keytab.base64 |\
     base64 --decode > ${PROJECT_DIRECTORY}/.evergreen/drivers.keytab
-  
+
   (echo masterp; echo masterp) |kdb5_util create -s
   (echo testp; echo testp) |kadmin.local addprinc rubytest@LOCALKRB
-  
+
   krb5kdc
   kadmind
-  
+
   echo 127.0.0.1 krb.local |tee -a /etc/hosts
   echo testp |kinit rubytest@LOCALKRB
 
@@ -59,10 +59,10 @@ configure_local_kerberos() {
     echo MongoDB server is not an enterprise one 1>&2
     exit 44
   fi
-  
+
   mkdir /db
   "$BINDIR"/mongod --dbpath /db --fork --logpath /db/mongod.log
-  
+
   create_user_cmd="`cat <<'EOT'
     db.getSiblingDB("$external").runCommand(
       {
@@ -81,7 +81,7 @@ EOT
   pkill mongod
   sleep 1
 
-  # https://docs.mongodb.com/manual/tutorial/control-access-to-mongodb-with-kerberos-authentication/
+  # https://mongodb.com/docs/manual/tutorial/control-access-to-mongodb-with-kerberos-authentication/
   "$BINDIR"/mongod --dbpath /db --fork --logpath /db/mongod.log \
     --bind_ip 0.0.0.0 \
     --auth --setParameter authenticationMechanisms=GSSAPI &

--- a/README.md
+++ b/README.md
@@ -7,21 +7,17 @@ The officially supported Ruby driver for [MongoDB](https://www.mongodb.org/).
 
 The Ruby driver supports Ruby 2.5-3.0 and JRuby 9.2.
 
-
-Documentation
--------------
+## Documentation
 
 High level documentation and usage examples are located
 [here](http://docs.mongodb.org/ecosystem/drivers/ruby/).
 
 API documentation for the most recent release can be found
-[here](https://docs.mongodb.com/ruby-driver/current/api/).
+[here](https://mongodb.com/docs/ruby-driver/current/api/).
 To build API documentation for the master branch, check out the
 repository locally and run `rake docs`.
 
-
-Support
--------
+## Support
 
 Commercial support for the driver is available through the
 [MongoDB Support Portal](https://support.mongodb.com/).
@@ -29,17 +25,15 @@ Commercial support for the driver is available through the
 For questions, discussions or general technical support, please visit the
 [MongoDB Community Forum](https://developer.mongodb.com/community/forums/tags/c/drivers-odms-connectors/7/ruby-driver).
 
-Please see [Technical Support](https://docs.mongodb.com/manual/support/) page
+Please see [Technical Support](https://mongodb.com/docs/manual/support/) page
 in the documentation for other support resources.
 
-
-Bugs & Feature Requests
------------------------
+## Bugs & Feature Requests
 
 To report a bug in the driver or request a feature specific to the Ruby driver:
 
 1. Visit [our issue tracker](https://jira.mongodb.org/) and login
-(or create an account if you do not have one already).
+   (or create an account if you do not have one already).
 2. Navigate to the [RUBY project](https://jira.mongodb.org/browse/RUBY).
 3. Click 'Create Issue' and fill out all of the applicable form fields.
 
@@ -60,54 +54,44 @@ is publicly visible.
 - Provide any sensitive data or server logs.
 - Report potential security issues publicly (see 'Security Issues' below).
 
-
-Security Issues
----------------
+## Security Issues
 
 If you have identified a potential security-related issue in the Ruby driver
 (or any other MongoDB product), please report it by following the
 [instructions here](http://docs.mongodb.org/manual/tutorial/create-a-vulnerability-report).
 
-
-Product Feature Requests
-------------------------
+## Product Feature Requests
 
 To request a feature which is not specific to the Ruby driver, or which
 affects more than the driver alone (for example, a feature which requires
 MongoDB server support), please submit your idea through the
 [MongoDB Feedback Forum](https://feedback.mongodb.com/forums/924286-drivers).
 
-
-Running Tests
--------------
+## Running Tests
 
 Please refer to [spec/README.md](spec/README.md) for instructions on how
 to run the driver's test suite.
 
-
-Release History
----------------
+## Release History
 
 Full release notes and release history are available [on the GitHub releases
 page](https://github.com/mongodb/mongo-ruby-driver/releases).
 
+## License
 
-License
--------
+Copyright (C) 2009-2020 MongoDB, Inc.
 
- Copyright (C) 2009-2020 MongoDB, Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
+http://www.apache.org/licenses/LICENSE-2.0
 
-   http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 
 [rubygems-img]: https://badge.fury.io/rb/mongo.svg
 [rubygems-url]: http://badge.fury.io/rb/mongo

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -8,8 +8,8 @@ Ruby MongoDB Driver
 
 .. default-domain:: mongodb
 
-Welcome to the documentation site for the official MongoDB Ruby driver. 
-You can add the driver to your application to work with MongoDB in 
+Welcome to the documentation site for the official MongoDB Ruby driver.
+You can add the driver to your application to work with MongoDB in
 Ruby.
 
 Get Started
@@ -44,7 +44,7 @@ Object Document Mappers (ODM) as opposed to Object Relational Mappers
 The ODM officially supported by MongoDB is Mongoid, originally written
 by Durran Jordan.
 
-For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mongoid/master>`_.
+For tutorials on Mongoid, see the `Mongoid Manual <https://mongodb.com/docs/mongoid/master>`_.
 
 .. COMMENT  For the actual build, see mongodb/docs-ruby repo which pulls the documentation source from:
 ..    mongo-ruby-driver,
@@ -62,7 +62,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mong
     reference/working-with-data
     reference/schema-operations
     bson-tutorials
-    API <https://docs.mongodb.com/ruby-driver/master/api/>
+    API <https://mongodb.com/docs/ruby-driver/master/api/>
     release-notes
     reference/additional-resources
     contribute

--- a/docs/reference/client-side-encryption.txt
+++ b/docs/reference/client-side-encryption.txt
@@ -75,7 +75,7 @@ skip this step.
 
 Mongocryptd comes pre-packaged with enterprise builds of the MongoDB server
 (versions 4.2 and newer). For installation instructions, see
-`the MongoDB manual <https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/#installation>`_.
+`the MongoDB manual <https://mongodb.com/docs/manual/reference/security-client-side-encryption-appendix/#installation>`_.
 
 In order to configure mongocryptd (for example, which port it listens on or the
 path used to spawn the daemon), it is necessary to pass different options to the

--- a/docs/reference/create-client.txt
+++ b/docs/reference/create-client.txt
@@ -1578,7 +1578,7 @@ Usage with Forking Servers
 .. note::
 
   Applications using Mongoid should follow `Mongoid's forking guidance
-  <https://docs.mongodb.com/mongoid/current/tutorials/mongoid-configuration/#usage-with-forking-servers>`_.
+  <https://mongodb.com/docs/mongoid/current/tutorials/mongoid-configuration/#usage-with-forking-servers>`_.
   The guidance and sample code below is provided for applications using the
   Ruby driver directly.
 
@@ -1670,7 +1670,7 @@ to use are:
 This documentation does not provide example code for using the aforementioned
 hooks, because there is no standard for client instance management when
 using the Ruby driver directly. `Mongoid documentation
-<https://docs.mongodb.com/mongoid/current/tutorials/mongoid-configuration/#usage-with-forking-servers>`_
+<https://mongodb.com/docs/mongoid/current/tutorials/mongoid-configuration/#usage-with-forking-servers>`_
 however provides examples for closing clients in the parent process and
 reconnecting clients in the child processes.
 

--- a/docs/reference/crud-operations.txt
+++ b/docs/reference/crud-operations.txt
@@ -801,7 +801,7 @@ Write Concern
 All write operations in MongoDB are executed with a write concern which is
 the level of acknowledgment requested from MongoDB for the particular write.
 More information about write concerns in general is available in the
-`MongoDB manual <https://docs.mongodb.com/manual/reference/write-concern/>`_.
+`MongoDB manual <https://mongodb.com/docs/manual/reference/write-concern/>`_.
 
 The Ruby driver supports specifying write concern on client, collection,
 session (for transactions on that session), transaction, GridFS bucket

--- a/docs/reference/transactions.txt
+++ b/docs/reference/transactions.txt
@@ -12,7 +12,7 @@ Transactions
 
 
 Version 4.0 of the MongoDB server introduces
-`multi-document transactions <https://docs.mongodb.com/manual/core/transactions/>`_.
+`multi-document transactions <https://mongodb.com/docs/manual/core/transactions/>`_.
 (Updates to multiple fields within a single document are atomic in all
 versions of MongoDB.) Ruby driver version 2.6.0 adds support for transactions.
 
@@ -100,7 +100,7 @@ when starting a transaction:
 
 To persist changes made in a transaction to the database, the transaction
 must be explicitly committed. If a session ends with an open transaction,
-`the transaction is aborted <https://docs.mongodb.com/manual/core/transactions/#transactions-and-sessions>`_.
+`the transaction is aborted <https://mongodb.com/docs/manual/core/transactions/#transactions-and-sessions>`_.
 A transaction may also be aborted explicitly.
 
 To commit or abort a transaction, call ``commit_transaction`` or
@@ -109,13 +109,13 @@ To commit or abort a transaction, call ``commit_transaction`` or
 .. code-block:: ruby
 
   session.commit_transaction
-  
+
   session.abort_transaction
 
 Note: an outstanding transaction can hold locks to various objects in the
 server, such as the database. For example, the drop call in the following
 snippet will hang for `transactionLifetimeLimitSeconds
-<https://docs.mongodb.com/manual/reference/parameters/#param.transactionLifetimeLimitSeconds>`_
+<https://mongodb.com/docs/manual/reference/parameters/#param.transactionLifetimeLimitSeconds>`_
 seconds (default 60) until the server expires and aborts the transaction:
 
 .. code-block:: ruby
@@ -125,7 +125,7 @@ seconds (default 60) until the server expires and aborts the transaction:
   c1['foo'].insert_one(test: 1)
   session.start_transaction
   c1['foo'].insert_one({test: 2}, session: session)
-  
+
   c2 = Mongo::Client.new(['127.0.0.1:27017']).use(:test_db)
   # hangs
   c2.database.drop
@@ -150,7 +150,7 @@ Retrying Commits
 ================
 
 The transaction commit `can be retried
-<https://docs.mongodb.com/manual/core/transactions/#retry-commit-operation>`_
+<https://mongodb.com/docs/manual/core/transactions/#retry-commit-operation>`_
 if it fails. Here is the Ruby code to do so:
 
 .. code-block:: ruby

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -898,7 +898,7 @@ module Mongo
     #   which databases are returned based on user privileges when access control
     #   is enabled
     #
-    #   See https://docs.mongodb.com/manual/reference/command/listDatabases/
+    #   See https://mongodb.com/docs/manual/reference/command/listDatabases/
     #   for more information and usage.
     # @option opts [ Session ] :session The session to use.
     # @option options [ Object ] :comment A user-provided
@@ -924,7 +924,7 @@ module Mongo
     #   which databases are returned based on user privileges when access control
     #   is enabled
     #
-    #   See https://docs.mongodb.com/manual/reference/command/listDatabases/
+    #   See https://mongodb.com/docs/manual/reference/command/listDatabases/
     #   for more information and usage.
     # @option opts [ Session ] :session The session to use.
     # @option options [ Object ] :comment A user-provided

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -94,7 +94,7 @@ module Mongo
     # @option options [ Hash ] :write_concern The write concern options.
     #   Can be :w => Integer|String, :fsync => Boolean, :j => Boolean.
     # @option options [ Hash ] :time_series Create a time-series collection.
-    #   See https://docs.mongodb.com/manual/core/timeseries-collections/ for more
+    #   See https://mongodb.com/docs/manual/core/timeseries-collections/ for more
     #   information about time-series collection.
     # @option options [ Integer ] :expire_after Number indicating
     #   after how many seconds old time-series data should be deleted.

--- a/lib/mongo/collection/view/explainable.rb
+++ b/lib/mongo/collection/view/explainable.rb
@@ -53,7 +53,7 @@ module Mongo
         #
         # @return [ Hash ] A single document with the query plan.
         #
-        # @see https://docs.mongodb.com/manual/reference/method/db.collection.explain/#db.collection.explain
+        # @see https://mongodb.com/docs/manual/reference/method/db.collection.explain/#db.collection.explain
         #
         # @since 2.0.0
         def explain(**opts)

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -128,7 +128,7 @@ module Mongo
     # @option options [ Object ] :comment A user-provided
     #   comment to attach to this command.
     #
-    #   See https://docs.mongodb.com/manual/reference/command/listCollections/
+    #   See https://mongodb.com/docs/manual/reference/command/listCollections/
     #   for more information and usage.
     #
     # @return [ Array<String> ] Names of the collections.
@@ -156,7 +156,7 @@ module Mongo
     # @option options [ Object ] :comment A user-provided
     #   comment to attach to this command.
     #
-    #   See https://docs.mongodb.com/manual/reference/command/listCollections/
+    #   See https://mongodb.com/docs/manual/reference/command/listCollections/
     #   for more information and usage.
     #
     # @return [ Array<Hash> ] Array of information hashes, one for each
@@ -181,7 +181,7 @@ module Mongo
     # @option options [ Object ] :comment A user-provided
     #   comment to attach to this command.
     #
-    #   See https://docs.mongodb.com/manual/reference/command/listCollections/
+    #   See https://mongodb.com/docs/manual/reference/command/listCollections/
     #   for more information and usage.
     #
     # @return [ Array<Mongo::Collection> ] The collections.

--- a/lib/mongo/database/view.rb
+++ b/lib/mongo/database/view.rb
@@ -57,7 +57,7 @@ module Mongo
       # @option options [ Object ] :comment A user-provided
       #   comment to attach to this command.
       #
-      #   See https://docs.mongodb.com/manual/reference/command/listCollections/
+      #   See https://mongodb.com/docs/manual/reference/command/listCollections/
       #   for more information and usage.
       # @option options [ Session ] :session The session to use.
       #
@@ -101,7 +101,7 @@ module Mongo
       #   set to true and used with nameOnly: true, that allows a user without the
       #   required privilege to run the command when access control is enforced
       #
-      #   See https://docs.mongodb.com/manual/reference/command/listCollections/
+      #   See https://mongodb.com/docs/manual/reference/command/listCollections/
       #   for more information and usage.
       # @option options [ Session ] :session The session to use.
       #

--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY
 
   s.authors           = ['Tyler Brock', 'Emily Stolfo', 'Durran Jordan']
-  s.homepage          = 'https://docs.mongodb.com/ruby-driver/'
+  s.homepage          = 'https://mongodb.com/docs/ruby-driver/'
   s.summary           = 'Ruby driver for MongoDB'
   s.description       = 'A Ruby driver for MongoDB'
   s.license           = 'Apache-2.0'
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.metadata = {
     'bug_tracker_uri' => 'https://jira.mongodb.org/projects/RUBY',
     'changelog_uri' => 'https://github.com/mongodb/mongo-ruby-driver/releases',
-    'documentation_uri' => 'https://docs.mongodb.com/ruby-driver/',
-    'homepage_uri' => 'https://docs.mongodb.com/ruby-driver/',
+    'documentation_uri' => 'https://mongodb.com/docs/ruby-driver/',
+    'homepage_uri' => 'https://mongodb.com/docs/ruby-driver/',
     'source_code_uri' => 'https://github.com/mongodb/mongo-ruby-driver',
   }
 
@@ -37,12 +37,12 @@ Gem::Specification.new do |s|
   s.bindir            = 'bin'
 
   s.required_ruby_version = ">= 2.5"
-  
-  # For testing driver against bson master we need to depend on bson < 6.0.0 
+
+  # For testing driver against bson master we need to depend on bson < 6.0.0
   # but in release version we want to depend on bson < 5.0.0.
   if %w(1 yes true).include?(ENV['MONGO_RUBY_DRIVER_BSON_MASTER'])
     s.add_dependency 'bson', '>=4.13.0', '<6.0.0'
-  else 
+  else
     s.add_dependency 'bson', '>=4.14.1', '<5.0.0'
   end
 end

--- a/spec/README.md
+++ b/spec/README.md
@@ -408,7 +408,7 @@ The client-side encryption tests require the mongocryptd binary to be in the
 system path.
 
 Download enterprise versions of MongoDB here: https://www.mongodb.com/download-center/enterprise
-Read more about installing mongocryptd here: https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/#mongocryptd
+Read more about installing mongocryptd here: https://mongodb.com/docs/manual/reference/security-client-side-encryption-appendix/#mongocryptd
 
 Install libmongocrypt on your machine:
 
@@ -513,9 +513,9 @@ To test compression, set the `compressors` URI option:
     MONGODB_URI="mongodb://localhost:27017/?compressors=zlib" rake
 
 Note that as of this writing, the driver supports
-[ztsd](https://docs.mongodb.com/manual/reference/glossary/#term-zstd),
-[snappy](https://docs.mongodb.com/manual/reference/glossary/#term-snappy)
-and [zlib](https://docs.mongodb.com/manual/reference/glossary/#term-zlib)
+[ztsd](https://mongodb.com/docs/manual/reference/glossary/#term-zstd),
+[snappy](https://mongodb.com/docs/manual/reference/glossary/#term-snappy)
+and [zlib](https://mongodb.com/docs/manual/reference/glossary/#term-zlib)
 compression.
 
 Servers 4.2+ enable zlib by default; to test older servers, explicitly enable
@@ -530,7 +530,7 @@ To specify server API parameters, use the `SERVER_API` environment variable.
 The server API parameters cannot be specified via URI options.
 
 Both YAML and JSON syntaxes are accepted:
-    
+
     SERVER_API='{version: "1", strict: true}' rake
 
     SERVER_API='{"version":"1","strict":true}' rake

--- a/spec/spec_tests/data/crud/read/aggregate-collation.yml
+++ b/spec/spec_tests/data/crud/read/aggregate-collation.yml
@@ -12,7 +12,7 @@ tests:
                 pipeline:
                     - $match:
                         x: 'PING'
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
         outcome:
             result:
                 - {_id: 1, x: 'ping'}

--- a/spec/spec_tests/data/crud/read/count-collation.yml
+++ b/spec/spec_tests/data/crud/read/count-collation.yml
@@ -10,7 +10,7 @@ tests:
             name: countDocuments
             arguments:
                 filter: { x: 'ping' }
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result: 1

--- a/spec/spec_tests/data/crud/read/distinct-collation.yml
+++ b/spec/spec_tests/data/crud/read/distinct-collation.yml
@@ -11,7 +11,7 @@ tests:
             name: distinct
             arguments:
                 fieldName: "string"
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/spec/spec_tests/data/crud/read/find-collation.yml
+++ b/spec/spec_tests/data/crud/read/find-collation.yml
@@ -10,7 +10,7 @@ tests:
             name: "find"
             arguments:
                 filter: {x: 'PING'}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
         outcome:
             result:
                 - {_id: 1, x: 'ping'}

--- a/spec/spec_tests/data/crud/write/bulkWrite-collation.yml
+++ b/spec/spec_tests/data/crud/write/bulkWrite-collation.yml
@@ -8,7 +8,7 @@ data:
 minServerVersion: '3.4'
 serverless: 'forbid'
 
-# See: https://docs.mongodb.com/manual/reference/collation/#collation-document
+# See: https://mongodb.com/docs/manual/reference/collation/#collation-document
 tests:
     -
         description: "BulkWrite with delete operations and collation"

--- a/spec/spec_tests/data/crud/write/deleteMany-collation.yml
+++ b/spec/spec_tests/data/crud/write/deleteMany-collation.yml
@@ -13,7 +13,7 @@ tests:
             arguments:
                 filter:
                     x: 'PING'
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/spec/spec_tests/data/crud/write/deleteOne-collation.yml
+++ b/spec/spec_tests/data/crud/write/deleteOne-collation.yml
@@ -12,7 +12,7 @@ tests:
             name: "deleteOne"
             arguments:
                 filter: {x: 'PING'}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/spec/spec_tests/data/crud/write/findOneAndDelete-collation.yml
+++ b/spec/spec_tests/data/crud/write/findOneAndDelete-collation.yml
@@ -14,7 +14,7 @@ tests:
                 filter: {_id: 2, x: 'PING'}
                 projection: {x: 1, _id: 0}
                 sort: {x: 1}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result: {x: 'ping'}

--- a/spec/spec_tests/data/crud/write/findOneAndReplace-collation.yml
+++ b/spec/spec_tests/data/crud/write/findOneAndReplace-collation.yml
@@ -15,7 +15,7 @@ tests:
                 projection: {x: 1, _id: 0}
                 returnDocument: After
                 sort: {x: 1}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result: {x: 'pong'}

--- a/spec/spec_tests/data/crud/write/findOneAndUpdate-collation.yml
+++ b/spec/spec_tests/data/crud/write/findOneAndUpdate-collation.yml
@@ -17,7 +17,7 @@ tests:
                     $set: {x: 'pong'}
                 projection: {x: 1, _id: 0}
                 sort: {_id: 1}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result: {x: 'ping'}

--- a/spec/spec_tests/data/crud/write/replaceOne-collation.yml
+++ b/spec/spec_tests/data/crud/write/replaceOne-collation.yml
@@ -12,7 +12,7 @@ tests:
             arguments:
                 filter: {x: 'PING'}
                 replacement: {_id: 2, x: 'pong'}
-                collation: {locale: 'en_US', strength: 2} # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: {locale: 'en_US', strength: 2} # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/spec/spec_tests/data/crud/write/updateMany-collation.yml
+++ b/spec/spec_tests/data/crud/write/updateMany-collation.yml
@@ -15,7 +15,7 @@ tests:
                     x: 'ping'
                 update:
                     $set: {x: 'pong'}
-                collation: { locale: 'en_US', strength: 2 } # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2 } # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/spec/spec_tests/data/crud/write/updateOne-collation.yml
+++ b/spec/spec_tests/data/crud/write/updateOne-collation.yml
@@ -13,7 +13,7 @@ tests:
                 filter: {x: 'PING'}
                 update:
                     $set: {x: 'pong'}
-                collation: { locale: 'en_US', strength: 2} # https://docs.mongodb.com/manual/reference/collation/#collation-document
+                collation: { locale: 'en_US', strength: 2} # https://mongodb.com/docs/manual/reference/collation/#collation-document
 
         outcome:
             result:

--- a/spec/support/cluster_tools.rb
+++ b/spec/support/cluster_tools.rb
@@ -55,7 +55,7 @@ class ClusterTools
       replSetStepDown: 1, force: true)
   end
 
-  # https://docs.mongodb.com/manual/reference/parameters/#param.enableElectionHandoff
+  # https://mongodb.com/docs/manual/reference/parameters/#param.enableElectionHandoff
   def set_election_handoff(value)
     unless [true, false].include?(value)
       raise ArgumentError, 'Value must be true or false'


### PR DESCRIPTION
We've migrated docs to www.mongodb.com/docs. As such, this updates links in the source!