### PR TITLE
RUBY-1599 Test against BSON 5

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1338,7 +1338,7 @@ buildvariants:
       topology: replica-set
       bson: "*"
       os: rhel8
-    display_name: "AS ${mongodb-version} ${topology} ${ruby} ${bson}"
+    display_name: "bson-${bson} ${mongodb-version} ${topology} ${ruby}"
     tasks:
       - name: "test-mlaunch"
 

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1063,7 +1063,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
       ruby: "ruby-3.2"
-      mongodb-version: "6.0"
+      mongodb-version: ["latest", "7.0", "6.0"]
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
     display_name: ${auth-and-ssl} ${ruby} ${topology}
@@ -1073,7 +1073,7 @@ buildvariants:
   - matrix_name: "mongo-recent"
     matrix_spec:
       ruby: ["ruby-3.2", "ruby-3.1", "jruby-9.3"]
-      mongodb-version: "6.0"
+      mongodb-version: ["latest", "7.0", "6.0"]
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ['rhel8']
       # There is no latest for ubuntu2204, so we can't test it here.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1063,7 +1063,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
       ruby: "ruby-3.2"
-      mongodb-version: ["latest", "7.0", "6.0"]
+      mongodb-version: "6.0"
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
     display_name: ${auth-and-ssl} ${ruby} ${topology}
@@ -1073,7 +1073,7 @@ buildvariants:
   - matrix_name: "mongo-recent"
     matrix_spec:
       ruby: ["ruby-3.2", "ruby-3.1", "jruby-9.3"]
-      mongodb-version: ["latest", "7.0", "6.0"]
+      mongodb-version: "6.0"
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ['rhel8']
       # There is no latest for ubuntu2204, so we can't test it here.

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1066,7 +1066,7 @@ buildvariants:
       mongodb-version: ["latest", "7.0", "6.0"]
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
-    display_name: ${auth-and-ssl} ${ruby} ${topology}
+    display_name: ${auth-and-ssl} ${ruby} db-${mongodb-version} ${topology}
     tasks:
       - name: "test-mlaunch"
 

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -35,7 +35,6 @@
   latest_stable_mdb = "6.0".inspect # so it gets quoted as a string
 
   # A few of the most recent MongoDB versions
-  actual_and_upcoming_mdb = %w( latest 7.0 6.0 )
   recent_mdb = %w( 6.0 5.3 )
   latest_5x_mdb = "5.3".inspect # so it gets quoted as a string
 %>
@@ -45,7 +44,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
       ruby: <%= latest_ruby %>
-      mongodb-version: <%= actual_and_upcoming_mdb %>
+      mongodb-version: <%= latest_stable_mdb %>
       topology: <%= topologies %>
       os: rhel8
     display_name: ${auth-and-ssl} ${ruby} ${topology}
@@ -55,7 +54,7 @@ buildvariants:
   - matrix_name: "mongo-recent"
     matrix_spec:
       ruby: <%= recent_rubies %>
-      mongodb-version: <%= actual_and_upcoming_mdb %>
+      mongodb-version: <%= latest_stable_mdb %>
       topology: <%= topologies %>
       os: ['rhel8']
       # There is no latest for ubuntu2204, so we can't test it here.

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -320,7 +320,7 @@ buildvariants:
       topology: replica-set
       bson: "*"
       os: rhel8
-    display_name: "AS ${mongodb-version} ${topology} ${ruby} ${bson}"
+    display_name: "bson-${bson} ${mongodb-version} ${topology} ${ruby}"
     tasks:
       - name: "test-mlaunch"
 

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -48,7 +48,7 @@ buildvariants:
       mongodb-version: <%= actual_and_upcoming_mdb %>
       topology: <%= topologies %>
       os: rhel8
-    display_name: ${auth-and-ssl} ${ruby} ${topology}
+    display_name: ${auth-and-ssl} ${ruby} db-${mongodb-version} ${topology}
     tasks:
       - name: "test-mlaunch"
 

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -35,6 +35,7 @@
   latest_stable_mdb = "6.0".inspect # so it gets quoted as a string
 
   # A few of the most recent MongoDB versions
+  actual_and_upcoming_mdb = %w( latest 7.0 6.0 )
   recent_mdb = %w( 6.0 5.3 )
   latest_5x_mdb = "5.3".inspect # so it gets quoted as a string
 %>
@@ -44,7 +45,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
       ruby: <%= latest_ruby %>
-      mongodb-version: <%= latest_stable_mdb %>
+      mongodb-version: <%= actual_and_upcoming_mdb %>
       topology: <%= topologies %>
       os: rhel8
     display_name: ${auth-and-ssl} ${ruby} ${topology}
@@ -54,7 +55,7 @@ buildvariants:
   - matrix_name: "mongo-recent"
     matrix_spec:
       ruby: <%= recent_rubies %>
-      mongodb-version: <%= latest_stable_mdb %>
+      mongodb-version: <%= actual_and_upcoming_mdb %>
       topology: <%= topologies %>
       os: ['rhel8']
       # There is no latest for ubuntu2204, so we can't test it here.

--- a/spec/mongo/protocol/msg_spec.rb
+++ b/spec/mongo/protocol/msg_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # rubocop:todo all
 
-require 'lite_spec_helper'
+require 'spec_helper'
 require 'support/shared/protocol'
 
 describe Mongo::Protocol::Msg do
@@ -237,44 +237,6 @@ describe Mongo::Protocol::Msg do
         end
       end
 
-=begin no longer supported
-      context 'when a 0 payload type is specified' do
-
-        let(:section) do
-          { type: 0, payload: { ismaster: 1 } }
-        end
-
-        let(:section_payload_type) { bytes.to_s[36] }
-        let(:section_bytes) { bytes.to_s[37..-1] }
-
-        it 'sets the payload type' do
-          expect(section_payload_type).to eq(0.chr)
-        end
-
-        it 'serializes the section' do
-          expect(section_bytes).to be_bson(section[:payload])
-        end
-      end
-
-      context 'when a no payload type is specified' do
-
-        let(:section) do
-          { payload: { ismaster: 1 } }
-        end
-
-        let(:section_payload_type) { bytes.to_s[36] }
-        let(:section_bytes) { bytes.to_s[37..-1] }
-
-        it 'sets the payload type as 0' do
-          expect(section_payload_type).to eq(0.chr)
-        end
-
-        it 'serializes the section' do
-          expect(section_bytes).to be_bson(section[:payload])
-        end
-      end
-=end
-
       context 'when a payload of type 1 is specified' do
 
         let(:section) do
@@ -366,32 +328,9 @@ describe Mongo::Protocol::Msg do
           end
         end
       end
-
-=begin no longer supported
-      context 'when the sections are mixed types and payload type 1 comes before type 0' do
-
-        let(:section1) do
-          Mongo::Protocol::Msg::Section1.new('documents', [ { a: 1 } ])
-        end
-
-        let(:section2) do
-          { type: 0, payload: { 'b' => 2 } }
-        end
-
-        let(:sections) do
-          [ section1, section2 ]
-        end
-
-        it 'serializes all sections' do
-          expect(deserialized.documents).to eq([ BSON::Document.new(main_document), { 'a' => 1 }, { 'b' => 2 }])
-        end
-      end
-=end
     end
 
     context 'when the validating_keys option is true with payload 1' do
-      max_bson_version '4.99.99'
-
       let(:sequences) do
         [ section ]
       end


### PR DESCRIPTION
RUBY-1599 requires that we test the driver against BSON 5. It turns out, though, that we're already testing the driver against the BSON master branch. There was only one place where tests were being skipped if BSON 5 was present; the tests still pass, though, with that condition removed.

So, there's not much for this PR to do, aside from remove that condition, and do a little bit of cleanup.