### PR TITLE
RUBY-2807 - Proof-of-concept for compression warning

### DIFF
--- a/docs/reference/create-client.txt
+++ b/docs/reference/create-client.txt
@@ -517,6 +517,12 @@ Ruby Options
      - ``Array<String>``
      - none
 
+   * - ``:warn_compression_disabled``
+     - By default, the driver warns if you have not set the ``:compressors`` option.
+       Set this option ``false`` to silence the warning.
+     - ``true``, ``false``
+     - none
+
    * - ``:connect``
      - **Deprecated.** Disables deployment topology discovery normally
        performed by the dirver and forces the cluster topology to a specific

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -1353,6 +1353,13 @@ module Mongo
         end
         _options
       end
+
+      unless !opts[:compressors]&.empty? ||
+             opts[:warn_compression_disabled] == false ||
+             @@warned_compression_disabled
+        log_warn("Compression is disabled. Refer to: https://www.mongodb.com/docs/ruby-driver/current/reference/create-client/#compression. You may silence this warning by setting :warn_compression_disabled = false.")
+        @@warned_compression_disabled = true
+      end
     end
 
     # Validates all options after they are set on the client.


### PR DESCRIPTION
This PR adds a simple warning log message if compression is not enabled. It also adds an option `warn_compression_disabled` which can be set to false to silence the message.

This warning message would go a long way to help users avoid mistakenly not setting compression. (Note that this PR does *not* enable any compression by default.)