### PR TITLE
RUBY-3046 send no_cursor_timeout to server again

### DIFF
--- a/lib/mongo/collection/view/iterable.rb
+++ b/lib/mongo/collection/view/iterable.rb
@@ -170,6 +170,7 @@ module Mongo
             max_time_ms: options[:max_time_ms],
             max_value: options[:max_value],
             min_value: options[:min_value],
+            no_cursor_timeout: options[:no_cursor_timeout],
             return_key: options[:return_key],
             show_disk_loc: options[:show_disk_loc],
             comment: options[:comment],

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -1804,7 +1804,7 @@ describe Mongo::Collection::View::Readable do
         .fetch('noTimeout')
     end
 
-    it 'works' do
+    it 'is applied on the server' do
       # Initialize collection with two documents.
       new_view.collection.insert_many([{}, {}])
 

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -1790,6 +1790,42 @@ describe Mongo::Collection::View::Readable do
     it 'returns a new View' do
       expect(new_view).not_to be(view)
     end
+
+    # The number of open cursors with the option set to prevent timeout.
+    def current_no_timeout_count
+      new_view
+        .client
+        .command(serverStatus: 1)
+        .documents
+        .first
+        .fetch('metrics')
+        .fetch('cursor')
+        .fetch('open')
+        .fetch('noTimeout')
+    end
+
+    it 'works' do
+      # Initialize collection with two documents.
+      new_view.collection.insert_many([{}, {}])
+
+      expect(new_view.count).to be == 2
+
+      # Initial "noTimeout" count should be zero.
+      states = [current_no_timeout_count]
+
+      # The "noTimeout" count should be one while iterating.
+      new_view.batch_size(1).each { states << current_no_timeout_count }
+
+      # Final "noTimeout" count should be back to zero.
+      states << current_no_timeout_count
+
+      # This succeeds on:
+      #   commit aab776ebdfb15ddb9765039f7300e15796de0c5c
+      #
+      # This starts failing with [0, 0, 0, 0] from:
+      #   commit 2d9f0217ec904a1952a1ada2136502eefbca562e
+      expect(states).to be == [0, 1, 1, 0]
+    end
   end
 
   describe '#projection' do

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -1791,6 +1791,23 @@ describe Mongo::Collection::View::Readable do
       expect(new_view).not_to be(view)
     end
 
+    context 'when sending to server' do
+      let(:subscriber) { Mrss::EventSubscriber.new }
+
+      before do
+        authorized_collection.client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+      end
+
+      let(:event) do
+        subscriber.single_command_started_event('find')
+      end
+
+      it 'is sent to server' do
+        new_view.to_a
+        event.command.slice('noCursorTimeout').should == {'noCursorTimeout' => true}
+      end
+    end
+
     # The number of open cursors with the option set to prevent timeout.
     def current_no_timeout_count
       new_view

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -1810,8 +1810,7 @@ describe Mongo::Collection::View::Readable do
 
     # The number of open cursors with the option set to prevent timeout.
     def current_no_timeout_count
-      new_view
-        .client
+      root_authorized_client
         .command(serverStatus: 1)
         .documents
         .first


### PR DESCRIPTION
https://jira.mongodb.org/browse/RUBY-3046

Original report:

`Mongo::Collection::View#no_cursor_timeout` stopped working at commit 2d9f0217ec904a1952a1ada2136502eefbca562e (version 2.16.0).

I offer a _spec_ as proof that it is no longer working.

The _spec_ is green at commit aab776ebdfb15ddb9765039f7300e15796de0c5c (last working commit).

I am myself working with MongoDB 4.4 and Ruby 2.6.

The _bug_ also renders Mongoid's `.no_timeout` ineffective (does nothing).

Do not hesitate to ask me questions if something is unclear. 😄