### PR TITLE
DOCSP-34643 - Update API link

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -61,7 +61,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://mongodb.com/docs/mong
     reference/connection-and-configuration
     reference/working-with-data
     reference/schema-operations
-    API <https://mongodb.com/docs/ruby-driver/master/api/>
+    API <https://mongodb.com/docs/ruby-driver/current/api/>
     release-notes
     reference/additional-resources
     contribute


### PR DESCRIPTION
Updating the link to the API documentation to the correct URL to fix broken link

[JIRA](https://jira.mongodb.org/browse/DOCSP-34643)