### PR TITLE
RUBY-3324 expose $task_id to atlas setup/teardown so clusters are unique per invocation

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -489,6 +489,7 @@ task_groups:
               DRIVERS_ATLAS_LAMBDA_PASSWORD="${DRIVERS_ATLAS_LAMBDA_PASSWORD}" \
               LAMBDA_STACK_NAME="dbx-ruby-lambda" \
               MONGODB_VERSION="7.0" \
+              task_id="${task_id}" \
               $DRIVERS_TOOLS/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
         params:
@@ -505,6 +506,7 @@ task_groups:
               DRIVERS_ATLAS_PRIVATE_API_KEY="${DRIVERS_ATLAS_PRIVATE_API_KEY}" \
               DRIVERS_ATLAS_GROUP_ID="${DRIVERS_ATLAS_GROUP_ID}" \
               LAMBDA_STACK_NAME="dbx-ruby-lambda" \
+              task_id="${task_id}" \
               $DRIVERS_TOOLS/.evergreen/atlas/teardown-atlas-cluster.sh
     tasks:
       - test-full-atlas-task

--- a/.evergreen/config/common.yml.erb
+++ b/.evergreen/config/common.yml.erb
@@ -486,6 +486,7 @@ task_groups:
               DRIVERS_ATLAS_LAMBDA_PASSWORD="${DRIVERS_ATLAS_LAMBDA_PASSWORD}" \
               LAMBDA_STACK_NAME="dbx-ruby-lambda" \
               MONGODB_VERSION="7.0" \
+              task_id="${task_id}" \
               $DRIVERS_TOOLS/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
         params:
@@ -502,6 +503,7 @@ task_groups:
               DRIVERS_ATLAS_PRIVATE_API_KEY="${DRIVERS_ATLAS_PRIVATE_API_KEY}" \
               DRIVERS_ATLAS_GROUP_ID="${DRIVERS_ATLAS_GROUP_ID}" \
               LAMBDA_STACK_NAME="dbx-ruby-lambda" \
+              task_id="${task_id}" \
               $DRIVERS_TOOLS/.evergreen/atlas/teardown-atlas-cluster.sh
     tasks:
       - test-full-atlas-task


### PR DESCRIPTION
See https://jira.mongodb.org/browse/RUBY-3324