### PR TITLE
RUBY-2988 Add unified test format valid-fail test for unsupported operation

### DIFF
--- a/spec/runners/unified.rb
+++ b/spec/runners/unified.rb
@@ -88,6 +88,7 @@ def define_unified_spec_tests(base_path, paths, expect_failure: false)
               test.create_entities
               test.set_initial_data
               test.run
+              skip test.skip_reason if test.skip?
               test.assert_outcome
               test.assert_events
               test.cleanup

--- a/spec/runners/unified.rb
+++ b/spec/runners/unified.rb
@@ -63,7 +63,6 @@ def define_unified_spec_tests(base_path, paths, expect_failure: false)
                 test.set_initial_data
                 lambda do
                   test.run
-                  skip test.skip_reason if test.skip?
                   test.assert_outcome
                   test.assert_events
                 # HACK: other errors are possible and likely will need to
@@ -88,7 +87,6 @@ def define_unified_spec_tests(base_path, paths, expect_failure: false)
               test.create_entities
               test.set_initial_data
               test.run
-              skip test.skip_reason if test.skip?
               test.assert_outcome
               test.assert_events
               test.cleanup

--- a/spec/runners/unified.rb
+++ b/spec/runners/unified.rb
@@ -61,13 +61,18 @@ def define_unified_spec_tests(base_path, paths, expect_failure: false)
               begin
                 test.create_entities
                 test.set_initial_data
-                lambda do
+                begin
                   test.run
                   test.assert_outcome
                   test.assert_events
                 # HACK: other errors are possible and likely will need to
                 # be added here later as the tests evolve.
-                end.should raise_error(Mongo::Error::OperationFailure)
+                rescue Mongo::Error::OperationFailure, Unified::Error::UnsupportedOperation
+                rescue => e
+                  fail "Expected to raise Mongo::Error::OperationFailure or Unified::Error::UnsupportedOperation, got #{e}"
+                else
+                  fail "Expected to raise Mongo::Error::OperationFailure or Unified::Error::UnsupportedOperation, but no error was raised"
+                end
               ensure
                 test.cleanup
               end

--- a/spec/runners/unified.rb
+++ b/spec/runners/unified.rb
@@ -63,6 +63,7 @@ def define_unified_spec_tests(base_path, paths, expect_failure: false)
                 test.set_initial_data
                 lambda do
                   test.run
+                  skip test.skip_reason if test.skip?
                   test.assert_outcome
                   test.assert_events
                 # HACK: other errors are possible and likely will need to

--- a/spec/runners/unified/error.rb
+++ b/spec/runners/unified/error.rb
@@ -23,6 +23,7 @@ module Unified
     class InvalidTest < Error
     end
 
+    class UnsupportedOperation < Error
+    end
   end
-
 end

--- a/spec/runners/unified/test.rb
+++ b/spec/runners/unified/test.rb
@@ -19,6 +19,7 @@ module Unified
     include ChangeStreamOperations
     include SupportOperations
     include Assertions
+    include RSpec::Core::Pending
 
     def initialize(spec, **opts)
       @spec = spec
@@ -279,8 +280,7 @@ module Unified
         end
 
         if ["unsupported_operation"].include?(name.to_s)
-          @skip_reason = "Mongo Ruby Driver does not support #{name.to_s}"
-          return
+          skip "Mongo Ruby Driver does not support #{name.to_s}"
         end
 
         if expected_error = op.use('expectError')

--- a/spec/runners/unified/test.rb
+++ b/spec/runners/unified/test.rb
@@ -277,6 +277,12 @@ module Unified
         if name.to_s == 'loop'
           method_name = "_#{name}"
         end
+
+        if ["unsupported_operation"].include?(name.to_s)
+          @skip_reason = "Mongo Ruby Driver does not support #{name.to_s}"
+          return
+        end
+
         if expected_error = op.use('expectError')
           begin
             public_send(method_name, op)

--- a/spec/spec_tests/data/unified/valid-fail/operation-unsupported.yml
+++ b/spec/spec_tests/data/unified/valid-fail/operation-unsupported.yml
@@ -1,0 +1,13 @@
+description: "operation-unsupported"
+
+schemaVersion: "1.0"
+
+createEntities:
+  - client:
+      id: &client0 client0
+
+tests:
+  - description: "Unsupported operation"
+    operations:
+      - name: unsupportedOperation
+        object: *client0


### PR DESCRIPTION
The idea was to follow PyMongo's lead here: https://github.com/mongodb/specifications/pull/1206#discussion_r865396986