### PR TITLE
RUBY-2973 Add the acknowledged? field to the BulkWrite::Result class

### DIFF
--- a/lib/mongo/bulk_write/result.rb
+++ b/lib/mongo/bulk_write/result.rb
@@ -23,6 +23,11 @@ module Mongo
     # @since 2.0.6
     class Result
 
+      # @return [ Boolean ] Is the result acknowledged?
+      def acknowledged?
+        @acknowledged
+      end
+
       # Constant for number removed.
       #
       # @since 2.1.0
@@ -96,8 +101,11 @@ module Mongo
       # @param [ BSON::Document, Hash ] results The results document.
       #
       # @since 2.1.0
-      def initialize(results)
+      #
+      # @api private
+      def initialize(results, acknowledged)
         @results = results
+        @acknowledged = acknowledged
       end
 
       # Returns the number of documents inserted.

--- a/lib/mongo/bulk_write/result.rb
+++ b/lib/mongo/bulk_write/result.rb
@@ -99,6 +99,7 @@ module Mongo
       #   Result.new({ 'n_inserted' => 10 })
       #
       # @param [ BSON::Document, Hash ] results The results document.
+      # @param [ Boolean ] acknowledged Is the result acknowledged?
       #
       # @since 2.1.0
       #

--- a/lib/mongo/bulk_write/result_combiner.rb
+++ b/lib/mongo/bulk_write/result_combiner.rb
@@ -70,20 +70,18 @@ module Mongo
         end
         combine_errors!(result)
         @count += count
+        @acknowledged = result.acknowledged?
       end
 
       # Get the final result.
       #
       # @api private
       #
-      # @example Get the final result.
-      #   combinator.result
-      #
       # @return [ BulkWrite::Result ] The final result.
       #
       # @since 2.1.0
       def result
-        BulkWrite::Result.new(results).validate!
+        BulkWrite::Result.new(results, @acknowledged).validate!
       end
 
       private

--- a/spec/mongo/bulk_write/result_spec.rb
+++ b/spec/mongo/bulk_write/result_spec.rb
@@ -8,7 +8,7 @@ describe Mongo::BulkWrite::Result do
     {'n_inserted' => 2, 'n' => 3, 'inserted_ids' => [1, 2]}
   end
 
-  let(:subject) { described_class.new(results_document) }
+  let(:subject) { described_class.new(results_document, true) }
 
   describe 'construction' do
     it 'works' do
@@ -121,6 +121,20 @@ describe Mongo::BulkWrite::Result do
           subject.validate!
         # BulkWriteErrors don't have any messages on them
         end.to raise_error(Mongo::Error::BulkWriteError, nil)
+      end
+    end
+  end
+
+  describe ".acknowledged?" do
+
+    [true, false].each do |b|
+      context "when acknowledged is passed as #{b}" do
+
+        let(:result) { described_class.new(results_document, b) }
+
+        it "acknowledged? is #{b}" do
+          expect(result.acknowledged?).to be b
+        end
       end
     end
   end

--- a/spec/mongo/bulk_write/result_spec.rb
+++ b/spec/mongo/bulk_write/result_spec.rb
@@ -125,7 +125,7 @@ describe Mongo::BulkWrite::Result do
     end
   end
 
-  describe ".acknowledged?" do
+  describe "#acknowledged?" do
 
     [true, false].each do |b|
       context "when acknowledged is passed as #{b}" do

--- a/spec/mongo/bulk_write_spec.rb
+++ b/spec/mongo/bulk_write_spec.rb
@@ -2391,7 +2391,7 @@ describe Mongo::BulkWrite do
     end
   end
 
-  describe ".acknowledged?" do
+  describe "#acknowledged?" do
     let(:requests) { [ { insert_one: { x: 1 } } ] }
     let(:options) { {} }
     let(:bulk_write) do

--- a/spec/mongo/bulk_write_spec.rb
+++ b/spec/mongo/bulk_write_spec.rb
@@ -2390,4 +2390,42 @@ describe Mongo::BulkWrite do
       end
     end
   end
+
+  describe ".acknowledged?" do
+    let(:requests) { [ { insert_one: { x: 1 } } ] }
+    let(:options) { {} }
+    let(:bulk_write) do
+      described_class.new(
+        collection,
+        requests,
+        options
+      )
+    end
+    let(:result) { bulk_write.execute }
+
+    context "when using unacknowledged writes with one request" do
+     let(:options) { { write_concern: { w: 0 } } }
+
+      it 'acknowledged? returns false' do
+        expect(result.acknowledged?).to be false
+      end
+    end
+
+    context "when using unacknowledged writes with multiple requests" do
+     let(:options) { { write_concern: { w: 0 } } }
+     let(:requests) { [ { insert_one: { x: 1 } }, { insert_one: { x: 1 } } ] }
+
+      it 'acknowledged? returns false' do
+        expect(result.acknowledged?).to be false
+      end
+    end
+
+    context "when not using unacknowledged writes" do
+      let(:options) { { write_concern: { w: 1 } } }
+
+      it 'acknowledged? returns true' do
+        expect(result.acknowledged?).to be true
+      end
+    end
+  end
 end


### PR DESCRIPTION
All of the other Result classes descend form Operation::Result super class and therefore already have the acknowledged? method. This PR only adds it to the BulkWrite Result class. 