### PR TITLE
[READY FOR REVIEW] Add support for Ruby 3.2

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -724,6 +724,10 @@ axes:
   - id: "ruby"
     display_name: Ruby Version
     values:
+      - id: "ruby-3.2"
+        display_name: ruby-3.2
+        variables:
+          RVM_RUBY: "ruby-3.2"
       - id: "ruby-3.1"
         display_name: ruby-3.1
         variables:
@@ -1017,7 +1021,7 @@ buildvariants:
   - matrix_name: "mongo-latest"
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-      ruby: ["ruby-3.1"]
+      ruby: ["ruby-3.1", "ruby-3.2"]
       mongodb-version: ['latest']
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ubuntu2004
@@ -1028,7 +1032,7 @@ buildvariants:
   - matrix_name: "mongo-6.0"
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-      ruby: ["ruby-3.1"]
+      ruby: ["ruby-3.1", "ruby-3.2"]
       mongodb-version: ['6.0']
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ubuntu2004
@@ -1039,7 +1043,7 @@ buildvariants:
   - matrix_name: "mongo-5.3"
     matrix_spec:
       auth-and-ssl: noauth-and-nossl
-      ruby: ["ruby-3.1"]
+      ruby: ["ruby-3.1", "ruby-3.2"]
       mongodb-version: ['5.3']
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ubuntu2004
@@ -1094,7 +1098,7 @@ buildvariants:
   - matrix_name: "mongo-5.0"
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-2.7", "ruby-3.1", "ruby-3.2"]
       mongodb-version: '5.0'
       topology: '*'
       os: ubuntu1804
@@ -1117,7 +1121,7 @@ buildvariants:
   - matrix_name: "mongo-5.0-api-version"
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-      ruby: ["ruby-3.1"]
+      ruby: ["ruby-3.1", "ruby-3.2"]
       mongodb-version: '5.0'
       topology: standalone
       api-version-required: yes
@@ -1174,7 +1178,7 @@ buildvariants:
   - matrix_name: "lint-5.0"
     matrix_spec:
       lint: on
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-2.7", "ruby-3.1", "ruby-3.2"]
       mongodb-version: ["5.0"]
       topology: '*'
       os: ubuntu2004
@@ -1196,7 +1200,7 @@ buildvariants:
   - matrix_name: "solo"
     matrix_spec:
       solo: on
-      ruby: [ruby-3.1, ruby-3.0, ruby-2.7, ruby-2.6, ruby-2.5, jruby-9.2, jruby-9.3]
+      ruby: [ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0, ruby-3.1, ruby-3.2, jruby-9.2, jruby-9.3]
       mongodb-version: ["4.4"]
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ubuntu1804
@@ -1310,7 +1314,7 @@ buildvariants:
   - matrix_name: "snappy-auth-3"
     matrix_spec:
       auth-and-ssl: "auth-and-ssl"
-      ruby: ["ruby-3.1"]
+      ruby: ["ruby-3.1", "ruby-3.2"]
       mongodb-version: "4.4"
       topology: "standalone"
       compressor: 'snappy'
@@ -1415,7 +1419,7 @@ buildvariants:
 
   - matrix_name: "bson"
     matrix_spec:
-      ruby: [ruby-3.1, ruby-2.7, jruby-9.2]
+      ruby: [ruby-2.7, ruby-3.1, ruby-3.2, jruby-9.2]
       mongodb-version: '4.4'
       topology: replica-set
       bson: "*"
@@ -1461,7 +1465,7 @@ buildvariants:
   - matrix_name: "fle-latest"
     matrix_spec:
       auth-and-ssl: "noauth-and-nossl"
-      ruby: [ruby-3.1]
+      ruby: [ruby-3.1, ruby-3.2]
       topology: [replica-set, sharded-cluster]
       mongodb-version: ['latest']
       os: ubuntu2004
@@ -1473,7 +1477,7 @@ buildvariants:
   - matrix_name: "fle-6.0"
     matrix_spec:
       auth-and-ssl: "noauth-and-nossl"
-      ruby: [ruby-3.1, ruby-3.0, ruby-2.7]
+      ruby: [ruby-2.7, ruby-3.0, ruby-3.1, ruby-3.2]
       topology: [replica-set, sharded-cluster]
       mongodb-version: ['6.0']
       os: ubuntu2004
@@ -1485,7 +1489,7 @@ buildvariants:
   - matrix_name: "fle-4.4"
     matrix_spec:
       auth-and-ssl: "noauth-and-nossl"
-      ruby: [ruby-3.1]
+      ruby: [ruby-3.1, ruby-3.2]
       topology: standalone
       mongodb-version: ['4.4']
       os: ubuntu1804
@@ -1546,7 +1550,7 @@ buildvariants:
   - matrix_name: aws-auth-temporary
     matrix_spec:
       auth-and-ssl: [aws-assume-role, aws-ec2, aws-ecs, aws-web-identity]
-      ruby: [ruby-3.1]
+      ruby: [ruby-3.1, ruby-3.2]
       topology: standalone
       mongodb-version: '4.4'
       os: ubuntu1804
@@ -1778,7 +1782,7 @@ buildvariants:
 
   - matrix_name: "atlas"
     matrix_spec:
-      ruby: ["ruby-2.5", "ruby-2.6", "ruby-2.7", "ruby-3.0", "ruby-3.1", "jruby-9.2"]
+      ruby: ["ruby-2.5", "ruby-2.6", "ruby-2.7", "ruby-3.0", "ruby-3.1", "ruby-3.2", "jruby-9.2"]
     display_name: "Atlas tests ${ruby}"
     run_on:
       - ubuntu1804-small
@@ -1788,8 +1792,8 @@ buildvariants:
   - matrix_name: "serverless"
     matrix_spec:
       # https://jira.mongodb.org/browse/RUBY-3217
-      # ruby: ["ruby-2.5", "ruby-2.6", "ruby-2.7", "ruby-3.0", "ruby-3.1", "jruby-9.3"]
-      ruby: ["ruby-2.5", "ruby-2.6", "ruby-2.7", "ruby-3.0", "ruby-3.1"]
+      # ruby: ["ruby-2.5", "ruby-2.6", "ruby-2.7", "ruby-3.0", "ruby-3.1", "ruby-3.2", "jruby-9.3"]
+      ruby: ["ruby-2.5", "ruby-2.6", "ruby-2.7", "ruby-3.0", "ruby-3.1", "ruby-3.2"]
       fle: helper
     display_name: "Atlas serverless ${ruby} single mongos"
     run_on:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,46 +16,34 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04 ]
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1"]
-        mongodb: ["3.6", "4.4", "5.0"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
+        mongodb: ["3.6", "4.4", "5.0", "6.0"]
         topology: [replica_set, sharded_cluster]
         include:
           - os: macos
             ruby: "2.6"
             mongodb: "5.0"
-            topology: server
-          - os: macos
-            ruby: "2.7"
-            mongodb: "5.0"
-            topology: server
+            topology: replica_set
           - os: macos
             ruby: "3.0"
-            mongodb: "5.0"
+            mongodb: "6.0"
+            topology: sharded_cluster
+          - os: macos
+            ruby: "3.2"
+            mongodb: "6.0"
             topology: server
           - os: ubuntu-latest
             ruby: "2.6"
             mongodb: "5.0"
-            topology: server
-          - os: ubuntu-latest
-            ruby: "2.7"
-            mongodb: "5.0"
-            topology: server
+            topology: replica_set
           - os: ubuntu-latest
             ruby: "3.0"
-            mongodb: "5.0"
-            topology: server
-          - os: ubuntu-latest
-            ruby: "3.1"
-            mongodb: "5.0"
-            topology: server
-          - os: ubuntu-18.04
-            ruby: "2.5"
-            mongodb: "3.6"
-            topology: replica_set
-          - os: ubuntu-latest
-            ruby: "3.1"
             mongodb: "6.0"
-            topology: replica_set
+            topology: sharded_cluster
+          - os: ubuntu-latest
+            ruby: "3.2"
+            mongodb: "6.0"
+            topology: server
     steps:
     - name: repo checkout
       uses: actions/checkout@v2

--- a/docs/reference/driver-compatibility.txt
+++ b/docs/reference/driver-compatibility.txt
@@ -245,6 +245,7 @@ for that Ruby version is deprecated.
    :class: compatibility-large no-padding
 
    * - Ruby Driver
+     - Ruby 3.2
      - Ruby 3.1
      - Ruby 3.0
      - Ruby 2.7
@@ -260,7 +261,25 @@ for that Ruby version is deprecated.
      - JRuby 9.2
      - JRuby 9.1
 
+   * - 2.19
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+     -
+     -
+     -
+     -
+     - |checkmark|
+     - |checkmark|
+     -
+
    * - 2.18
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -277,6 +296,7 @@ for that Ruby version is deprecated.
      -
 
    * - 2.17
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -294,6 +314,7 @@ for that Ruby version is deprecated.
 
    * - 2.16
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -309,6 +330,7 @@ for that Ruby version is deprecated.
      -
 
    * - 2.15
+     -
      -
      - |checkmark|
      - |checkmark|
@@ -327,6 +349,7 @@ for that Ruby version is deprecated.
    * - 2.14
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -341,6 +364,7 @@ for that Ruby version is deprecated.
      -
 
    * - 2.13
+     -
      -
      -
      - |checkmark|
@@ -359,6 +383,7 @@ for that Ruby version is deprecated.
    * - 2.12
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -375,6 +400,7 @@ for that Ruby version is deprecated.
    * - 2.11
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -389,6 +415,7 @@ for that Ruby version is deprecated.
      -
 
    * - 2.10
+     -
      -
      -
      - |checkmark|
@@ -408,6 +435,7 @@ for that Ruby version is deprecated.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -421,6 +449,7 @@ for that Ruby version is deprecated.
      - |checkmark|
 
    * - 2.8
+     -
      -
      -
      -
@@ -440,6 +469,7 @@ for that Ruby version is deprecated.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -453,6 +483,7 @@ for that Ruby version is deprecated.
      - |checkmark|
 
    * - 2.6
+     -
      -
      -
      -

--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -25,6 +25,7 @@ its test suite.
 
 This release includes the following new features:
 
+- Added support for Ruby 3.2.
 - Added support for automatic AWS credentials retrieval when AWS KMS is used for
   client side encryption.
 - Added support for automatic GCP credentials retrieval when Google Cloud Key

--- a/gemfiles/standard.rb
+++ b/gemfiles/standard.rb
@@ -8,9 +8,6 @@ def standard_dependencies
   group :development, :testing do
     gem 'jruby-openssl', platforms: :jruby
     gem 'json', platforms: :jruby
-    # Explicitly specify each rspec dependency so that we can use
-    # rspec-mocks-diag instead of rspec-mocks
-    gem 'rspec-core', '~> 3.9'
     gem 'activesupport', '<7.1'
     gem 'rake'
     gem 'webrick'
@@ -45,9 +42,8 @@ def standard_dependencies
     gem 'timecop'
     gem 'ice_nine'
     gem 'rubydns', platforms: :mri
+    gem 'rspec', '~> 3.9'
     gem 'rspec-retry'
-    gem 'rspec-expectations', '~> 3.9'
-    gem 'rspec-mocks-diag', '~> 3.9'
     gem 'rfc', '~> 0.2.0'
     gem 'fuubar'
     gem 'timeout-interrupt', platforms: :mri

--- a/spec/integration/retryable_writes_errors_spec.rb
+++ b/spec/integration/retryable_writes_errors_spec.rb
@@ -71,10 +71,10 @@ describe 'Retryable writes errors tests' do
       authorized_client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
       authorized_client.use(:admin).command(failpoint1)
 
-      expect(authorized_collection.write_worker).to receive(:retry_write).once.and_wrap_original do |m, *args, &block|
+      expect(authorized_collection.write_worker).to receive(:retry_write).once.and_wrap_original do |m, *args, **kwargs, &block|
         expect(args.first.code).to eq(91)
         authorized_client.use(:admin).command(failpoint2)
-        m.call(*args, &block)
+        m.call(*args, **kwargs, &block)
       end
     end
 

--- a/spec/mongo/address_spec.rb
+++ b/spec/mongo/address_spec.rb
@@ -311,7 +311,7 @@ describe Mongo::Address do
         RSpec::Mocks.with_temporary_scope do
           resolved_address = double('address')
           # This test's expectation
-          expect(resolved_address).to receive(:socket).with(0, connect_timeout: 10)
+          expect(resolved_address).to receive(:socket).with(0, { connect_timeout: 10 })
 
           expect(Mongo::Address::IPv4).to receive(:new).and_return(resolved_address)
 

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -947,8 +947,8 @@ describe Mongo::Client do
           before do
             sessions_checked_out = 0
 
-            allow_any_instance_of(Mongo::Server).to receive(:with_connection).and_wrap_original do |m, *args, &block|
-              m.call(*args) do |connection|
+            allow_any_instance_of(Mongo::Server).to receive(:with_connection).and_wrap_original do |m, *args, **kwargs, &block|
+              m.call(*args, **kwargs) do |connection|
                 sessions_checked_out = 0
                 res = block.call(connection)
                 expect(sessions_checked_out).to be < 2
@@ -956,9 +956,9 @@ describe Mongo::Client do
               end
             end
 
-            allow_any_instance_of(Mongo::Session).to receive(:materialize).and_wrap_original do |m, *args|
+            allow_any_instance_of(Mongo::Session).to receive(:materialize).and_wrap_original do |m, *args, **kwargs|
               sessions_checked_out += 1
-              m.call(*args).tap do
+              m.call(*args, **kwargs).tap do
                 checked_out_connections = args[0].connection_pool.instance_variable_get("@checked_out_connections")
                 expect(checked_out_connections.length).to eq 1
               end

--- a/spec/mongo/collection/view/readable_spec.rb
+++ b/spec/mongo/collection/view/readable_spec.rb
@@ -848,10 +848,9 @@ describe Mongo::Collection::View::Readable do
           config_override :broken_view_options, false
 
           it "sets the option correctly" do
-            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts.dig(*obj_path)).to eq(param)
-              m.call(*args)
+            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs.dig(*obj_path)).to eq(param)
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).count(options)
           end
@@ -861,10 +860,9 @@ describe Mongo::Collection::View::Readable do
           config_override :broken_view_options, true
 
           it "doesn't set the option correctly" do
-            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts.dig(*obj_path)).to be_nil
-              m.call(*args)
+            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs.dig(*obj_path)).to be_nil
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).count(options)
           end
@@ -922,9 +920,9 @@ describe Mongo::Collection::View::Readable do
 
         with_config_values :broken_view_options, true, false do
           it "sets the option correctly" do
-            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-              expect(args.first[opt]).to eq(param)
-              m.call(*args)
+            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs[opt]).to eq(param)
+              m.call(*args, **kwargs)
             end
             authorized_collection.find({}, session: param).count(options)
           end
@@ -935,10 +933,9 @@ describe Mongo::Collection::View::Readable do
 
         with_config_values :broken_view_options, true, false do
           it "gives options higher precedence" do
-            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(:selector)
-              expect(opts.dig(:selector, :limit)).to eq(2)
-              m.call(*args)
+            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs.dig(:selector, :limit)).to eq(2)
+              m.call(*args, **kwargs)
             end
             view.limit(1).count({ limit: 2 })
           end
@@ -1038,10 +1035,9 @@ describe Mongo::Collection::View::Readable do
           let(:param) { 5000 }
 
           it "doesn't set the option correctly" do
-            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts.dig(:selector, :maxTimeMS)).to be_nil
-              m.call(*args)
+            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs.dig(:selector, :maxTimeMS)).to be_nil
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).estimated_document_count(options)
           end
@@ -1053,10 +1049,9 @@ describe Mongo::Collection::View::Readable do
           let(:obj_path) { opt }
 
           it "doesn't set the option correctly" do
-            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts[opt]).to be_nil
-              m.call(*args)
+            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs[opt]).to be_nil
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).estimated_document_count(options)
           end
@@ -1071,10 +1066,9 @@ describe Mongo::Collection::View::Readable do
           let(:param) { 5000 }
 
           it "sets the option correctly" do
-            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts.dig(:selector, :maxTimeMS)).to eq(param)
-              m.call(*args)
+            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs.dig(:selector, :maxTimeMS)).to eq(param)
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).estimated_document_count(options)
           end
@@ -1086,10 +1080,9 @@ describe Mongo::Collection::View::Readable do
           let(:obj_path) { opt }
 
           it "sets the option correctly" do
-            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts[opt]).to eq(param)
-              m.call(*args)
+            expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs[opt]).to eq(param)
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).estimated_document_count(options)
           end
@@ -1105,9 +1098,9 @@ describe Mongo::Collection::View::Readable do
 
           with_config_values :broken_view_options, true, false do
             it "sets the option correctly" do
-              expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-                expect(args.first[opt]).to eq(param)
-                m.call(*args)
+              expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+                expect(kwargs[opt]).to eq(param)
+                m.call(*args, **kwargs)
               end
               authorized_collection.find({}, session: param).estimated_document_count(options)
             end
@@ -1118,10 +1111,9 @@ describe Mongo::Collection::View::Readable do
 
           with_config_values :broken_view_options, true, false do
             it "gives options higher precedence" do
-              expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args|
-                opts = args.first.slice(:selector)
-                expect(opts.dig(:selector, :maxTimeMS)).to eq(2000)
-                m.call(*args)
+              expect(Mongo::Operation::Count).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+                expect(kwargs.dig(:selector, :maxTimeMS)).to eq(2000)
+                m.call(*args, **kwargs)
               end
               view.max_time_ms(1500).estimated_document_count({ max_time_ms: 2000 })
             end
@@ -1168,8 +1160,7 @@ describe Mongo::Collection::View::Readable do
 
           it "doesn't set the option correctly" do
             expect_any_instance_of(Mongo::Collection::View).to receive(:aggregate).once.and_wrap_original do |m, *args|
-              opts = args[1]
-              expect(opts[opt]).to be_nil
+              expect(args[1][opt]).to be_nil
               m.call(*args)
             end
             view.send(opt, param).count_documents(options)
@@ -1181,8 +1172,7 @@ describe Mongo::Collection::View::Readable do
 
           it "sets the option correctly" do
             expect_any_instance_of(Mongo::Collection::View).to receive(:aggregate).once.and_wrap_original do |m, *args|
-              opts = args[1]
-              expect(opts[opt]).to eq(param)
+              expect(args[1][opt]).to eq(param)
               m.call(*args)
             end
             view.send(opt, param).count_documents(options)
@@ -1217,7 +1207,7 @@ describe Mongo::Collection::View::Readable do
 
           it "sets the option correctly" do
             expect_any_instance_of(Mongo::Collection::View).to receive(:aggregate).once.and_wrap_original do |m, *args|
-              pipeline, opts = args
+              pipeline = args.first
               expect(pipeline[1][:'$limit']).to eq(1)
               m.call(*args)
             end
@@ -1230,7 +1220,7 @@ describe Mongo::Collection::View::Readable do
 
           it "doesn't set the option correctly" do
             expect_any_instance_of(Mongo::Collection::View).to receive(:aggregate).once.and_wrap_original do |m, *args|
-              pipeline, opts = args
+              pipeline = args.first
               expect(pipeline[1][:'$limit']).to be_nil
               m.call(*args)
             end
@@ -1245,7 +1235,7 @@ describe Mongo::Collection::View::Readable do
 
           it "doesn't set the option correctly" do
             expect_any_instance_of(Mongo::Collection::View).to receive(:aggregate).once.and_wrap_original do |m, *args|
-              pipeline, opts = args
+              pipeline = args.first
               expect(pipeline[1][:'$skip']).to be_nil
               m.call(*args)
             end
@@ -1258,7 +1248,7 @@ describe Mongo::Collection::View::Readable do
 
           it "sets the option correctly" do
             expect_any_instance_of(Mongo::Collection::View).to receive(:aggregate).once.and_wrap_original do |m, *args|
-              pipeline, opts = args
+              pipeline = args.first
               expect(pipeline[1][:'$skip']).to eq(1)
               m.call(*args)
             end
@@ -1303,7 +1293,7 @@ describe Mongo::Collection::View::Readable do
         with_config_values :broken_view_options, true, false do
           it "gives options higher precedence" do
             expect_any_instance_of(Mongo::Collection::View).to receive(:aggregate).once.and_wrap_original do |m, *args|
-              pipeline, opts = args
+              pipeline = args.first
               expect(pipeline[1][:'$limit']).to eq(2)
               m.call(*args)
             end
@@ -1724,10 +1714,9 @@ describe Mongo::Collection::View::Readable do
           config_override :broken_view_options, true
 
           it "doesn't set the option correctly" do
-            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts.dig(:selector, :maxTimeMS)).to be_nil
-              m.call(*args)
+            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs.dig(:selector, :maxTimeMS)).to be_nil
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).distinct(:name, options)
           end
@@ -1737,10 +1726,9 @@ describe Mongo::Collection::View::Readable do
           config_override :broken_view_options, false
 
           it "sets the option correctly" do
-            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts.dig(:selector, :maxTimeMS)).to eq(param)
-              m.call(*args)
+            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs.dig(:selector, :maxTimeMS)).to eq(param)
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).distinct(:name, options)
           end
@@ -1756,10 +1744,9 @@ describe Mongo::Collection::View::Readable do
           config_override :broken_view_options, true
 
           it "doesn't set the option correctly" do
-            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts[opt]).to be_nil
-              m.call(*args)
+            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs[opt]).to be_nil
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).distinct(:name, options)
           end
@@ -1769,10 +1756,9 @@ describe Mongo::Collection::View::Readable do
           config_override :broken_view_options, false
 
           it "sets the option correctly" do
-            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(*args.first.keys - [:session])
-              expect(opts[opt]).to eq(param)
-              m.call(*args)
+            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs[opt]).to eq(param)
+              m.call(*args, **kwargs)
             end
             view.send(opt, param).distinct(:name, options)
           end
@@ -1789,9 +1775,9 @@ describe Mongo::Collection::View::Readable do
 
         with_config_values :broken_view_options, true, false do
           it "sets the option correctly" do
-            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args|
-              expect(args.first[opt]).to eq(param)
-              m.call(*args)
+            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs[opt]).to eq(param)
+              m.call(*args, **kwargs)
             end
             authorized_collection.find({}, session: param).distinct(options)
           end
@@ -1802,10 +1788,9 @@ describe Mongo::Collection::View::Readable do
 
         with_config_values :broken_view_options, true, false do
           it "gives options higher precedence" do
-            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args|
-              opts = args.first.slice(:selector)
-              expect(opts.dig(:selector, :maxTimeMS)).to eq(2000)
-              m.call(*args)
+            expect(Mongo::Operation::Distinct).to receive(:new).once.and_wrap_original do |m, *args, **kwargs|
+              expect(kwargs.dig(:selector, :maxTimeMS)).to eq(2000)
+              m.call(*args, **kwargs)
             end
             view.max_time_ms(1500).distinct(:name, { max_time_ms: 2000 })
           end

--- a/spec/mongo/collection_ddl_spec.rb
+++ b/spec/mongo/collection_ddl_spec.rb
@@ -517,10 +517,10 @@ describe Mongo::Collection do
       end
 
       it "the pipeline gets passed to the command" do
-        expect(Mongo::Operation::Create).to receive(:new).and_wrap_original do |m, *args|
-          expect(args.first.slice(:selector)[:selector]).to have_key(:pipeline)
-          expect(args.first.slice(:selector)[:selector]).to have_key(:viewOn)
-          m.call(*args)
+        expect(Mongo::Operation::Create).to receive(:new).and_wrap_original do |m, *args, **kwargs|
+          expect(kwargs[:selector]).to have_key(:pipeline)
+          expect(kwargs[:selector]).to have_key(:viewOn)
+          m.call(*args, **kwargs)
         end
         expect_any_instance_of(Mongo::Operation::Create).to receive(:execute)
         authorized_client[:specs].create(options)

--- a/spec/mongo/server/connection_auth_spec.rb
+++ b/spec/mongo/server/connection_auth_spec.rb
@@ -84,8 +84,8 @@ describe Mongo::Server::Connection do
         connection
         RSpec::Mocks.with_temporary_scope do
           pending_conn = nil
-          Mongo::Server::PendingConnection.should receive(:new).and_wrap_original do |m, *args|
-            pending_conn = m.call(*args)
+          Mongo::Server::PendingConnection.should receive(:new).and_wrap_original do |m, *args, **kwargs|
+            pending_conn = m.call(*args, **kwargs)
           end
           connection.connect!
           expect(pending_conn.send(:default_mechanism)).to eq(:scram256)
@@ -106,8 +106,8 @@ describe Mongo::Server::Connection do
           expect(Mongo::Server::Description::Features).to receive(:new).and_return(features)
 
           pending_conn = nil
-          Mongo::Server::PendingConnection.should receive(:new).and_wrap_original do |m, *args|
-            pending_conn = m.call(*args)
+          Mongo::Server::PendingConnection.should receive(:new).and_wrap_original do |m, *args, **kwargs|
+            pending_conn = m.call(*args, **kwargs)
           end
           connection.connect!
           expect(pending_conn.send(:default_mechanism)).to eq(:scram)
@@ -126,8 +126,8 @@ describe Mongo::Server::Connection do
           expect(Mongo::Server::Description::Features).to receive(:new).and_return(features)
 
           pending_conn = nil
-          Mongo::Server::PendingConnection.should receive(:new).and_wrap_original do |m, *args|
-            pending_conn = m.call(*args)
+          Mongo::Server::PendingConnection.should receive(:new).and_wrap_original do |m, *args, **kwargs|
+            pending_conn = m.call(*args, **kwargs)
           end
           connection.connect!
           expect(pending_conn.send(:default_mechanism)).to eq(:mongodb_cr)

--- a/spec/mongo/server/connection_pool_spec.rb
+++ b/spec/mongo/server/connection_pool_spec.rb
@@ -1564,14 +1564,14 @@ describe Mongo::Server::ConnectionPool do
     context 'when connect fails with socket related error once' do
       before do
         i = 0
-        expect(pool).to receive(:connect_connection).exactly(:twice).and_wrap_original{ |m, *args|
+        expect(pool).to receive(:connect_connection).exactly(:twice).and_wrap_original do |m, *args|
           i += 1
           if i == 1
             raise Mongo::Error::SocketError
           else
             m.call(*args)
           end
-        }
+        end
         expect(pool.size).to eq 0
       end
 

--- a/spec/spec_tests/cmap_spec.rb
+++ b/spec/spec_tests/cmap_spec.rb
@@ -62,8 +62,8 @@ describe 'Cmap' do
             # Since we use a mock for the cluster, run_sdam_flow does not clear
             # the pool or mark the server unknown. Manually clear the pool and
             # mock the server as unknown.
-            allow(server).to receive(:unknown!).and_wrap_original do |m, *args|
-              m.call(*args)
+            allow(server).to receive(:unknown!).and_wrap_original do |m, *args, **kwargs|
+              m.call(*args, **kwargs)
               RSpec::Mocks.with_temporary_scope do
                 allow(server).to receive(:unknown?).and_return(true)
                 server.pool_internal&.clear(lazy: true)


### PR DESCRIPTION
This PR adds CI coverage for Ruby 3.2. There are several places in the `/spec/` files that need to have block keyword arg usage adjusted, but nowhere in the `/lib/` dir.

It also removes the `rspec-mocks-diag` hack gem in favor of standard `rspec`. `rspec-mocks-diag` does not support Ruby 3.2 kwargs as it is based on a stale version of rpsec-mocks. See MONGOID-5581.

Spec failures appear to be at parity with the current `master` branch, possibly some transient failures happening.