### PR TITLE
RUBY-2891 Change streams support for user-facing  PIT pre- and post-images

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -302,7 +302,7 @@ module Mongo
     # @option options [ Hash ] :read The read preference options. The hash
     #   may have the following items:
     #   - *:mode* -- read preference specified as a symbol; valid values are
-    #     #:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
+    #     *:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
     #     and *:nearest*.
     #   - *:tag_sets* -- an array of hashes.
     #   - *:local_threshold*.
@@ -701,7 +701,7 @@ module Mongo
     # @return [ BSON::Document ] The user-defined read preference.
     #   The document may have the following fields:
     #   - *:mode* -- read preference specified as a symbol; valid values are
-    #     #:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
+    #     *:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
     #     and *:nearest*.
     #   - *:tag_sets* -- an array of hashes.
     #   - *:local_threshold*.

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -302,7 +302,7 @@ module Mongo
     # @option options [ Hash ] :read The read preference options. The hash
     #   may have the following items:
     #   - *:mode* -- read preference specified as a symbol; valid values are
-    #     *:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
+    #     #:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
     #     and *:nearest*.
     #   - *:tag_sets* -- an array of hashes.
     #   - *:local_threshold*.
@@ -701,7 +701,7 @@ module Mongo
     # @return [ BSON::Document ] The user-defined read preference.
     #   The document may have the following fields:
     #   - *:mode* -- read preference specified as a symbol; valid values are
-    #     *:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
+    #     #:primary*, *:primary_preferred*, *:secondary*, *:secondary_preferred*
     #     and *:nearest*.
     #   - *:tag_sets* -- an array of hashes.
     #   - *:local_threshold*.
@@ -1003,13 +1003,35 @@ module Mongo
     #
     # @param [ Array<Hash> ] pipeline Optional additional filter operators.
     # @param [ Hash ] options The change stream options.
+    # @option options [ String ] :full_document Allowed values: nil, 'default',
+    #   'updateLookup', 'whenAvailable', 'required'.
     #
-    # @option options [ String ] :full_document Allowed values: nil, 'default'
-    #   (behaves same as nil), 'updateLookup'. When set to 'updateLookup', the
-    #   change notification for partial updates will include both a delta
-    #   describing the changes to the document, as well as a copy of the entire
-    #   document that was changed from some time after the change occurred. The
-    #   default is to not send a value.
+    #   The default is to not send a value (i.e. nil), which is equivalent to
+    #   'default'. By default, the change notification for partial updates will
+    #   include a delta describing the changes to the document.
+    #
+    #   When set to 'updateLookup', the change notification for partial updates
+    #   will include both a delta describing the changes to the document as well
+    #   as a copy of the entire document that was changed from some time after
+    #   the change occurred.
+    #
+    #   When set to 'whenAvailable', configures the change stream to return the
+    #   post-image of the modified document for replace and update change events
+    #   if the post-image for this event is available.
+    #
+    #   When set to 'required', the same behavior as 'whenAvailable' except that
+    #   an error is raised if the post-image is not available.
+    # @option options [ String ] :full_document_before_change Allowed values: nil,
+    #   'whenAvailable', 'required', 'off'.
+    #
+    #   The default is to not send a value (i.e. nil), which is equivalent to 'off'.
+    #
+    #   When set to 'whenAvailable', configures the change stream to return the
+    #   pre-image of the modified document for replace, update, and delete change
+    #   events if it is available.
+    #
+    #   When set to 'required', the same behavior as 'whenAvailable' except that
+    #   an error is raised if the pre-image is not available.
     # @option options [ BSON::Document, Hash ] :resume_after Specifies the logical starting point
     #   for the new change stream.
     # @option options [ Integer ] :max_await_time_ms The maximum amount of time for the server to

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -418,12 +418,35 @@ module Mongo
     # @param [ Array<Hash> ] pipeline Optional additional filter operators.
     # @param [ Hash ] options The change stream options.
     #
-    # @option options [ String ] :full_document Allowed values: nil, 'default'
-    #   (behaves same as nil), 'updateLookup'. When set to 'updateLookup', the
-    #   change notification for partial updates will include both a delta
-    #   describing the changes to the document, as well as a copy of the entire
-    #   document that was changed from some time after the change occurred. The
-    #   default is to not send a value.
+    # @option options [ String ] :full_document Allowed values: nil, 'default',
+    #   'updateLookup', 'whenAvailable', 'required'.
+    #
+    #   The default is to not send a value (i.e. nil), which is equivalent to
+    #   'default'. By default, the change notification for partial updates will
+    #   include a delta describing the changes to the document.
+    #
+    #   When set to 'updateLookup', the change notification for partial updates
+    #   will include both a delta describing the changes to the document as well
+    #   as a copy of the entire document that was changed from some time after
+    #   the change occurred.
+    #
+    #   When set to 'whenAvailable', configures the change stream to return the
+    #   post-image of the modified document for replace and update change events
+    #   if the post-image for this event is available.
+    #
+    #   When set to 'required', the same behavior as 'whenAvailable' except that
+    #   an error is raised if the post-image is not available.
+    # @option options [ String ] :full_document_before_change Allowed values: nil,
+    #   'whenAvailable', 'required', 'off'.
+    #
+    #   The default is to not send a value (i.e. nil), which is equivalent to 'off'.
+    #
+    #   When set to 'whenAvailable', configures the change stream to return the
+    #   pre-image of the modified document for replace, update, and delete change
+    #   events if it is available.
+    #
+    #   When set to 'required', the same behavior as 'whenAvailable' except that
+    #   an error is raised if the pre-image is not available.
     # @option options [ BSON::Document, Hash ] :resume_after Specifies the
     #   logical starting point for the new change stream.
     # @option options [ Integer ] :max_await_time_ms The maximum amount of time

--- a/lib/mongo/collection/view/change_stream.rb
+++ b/lib/mongo/collection/view/change_stream.rb
@@ -70,12 +70,35 @@ module Mongo
         # @param [ Array<Hash> ] pipeline The pipeline of operators to filter the change notifications.
         # @param [ Hash ] options The change stream options.
         #
-        # @option options [ String ] :full_document Allowed values: nil, 'default'
-        #   (behaves same as nil), 'updateLookup'. When set to 'updateLookup', the
-        #   change notification for partial updates will include both a delta
-        #   describing the changes to the document, as well as a copy of the entire
-        #   document that was changed from some time after the change occurred. The
-        #   default is to not send a value.
+        # @option options [ String ] :full_document Allowed values: nil, 'default',
+        #   'updateLookup', 'whenAvailable', 'required'.
+        #
+        #   The default is to not send a value (i.e. nil), which is equivalent to
+        #   'default'. By default, the change notification for partial updates will
+        #   include a delta describing the changes to the document.
+        #
+        #   When set to 'updateLookup', the change notification for partial updates
+        #   will include both a delta describing the changes to the document as well
+        #   as a copy of the entire document that was changed from some time after
+        #   the change occurred.
+        #
+        #   When set to 'whenAvailable', configures the change stream to return the
+        #   post-image of the modified document for replace and update change events
+        #   if the post-image for this event is available.
+        #
+        #   When set to 'required', the same behavior as 'whenAvailable' except that
+        #   an error is raised if the post-image is not available.
+        # @option options [ String ] :full_document_before_change Allowed values: nil,
+        #   'whenAvailable', 'required', 'off'.
+        #
+        #   The default is to not send a value (i.e. nil), which is equivalent to 'off'.
+        #
+        #   When set to 'whenAvailable', configures the change stream to return the
+        #   pre-image of the modified document for replace, update, and delete change
+        #   events if it is available.
+        #
+        #   When set to 'required', the same behavior as 'whenAvailable' except that
+        #   an error is raised if the pre-image is not available.
         # @option options [ BSON::Document, Hash ] :resume_after Specifies the logical starting point for the
         #   new change stream.
         # @option options [ Integer ] :max_await_time_ms The maximum amount of time for the server to wait
@@ -314,6 +337,10 @@ module Mongo
           {}.tap do |doc|
             if @options[:full_document]
               doc[:fullDocument] = @options[:full_document]
+            end
+
+            if @options[:full_document_before_change]
+              doc[:fullDocumentBeforeChange] = @options[:full_document_before_change]
             end
 
             if resuming?

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -413,12 +413,35 @@ module Mongo
     # @param [ Array<Hash> ] pipeline Optional additional filter operators.
     # @param [ Hash ] options The change stream options.
     #
-    # @option options [ String ] :full_document Allowed values: nil, 'default'
-    #   (behaves same as nil), 'updateLookup'. When set to 'updateLookup', the
-    #   change notification for partial updates will include both a delta
-    #   describing the changes to the document, as well as a copy of the entire
-    #   document that was changed from some time after the change occurred. The
-    #   default is to not send a value.
+    # @option options [ String ] :full_document Allowed values: nil, 'default',
+    #   'updateLookup', 'whenAvailable', 'required'.
+    #
+    #   The default is to not send a value (i.e. nil), which is equivalent to
+    #   'default'. By default, the change notification for partial updates will
+    #   include a delta describing the changes to the document.
+    #
+    #   When set to 'updateLookup', the change notification for partial updates
+    #   will include both a delta describing the changes to the document as well
+    #   as a copy of the entire document that was changed from some time after
+    #   the change occurred.
+    #
+    #   When set to 'whenAvailable', configures the change stream to return the
+    #   post-image of the modified document for replace and update change events
+    #   if the post-image for this event is available.
+    #
+    #   When set to 'required', the same behavior as 'whenAvailable' except that
+    #   an error is raised if the post-image is not available.
+    # @option options [ String ] :full_document_before_change Allowed values: nil,
+    #   'whenAvailable', 'required', 'off'.
+    #
+    #   The default is to not send a value (i.e. nil), which is equivalent to 'off'.
+    #
+    #   When set to 'whenAvailable', configures the change stream to return the
+    #   pre-image of the modified document for replace, update, and delete change
+    #   events if it is available.
+    #
+    #   When set to 'required', the same behavior as 'whenAvailable' except that
+    #   an error is raised if the pre-image is not available.
     # @option options [ BSON::Document, Hash ] :resume_after Specifies the logical starting point
     #   for the new change stream.
     # @option options [ Integer ] :max_await_time_ms The maximum amount of time for the server to

--- a/spec/runners/unified/change_stream_operations.rb
+++ b/spec/runners/unified/change_stream_operations.rb
@@ -17,6 +17,12 @@ module Unified
         if comment = args.use('comment')
           opts[:comment] = comment
         end
+        if full_document = args.use('fullDocument')
+          opts[:full_document] = full_document
+        end
+        if full_document_before_change = args.use('fullDocumentBeforeChange')
+          opts[:full_document_before_change] = full_document_before_change
+        end
         cs = object.watch(pipeline, **opts)
         name = op.use!('saveResultAsEntity')
         entities.set(:change_stream, name, cs)

--- a/spec/spec_tests/data/change_streams_unified/change-streams-pre_and_post_images.yml
+++ b/spec/spec_tests/data/change_streams_unified/change-streams-pre_and_post_images.yml
@@ -1,0 +1,350 @@
+description: "change-streams-pre_and_post_images"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "6.0.0"
+    topologies: [ replicaset, sharded-replicaset, load-balanced ]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+      ignoreCommandMonitoringEvents: [ collMod, insert, update, getMore, killCursors ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name change-stream-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &enablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: true }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: &disablePreAndPostImages
+          commandName: collMod
+          command:
+            collMod: *collection0Name
+            changeStreamPreAndPostImages: { enabled: false }
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "whenAvailable" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocument: { _id: 1, x: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+  - description: "fullDocument:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocument: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocument: "required" }
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:whenAvailable with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "whenAvailable"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: null
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "whenAvailable" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { _id: 1 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:required with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "required"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectError:
+          isClientError: false
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "required" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *enablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }
+
+  - description: "fullDocumentBeforeChange:off with changeStreamPreAndPostImages disabled"
+    operations:
+      - name: runCommand
+        object: *database0
+        arguments: *disablePreAndPostImages
+      - name: createChangeStream
+        object: *collection0
+        arguments:
+          pipeline: []
+          fullDocumentBeforeChange: "off"
+        saveResultAsEntity: &changeStream0 changeStream0
+      - name: updateOne
+        object: *collection0
+        arguments:
+          filter: { _id: 1 }
+          update: { $set: { x: 1 }}
+      - name: iterateUntilDocumentOrError
+        object: *changeStream0
+        expectResult:
+          operationType: "update"
+          ns: { db: *database0Name, coll: *collection0Name }
+          updateDescription: { $$type: "object" }
+          fullDocumentBeforeChange: { $$exists: false }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0Name
+                pipeline:
+                  - $changeStream: { fullDocumentBeforeChange: "off" }


### PR DESCRIPTION
RUBY-2891

I tested this locally on MongoDB 6.0.0-rc0