### PR TITLE
RUBY-2908 Convert sessions spec tests to unified test format

### DIFF
--- a/spec/runners/unified/support_operations.rb
+++ b/spec/runners/unified/support_operations.rb
@@ -59,8 +59,11 @@ module Unified
 
     def assert_session_dirty(op)
       consume_test_runner(op)
-      # https://jira.mongodb.org/browse/RUBY-1813
-      true
+      use_arguments(op) do |args|
+        session = entities.get(:session, args.use!('session'))
+        # https://jira.mongodb.org/browse/RUBY-1813
+        true
+      end
     end
 
     def assert_session_not_dirty(op)

--- a/spec/spec_tests/data/sessions_unified/driver-sessions-server-support.yml
+++ b/spec/spec_tests/data/sessions_unified/driver-sessions-server-support.yml
@@ -1,0 +1,123 @@
+description: "driver-sessions-server-support"
+
+schemaVersion: "1.0"
+
+runOnRequirements:
+  - minServerVersion: "3.6"
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name session-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name test
+  - session:
+      id: &session0 session0
+      client: *client0
+
+initialData:
+  - collectionName: *collection0Name
+    databaseName: *database0Name
+    documents:
+      - { _id: 1 }
+
+tests:
+  - description: "Server supports explicit sessions"
+    operations:
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - name: assertSessionNotDirty
+        object: testRunner
+        arguments:
+          session: *session0
+      - name: endSession
+        object: *session0
+      - &find_with_implicit_session
+        name: find
+        object: *collection0
+        arguments:
+          filter: { _id: -1 }
+        expectResult: []
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents: [ { _id: 2 } ]
+                ordered: true
+                lsid: { $$sessionLsid: *session0 }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$sessionLsid: *session0 }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }
+
+  - description: "Server supports implicit sessions"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          document: { _id: 2 }
+        expectResult: { $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 2 } } }
+      - *find_with_implicit_session
+      - name: assertSameLsidOnLastTwoCommands
+        object: testRunner
+        arguments:
+          client: *client0
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                insert: *collection0Name
+                documents:
+                  - { _id: 2 }
+                ordered: true
+                # There is no explicit session to use with $$sessionLsid, so
+                # just assert an arbitrary lsid document
+                lsid: { $$type: object }
+              commandName: insert
+              databaseName: *database0Name
+          - commandStartedEvent:
+              command:
+                find: *collection0Name
+                filter: { _id: -1 }
+                lsid: { $$type: object }
+              commandName: find
+              databaseName: *database0Name
+    outcome:
+      - collectionName: *collection0Name
+        databaseName: *database0Name
+        documents:
+          - { _id: 1 }
+          - { _id: 2 }

--- a/spec/spec_tests/data/sessions_unified/snapshot-sessions-not-supported-client-error.yml
+++ b/spec/spec_tests/data/sessions_unified/snapshot-sessions-not-supported-client-error.yml
@@ -41,7 +41,9 @@ tests:
     expectError:
       isClientError: true
       errorContains: Snapshot reads require MongoDB 5.0 or later
-  expectEvents: []
+  expectEvents:
+    - client: *client0
+      events: []
 
 - description: Client error on aggregate with snapshot
   operations:
@@ -53,7 +55,9 @@ tests:
     expectError:
       isClientError: true
       errorContains: Snapshot reads require MongoDB 5.0 or later
-  expectEvents: []
+  expectEvents:
+    - client: *client0
+      events: []
 
 - description: Client error on distinct with snapshot
   operations:
@@ -66,4 +70,6 @@ tests:
     expectError:
       isClientError: true
       errorContains: Snapshot reads require MongoDB 5.0 or later
-  expectEvents: []
+  expectEvents:
+    - client: *client0
+      events: []


### PR DESCRIPTION
Could not add the following test: `driver-sessions-dirty-session-errors.yml` as it's tests all failed. Looking 
after very littel investigation it looks like a lot more work needs to be done to get them passing. I am going 
to make a ticket for it.