### PR TITLE
RUBY-3152 FaaS environment detection spec changes

### DIFF
--- a/lib/mongo/server/app_metadata/environment.rb
+++ b/lib/mongo/server/app_metadata/environment.rb
@@ -182,6 +182,11 @@ module Mongo
           matches = DISCRIMINATORS.keys.select { |k| discriminator_matches?(k) }
           names = matches.map { |m| DISCRIMINATORS[m][:name] }.uniq
 
+          # From the spec:
+          # When variables for multiple ``client.env.name`` values are present,
+          # ``vercel`` takes precedence over ``aws.lambda``; any other
+          # combination MUST cause ``client.env`` to be entirely omitted.
+          return 'vercel' if names.sort == %w[ aws.lambda vercel ]
           raise TooManyEnvironments, names.join(', ') if names.length > 1
 
           names.first

--- a/lib/mongo/server/app_metadata/environment.rb
+++ b/lib/mongo/server/app_metadata/environment.rb
@@ -78,7 +78,6 @@ module Mongo
           },
 
           'vercel' => {
-            'VERCEL_URL' => { field: :url, type: :string },
             'VERCEL_REGION' => { field: :region, type: :string },
           },
         }.freeze

--- a/spec/integration/connection/faas_env_spec.rb
+++ b/spec/integration/connection/faas_env_spec.rb
@@ -23,7 +23,6 @@ SCENARIOS = {
 
   'Valid Vercel' => {
     'VERCEL' => '1',
-    'VERCEL_URL' => '*.vercel.app',
     'VERCEL_REGION' => 'cdg1',
   },
 

--- a/spec/mongo/server/app_metadata/environment_spec.rb
+++ b/spec/mongo/server/app_metadata/environment_spec.rb
@@ -161,7 +161,6 @@ describe Mongo::Server::AppMetadata::Environment do
     context 'when FaaS environment is Vercel' do
       local_env(
         'VERCEL' => '1',
-        'VERCEL_URL' => '*.vercel.app',
         'VERCEL_REGION' => 'cdg1'
       )
 
@@ -169,7 +168,6 @@ describe Mongo::Server::AppMetadata::Environment do
 
       it 'recognizes Vercel' do
         expect(env.name).to be == 'vercel'
-        expect(env.fields[:url]).to be == '*.vercel.app'
         expect(env.fields[:region]).to be == 'cdg1'
       end
     end

--- a/spec/mongo/server/app_metadata/environment_spec.rb
+++ b/spec/mongo/server/app_metadata/environment_spec.rb
@@ -65,6 +65,24 @@ describe Mongo::Server::AppMetadata::Environment do
       end
     end
 
+    context 'when VERCEL and AWS are both given' do
+      local_env(
+        'AWS_EXECUTION_ENV' => 'AWS_Lambda_ruby2.7',
+        'AWS_REGION' => 'us-east-2',
+        'AWS_LAMBDA_FUNCTION_MEMORY_SIZE' => '1024',
+        'VERCEL' => '1',
+        'VERCEL_REGION' => 'cdg1'
+      )
+
+      it_behaves_like 'running in a FaaS environment'
+
+      it 'prefers vercel' do
+        expect(env.aws?).to be false
+        expect(env.vercel?).to be true
+        expect(env.fields[:region]).to be == 'cdg1'
+      end
+    end
+
     context 'when environment is invalid due to missing variable' do
       local_env(
         'AWS_EXECUTION_ENV' => 'AWS_Lambda_ruby2.7',


### PR DESCRIPTION
A later spec change (https://github.com/mongodb/specifications/commit/27f9a691008538b939467581e56eaac66191e665) removed VERCEL_URL and changed the behavior when multiple names are present.