### PR TITLE
RUBY-2971 Add createCollection and collMod spec tests for changeStreamPreAndPostImages option

### DIFF
--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -58,11 +58,12 @@ module Mongo
     # @since 2.1.0
     CHANGEABLE_OPTIONS = [ :read, :read_concern, :write, :write_concern ].freeze
 
-    # Options that can be used for creating a time-series collection.
-    TIME_SERIES_OPTIONS = {
+    # Options map to transform create collection options.
+    CREATE_COLLECTION_OPTIONS = {
       :time_series => :timeseries,
       :expire_after => :expireAfterSeconds,
       :clustered_index => :clusteredIndex,
+      :change_stream_pre_and_post_images => :changeStreamPreAndPostImages,
     }
 
     # Check if a collection is equal to another object. Will check the name and
@@ -246,6 +247,8 @@ module Mongo
     # @option opts [ Hash ] :time_series Create a time-series collection.
     # @option opts [ Integer ] :expire_after Number indicating
     #   after how many seconds old time-series data should be deleted.
+    # @option opts [ Hash ] :change_stream_pre_and_post_images Used to enable
+    #   pre- and post-images on the created collection.
     #
     # @return [ Result ] The result of the command.
     #
@@ -258,9 +261,9 @@ module Mongo
       options = Hash[self.options.reject do |key, value|
         %w(read read_preference read_concern).include?(key.to_s)
       end]
-      options.update(opts.slice(*TIME_SERIES_OPTIONS.keys))
-      # Converting Ruby spelled time series options to server style.
-      TIME_SERIES_OPTIONS.each do |ruby_key, server_key|
+      options.update(opts.slice(*CREATE_COLLECTION_OPTIONS.keys))
+      # Converting Ruby options to server style.
+      CREATE_COLLECTION_OPTIONS.each do |ruby_key, server_key|
         if options.key?(ruby_key)
           options[server_key] = options.delete(ruby_key)
         end

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -59,6 +59,8 @@ module Mongo
     CHANGEABLE_OPTIONS = [ :read, :read_concern, :write, :write_concern ].freeze
 
     # Options map to transform create collection options.
+    #
+    # @api private
     CREATE_COLLECTION_OPTIONS = {
       :time_series => :timeseries,
       :expire_after => :expireAfterSeconds,

--- a/spec/runners/unified/ddl_operations.rb
+++ b/spec/runners/unified/ddl_operations.rb
@@ -33,6 +33,9 @@ module Unified
         if clustered_index = args.use('clusteredIndex')
           collection_opts[:clustered_index] = clustered_index
         end
+        if change_stream_pre_and_post_images = args.use('changeStreamPreAndPostImages')
+          collection_opts[:change_stream_pre_and_post_images] = change_stream_pre_and_post_images
+        end
         database[args.use!('collection'), collection_opts].create(**opts)
       end
     end

--- a/spec/runners/unified/test.rb
+++ b/spec/runners/unified/test.rb
@@ -279,7 +279,7 @@ module Unified
           method_name = "_#{name}"
         end
 
-        if [].include?(name.to_s)
+        if ["modify_collections"].include?(name.to_s)
           skip "Mongo Ruby Driver does not support #{name.to_s}"
         end
 

--- a/spec/runners/unified/test.rb
+++ b/spec/runners/unified/test.rb
@@ -279,7 +279,7 @@ module Unified
           method_name = "_#{name}"
         end
 
-        if ["modify_collections"].include?(name.to_s)
+        if ["modify_collection"].include?(name.to_s)
           skip "Mongo Ruby Driver does not support #{name.to_s}"
         end
 

--- a/spec/spec_tests/data/collection_management/createCollection-pre_and_post_images.yml
+++ b/spec/spec_tests/data/collection_management/createCollection-pre_and_post_images.yml
@@ -1,0 +1,49 @@
+description: "createCollection-pre_and_post_images"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "6.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name papi-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "createCollection with changeStreamPreAndPostImages enabled"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          changeStreamPreAndPostImages: { enabled: true }
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                changeStreamPreAndPostImages: { enabled: true }
+              databaseName: *database0Name

--- a/spec/spec_tests/data/collection_management/modifyCollection-pre_and_post_images.yml
+++ b/spec/spec_tests/data/collection_management/modifyCollection-pre_and_post_images.yml
@@ -1,0 +1,57 @@
+description: "modifyCollection-pre_and_post_images"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "6.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name papi-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+
+tests:
+  - description: "modifyCollection to changeStreamPreAndPostImages enabled"
+    operations:
+      - name: dropCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+      - name: createCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          changeStreamPreAndPostImages: { enabled: false }
+      - name: assertCollectionExists
+        object: testRunner
+        arguments:
+          databaseName: *database0Name
+          collectionName: *collection0Name
+      - name: modifyCollection
+        object: *database0
+        arguments:
+          collection: *collection0Name
+          changeStreamPreAndPostImages: { enabled: true }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                drop: *collection0Name
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                create: *collection0Name
+                changeStreamPreAndPostImages: { enabled: false }
+          - commandStartedEvent:
+              command:
+                collMod: *collection0Name
+                changeStreamPreAndPostImages: { enabled: true }


### PR DESCRIPTION
RUBY-2971. Did not add the collMod spec tests since we don't have a modify collections helper function.

EDIT: Must review this PR first: https://github.com/mongodb/mongo-ruby-driver/pull/2488

I was able to add the modifyCollections test back after skipping unsupported operations.