### PR TITLE
RUBY-3328 Atlas cluster setup generating duplicate cluster names 

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -490,6 +490,7 @@ task_groups:
               LAMBDA_STACK_NAME="dbx-ruby-lambda" \
               MONGODB_VERSION="7.0" \
               task_id="${task_id}" \
+              execution="${execution}" \
               $DRIVERS_TOOLS/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
         params:
@@ -507,6 +508,7 @@ task_groups:
               DRIVERS_ATLAS_GROUP_ID="${DRIVERS_ATLAS_GROUP_ID}" \
               LAMBDA_STACK_NAME="dbx-ruby-lambda" \
               task_id="${task_id}" \
+              execution="${execution}" \
               $DRIVERS_TOOLS/.evergreen/atlas/teardown-atlas-cluster.sh
     tasks:
       - test-full-atlas-task

--- a/.evergreen/config/common.yml.erb
+++ b/.evergreen/config/common.yml.erb
@@ -487,6 +487,7 @@ task_groups:
               LAMBDA_STACK_NAME="dbx-ruby-lambda" \
               MONGODB_VERSION="7.0" \
               task_id="${task_id}" \
+              execution="${execution}" \
               $DRIVERS_TOOLS/.evergreen/atlas/setup-atlas-cluster.sh
       - command: expansions.update
         params:
@@ -504,6 +505,7 @@ task_groups:
               DRIVERS_ATLAS_GROUP_ID="${DRIVERS_ATLAS_GROUP_ID}" \
               LAMBDA_STACK_NAME="dbx-ruby-lambda" \
               task_id="${task_id}" \
+              execution="${execution}" \
               $DRIVERS_TOOLS/.evergreen/atlas/teardown-atlas-cluster.sh
     tasks:
       - test-full-atlas-task


### PR DESCRIPTION
This PR adds the `execution` expansion to the process environment for setting up and tearing down Atlas clusters.

ref: https://jira.mongodb.org/browse/RUBY-3328