### PR TITLE
DOCSP-32949: docs link to the BSON 4.x Tutorial

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -25,7 +25,7 @@ BSON
 The Ruby BSON implementation is packaged in a separate gem with C and
 Java extensions for speed depending on the runtime enviroment.
 
-For reference on the Ruby BSON gem, see :doc:`/bson-tutorials`.
+For reference on the Ruby BSON gem, see the :doc:`/tutorials/bson-v4`.
 
 Object Mappers
 ==============
@@ -61,8 +61,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://mongodb.com/docs/mong
     reference/connection-and-configuration
     reference/working-with-data
     reference/schema-operations
-    bson-tutorials
-    API <https://mongodb.com/docs/ruby-driver/current/api/>
+    API <https://mongodb.com/docs/ruby-driver/master/api/>
     release-notes
     reference/additional-resources
     contribute

--- a/docs/reference/crud-operations.txt
+++ b/docs/reference/crud-operations.txt
@@ -93,7 +93,7 @@ Specify a ``Decimal128`` number
 .. versionadded:: 3.4
 
 :manual:`Decimal128</tutorial/model-monetary-data>` is a
-:doc:`BSON datatype </bson-tutorials>`
+:doc:`BSON datatype </tutorials/bson-v4>`
 that employs 128-bit decimal-based floating-point values capable
 of emulating decimal rounding with exact precision. This
 functionality is intended for applications that handle

--- a/docs/tutorials.txt
+++ b/docs/tutorials.txt
@@ -15,3 +15,5 @@ operations available in the Ruby driver.
 
   tutorials/quick-start
   tutorials/common-errors
+  tutorials/bson-v4
+


### PR DESCRIPTION
Backport to 2.18-stable:

* DOCSP-32949: docs link to the BSON 4.x Tutorial

* resolve link errors
