### PR TITLE
RUBY-3087 reinstate ability to call insert_many with Enumerable inputs which are not Array instances

### DIFF
--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -79,7 +79,6 @@ This release includes the following new features:
 - When 0 is given as the max connection pool size, it is now interpreted to
   mean no limit.
 - The default maximum connection pool size has been increased to 20 from 5.
-- Added support for enumerables in bulk write operations.
 
 This release adds supports for JRuby 9.3.
 

--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -79,6 +79,7 @@ This release includes the following new features:
 - When 0 is given as the max connection pool size, it is now interpreted to
   mean no limit.
 - The default maximum connection pool size has been increased to 20 from 5.
+- Added support for enumerables in bulk write operations.
 
 This release adds supports for JRuby 9.3.
 

--- a/lib/mongo/bulk_write.rb
+++ b/lib/mongo/bulk_write.rb
@@ -115,7 +115,7 @@ module Mongo
     #   )
     #
     # @param [ Mongo::Collection ] collection The collection.
-    # @param [ Array<Hash, BSON::Document>, Enumerable ] requests The requests,
+    # @param [ Enumerable<Hash, BSON::Document> ] requests The requests,
     #   cannot be empty.
     # @param [ Hash, BSON::Document ] options The options.
     #

--- a/lib/mongo/bulk_write.rb
+++ b/lib/mongo/bulk_write.rb
@@ -115,7 +115,8 @@ module Mongo
     #   )
     #
     # @param [ Mongo::Collection ] collection The collection.
-    # @param [ Array<Hash, BSON::Document> ] requests The requests, cannot be empty.
+    # @param [ Array<Hash, BSON::Document>, Enumerable ] requests The requests,
+    #   cannot be empty.
     # @param [ Hash, BSON::Document ] options The options.
     #
     # @since 2.1.0

--- a/lib/mongo/bulk_write.rb
+++ b/lib/mongo/bulk_write.rb
@@ -330,10 +330,9 @@ module Mongo
     #   ArgumentError ]
     #   if the document is invalid.
     def validate_requests!
-      if @requests.empty?
-        raise ArgumentError, "Bulk write requests cannot be empty"
-      end
+      requests_empty = true
       @requests.each do |req|
+        requests_empty = false
         if op = req.keys.first
           if [:update_one, :update_many].include?(op)
             if doc = maybe_first(req.dig(op, :update))
@@ -359,6 +358,8 @@ module Mongo
             end
           end
         end
+      end.tap do
+        raise ArgumentError, "Bulk write requests cannot be empty" if requests_empty
       end
     end
 

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -692,7 +692,7 @@ module Mongo
     # @example Insert documents into the collection.
     #   collection.insert_many([{ name: 'test' }])
     #
-    # @param [ Array<Hash> ] documents The documents to insert.
+    # @param [ Array<Hash>, Enumerable ] documents The documents to insert.
     # @param [ Hash ] options The insert options.
     #
     # @option options [ true | false ] :bypass_document_validation Whether or

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -720,7 +720,7 @@ module Mongo
     # @example Execute a bulk write.
     #   collection.bulk_write(operations, options)
     #
-    # @param [ Array<Hash> ] requests The bulk write requests.
+    # @param [ Array<Hash>, Enumerable ] requests The bulk write requests.
     # @param [ Hash ] options The options.
     #
     # @option options [ true | false ] :ordered Whether the operations

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -692,7 +692,7 @@ module Mongo
     # @example Insert documents into the collection.
     #   collection.insert_many([{ name: 'test' }])
     #
-    # @param [ Array<Hash>, Enumerable ] documents The documents to insert.
+    # @param [ Enumerable<Hash> ] documents The documents to insert.
     # @param [ Hash ] options The insert options.
     #
     # @option options [ true | false ] :bypass_document_validation Whether or
@@ -720,7 +720,7 @@ module Mongo
     # @example Execute a bulk write.
     #   collection.bulk_write(operations, options)
     #
-    # @param [ Array<Hash>, Enumerable ] requests The bulk write requests.
+    # @param [ Enumerable<Hash> ] requests The bulk write requests.
     # @param [ Hash ] options The options.
     #
     # @option options [ true | false ] :ordered Whether the operations

--- a/lib/mongo/collection/view/writable.rb
+++ b/lib/mongo/collection/view/writable.rb
@@ -98,8 +98,6 @@ module Mongo
           end.first&.fetch('value', nil)
         end
 
-        # db['users'].bulk_write([{insert_one: {x: 1}}, {insert_one: {x: 2}}])
-
         # Finds a single document and replaces it.
         #
         # @example Find a document and replace it, returning the original.

--- a/spec/mongo/collection_crud_spec.rb
+++ b/spec/mongo/collection_crud_spec.rb
@@ -390,7 +390,7 @@ describe Mongo::Collection do
           authorized_collection.insert_many(source_data.lazy)
         end
 
-        it 'should accepts them without raising an error' do
+        it 'should raise ArgumentError' do
           expect do
             result
           end.to raise_error(ArgumentError, /Bulk write requests cannot be empty/)

--- a/spec/mongo/collection_crud_spec.rb
+++ b/spec/mongo/collection_crud_spec.rb
@@ -362,6 +362,22 @@ describe Mongo::Collection do
       expect(result.inserted_ids.size).to eq(2)
     end
 
+    context 'when an enumerable is used instead of an array' do
+
+      let(:source_data) do
+        [{ name: 'test1' }, { name: 'test2' }]
+      end
+
+      let(:result) do
+        authorized_collection.insert_many(source_data.lazy)
+      end
+
+      it 'should accepts them without raising an error' do
+        expect { result }.to_not raise_error
+        expect(result.inserted_count).to eq(source_data.size)
+      end
+    end
+
     context 'when a session is provided' do
 
       let(:session) do

--- a/spec/mongo/collection_crud_spec.rb
+++ b/spec/mongo/collection_crud_spec.rb
@@ -364,17 +364,37 @@ describe Mongo::Collection do
 
     context 'when an enumerable is used instead of an array' do
 
-      let(:source_data) do
-        [{ name: 'test1' }, { name: 'test2' }]
+      context 'when the enumerable is not empty' do
+
+        let(:source_data) do
+          [{ name: 'test1' }, { name: 'test2' }]
+        end
+
+        let(:result) do
+          authorized_collection.insert_many(source_data.lazy)
+        end
+
+        it 'should accepts them without raising an error' do
+          expect { result }.to_not raise_error
+          expect(result.inserted_count).to eq(source_data.size)
+        end
       end
 
-      let(:result) do
-        authorized_collection.insert_many(source_data.lazy)
-      end
+      context 'when the enumerable is empty' do
 
-      it 'should accepts them without raising an error' do
-        expect { result }.to_not raise_error
-        expect(result.inserted_count).to eq(source_data.size)
+        let(:source_data) do
+          []
+        end
+
+        let(:result) do
+          authorized_collection.insert_many(source_data.lazy)
+        end
+
+        it 'should accepts them without raising an error' do
+          expect do
+            result
+          end.to raise_error(ArgumentError, /Bulk write requests cannot be empty/)
+        end
       end
     end
 


### PR DESCRIPTION
Hello,
As I mentioned on https://github.com/mongodb/mongo-ruby-driver/discussions/2430, we use `insert_many` with an enumerable instead of an array; we want to make sure it will continue to work into the future.

It would be great if you guys could include this test.  
I am happy to adjust the pull request as you see fit.