### PR TITLE
RUBY-3308 Fixing serverless test failures

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -453,7 +453,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          SERVERLESS=1 SSL=ssl RVM_RUBY="${RVM_RUBY}" SINGLE_MONGOS="${SINGLE_MONGOS}" SERVERLESS_URI="${SERVERLESS_URI}" FLE="${FLE}" SERVERLESS_MONGODB_VERSION="${SERVERLESS_MONGODB_VERSION}" .evergreen/run-tests-serverless.sh
+          CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" SERVERLESS=1 SSL=ssl RVM_RUBY="${RVM_RUBY}" SINGLE_MONGOS="${SINGLE_MONGOS}" SERVERLESS_URI="${SERVERLESS_URI}" FLE="${FLE}" SERVERLESS_MONGODB_VERSION="${SERVERLESS_MONGODB_VERSION}" .evergreen/run-tests-serverless.sh
 
 pre:
   - func: "fetch source"

--- a/.evergreen/config/common.yml.erb
+++ b/.evergreen/config/common.yml.erb
@@ -450,7 +450,7 @@ functions:
         working_dir: "src"
         script: |
           ${PREPARE_SHELL}
-          SERVERLESS=1 SSL=ssl RVM_RUBY="${RVM_RUBY}" SINGLE_MONGOS="${SINGLE_MONGOS}" SERVERLESS_URI="${SERVERLESS_URI}" FLE="${FLE}" SERVERLESS_MONGODB_VERSION="${SERVERLESS_MONGODB_VERSION}" .evergreen/run-tests-serverless.sh
+          CRYPT_SHARED_LIB_PATH="${CRYPT_SHARED_LIB_PATH}" SERVERLESS=1 SSL=ssl RVM_RUBY="${RVM_RUBY}" SINGLE_MONGOS="${SINGLE_MONGOS}" SERVERLESS_URI="${SERVERLESS_URI}" FLE="${FLE}" SERVERLESS_MONGODB_VERSION="${SERVERLESS_MONGODB_VERSION}" .evergreen/run-tests-serverless.sh
 
 pre:
   - func: "fetch source"

--- a/.evergreen/run-tests-serverless.sh
+++ b/.evergreen/run-tests-serverless.sh
@@ -16,14 +16,19 @@ export MONGODB_URI=`echo ${SERVERLESS_URI} | sed -r 's/mongodb\+srv:\/\//mongodb
 
 export TOPOLOGY="load-balanced"
 
-python3 -u .evergreen/mongodl.py --component crypt_shared -V ${SERVERLESS_MONGODB_VERSION} --out `pwd`/csfle_lib  --target `host_distro` || true
-if test -f `pwd`/csfle_lib/lib/mongo_crypt_v1.so
-then
-    echo Usinn crypt shared library version ${SERVERLESS_MONGODB_VERSION}
-    export MONGO_RUBY_DRIVER_CRYPT_SHARED_LIB_PATH=`pwd`/csfle_lib/lib/mongo_crypt_v1.so
+if [ -n "${CRYPT_SHARED_LIB_PATH}" ]; then
+    echo crypt_shared already present at ${CRYPT_SHARED_LIB_PATH} -- using this version
+    export MONGO_RUBY_DRIVER_CRYPT_SHARED_LIB_PATH=$CRYPT_SHARED_LIB_PATH
 else
-    echo Failed to download crypt shared library
-    exit -1
+    python3 -u .evergreen/mongodl.py --component crypt_shared -V ${SERVERLESS_MONGODB_VERSION} --out `pwd`/csfle_lib  --target `host_distro` || true
+    if test -f `pwd`/csfle_lib/lib/mongo_crypt_v1.so
+    then
+        echo Usinn crypt shared library version ${SERVERLESS_MONGODB_VERSION}
+        export MONGO_RUBY_DRIVER_CRYPT_SHARED_LIB_PATH=`pwd`/csfle_lib/lib/mongo_crypt_v1.so
+    else
+        echo Failed to download crypt shared library
+        exit -1
+    fi
 fi
 
 if ! ( test -f /etc/os-release & grep -q ^ID.*rhel /etc/os-release & grep -q ^VERSION_ID.*8.0 /etc/os-release ); then


### PR DESCRIPTION
This addresses serverless test failures that cropped up since 7.0.0 was added as a "production release" to full.json. The problem is that the 7.0.0 entry for full.json omits the download entries, and thus the serverless tests were unable to download the crypt_shared library (because the code was relying on full.json).

It turns out, however, that crypt_shared was already being downloaded previously in the task setup, using a different approach (`download-crypt.sh`). All that's needed is to propagate one of the variables forward to the `run-serverless-tests.sh` script, so that the script can see and use the already-downloaded crypt_shared library.

So, this addresses those failures. The bad news is that the serverless tests are still failing, but now due to a different error (see https://jira.mongodb.org/browse/CLOUDP-192859). I'm putting this PR up for review anyway, since it at least fixes one issue with the serverless tests.