### PR TITLE
RUBY-3038: Fix lite_spec_helper on Windows

### DIFF
--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -32,7 +32,10 @@ else
   begin
     require 'byebug'
   rescue LoadError
-    require 'ruby-debug' rescue LoadError
+    begin
+      require 'ruby-debug'
+    rescue LoadError
+    end
   end
 end
 

--- a/spec/lite_spec_helper.rb
+++ b/spec/lite_spec_helper.rb
@@ -32,7 +32,7 @@ else
   begin
     require 'byebug'
   rescue LoadError
-    require 'ruby-debug'
+    require 'ruby-debug' rescue LoadError
   end
 end
 
@@ -88,7 +88,7 @@ require 'support/background_thread_registry'
 require 'mrss/session_registry'
 require 'support/local_resource_registry'
 
-if SpecConfig.instance.mri?
+if SpecConfig.instance.mri? && !SpecConfig.instance.windows?
   require 'timeout_interrupt'
 else
   require 'timeout'

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -126,6 +126,10 @@ class SpecConfig
     !!(RbConfig::CONFIG['host_os'].downcase =~ /\bdarwin/)
   end
 
+  def windows?
+    ENV['OS'] == 'Windows_NT' && !RUBY_PLATFORM.match?(/cygwin/)
+  end
+
   def platform
     RUBY_PLATFORM
   end


### PR DESCRIPTION
The following changes to `lite_spec_helper.rb` are required for specs to run on Windows:
- Use "timeout" instead of "timeout_interrupt"
- Skip loading debug gems if neither is present
