### PR TITLE
ruby2.7 Using the last argument as keyword parameters is deprecated

### DIFF
--- a/lib/mongo/server.rb
+++ b/lib/mongo/server.rb
@@ -655,7 +655,7 @@ module Mongo
     #
     # @api private
     def clear_description
-      @description = Mongo::Server::Description.new(address, {})
+      @description = Mongo::Server::Description.new(address, **{})
     end
 
     # @param [ Object ] :service_id Close connections with the specified


### PR DESCRIPTION
Hi I faced problem on my script I saw warnings:  
/var/lib/gems/2.7.0/gems/mongo-2.19.1/lib/mongo/server.rb:658: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/var/lib/gems/2.7.0/gems/mongo-2.19.1/lib/mongo/server/description.rb:220: warning: The called method `initialize' is defined here

This small changes fix the problem.