### PR TITLE
Revert "RUBY-3184 Rename crypt_shared_lib_required (#2670)"

### DIFF
--- a/docs/reference/client-side-encryption.txt
+++ b/docs/reference/client-side-encryption.txt
@@ -111,7 +111,7 @@ If the library can be loaded, then the driver will not try to spawn mongocryptd 
 The daemon will be still spawned if the shared library cannot be found.
 
 It is also possible to require using the shared library by passing
-``crypt_shared_required: true`` option when creating a client. In this case,
+``crypt_shared_lib_required: true`` option when creating a client. In this case,
 an error will be raised if the shared library cannot be loaded.
 
 .. note::

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -466,7 +466,7 @@ module Mongo
     #   - :crypt_shared_lib_path => [ String | nil ]  Path that should
     #     be  the used to load the crypt shared library. Providing this option
     #     overrides default crypt shared library load paths for libmongocrypt.
-    #   - :crypt_shared_required => [ Boolean | nil ]  Whether
+    #   - :crypt_shared_lib_required => [ Boolean | nil ]  Whether
     #     crypt shared library is required. If 'true', an error will be raised
     #     if a crypt_shared library cannot be loaded by libmongocrypt.
     #

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -84,7 +84,7 @@ module Mongo
       # @option options [ String | nil ] :crypt_shared_lib_path Path that should
       #   be  the used to load the crypt shared library. Providing this option
       #   overrides default crypt shared library load paths for libmongocrypt.
-      # @option options [ Boolean | nil ] :crypt_shared_required Whether
+      # @option options [ Boolean | nil ] :crypt_shared_lib_required Whether
       #   crypt shared library is required. If 'true', an error will be raised
       #   if a crypt_shared library cannot be loaded by libmongocrypt.
       #
@@ -103,7 +103,7 @@ module Mongo
           encrypted_fields_map: @options[:encrypted_fields_map],
           bypass_query_analysis: @options[:bypass_query_analysis],
           crypt_shared_lib_path: @options[:extra_options][:crypt_shared_lib_path],
-          crypt_shared_required: @options[:extra_options][:crypt_shared_required],
+          crypt_shared_lib_required: @options[:extra_options][:crypt_shared_lib_required],
         )
 
         @mongocryptd_options = @options[:extra_options].slice(
@@ -115,9 +115,9 @@ module Mongo
         @mongocryptd_options[:mongocryptd_bypass_spawn] = @options[:bypass_auto_encryption] ||
           @options[:extra_options][:mongocryptd_bypass_spawn] ||
           @crypt_handle.crypt_shared_lib_available? ||
-          @options[:extra_options][:crypt_shared_required]
+          @options[:extra_options][:crypt_shared_lib_required]
 
-        unless @options[:extra_options][:crypt_shared_required] || @crypt_handle.crypt_shared_lib_available?
+        unless @options[:extra_options][:crypt_shared_lib_required] || @crypt_handle.crypt_shared_lib_available?
           # Set server selection timeout to 1 to prevent the client waiting for a
           # long timeout before spawning mongocryptd
           @mongocryptd_client = Client.new(

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -56,7 +56,7 @@ module Mongo
       # @option options [ String | nil ] :crypt_shared_lib_path Path that should
       #   be  the used to load the crypt shared library. Providing this option
       #   overrides default crypt shared library load paths for libmongocrypt.
-      # @option options [ Boolean | nil ] :crypt_shared_required Whether
+      # @option options [ Boolean | nil ] :crypt_shared_lib_required Whether
       #   crypt_shared library is required. If 'true', an error will be raised
       #   if a crypt_shared library cannot be loaded by libmongocrypt.
       # @option options [ Boolean | nil ] :explicit_encryption_only Whether this
@@ -104,8 +104,8 @@ module Mongo
 
         initialize_mongocrypt
 
-        @crypt_shared_required = !!options[:crypt_shared_required]
-        if @crypt_shared_required && crypt_shared_lib_version == 0
+        @crypt_shared_lib_required = !!options[:crypt_shared_lib_required]
+        if @crypt_shared_lib_required && crypt_shared_lib_version == 0
           raise Mongo::Error::CryptError.new(
             "Crypt shared library is required, but cannot be loaded  according to libmongocrypt"
           )

--- a/spec/integration/client_side_encryption/mongocryptd_prose_spec.rb
+++ b/spec/integration/client_side_encryption/mongocryptd_prose_spec.rb
@@ -81,7 +81,7 @@ describe 'mongcryptd prose tests' do
     let(:extra_options) do
       {
         crypt_shared_lib_path: SpecConfig.instance.crypt_shared_lib_path,
-        crypt_shared_required: true,
+        crypt_shared_lib_required: true,
         mongocryptd_uri: mongocryptd_uri,
         mongocryptd_spawn_args: [ "--pidfilepath=bypass-spawning-mongocryptd.pid", "--port=27777"]
       }

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -20,7 +20,7 @@ describe Mongo::Crypt::Handle do
         schema_map_path: schema_map_path,
         bypass_query_analysis: bypass_query_analysis,
         crypt_shared_lib_path: crypt_shared_lib_path,
-        crypt_shared_required: crypt_shared_required,
+        crypt_shared_lib_required: crypt_shared_lib_required,
         explicit_encryption_only: explicit_encryption_only,
       )
     end
@@ -41,7 +41,7 @@ describe Mongo::Crypt::Handle do
       nil
     end
 
-    let(:crypt_shared_required) do
+    let(:crypt_shared_lib_required) do
       nil
     end
 
@@ -118,11 +118,11 @@ describe Mongo::Crypt::Handle do
         end
       end
 
-      context 'with crypt_shared_required' do
+      context 'with crypt_shared_lib_required' do
         min_server_version '6.0.0'
 
         context 'set to true' do
-          let(:crypt_shared_required) do
+          let(:crypt_shared_lib_required) do
             true
           end
 


### PR DESCRIPTION
The cryptSharedRequired name was a typo. Other drivers refer to the option as cryptSharedLibRequired. See: https://github.com/mongodb/specifications/pull/1353