### PR TITLE
RUBY-2920 ChangeStream Spec: fullDocument field in ChangeStreamOptions should be an optional to handle "default" case.

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -1004,10 +1004,11 @@ module Mongo
     # @param [ Array<Hash> ] pipeline Optional additional filter operators.
     # @param [ Hash ] options The change stream options.
     #
-    # @option options [ String ] :full_document Allowed values: 'default', 'updateLookup'.
-    #   Defaults to 'default'. When set to 'updateLookup', the change notification for partial
-    #   updates will include both a delta describing the changes to the document, as well as a copy
-    #   of the entire document that was changed from some time after the change occurred.
+    # @option options [ String ] :full_document Allowed values: 'updateLookup'.
+    #   When set to 'updateLookup', the change notification for partial updates
+    #   will include both a delta describing the changes to the document, as
+    #   well as a copy of the entire document that was changed from some time
+    #   after the change occurred. The default is to not send a value.
     # @option options [ BSON::Document, Hash ] :resume_after Specifies the logical starting point
     #   for the new change stream.
     # @option options [ Integer ] :max_await_time_ms The maximum amount of time for the server to

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -1004,11 +1004,12 @@ module Mongo
     # @param [ Array<Hash> ] pipeline Optional additional filter operators.
     # @param [ Hash ] options The change stream options.
     #
-    # @option options [ String ] :full_document Allowed values: 'updateLookup'.
-    #   When set to 'updateLookup', the change notification for partial updates
-    #   will include both a delta describing the changes to the document, as
-    #   well as a copy of the entire document that was changed from some time
-    #   after the change occurred. The default is to not send a value.
+    # @option options [ String ] :full_document Allowed values: nil, 'default'
+    #   (behaves same as nil), 'updateLookup'. When set to 'updateLookup', the
+    #   change notification for partial updates will include both a delta
+    #   describing the changes to the document, as well as a copy of the entire
+    #   document that was changed from some time after the change occurred. The
+    #   default is to not send a value.
     # @option options [ BSON::Document, Hash ] :resume_after Specifies the logical starting point
     #   for the new change stream.
     # @option options [ Integer ] :max_await_time_ms The maximum amount of time for the server to

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -418,11 +418,12 @@ module Mongo
     # @param [ Array<Hash> ] pipeline Optional additional filter operators.
     # @param [ Hash ] options The change stream options.
     #
-    # @option options [ String ] :full_document Allowed values: 'updateLookup'.
-    #   When set to 'updateLookup', the change notification for partial updates
-    #   will include both a delta describing the changes to the document, as
-    #   well as a copy of the entire document that was changed from some time
-    #   after the change occurred. The default is to not send a value.
+    # @option options [ String ] :full_document Allowed values: nil, 'default'
+    #   (behaves same as nil), 'updateLookup'. When set to 'updateLookup', the
+    #   change notification for partial updates will include both a delta
+    #   describing the changes to the document, as well as a copy of the entire
+    #   document that was changed from some time after the change occurred. The
+    #   default is to not send a value.
     # @option options [ BSON::Document, Hash ] :resume_after Specifies the
     #   logical starting point for the new change stream.
     # @option options [ Integer ] :max_await_time_ms The maximum amount of time

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -418,11 +418,11 @@ module Mongo
     # @param [ Array<Hash> ] pipeline Optional additional filter operators.
     # @param [ Hash ] options The change stream options.
     #
-    # @option options [ String ] :full_document Allowed values: ‘default’,
-    #   ‘updateLookup’. Defaults to ‘default’. When set to ‘updateLookup’,
-    #   the change notification for partial updates will include both a delta
-    #   describing the changes to the document, as well as a copy of the entire
-    #   document that was changed from some time after the change occurred.
+    # @option options [ String ] :full_document Allowed values: 'updateLookup'.
+    #   When set to 'updateLookup', the change notification for partial updates
+    #   will include both a delta describing the changes to the document, as
+    #   well as a copy of the entire document that was changed from some time
+    #   after the change occurred. The default is to not send a value.
     # @option options [ BSON::Document, Hash ] :resume_after Specifies the
     #   logical starting point for the new change stream.
     # @option options [ Integer ] :max_await_time_ms The maximum amount of time

--- a/lib/mongo/collection/view/change_stream.rb
+++ b/lib/mongo/collection/view/change_stream.rb
@@ -70,10 +70,12 @@ module Mongo
         # @param [ Array<Hash> ] pipeline The pipeline of operators to filter the change notifications.
         # @param [ Hash ] options The change stream options.
         #
-        # @option options [ String ] :full_document Allowed values: 'default', 'updateLookup'. Defaults to 'default'.
-        #   When set to 'updateLookup', the change notification for partial updates will include both a delta
-        #   describing the changes to the document, as well as a copy of the entire document that was changed
-        #   from some time after the change occurred.
+        # @option options [ String ] :full_document Allowed values: 'updateLookup'.
+        #   When set to 'updateLookup', the change notification for partial
+        #   updates will include both a delta describing the changes to the
+        #   document, as well as a copy of the entire document that was changed
+        #   from some time after the change occurred. The default is to not send
+        #   a value.
         # @option options [ BSON::Document, Hash ] :resume_after Specifies the logical starting point for the
         #   new change stream.
         # @option options [ Integer ] :max_await_time_ms The maximum amount of time for the server to wait

--- a/lib/mongo/collection/view/change_stream.rb
+++ b/lib/mongo/collection/view/change_stream.rb
@@ -70,12 +70,12 @@ module Mongo
         # @param [ Array<Hash> ] pipeline The pipeline of operators to filter the change notifications.
         # @param [ Hash ] options The change stream options.
         #
-        # @option options [ String ] :full_document Allowed values: 'updateLookup'.
-        #   When set to 'updateLookup', the change notification for partial
-        #   updates will include both a delta describing the changes to the
-        #   document, as well as a copy of the entire document that was changed
-        #   from some time after the change occurred. The default is to not send
-        #   a value.
+        # @option options [ String ] :full_document Allowed values: nil, 'default'
+        #   (behaves same as nil), 'updateLookup'. When set to 'updateLookup', the
+        #   change notification for partial updates will include both a delta
+        #   describing the changes to the document, as well as a copy of the entire
+        #   document that was changed from some time after the change occurred. The
+        #   default is to not send a value.
         # @option options [ BSON::Document, Hash ] :resume_after Specifies the logical starting point for the
         #   new change stream.
         # @option options [ Integer ] :max_await_time_ms The maximum amount of time for the server to wait

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -413,10 +413,11 @@ module Mongo
     # @param [ Array<Hash> ] pipeline Optional additional filter operators.
     # @param [ Hash ] options The change stream options.
     #
-    # @option options [ String ] :full_document Allowed values: 'default', 'updateLookup'.
-    #   Defaults to 'default'. When set to 'updateLookup', the change notification for partial
-    #   updates will include both a delta describing the changes to the document, as well as a copy
-    #   of the entire document that was changed from some time after the change occurred.
+    # @option options [ String ] :full_document Allowed values: 'updateLookup'.
+    #   When set to 'updateLookup', the change notification for partial updates
+    #   will include both a delta describing the changes to the document, as
+    #   well as a copy of the entire document that was changed from some time
+    #   after the change occurred. The default is to not send a value.
     # @option options [ BSON::Document, Hash ] :resume_after Specifies the logical starting point
     #   for the new change stream.
     # @option options [ Integer ] :max_await_time_ms The maximum amount of time for the server to

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -413,11 +413,12 @@ module Mongo
     # @param [ Array<Hash> ] pipeline Optional additional filter operators.
     # @param [ Hash ] options The change stream options.
     #
-    # @option options [ String ] :full_document Allowed values: 'updateLookup'.
-    #   When set to 'updateLookup', the change notification for partial updates
-    #   will include both a delta describing the changes to the document, as
-    #   well as a copy of the entire document that was changed from some time
-    #   after the change occurred. The default is to not send a value.
+    # @option options [ String ] :full_document Allowed values: nil, 'default'
+    #   (behaves same as nil), 'updateLookup'. When set to 'updateLookup', the
+    #   change notification for partial updates will include both a delta
+    #   describing the changes to the document, as well as a copy of the entire
+    #   document that was changed from some time after the change occurred. The
+    #   default is to not send a value.
     # @option options [ BSON::Document, Hash ] :resume_after Specifies the logical starting point
     #   for the new change stream.
     # @option options [ Integer ] :max_await_time_ms The maximum amount of time for the server to


### PR DESCRIPTION
This spec change was done in RUBY-1940 but the comments on the affected functions were not updated. The ticket can RUBY-2920 can be marked as a duplicate, since the work was already done. 