### PR TITLE
RUBY-2808 Add a CMAP test that verifies the background thread hands over connections to threads doing checkout

### DIFF
--- a/spec/runners/cmap.rb
+++ b/spec/runners/cmap.rb
@@ -265,6 +265,8 @@ module Mongo
         case name
         when 'start'
           run_start_op(state)
+        when 'ready'
+          run_ready_op(state)
         when 'wait'
           run_wait_op(state)
         when 'waitForThread'
@@ -316,6 +318,10 @@ module Mongo
         if state[target].respond_to?(:report_on_exception)
           state[target].report_on_exception = false
         end
+      end
+
+      # Ruby driver does not have the concept of pausing and readying the pool.
+      def run_ready_op(_state)
       end
 
       def run_wait_op(_state)

--- a/spec/runners/cmap/verifier.rb
+++ b/spec/runners/cmap/verifier.rb
@@ -41,7 +41,9 @@ module Mongo
           end
         end
 
-        expect(actual_modified).to eq(expected)
+        expected.each do |k, v|
+          expect(actual_modified[k]).to eq(v)
+        end
       end
     end
   end

--- a/spec/spec_tests/data/cmap/pool-checkout-minPoolSize-connection-maxConnecting.yml
+++ b/spec/spec_tests/data/cmap/pool-checkout-minPoolSize-connection-maxConnecting.yml
@@ -1,0 +1,63 @@
+version: 1
+style: integration
+description: threads blocked by maxConnecting check out minPoolSize connections
+runOn:
+  -
+    # required for blockConnection in fail point
+    minServerVersion: "4.4.0"
+failPoint:
+  configureFailPoint: failCommand
+  mode: "alwaysOn"
+  data:
+    failCommands: ["isMaster","hello"]
+    closeConnection: false
+    blockConnection: true
+    blockTimeMS: 500
+poolOptions:
+  # allows both thread1 and the background thread to start opening connections concurrently
+  minPoolSize: 2
+  # gives opportunity for the checkout in thread2 to open a new connection, which it must not do nonetheless
+  maxPoolSize: 3
+  waitQueueTimeoutMS: 5000
+operations:
+  - name: ready
+  # thread1 exists to hold on one of the two permits to open a connection (the other one is initially held by the background thread),
+  # so that thread2 would be blocked acquiring a permit, which opens an opportunity for it to grab the connection newly opened
+  # by the background thread instead of opening a third connection.
+  - name: start
+    target: thread1
+  - name: start
+    target: thread2
+  # Ideally, thread1 should be holding for its permit to open a connection till the end of the test, but we cannot express that.
+  # This delay emulates the above requirement:
+  # - it is long enough to make sure that the background thread opens a connection before thread1 releases its permit;
+  # - it is short enough to allow thread2 to become blocked acquiring a permit to open a connection, and then grab the connection
+  #   opened by the background thread, before the background thread releases its permit.
+  - name: wait
+    ms: 200
+  - name: checkOut
+    thread: thread1
+  - name: waitForEvent
+    event: ConnectionCreated
+    count: 2
+  - name: checkOut
+    thread: thread2
+  - name: waitForEvent
+    event: ConnectionCheckedOut
+    count: 2
+events:
+  # exactly 2 connections must be created and checked out
+  - type: ConnectionCreated
+    address: 42
+  - type: ConnectionCreated
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+  - type: ConnectionCheckedOut
+    address: 42
+ignore:
+  - ConnectionPoolReady
+  - ConnectionClosed
+  - ConnectionReady
+  - ConnectionPoolCreated
+  - ConnectionCheckOutStarted


### PR DESCRIPTION
Look at #2641 when this is done

Still failing tests related to this. I cannot reproduce them.