### PR TITLE
Fix failing atlas connectivity specs

### DIFF
--- a/spec/atlas/atlas_connectivity_spec.rb
+++ b/spec/atlas/atlas_connectivity_spec.rb
@@ -11,13 +11,13 @@ describe 'Atlas connectivity' do
 
   describe 'connection to Atlas' do
     it 'runs ismaster successfully' do
-      result = client.database.command(:ismaster => 1)
-      expect(result.documents.first['ismaster']).to be true
+      expect { client.database.command(:ismaster => 1) }
+        .not_to raise_error
     end
 
     it 'runs findOne successfully' do
-      result = client.use(:test)['test'].find.to_a
-      expect(result).to be_a(Array)
+      expect { client.use(:test)['test'].find.to_a }
+        .not_to raise_error
     end
   end
 end

--- a/spec/atlas/atlas_connectivity_spec.rb
+++ b/spec/atlas/atlas_connectivity_spec.rb
@@ -11,7 +11,7 @@ describe 'Atlas connectivity' do
 
   describe 'connection to Atlas' do
     it 'runs ismaster successfully' do
-      expect { client.database.command(:ismaster => 1) }
+      expect { client.database.command(:hello => 1) }
         .not_to raise_error
     end
 


### PR DESCRIPTION
The Atlas connectivity specs were failing when testing the "free tier" atlas URI, because the "ismaster" command wasn't returning the expected results.

Looking at the Go and Python drivers, it looks like they are only testing for the absence of an error when executing these commands; the original ticket (https://jira.mongodb.org/browse/DRIVERS-382) also stipulates that drivers should merely "verify that no error occurred." I've updated the specs so they no longer check for the contents of the result, and only confirm that no error occurred.