### PR TITLE
Fix: Delete "_id" key from document if equal to nil to avoid having two different _id keys in the document

### DIFF
--- a/lib/mongo/operation/shared/idable.rb
+++ b/lib/mongo/operation/shared/idable.rb
@@ -58,7 +58,13 @@ module Mongo
       def ensure_ids(documents)
         @ids = []
         documents.collect do |doc|
-          doc_with_id = has_id?(doc) ? doc : doc.merge(_id: id_generator.generate)
+          doc_with_id = if has_id?(doc)
+                          doc
+                        else
+                          doc.delete('_id')
+                          doc.merge(_id: id_generator.generate)
+                        end
+
           @ids << id(doc_with_id)
           doc_with_id
         end

--- a/spec/mongo/operation/insert_spec.rb
+++ b/spec/mongo/operation/insert_spec.rb
@@ -100,6 +100,25 @@ describe Mongo::Operation::Insert do
         expect(inserted_ids).to eq(collection_ids)
       end
     end
+
+    context 'when document contains a nil id' do
+
+      let(:documents) do
+        [{ 'field' => 'test', '_id' => nil }]
+      end
+
+      let(:inserted_ids) do
+        insert.execute(authorized_primary, context: context).inserted_ids
+      end
+
+      let(:collection_ids) do
+        authorized_collection.find(field: 'test').collect { |d| d['_id'] }
+      end
+
+      it 'adds an id to the documents' do
+        expect(inserted_ids).to eq(collection_ids)
+      end
+    end
   end
 
   describe '#execute' do


### PR DESCRIPTION
Hi!

While investigating an issue in an application I'm working on I discovered that trying to insert a document containing `'_id' => nil` will raise the following exception:

```
.../lib/mongo/operation/result.rb:364:in `raise_operation_failure': [2]: can't have multiple _id fields in one document (on 127.0.0.1:27017, legacy retry, attempt 1) (Mongo::Error::OperationFailure)
```

Here's a reproduction script:
```ruby
require 'bundler/inline'

gemfile do
  source 'https://rubygems.org'
  gem 'mongo'
end

client = Mongo::Client.new(['127.0.0.1:27017'], database: 'PoC_DTM') # Assuming you have a mongo server running on port 27017
db = client.database
collection = db[:fake_collection]

collection.insert_one({ field: 'test', _id: nil }) # => OK
collection.insert_one({ field: 'test', '_id' => nil }) # => KO
```

I was able to track down the issue in the `lib/mongo/operation/shared/idable.rb` file:

```ruby
...
      def id(doc)
        doc.respond_to?(:id) ? doc.id : (doc['_id'] || doc[:_id])
      end

      def has_id?(doc)
        !!id(doc)
      end

      def ensure_ids(documents)
        @ids = []
        documents.collect do |doc|
          doc_with_id = has_id?(doc) ? doc : doc.merge(_id: id_generator.generate)
          @ids << id(doc_with_id)
          doc_with_id
        end
      end
...
```

When `'_id'` is equal to `nil` `has_id?` returns `false` which causes `ensure_ids` to generate an id that it stores in `:_id` but without removing the `'_id'` key which results in the document having both `'_id'` and `:_id`, hence the exception mentioned above.

<br/>
Let me know if I should create an issue in JIRA first