### PR TITLE
RUBY-2959 RUBY-2971 forbid serverless

### DIFF
--- a/spec/spec_tests/data/collection_management/clustered-indexes.yml
+++ b/spec/spec_tests/data/collection_management/clustered-indexes.yml
@@ -1,9 +1,10 @@
 description: "clustered-indexes"
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "5.3"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/spec/spec_tests/data/collection_management/createCollection-pre_and_post_images.yml
+++ b/spec/spec_tests/data/collection_management/createCollection-pre_and_post_images.yml
@@ -1,9 +1,10 @@
 description: "createCollection-pre_and_post_images"
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "6.0"
+    serverless: forbid
 
 createEntities:
   - client:

--- a/spec/spec_tests/data/collection_management/modifyCollection-pre_and_post_images.yml
+++ b/spec/spec_tests/data/collection_management/modifyCollection-pre_and_post_images.yml
@@ -1,9 +1,10 @@
 description: "modifyCollection-pre_and_post_images"
 
-schemaVersion: "1.0"
+schemaVersion: "1.4"
 
 runOnRequirements:
   - minServerVersion: "6.0"
+    serverless: forbid
 
 createEntities:
   - client:


### PR DESCRIPTION
This PR is to update the spec tests with additional downstream changes on the corresponding drivers tickets.

The CI failures all look unrelated and additionally they come up on other PRs.