### PR TITLE
RUBY-3007 make comment its own option

### DIFF
--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -317,8 +317,7 @@ module Mongo
           end
           cmd = { :distinct => collection.name,
                   :key => field_name.to_s,
-                  :query => filter,
-                  :comment => opts[:comment] }
+                  :query => filter, }
           cmd[:maxTimeMS] = opts[:max_time_ms] if opts[:max_time_ms]
           if read_concern
             cmd[:readConcern] = Options::Mapper.transform_values_to_strings(
@@ -335,6 +334,7 @@ module Mongo
                 options: {:limit => -1},
                 read: read_pref,
                 session: session,
+                comment: opts[:comment],
                 # For some reason collation was historically accepted as a
                 # string key. Note that this isn't documented as valid usage.
                 collation: opts[:collation] || opts['collation'] || collation,

--- a/lib/mongo/operation/distinct/op_msg.rb
+++ b/lib/mongo/operation/distinct/op_msg.rb
@@ -32,7 +32,10 @@ module Mongo
 
         def selector(connection)
           # Collation is always supported on 3.6+ servers that would use OP_MSG.
-          spec[:selector].merge(collation: spec[:collation]).compact
+          spec[:selector].merge(
+            collation: spec[:collation],
+            comment: spec[:comment],
+          ).compact
         end
       end
     end


### PR DESCRIPTION
When I originally implemented this I incorrectly put the comment option inside the command... This PR moves it to its own option, which is consistent with the other commands. 