### PR TITLE
Treat 0 limit as no limit in query caching

### DIFF
--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -71,6 +71,9 @@ module Mongo
             # re-use results from an earlier query with the same or larger
             # limit, and then impose the lower limit during iteration.
             limit_for_cached_query = respond_to?(:limit) ? limit : nil
+
+            # For the purposes of caching, a limit of 0 means no limit, as mongo treats it as such.
+            limit_for_cached_query = nil if limit_for_cached_query == 0
           end
 
           if block_given?

--- a/lib/mongo/query_cache.rb
+++ b/lib/mongo/query_cache.rb
@@ -180,6 +180,9 @@ module Mongo
       # @api private
       def get(**opts)
         limit = opts[:limit]
+        # For the purposes of caching, a limit of 0 means no limit, as mongo treats it as such.
+        limit = nil if limit == 0
+
         _namespace_key = namespace_key(**opts)
         _cache_key = cache_key(**opts)
 
@@ -190,6 +193,8 @@ module Mongo
         return nil unless caching_cursor
 
         caching_cursor_limit = caching_cursor.view.limit
+        # For the purposes of caching, a limit of 0 means no limit, as mongo treats it as such.
+        caching_cursor_limit = nil if caching_cursor_limit == 0
 
         # There are two scenarios in which a caching cursor could fulfill the
         # query:
@@ -199,6 +204,7 @@ module Mongo
         #
         # Otherwise, return nil because the stored cursor will not satisfy
         # the query.
+
         if limit && (caching_cursor_limit.nil? || caching_cursor_limit >= limit)
           caching_cursor
         elsif limit.nil? && caching_cursor_limit.nil?

--- a/spec/integration/query_cache_spec.rb
+++ b/spec/integration/query_cache_spec.rb
@@ -347,6 +347,7 @@ describe 'QueryCache' do
           results_limit_5 = authorized_collection.find.limit(5).to_a
           results_limit_3 = authorized_collection.find.limit(3).to_a
           results_no_limit = authorized_collection.find.to_a
+          results_limit_0 = authorized_collection.find.limit(0).to_a
 
           expect(results_limit_5.length).to eq(5)
           expect(results_limit_5.map { |r| r["test"] }).to eq([0, 1, 2, 3, 4])
@@ -356,6 +357,36 @@ describe 'QueryCache' do
 
           expect(results_no_limit.length).to eq(10)
           expect(results_no_limit.map { |r| r["test"] }).to eq([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+          expect(results_limit_0.length).to eq(10)
+          expect(results_limit_0.map { |r| r["test"] }).to eq([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+          expect(events.length).to eq(1)
+        end
+      end
+
+      context 'when the first query has a 0 limit' do
+        before do
+          authorized_collection.find.limit(0).to_a
+        end
+
+        it 'uses the cache' do
+          results_limit_5 = authorized_collection.find.limit(5).to_a
+          results_limit_3 = authorized_collection.find.limit(3).to_a
+          results_no_limit = authorized_collection.find.to_a
+          results_limit_0 = authorized_collection.find.limit(0).to_a
+
+          expect(results_limit_5.length).to eq(5)
+          expect(results_limit_5.map { |r| r["test"] }).to eq([0, 1, 2, 3, 4])
+
+          expect(results_limit_3.length).to eq(3)
+          expect(results_limit_3.map { |r| r["test"] }).to eq([0, 1, 2])
+
+          expect(results_no_limit.length).to eq(10)
+          expect(results_no_limit.map { |r| r["test"] }).to eq([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+          expect(results_limit_0.length).to eq(10)
+          expect(results_limit_0.map { |r| r["test"] }).to eq([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])
 
           expect(events.length).to eq(1)
         end

--- a/spec/mongo/query_cache_spec.rb
+++ b/spec/mongo/query_cache_spec.rb
@@ -199,6 +199,56 @@ describe Mongo::QueryCache do
             expect(Mongo::QueryCache.get(**query_options)).to eq(caching_cursor)
           end
         end
+
+        context 'when the query has a 0 limit' do
+          let(:limit) { 0 }
+
+          it 'returns the caching cursor' do
+            expect(Mongo::QueryCache.get(**query_options)).to eq(caching_cursor)
+          end
+        end
+      end
+
+      context 'when that entry has a 0 limit' do
+        let(:caching_cursor_options) do
+          {
+            namespace: 'db.coll',
+            selector: { field: 'value' },
+            limit: 0,
+          }
+        end
+
+        let(:query_options) do
+          caching_cursor_options.merge(limit: limit)
+        end
+
+        before do
+          allow(view).to receive(:limit) { 0 }
+        end
+
+        context 'when the query has a limit' do
+          let(:limit) { 5 }
+
+          it 'returns the caching cursor' do
+            expect(Mongo::QueryCache.get(**query_options)).to eq(caching_cursor)
+          end
+        end
+
+        context 'when the query has no limit' do
+          let(:limit) { nil }
+
+          it 'returns the caching cursor' do
+            expect(Mongo::QueryCache.get(**query_options)).to eq(caching_cursor)
+          end
+        end
+
+        context 'when the query has a 0 limit' do
+          let(:limit) { 0 }
+
+          it 'returns the caching cursor' do
+            expect(Mongo::QueryCache.get(**query_options)).to eq(caching_cursor)
+          end
+        end
       end
 
       context 'when that entry has a limit' do
@@ -244,6 +294,14 @@ describe Mongo::QueryCache do
 
         context 'and the new query has no limit' do
           let(:limit) { nil }
+
+          it 'returns nil' do
+            expect(Mongo::QueryCache.get(**query_options)).to be_nil
+          end
+        end
+
+        context 'and the new query has a 0 limit' do
+          let(:limit) { 0 }
 
           it 'returns nil' do
             expect(Mongo::QueryCache.get(**query_options)).to be_nil


### PR DESCRIPTION
Related to https://jira.mongodb.org/browse/MONGOID-5285

MongoDB treats a `limit` of `0` as having no limit at all but the query caching does not take this in to consideration, returning 0 records, nor using existing cached items with a 0 limit when they could be used.