### PR TITLE
RUBY-3329 Connection String: make delimiting slash between hosts and options optional

### DIFF
--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -377,10 +377,6 @@ module Mongo
         raise_invalid_error!("Options contain an unescaped question mark (?), or the database name contains a question mark and was not escaped")
       end
 
-      if options && !hosts_and_db.index('/')
-        raise_invalid_error!("MongoDB URI must have a slash (/) after the hosts if options are given")
-      end
-
       hosts, db = hosts_and_db.split('/', 2)
       if db && db.index('/')
         raise_invalid_error!("Database name contains an unescaped slash (/): #{db}")

--- a/spec/mongo/uri_spec.rb
+++ b/spec/mongo/uri_spec.rb
@@ -266,15 +266,6 @@ describe Mongo::URI do
       end
     end
 
-    context 'no slash after hosts, and options' do
-
-      let(:string) { 'mongodb://example.com?tls=true' }
-
-      it 'raises an error' do
-        expect { uri }.to raise_error(Mongo::Error::InvalidURI, %r,MongoDB URI must have a slash \(/\) after the hosts if options are given,)
-      end
-    end
-
     context 'mongodb://example.com/?w' do
 
       let(:string) { 'mongodb://example.com/?w' }

--- a/spec/spec_tests/data/connection_string/invalid-uris.yml
+++ b/spec/spec_tests/data/connection_string/invalid-uris.yml
@@ -144,14 +144,6 @@ tests:
         auth: ~
         options: ~
     -
-        description: "Missing delimiting slash between hosts and options"
-        uri: "mongodb://example.com?w=1"
-        valid: false
-        warning: ~
-        hosts: ~
-        auth: ~
-        options: ~
-    -
         description: "Incomplete key value pair for option"
         uri: "mongodb://example.com/?w"
         valid: false
@@ -257,5 +249,3 @@ tests:
         hosts: ~
         auth: ~
         options: ~
-
-    

--- a/spec/spec_tests/data/connection_string/valid-options.yml
+++ b/spec/spec_tests/data/connection_string/valid-options.yml
@@ -15,3 +15,16 @@ tests:
             db: "admin"
         options:
             authmechanism: "MONGODB-CR"
+    -
+        description: "Missing delimiting slash between hosts and options"
+        uri: "mongodb://example.com?tls=true"
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: "hostname"
+                host: "example.com"
+                port: ~
+        auth: ~
+        options:
+              tls: true


### PR DESCRIPTION
REF: https://jira.mongodb.org/browse/RUBY-3329, https://jira.mongodb.org/browse/DRIVERS-2679