### PR TITLE
RUBY-2977 Test against MongoDB 6.0; Fix GH actions: replace 5.1 with 6.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
             topology: replica_set
           - os: ubuntu-latest
             ruby: "3.1"
-            mongodb: "5.1"
+            mongodb: "5.2"
             topology: replica_set
     steps:
     - name: repo checkout

--- a/spec/runners/unified/assertions.rb
+++ b/spec/runners/unified/assertions.rb
@@ -164,7 +164,7 @@ module Unified
 
     def assert_matches(actual, expected, msg)
       if actual.nil?
-        if expected.keys == ["$$unsetOrMatches"]
+        if expected&.keys == ["$$unsetOrMatches"]
           return
         elsif !expected.nil?
           raise Error::ResultMismatch, "#{msg}: expected #{expected} but got nil"


### PR DESCRIPTION
This PR is to fix the following test:
```
Run Driver Tests / ubuntu-latest ruby-3.1 mongodb-5.1 replica_set (pull_request)
```
This PR adds a test for MongoDB 6.0