### PR TITLE
RUBY-3200 add Ruby 3.2 to CI

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1058,7 +1058,7 @@ buildvariants:
   - matrix_name: "auth/ssl"
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: "6.0"
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1069,7 +1069,7 @@ buildvariants:
   # 'latest' is broken until the QE2 changes are merged (RUBY-3211, RUBY-3226)
   - matrix_name: "mongo-recent"
     matrix_spec:
-      ruby: ["ruby-3.1", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-3.1", "jruby-9.3"]
       #mongodb-version: ['latest', '6.0']
       mongodb-version: ['6.0']
       topology: ["standalone", "replica-set", "sharded-cluster"]
@@ -1086,7 +1086,7 @@ buildvariants:
   # RUBY-3226)
   - matrix_name: "mongo-recent-arm"
     matrix_spec:
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       #mongodb-version: ['latest', '6.0']
       mongodb-version: ['6.0']
       topology: ["standalone", "replica-set", "sharded-cluster"]
@@ -1097,7 +1097,7 @@ buildvariants:
 
   - matrix_name: "mongo-5.x"
     matrix_spec:
-      ruby: ["ruby-3.1", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
       mongodb-version: ['5.3', '5.0']
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1127,7 +1127,7 @@ buildvariants:
 
   - matrix_name: "single-lb"
     matrix_spec:
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: "6.0"
       topology: load-balanced
       single-mongos: single-mongos
@@ -1138,7 +1138,7 @@ buildvariants:
 
   - matrix_name: "mongo-5.0-api-version"
     matrix_spec:
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: '5.0'
       topology: standalone
       api-version-required: yes
@@ -1149,7 +1149,7 @@ buildvariants:
 
   - matrix_name: "single-mongos"
     matrix_spec:
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: "6.0"
       topology: "sharded-cluster"
       single-mongos: single-mongos
@@ -1161,7 +1161,7 @@ buildvariants:
   - matrix_name: "no-retry-reads"
     matrix_spec:
       retry-reads: no-retry-reads
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: "6.0"
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1172,7 +1172,7 @@ buildvariants:
   - matrix_name: "no-retry-writes"
     matrix_spec:
       retry-writes: no-retry-writes
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: "6.0"
       topology: [replica-set, sharded-cluster]
       os: rhel8
@@ -1194,7 +1194,7 @@ buildvariants:
   - matrix_name: "lint"
     matrix_spec:
       lint: on
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: "6.0"
       topology: '*'
       os: rhel8
@@ -1205,7 +1205,7 @@ buildvariants:
   - matrix_name: "fork"
     matrix_spec:
       fork: on
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: "6.0"
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1216,7 +1216,7 @@ buildvariants:
   - matrix_name: "solo"
     matrix_spec:
       solo: on
-      ruby: ["ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
+      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
       mongodb-version: "6.0"
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1238,7 +1238,7 @@ buildvariants:
   - matrix_name: "stress"
     matrix_spec:
       stress: on
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: ["6.0", "5.3"]
       topology: replica-set
       os: rhel8
@@ -1252,7 +1252,7 @@ buildvariants:
   # - matrix_name: "x509-tests"
   #   matrix_spec:
   #     auth-and-ssl: "x509"
-  #     ruby: "ruby-3.1"
+  #     ruby: "ruby-3.2"
   #     # needs the latest_5x_mdb because run-tests.sh uses `mongo` to configure
   #     # the server for certain auth mechanisms. Once run-tests.sh is made smart
   #     # enough to install mongosh, and then use either mongo or mongosh
@@ -1279,7 +1279,7 @@ buildvariants:
   - matrix_name: "zlib"
     matrix_spec:
       auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
-      ruby: ["ruby-3.1", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
       mongodb-version: "6.0"
       topology: "replica-set"
       compressor: 'zlib'
@@ -1291,7 +1291,7 @@ buildvariants:
   - matrix_name: "snappy"
     matrix_spec:
       auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
-      ruby: ["ruby-3.1", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
       mongodb-version: "6.0"
       topology: "replica-set"
       compressor: 'snappy'
@@ -1307,7 +1307,7 @@ buildvariants:
   - matrix_name: "zstd-auth"
     matrix_spec:
       auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       mongodb-version: "6.0"
       topology: "replica-set"
       compressor: 'zstd'
@@ -1318,7 +1318,7 @@ buildvariants:
 
   - matrix_name: "activesupport"
     matrix_spec:
-      ruby: ["ruby-3.1", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
       mongodb-version: "6.0"
       topology: replica-set
       as: as
@@ -1329,7 +1329,7 @@ buildvariants:
 
   - matrix_name: "bson"
     matrix_spec:
-      ruby: ["ruby-3.1", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
       mongodb-version: "6.0"
       topology: replica-set
       bson: "*"
@@ -1341,7 +1341,7 @@ buildvariants:
   # kerberos integration tests are broken (RUBY-3266)
   # - matrix_name: "kerberos-integration"
   #   matrix_spec:
-  #     ruby: ["ruby-3.1", "ruby-2.7", "jruby-9.3"]
+  #     ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
   #     os: rhel8
   #   display_name: "Kerberos integration ${os} ${ruby}"
   #   tasks:
@@ -1349,7 +1349,7 @@ buildvariants:
 
   - matrix_name: "kerberos-unit"
     matrix_spec:
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       mongodb-version: "6.0"
       topology: standalone
       os: rhel8
@@ -1363,7 +1363,7 @@ buildvariants:
   # - matrix_name: "fle-latest"
   #   matrix_spec:
   #     auth-and-ssl: "noauth-and-nossl"
-  #     ruby: "ruby-3.1"
+  #     ruby: "ruby-3.2"
   #     topology: [replica-set, sharded-cluster]
   #     mongodb-version: [ 'latest' ]
   #     os: rhel8
@@ -1375,7 +1375,7 @@ buildvariants:
   - matrix_name: "fle"
     matrix_spec:
       auth-and-ssl: "noauth-and-nossl"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: [replica-set, sharded-cluster]
       mongodb-version: [ '6.0', '4.4', '4.2', '4.0' ]
       os: rhel8
@@ -1387,7 +1387,7 @@ buildvariants:
   - matrix_name: aws-auth-regular
     matrix_spec:
       auth-and-ssl: [ aws-regular, aws-assume-role, aws-ec2, aws-ecs, aws-web-identity ]
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       topology: standalone
       # needs the latest_5x_mdb because run-tests.sh uses `mongo` to configure
       # the server for certain auth mechanisms. Once run-tests.sh is made smart
@@ -1404,7 +1404,7 @@ buildvariants:
     matrix_spec:
       ocsp-verifier: true
       # No JRuby due to https://github.com/jruby/jruby-openssl/issues/210
-      ruby: ["ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5"]
+      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1417,7 +1417,7 @@ buildvariants:
       ocsp-algorithm: ecdsa
       ocsp-must-staple: on
       ocsp-delegate: on
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1430,7 +1430,7 @@ buildvariants:
     matrix_spec:
       ocsp-algorithm: rsa
       ocsp-status: unknown
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1446,7 +1446,7 @@ buildvariants:
       ocsp-delegate: '*'
       ocsp-connectivity: pass
       extra-uri-options: "none"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1460,7 +1460,7 @@ buildvariants:
       ocsp-delegate: '*'
       ocsp-connectivity: pass
       extra-uri-options: "none"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1474,7 +1474,7 @@ buildvariants:
       ocsp-delegate: '*'
       ocsp-connectivity: fail
       extra-uri-options: "none"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1488,7 +1488,7 @@ buildvariants:
       ocsp-delegate: '*'
       ocsp-connectivity: pass
       extra-uri-options: "tlsInsecure=true"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1502,7 +1502,7 @@ buildvariants:
       ocsp-delegate: '*'
       ocsp-connectivity: pass
       extra-uri-options: "tlsInsecure=true"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1516,7 +1516,7 @@ buildvariants:
       ocsp-delegate: '*'
       ocsp-connectivity: pass
       extra-uri-options: "tlsInsecure=true"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1530,7 +1530,7 @@ buildvariants:
       ocsp-delegate: '*'
       ocsp-connectivity: pass
       extra-uri-options: "tlsAllowInvalidCertificates=true"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1544,7 +1544,7 @@ buildvariants:
       ocsp-delegate: '*'
       ocsp-connectivity: pass
       extra-uri-options: "tlsAllowInvalidCertificates=true"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1558,7 +1558,7 @@ buildvariants:
       ocsp-delegate: '*'
       ocsp-connectivity: pass
       extra-uri-options: "tlsAllowInvalidCertificates=true"
-      ruby: ["ruby-3.1", "ruby-2.7"]
+      ruby: ["ruby-3.2", "ruby-2.7"]
       topology: standalone
       mongodb-version: "6.0"
       os: rhel8
@@ -1588,7 +1588,7 @@ buildvariants:
 
   - matrix_name: testgcpkms-variant
     matrix_spec:
-      ruby: "ruby-3.1"
+      ruby: "ruby-3.2"
       fle: helper
       topology: standalone
       os: rhel8
@@ -1612,7 +1612,7 @@ buildvariants:
 
   - matrix_name: "atlas"
     matrix_spec:
-      ruby: ["ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
+      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
       os: rhel8
     display_name: "Atlas tests ${ruby}"
     tasks:
@@ -1621,8 +1621,8 @@ buildvariants:
   - matrix_name: "serverless"
     matrix_spec:
       # https://jira.mongodb.org/browse/RUBY-3217
-      # ruby: ["ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
-      ruby: ["ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5"]
+      # ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
+      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5"]
       fle: path
       os: rhel8
     display_name: "Atlas serverless ${ruby} single mongos"

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -1,12 +1,6 @@
 <%
   topologies = %w( standalone replica-set sharded-cluster )
 
-  # ruby-3.2 is available in the toolchain, but tests break. It will
-  # require some investigation. Once available:
-  #   1. set `latest_ruby` to ruby-3.2
-  #   2. add ruby-3.2 to `recent_rubies` and `supported_mri_rubies`
-  #   3. replace ruby-3.1 with ruby-3.2 in `sample_mri_rubies`.
-
   # jruby-9.4 is available in the toolchain, but tests break. It will
   # require some investigation. Once available:
   #  1. replace jruby-9.3 with jruby-9.4 in `recent_rubies` and
@@ -15,13 +9,13 @@
 
   # latest_ruby = the most recently released, stable version of Ruby
   #    (make sure this version is being built by 10gen/mongo-ruby-toolchain)
-  latest_ruby = "ruby-3.1".inspect # so it gets quoted as a string
+  latest_ruby = "ruby-3.2".inspect # so it gets quoted as a string
 
   # these are used for testing against a few recent ruby versions
-  recent_rubies = %w( ruby-3.1 jruby-9.3 )
+  recent_rubies = %w( ruby-3.2 ruby-3.1 jruby-9.3 )
 
   # this is a list of the most most recent 3.x and 2.x MRI ruby versions
-  sample_mri_rubies = %w( ruby-3.1 ruby-2.7 )
+  sample_mri_rubies = %w( ruby-3.2 ruby-2.7 )
 
   # as above, but including the most recent JRuby release
   sample_rubies = sample_mri_rubies + %w( jruby-9.3 )
@@ -32,7 +26,7 @@
   # all supported JRuby versions provided by 10gen/mongo-ruby-toolchain
   jrubies = %w( jruby-9.3 jruby-9.2 )
 
-  supported_mri_rubies = %w( ruby-3.1 ruby-3.0
+  supported_mri_rubies = %w( ruby-3.2 ruby-3.1 ruby-3.0
                              ruby-2.7 ruby-2.6 ruby-2.5 )
 
   supported_rubies = supported_mri_rubies + jrubies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04 ]
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
         mongodb: ["3.6", "4.4", "5.0"]
         topology: [replica_set, sharded_cluster]
         include:
@@ -41,11 +41,11 @@ jobs:
             mongodb: "5.0"
             topology: server
           - os: ubuntu-latest
-            ruby: "3.0"
+            ruby: "3.1"
             mongodb: "5.0"
             topology: server
           - os: ubuntu-latest
-            ruby: "3.1"
+            ruby: "3.2"
             mongodb: "5.0"
             topology: server
           - os: ubuntu-18.04
@@ -53,7 +53,7 @@ jobs:
             mongodb: "3.6"
             topology: replica_set
           - os: ubuntu-latest
-            ruby: "3.1"
+            ruby: "3.2"
             mongodb: "6.0"
             topology: replica_set
     steps:

--- a/docs/reference/driver-compatibility.txt
+++ b/docs/reference/driver-compatibility.txt
@@ -245,6 +245,7 @@ for that Ruby version is deprecated.
    :class: compatibility-large no-padding
 
    * - Ruby Driver
+     - Ruby 3.2
      - Ruby 3.1
      - Ruby 3.0
      - Ruby 2.7
@@ -260,7 +261,25 @@ for that Ruby version is deprecated.
      - JRuby 9.2
      - JRuby 9.1
 
+   * - 2.19
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - D
+     - D
+     -
+     -
+     -
+     -
+     -
+     -
+     - |checkmark|
+     - |checkmark|
+     -
+
    * - 2.18
+     - |checkmark|
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -277,6 +296,7 @@ for that Ruby version is deprecated.
      -
 
    * - 2.17
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -294,6 +314,7 @@ for that Ruby version is deprecated.
 
    * - 2.16
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -309,6 +330,7 @@ for that Ruby version is deprecated.
      -
 
    * - 2.15
+     -
      -
      - |checkmark|
      - |checkmark|
@@ -327,6 +349,7 @@ for that Ruby version is deprecated.
    * - 2.14
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -341,6 +364,7 @@ for that Ruby version is deprecated.
      -
 
    * - 2.13
+     -
      -
      -
      - |checkmark|
@@ -359,6 +383,7 @@ for that Ruby version is deprecated.
    * - 2.12
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -375,6 +400,7 @@ for that Ruby version is deprecated.
    * - 2.11
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -389,6 +415,7 @@ for that Ruby version is deprecated.
      -
 
    * - 2.10
+     -
      -
      -
      - |checkmark|
@@ -408,6 +435,7 @@ for that Ruby version is deprecated.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -421,6 +449,7 @@ for that Ruby version is deprecated.
      - |checkmark|
 
    * - 2.8
+     -
      -
      -
      -
@@ -440,6 +469,7 @@ for that Ruby version is deprecated.
      -
      -
      -
+     -
      - |checkmark|
      - |checkmark|
      - |checkmark|
@@ -453,6 +483,7 @@ for that Ruby version is deprecated.
      - |checkmark|
 
    * - 2.6
+     -
      -
      -
      -

--- a/gemfiles/standard.rb
+++ b/gemfiles/standard.rb
@@ -21,6 +21,7 @@ def standard_dependencies
     gem 'aws-sdk-ec2'
     gem 'aws-sdk-ecs'
     gem 'aws-sdk-iam'
+    gem 'aws-sdk-sts'
     gem 'paint'
 
     # for benchmark tests

--- a/spec/integration/retryable_writes_errors_spec.rb
+++ b/spec/integration/retryable_writes_errors_spec.rb
@@ -71,10 +71,10 @@ describe 'Retryable writes errors tests' do
       authorized_client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
       authorized_client.use(:admin).command(failpoint1)
 
-      expect(authorized_collection.write_worker).to receive(:retry_write).once.and_wrap_original do |m, *args, &block|
+      expect(authorized_collection.write_worker).to receive(:retry_write).once.and_wrap_original do |m, *args, **kwargs, &block|
         expect(args.first.code).to eq(91)
         authorized_client.use(:admin).command(failpoint2)
-        m.call(*args, &block)
+        m.call(*args, **kwargs, &block)
       end
     end
 

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -3,11 +3,13 @@
 
 require 'spec_helper'
 
+DEFAULT_LOCAL_HOST = '127.0.0.1:27017'
+ALT_LOCAL_HOST = '127.0.0.1:27010'
+
 # NB: tests for .new, #initialize, #use, #with and #dup are in
 # client_construction_spec.rb.
 
 describe Mongo::Client do
-
   let(:subscriber) { Mrss::EventSubscriber.new }
 
   let(:monitored_client) do
@@ -17,24 +19,21 @@ describe Mongo::Client do
   end
 
   describe '#==' do
-
     let(:client) do
       new_local_client_nmio(
-        ['127.0.0.1:27017'],
-        :read => { :mode => :primary },
-        :database => SpecConfig.instance.test_db
+        [ DEFAULT_LOCAL_HOST ],
+        read: { mode: :primary },
+        database: SpecConfig.instance.test_db
       )
     end
 
     context 'when the other is a client' do
-
       context 'when the options and cluster are equal' do
-
         let(:other) do
           new_local_client_nmio(
-            ['127.0.0.1:27017'],
-            :read => { :mode => :primary },
-            :database => SpecConfig.instance.test_db
+            [ DEFAULT_LOCAL_HOST ],
+            read: { mode: :primary },
+            database: SpecConfig.instance.test_db
           )
         end
 
@@ -44,12 +43,11 @@ describe Mongo::Client do
       end
 
       context 'when the options are not equal' do
-
         let(:other) do
           new_local_client_nmio(
-            ['127.0.0.1:27017'],
-            :read => { :mode => :secondary },
-            :database => SpecConfig.instance.test_db
+            [ DEFAULT_LOCAL_HOST ],
+            read: { mode: :secondary },
+            database: SpecConfig.instance.test_db
           )
         end
 
@@ -59,12 +57,11 @@ describe Mongo::Client do
       end
 
       context 'when cluster is not equal' do
-
         let(:other) do
           new_local_client_nmio(
-            ['127.0.0.1:27010'],
-            :read => { :mode => :primary },
-            :database => SpecConfig.instance.test_db
+            [ ALT_LOCAL_HOST ],
+            read: { mode: :primary },
+            database: SpecConfig.instance.test_db
           )
         end
 
@@ -75,7 +72,6 @@ describe Mongo::Client do
     end
 
     context 'when the other is not a client' do
-
       it 'returns false' do
         expect(client).not_to eq('test')
       end
@@ -83,14 +79,12 @@ describe Mongo::Client do
   end
 
   describe '#[]' do
-
     let(:client) do
-      new_local_client_nmio(['127.0.0.1:27017'],
-        :database => SpecConfig.instance.test_db)
+      new_local_client_nmio([ DEFAULT_LOCAL_HOST ],
+        database: SpecConfig.instance.test_db)
     end
 
     shared_examples_for 'a collection switching object' do
-
       before do
         client.use(:dbtest)
       end
@@ -101,7 +95,6 @@ describe Mongo::Client do
     end
 
     context 'when provided a string' do
-
       let(:collection) do
         client['users']
       end
@@ -110,7 +103,6 @@ describe Mongo::Client do
     end
 
     context 'when provided a symbol' do
-
       let(:collection) do
         client[:users]
       end
@@ -120,24 +112,21 @@ describe Mongo::Client do
   end
 
   describe '#eql' do
-
     let(:client) do
       new_local_client_nmio(
-        ['127.0.0.1:27017'],
-        :read => { :mode => :primary },
-        :database => SpecConfig.instance.test_db
+        [ DEFAULT_LOCAL_HOST ],
+        read: { mode: :primary },
+        database: SpecConfig.instance.test_db
       )
     end
 
     context 'when the other is a client' do
-
       context 'when the options and cluster are equal' do
-
         let(:other) do
           new_local_client_nmio(
-            ['127.0.0.1:27017'],
-            :read => { :mode => :primary },
-            :database => SpecConfig.instance.test_db
+            [ DEFAULT_LOCAL_HOST ],
+            read: { mode: :primary },
+            database: SpecConfig.instance.test_db
           )
         end
 
@@ -147,12 +136,11 @@ describe Mongo::Client do
       end
 
       context 'when the options are not equal' do
-
         let(:other) do
           new_local_client_nmio(
-            ['127.0.0.1:27017'],
-            :read => { :mode => :secondary },
-            :database => SpecConfig.instance.test_db
+            [ DEFAULT_LOCAL_HOST ],
+            read: { mode: :secondary },
+            database: SpecConfig.instance.test_db
           )
         end
 
@@ -162,12 +150,11 @@ describe Mongo::Client do
       end
 
       context 'when the cluster is not equal' do
-
         let(:other) do
           new_local_client_nmio(
-            ['127.0.0.1:27010'],
-            :read => { :mode => :primary },
-            :database => SpecConfig.instance.test_db
+            [ ALT_LOCAL_HOST ],
+            read: { mode: :primary },
+            database: SpecConfig.instance.test_db
           )
         end
 
@@ -178,12 +165,11 @@ describe Mongo::Client do
     end
 
     context 'when the other is not a client' do
-
       let(:client) do
         new_local_client_nmio(
-          ['127.0.0.1:27017'],
-          :read => { :mode => :primary },
-          :database => SpecConfig.instance.test_db
+          [ DEFAULT_LOCAL_HOST ],
+          read: { mode: :primary },
+          database: SpecConfig.instance.test_db
         )
       end
 
@@ -194,14 +180,13 @@ describe Mongo::Client do
   end
 
   describe '#hash' do
-
     let(:client) do
       new_local_client_nmio(
-        ['127.0.0.1:27017'],
-        :read => { :mode => :primary },
-        :local_threshold => 0.010,
-        :server_selection_timeout => 10000,
-        :database => SpecConfig.instance.test_db
+        [ DEFAULT_LOCAL_HOST ],
+        read: { mode: :primary },
+        local_threshold: 0.010,
+        server_selection_timeout: 10000,
+        database: SpecConfig.instance.test_db
       )
     end
 
@@ -209,14 +194,14 @@ describe Mongo::Client do
       retry_writes: true, retry_reads: true, monitoring_io: false) }
 
     let(:options) do
-      Mongo::Options::Redacted.new(:read => { :mode => :primary },
-                                    :local_threshold => 0.010,
-                                    :server_selection_timeout => 10000,
-                                    :database => SpecConfig.instance.test_db)
+      Mongo::Options::Redacted.new(read: { mode: :primary },
+                                    local_threshold: 0.010,
+                                    server_selection_timeout: 10000,
+                                    database: SpecConfig.instance.test_db)
     end
 
     let(:expected) do
-      [client.cluster, default_options.merge(options)].hash
+      [ client.cluster, default_options.merge(options) ].hash
     end
 
     it 'returns a hash of the cluster and options' do
@@ -225,12 +210,11 @@ describe Mongo::Client do
   end
 
   describe '#inspect' do
-
     let(:client) do
       new_local_client_nmio(
-        ['127.0.0.1:27017'],
-        :read => { :mode => :primary },
-        :database => SpecConfig.instance.test_db
+        [ DEFAULT_LOCAL_HOST ],
+        read: { mode: :primary },
+        database: SpecConfig.instance.test_db
       )
     end
 
@@ -239,14 +223,13 @@ describe Mongo::Client do
     end
 
     context 'when there is sensitive data in the options' do
-
       let(:client) do
         new_local_client_nmio(
-            ['127.0.0.1:27017'],
-            :read => { :mode => :primary },
-            :database => SpecConfig.instance.test_db,
-            :password => 'some_password',
-            :user => 'emily'
+            [ DEFAULT_LOCAL_HOST ],
+            read: { mode: :primary },
+            database: SpecConfig.instance.test_db,
+            password: 'some_password',
+            user: 'emily'
         )
       end
 
@@ -257,14 +240,12 @@ describe Mongo::Client do
   end
 
   describe '#server_selector' do
-
     context 'when there is a read preference set' do
-
       let(:client) do
-        new_local_client_nmio(['127.0.0.1:27017'],
-                            :database => SpecConfig.instance.test_db,
-                            :read => mode,
-                            :server_selection_timeout => 2)
+        new_local_client_nmio([ DEFAULT_LOCAL_HOST ],
+                            database: SpecConfig.instance.test_db,
+                            read: mode,
+                            server_selection_timeout: 2)
       end
 
       let(:server_selector) do
@@ -272,9 +253,8 @@ describe Mongo::Client do
       end
 
       context 'when mode is primary' do
-
         let(:mode) do
-          { :mode => :primary }
+          { mode: :primary }
         end
 
         it 'returns a primary server selector' do
@@ -287,9 +267,8 @@ describe Mongo::Client do
       end
 
       context 'when mode is primary_preferred' do
-
         let(:mode) do
-          { :mode => :primary_preferred }
+          { mode: :primary_preferred }
         end
 
         it 'returns a primary preferred server selector' do
@@ -298,9 +277,8 @@ describe Mongo::Client do
       end
 
       context 'when mode is secondary' do
-
         let(:mode) do
-          { :mode => :secondary }
+          { mode: :secondary }
         end
 
         it 'uses a Secondary server selector' do
@@ -309,9 +287,8 @@ describe Mongo::Client do
       end
 
       context 'when mode is secondary preferred' do
-
         let(:mode) do
-          { :mode => :secondary_preferred }
+          { mode: :secondary_preferred }
         end
 
         it 'uses a Secondary server selector' do
@@ -320,9 +297,8 @@ describe Mongo::Client do
       end
 
       context 'when mode is nearest' do
-
         let(:mode) do
-          { :mode => :nearest }
+          { mode: :nearest }
         end
 
         it 'uses a Secondary server selector' do
@@ -331,11 +307,10 @@ describe Mongo::Client do
       end
 
       context 'when no mode provided' do
-
         let(:client) do
-          new_local_client_nmio(['127.0.0.1:27017'],
-                              :database => SpecConfig.instance.test_db,
-                              :server_selection_timeout => 2)
+          new_local_client_nmio([ DEFAULT_LOCAL_HOST ],
+                              database: SpecConfig.instance.test_db,
+                              server_selection_timeout: 2)
         end
 
         it 'returns a primary server selector' do
@@ -344,7 +319,6 @@ describe Mongo::Client do
       end
 
       context 'when the read preference is printed' do
-
         let(:client) do
           new_local_client_nmio(SpecConfig.instance.addresses, options)
         end
@@ -360,7 +334,7 @@ describe Mongo::Client do
         let(:error) do
           begin
             client.database.command(ping: 1)
-          rescue => e
+          rescue StandardError => e
             e
           end
         end
@@ -373,12 +347,11 @@ describe Mongo::Client do
   end
 
   describe '#read_preference' do
-
     let(:client) do
-      new_local_client_nmio(['127.0.0.1:27017'],
-                          :database => SpecConfig.instance.test_db,
-                          :read => mode,
-                          :server_selection_timeout => 2)
+      new_local_client_nmio([ DEFAULT_LOCAL_HOST ],
+                          database: SpecConfig.instance.test_db,
+                          read: mode,
+                          server_selection_timeout: 2)
     end
 
     let(:preference) do
@@ -386,9 +359,8 @@ describe Mongo::Client do
     end
 
     context 'when mode is primary' do
-
       let(:mode) do
-        { :mode => :primary }
+        { mode: :primary }
       end
 
       it 'returns a primary read preference' do
@@ -397,9 +369,8 @@ describe Mongo::Client do
     end
 
     context 'when mode is primary_preferred' do
-
       let(:mode) do
-        { :mode => :primary_preferred }
+        { mode: :primary_preferred }
       end
 
       it 'returns a primary preferred read preference' do
@@ -408,9 +379,8 @@ describe Mongo::Client do
     end
 
     context 'when mode is secondary' do
-
       let(:mode) do
-        { :mode => :secondary }
+        { mode: :secondary }
       end
 
       it 'returns a secondary read preference' do
@@ -419,9 +389,8 @@ describe Mongo::Client do
     end
 
     context 'when mode is secondary preferred' do
-
       let(:mode) do
-        { :mode => :secondary_preferred }
+        { mode: :secondary_preferred }
       end
 
       it 'returns a secondary preferred read preference' do
@@ -430,9 +399,8 @@ describe Mongo::Client do
     end
 
     context 'when mode is nearest' do
-
       let(:mode) do
-        { :mode => :nearest }
+        { mode: :nearest }
       end
 
       it 'returns a nearest read preference' do
@@ -441,11 +409,10 @@ describe Mongo::Client do
     end
 
     context 'when no mode provided' do
-
       let(:client) do
-        new_local_client_nmio(['127.0.0.1:27017'],
-                            :database => SpecConfig.instance.test_db,
-                            :server_selection_timeout => 2)
+        new_local_client_nmio([ DEFAULT_LOCAL_HOST ],
+                            database: SpecConfig.instance.test_db,
+                            server_selection_timeout: 2)
       end
 
       it 'returns nil' do
@@ -455,12 +422,10 @@ describe Mongo::Client do
   end
 
   describe '#write_concern' do
-
     let(:concern) { client.write_concern }
 
     context 'when no option was provided to the client' do
-
-      let(:client) { new_local_client_nmio(['127.0.0.1:27017'], :database => SpecConfig.instance.test_db) }
+      let(:client) { new_local_client_nmio([ DEFAULT_LOCAL_HOST ], database: SpecConfig.instance.test_db) }
 
       it 'does not set the write concern' do
         expect(concern).to be_nil
@@ -468,24 +433,20 @@ describe Mongo::Client do
     end
 
     context 'when an option is provided' do
-
       context 'when the option is acknowledged' do
-
         let(:client) do
-          new_local_client_nmio(['127.0.0.1:27017'], :write => { :j => true }, :database => SpecConfig.instance.test_db)
+          new_local_client_nmio([ DEFAULT_LOCAL_HOST ], write: { j: true }, database: SpecConfig.instance.test_db)
         end
 
         it 'returns a acknowledged write concern' do
-          expect(concern.get_last_error).to eq(:getlasterror => 1, :j => true)
+          expect(concern.get_last_error).to eq(getlasterror: 1, j: true)
         end
       end
 
       context 'when the option is unacknowledged' do
-
         context 'when the w is 0' do
-
           let(:client) do
-            new_local_client_nmio(['127.0.0.1:27017'], :write => { :w => 0 }, :database => SpecConfig.instance.test_db)
+            new_local_client_nmio([ DEFAULT_LOCAL_HOST ], write: { w: 0 }, database: SpecConfig.instance.test_db)
           end
 
           it 'returns an unacknowledged write concern' do
@@ -494,9 +455,8 @@ describe Mongo::Client do
         end
 
         context 'when the w is -1' do
-
           let(:client) do
-            new_local_client_nmio(['127.0.0.1:27017'], :write => { :w => -1 }, :database => SpecConfig.instance.test_db)
+            new_local_client_nmio([ DEFAULT_LOCAL_HOST ], write: { w: -1 }, database: SpecConfig.instance.test_db)
           end
 
           it 'raises an error' do
@@ -510,15 +470,15 @@ describe Mongo::Client do
   end
 
   [
-    [:max_read_retries, 1],
-    [:read_retry_interval, 5],
-    [:max_write_retries, 1],
+    [ :max_read_retries, 1 ],
+    [ :read_retry_interval, 5 ],
+    [ :max_write_retries, 1 ],
   ].each do |opt, default|
     describe "##{opt}" do
       let(:client_options) { {} }
 
       let(:client) do
-        new_local_client_nmio(['127.0.0.1:27017'], client_options)
+        new_local_client_nmio([ DEFAULT_LOCAL_HOST ], client_options)
       end
 
       it "defaults to #{default}" do
@@ -528,7 +488,7 @@ describe Mongo::Client do
       end
 
       context 'specified on client' do
-        let(:client_options) { {opt => 2} }
+        let(:client_options) { { opt => 2 } }
 
         it 'inherits from client' do
           expect(client.options[opt]).to eq(2)
@@ -550,24 +510,21 @@ describe Mongo::Client do
   end
 
   describe '#database' do
-
     let(:database) { client.database }
 
     context 'when client has :server_api option' do
-
       let(:client) do
-        new_local_client_nmio(['localhost'], server_api: {version: '1'})
+        new_local_client_nmio([ 'localhost' ], server_api: { version: '1' })
       end
 
       it 'is not transfered to the collection' do
-        database.options[:server_api].should be nil
+        expect(database.options[:server_api]).to be_nil
       end
     end
 
   end
 
   describe '#database_names' do
-
     it 'returns a list of database names' do
       expect(root_authorized_client.database_names).to include(
         'admin'
@@ -597,17 +554,16 @@ describe Mongo::Client do
       min_server_version '4.4'
 
       it 'returns a list of database names and send comment' do
-        result = monitored_client.database_names({}, comment: "comment")
+        result = monitored_client.database_names({}, comment: 'comment')
         expect(result).to include('admin')
-        command = subscriber.command_started_events("listDatabases").last&.command
+        command = subscriber.command_started_events('listDatabases').last&.command
         expect(command).not_to be_nil
-        expect(command["comment"]).to eq("comment")
+        expect(command['comment']).to eq('comment')
       end
     end
   end
 
   describe '#list_databases' do
-
     it 'returns a list of database info documents' do
       expect(
         root_authorized_client.list_databases.collect do |i|
@@ -702,19 +658,18 @@ describe Mongo::Client do
       min_server_version '4.4'
 
       it 'returns a list of database names and send comment' do
-        result = monitored_client.list_databases({}, false, comment: "comment").collect do |i|
+        result = monitored_client.list_databases({}, false, comment: 'comment').collect do |i|
           i['name']
         end
         expect(result).to include('admin')
-        command = subscriber.command_started_events("listDatabases").last&.command
+        command = subscriber.command_started_events('listDatabases').last&.command
         expect(command).not_to be_nil
-        expect(command["comment"]).to eq("comment")
+        expect(command['comment']).to eq('comment')
       end
     end
   end
 
   describe '#list_mongo_databases' do
-
     let(:options) do
       { read: { mode: :secondary } }
     end
@@ -758,18 +713,18 @@ describe Mongo::Client do
       min_server_version '4.4'
 
       it 'returns a list of database names and send comment' do
-        result = monitored_client.list_mongo_databases({}, comment: "comment")
+        result = monitored_client.list_mongo_databases({}, comment: 'comment')
         expect(result).to all(be_a(Mongo::Database))
-        command = subscriber.command_started_events("listDatabases").last&.command
+        command = subscriber.command_started_events('listDatabases').last&.command
         expect(command).not_to be_nil
-        expect(command["comment"]).to eq("comment")
+        expect(command['comment']).to eq('comment')
       end
     end
   end
 
   describe '#close' do
     let(:client) do
-      new_local_client_nmio(['127.0.0.1:27017'])
+      new_local_client_nmio([ DEFAULT_LOCAL_HOST ])
     end
 
     it 'disconnects the cluster and returns true' do
@@ -781,9 +736,8 @@ describe Mongo::Client do
   end
 
   describe '#reconnect' do
-
     let(:client) do
-      new_local_client_nmio([ClusterConfig.instance.primary_address_str])
+      new_local_client_nmio([ ClusterConfig.instance.primary_address_str ])
     end
 
     it 'replaces the cluster' do
@@ -806,7 +760,6 @@ describe Mongo::Client do
   end
 
   describe '#collections' do
-
     before do
       authorized_client.database[:users].drop
       authorized_client.database[:users].create
@@ -823,7 +776,6 @@ describe Mongo::Client do
   end
 
   describe '#start_session' do
-
     let(:session) do
       authorized_client.start_session
     end
@@ -842,7 +794,6 @@ describe Mongo::Client do
       end
 
       context 'when options are provided' do
-
         let(:options) do
           { causal_consistency: true }
         end
@@ -857,14 +808,12 @@ describe Mongo::Client do
       end
 
       context 'when options are not provided' do
-
         it 'does not set options on the session' do
           expect(session.options).to eq({ implicit: false })
         end
       end
 
       context 'when a session is checked out and checked back in' do
-
         let!(:session_a) do
           authorized_client.start_session
         end
@@ -902,7 +851,6 @@ describe Mongo::Client do
       end
 
       context 'when an implicit session is used' do
-
         before do
           authorized_client.database.command(ping: 1)
         end
@@ -932,10 +880,10 @@ describe Mongo::Client do
         end
 
         let(:options) do
-          { :max_pool_size => 1, :retry_writes => true }
+          { max_pool_size: 1, retry_writes: true }
         end
 
-        shared_examples "a single connection" do
+        shared_examples 'a single connection' do
           # JRuby, due to being concurrent, does not like rspec setting mocks
           # in threads while other threads are calling the methods being mocked.
           # My theory is that rspec removes & redefines methods as part of
@@ -957,208 +905,208 @@ describe Mongo::Client do
             end
           end
 
-          it 'doesn\'t have any live sessions' do
+          it "doesn't have any live sessions" do
             threads.each do |thread|
               thread.join
             end
           end
         end
 
-        context "when doing three inserts" do
+        context 'when doing three inserts' do
           let(:threads) do
             (1..3).map do |i|
               Thread.new do
-                client['test'].insert_one({test: "test#{i}"})
+                client['test'].insert_one({ test: "test#{i}" })
               end
             end
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
 
-        context "when doing an insert and two updates" do
+        context 'when doing an insert and two updates' do
           let(:threads) do
             threads = []
             threads << Thread.new do
-              client['test'].insert_one({test: "test"})
+              client['test'].insert_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].update_one({test: "test"}, { "$set" => { test: "test2" } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 'test2' } })
             end
             threads << Thread.new do
-              client['test'].update_one({test: "test"}, { "$set" => { test: "test2" } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 'test2' } })
             end
             threads
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
 
-        context "when doing an insert, update and delete" do
+        context 'when doing an insert, update and delete' do
           let(:threads) do
             threads = []
             threads << Thread.new do
-              client['test'].insert_one({test: "test"})
+              client['test'].insert_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].update_one({test: "test"}, { "$set" => { test: "test2" } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 'test2' } })
             end
             threads << Thread.new do
-              client['test'].delete_one({test: "test"})
+              client['test'].delete_one({ test: 'test' })
             end
             threads
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
 
-        context "when doing an insert, update and find" do
+        context 'when doing an insert, update and find' do
           let(:threads) do
             threads = []
             threads << Thread.new do
-              client['test'].insert_one({test: "test"})
+              client['test'].insert_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].update_one({test: "test"}, { "$set" => { test: "test2" } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 'test2' } })
             end
             threads << Thread.new do
-              client['test'].find({test: "test"}).to_a
+              client['test'].find({ test: 'test' }).to_a
             end
             threads
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
 
-        context "when doing an insert, update and bulk write" do
+        context 'when doing an insert, update and bulk write' do
           let(:threads) do
             threads = []
             threads << Thread.new do
-              client['test'].insert_one({test: "test"})
+              client['test'].insert_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].update_one({test: "test"}, { "$set" => { test: "test2" } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 'test2' } })
             end
             threads << Thread.new do
-              client['test'].bulk_write([{ insert_one: { test: "test1" } },
-                                         { update_one: { filter: { test: "test1" }, update: { "$set" => { test: "test2" } } } } ])
+              client['test'].bulk_write([ { insert_one: { test: 'test1' } },
+                                          { update_one: { filter: { test: 'test1' }, update: { '$set' => { test: 'test2' } } } } ])
             end
             threads
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
 
-        context "when doing an insert, update and find_one_and_delete" do
+        context 'when doing an insert, update and find_one_and_delete' do
           let(:threads) do
             threads = []
             threads << Thread.new do
-              client['test'].insert_one({test: "test"})
+              client['test'].insert_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].update_one({test: "test"}, { "$set" => { test: "test2" } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 'test2' } })
             end
             threads << Thread.new do
-              client['test'].find_one_and_delete({test: "test"})
+              client['test'].find_one_and_delete({ test: 'test' })
             end
             threads
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
 
-        context "when doing an insert, update and find_one_and_update" do
+        context 'when doing an insert, update and find_one_and_update' do
           let(:threads) do
             threads = []
             threads << Thread.new do
-              client['test'].insert_one({test: "test"})
+              client['test'].insert_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].update_one({test: "test"}, { "$set" => { test: "test2" } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 'test2' } })
             end
             threads << Thread.new do
-              client['test'].find_one_and_update({test: "test"}, {test: "test2"})
+              client['test'].find_one_and_update({ test: 'test' }, { test: 'test2' })
             end
             threads
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
 
-        context "when doing an insert, update and find_one_and_replace" do
+        context 'when doing an insert, update and find_one_and_replace' do
           let(:threads) do
             threads = []
             threads << Thread.new do
-              client['test'].insert_one({test: "test"})
+              client['test'].insert_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].update_one({test: "test"}, { "$set" => { test: "test2" } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 'test2' } })
             end
             threads << Thread.new do
-              client['test'].find_one_and_replace({test: "test"}, {test: "test2"})
+              client['test'].find_one_and_replace({ test: 'test' }, { test: 'test2' })
             end
             threads
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
 
-        context "when doing an insert, update and a replace" do
+        context 'when doing an insert, update and a replace' do
           let(:threads) do
             threads = []
             threads << Thread.new do
-              client['test'].insert_one({test: "test"})
+              client['test'].insert_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].update_one({test: "test"}, { "$set" => { test: "test2" } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 'test2' } })
             end
             threads << Thread.new do
-              client['test'].replace_one({test: "test"}, {test: "test2"})
+              client['test'].replace_one({ test: 'test' }, { test: 'test2' })
             end
             threads
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
 
-        context "when doing all of the operations" do
+        context 'when doing all of the operations' do
           let(:threads) do
             threads = []
             threads << Thread.new do
-              client['test'].insert_one({test: "test"})
+              client['test'].insert_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].update_one({ test: "test" }, { "$set" => { test: 1 } })
+              client['test'].update_one({ test: 'test' }, { '$set' => { test: 1 } })
             end
             threads << Thread.new do
-              client['test'].find_one_and_replace({test: "test"}, {test: "test2"})
+              client['test'].find_one_and_replace({ test: 'test' }, { test: 'test2' })
             end
             threads << Thread.new do
-              client['test'].delete_one({test: "test"})
+              client['test'].delete_one({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].find({test: "test"}).to_a
+              client['test'].find({ test: 'test' }).to_a
             end
             threads << Thread.new do
-              client['test'].bulk_write([{ insert_one: { test: "test1" } },
-                                         { update_one: { filter: { test: "test1" }, update: { "$set" => { test: "test2" } } } } ])
+              client['test'].bulk_write([ { insert_one: { test: 'test1' } },
+                                          { update_one: { filter: { test: 'test1' }, update: { '$set' => { test: 'test2' } } } } ])
             end
             threads << Thread.new do
-              client['test'].find_one_and_delete({test: "test"})
+              client['test'].find_one_and_delete({ test: 'test' })
             end
             threads << Thread.new do
-              client['test'].find_one_and_update({test: "test"}, {test: "test2"})
+              client['test'].find_one_and_update({ test: 'test' }, { test: 'test2' })
             end
             threads << Thread.new do
-              client['test'].find_one_and_replace({test: "test"}, {test: "test2"})
+              client['test'].find_one_and_replace({ test: 'test' }, { test: 'test2' })
             end
             threads << Thread.new do
-              client['test'].replace_one({test: "test"}, {test: "test2"})
+              client['test'].replace_one({ test: 'test' }, { test: 'test2' })
             end
             threads
           end
 
-          include_examples "a single connection"
+          include_examples 'a single connection'
         end
       end
     end
@@ -1211,18 +1159,17 @@ describe Mongo::Client do
   end
 
   describe '#summary' do
-
     context 'monitoring omitted' do
       let(:client) do
         new_local_client_nmio(
-          ['127.0.0.1:27017'],
-          :read => { :mode => :primary },
-          :database => SpecConfig.instance.test_db
+          [ DEFAULT_LOCAL_HOST ],
+          read: { mode: :primary },
+          database: SpecConfig.instance.test_db
         )
       end
 
       it 'indicates lack of monitoring' do
-        client.summary.should =~ /servers=.*UNKNOWN.*NO-MONITORING/
+        expect(client.summary).to match /servers=.*UNKNOWN.*NO-MONITORING/
       end
     end
 
@@ -1234,8 +1181,8 @@ describe Mongo::Client do
       end
 
       it 'does not indicate lack of monitoring' do
-        client.summary.should =~ /servers=.*(?:STANDALONE|PRIMARY|MONGOS)/
-        client.summary.should_not =~ /servers=.*(?:STANDALONE|PRIMARY|MONGOS).*NO-MONITORING/
+        expect(client.summary).to match /servers=.*(?:STANDALONE|PRIMARY|MONGOS)/
+        expect(client.summary).not_to match /servers=.*(?:STANDALONE|PRIMARY|MONGOS).*NO-MONITORING/
       end
     end
 
@@ -1249,7 +1196,7 @@ describe Mongo::Client do
       end
 
       it 'does not indicate lack of monitoring' do
-        client.summary.should =~ /servers=.*(STANDALONE|PRIMARY|MONGOS|\bLB\b).*NO-MONITORING/
+        expect(client.summary).to match /servers=.*(STANDALONE|PRIMARY|MONGOS|\bLB\b).*NO-MONITORING/
       end
     end
   end

--- a/spec/mongo/client_spec.rb
+++ b/spec/mongo/client_spec.rb
@@ -947,20 +947,12 @@ describe Mongo::Client do
           before do
             sessions_checked_out = 0
 
-            allow_any_instance_of(Mongo::Server).to receive(:with_connection).and_wrap_original do |m, *args, &block|
-              m.call(*args) do |connection|
+            allow_any_instance_of(Mongo::Server).to receive(:with_connection).and_wrap_original do |m, *args, **kwargs, &block|
+              m.call(*args, **kwargs) do |connection|
                 sessions_checked_out = 0
                 res = block.call(connection)
                 expect(sessions_checked_out).to be < 2
                 res
-              end
-            end
-
-            allow_any_instance_of(Mongo::Session).to receive(:materialize).and_wrap_original do |m, *args|
-              sessions_checked_out += 1
-              m.call(*args).tap do
-                checked_out_connections = args[0].connection_pool.instance_variable_get("@checked_out_connections")
-                expect(checked_out_connections.length).to eq 1
               end
             end
           end

--- a/spec/support/aws_utils.rb
+++ b/spec/support/aws_utils.rb
@@ -4,13 +4,14 @@
 autoload :Byebug, 'byebug'
 autoload :Paint, 'paint'
 
+require 'aws-sdk-core'
+
 module Aws
   autoload :CloudWatchLogs, 'aws-sdk-cloudwatchlogs'
-  autoload :Credentials, 'aws-sdk-core'
   autoload :EC2, 'aws-sdk-ec2'
   autoload :ECS, 'aws-sdk-ecs'
   autoload :IAM, 'aws-sdk-iam'
-  autoload :STS, 'aws-sdk-core'
+  autoload :STS, 'aws-sdk-sts'
 end
 
 module AwsUtils


### PR DESCRIPTION
This PR adds ruby 3.2 to the CI matrices.

ref: https://jira.mongodb.org/browse/RUBY-3200