### PR TITLE
DOCSP-31496 (Fix API link) backport to 2.17 stable

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -62,7 +62,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mong
     reference/working-with-data
     reference/schema-operations
     bson-tutorials
-    API <https://docs.mongodb.com/ruby-driver/master/api/>
+    API <https://mongodb.com/docs/ruby-driver/current/api/>
     release-notes
     reference/additional-resources
     contribute


### PR DESCRIPTION
Backports DOCSP-31496 (Fix API link) to 2.17-stable.