### PR TITLE
DOCSP-34643 - Fix API link

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -61,7 +61,7 @@ For tutorials on Mongoid, see the `Mongoid Manual <https://docs.mongodb.com/mong
     reference/connection-and-configuration
     reference/working-with-data
     reference/schema-operations
-    API <https://mongodb.com/docs/ruby-driver/master/api/>
+    API <https://mongodb.com/docs/ruby-driver/current/api/>
     release-notes
     reference/additional-resources
     contribute


### PR DESCRIPTION
Updating the link to the API documentation to the correct URL to fix broken link

Backport of https://github.com/mongodb/mongo-ruby-driver/pull/2812