### PR TITLE
MONGOID-5552 session should not change the client that created it

### DIFF
--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -1200,7 +1200,7 @@ module Mongo
     end
 
     def check_matching_client!(client)
-      if @client != client
+      if @client.cluster != client.cluster
         raise Mongo::Error::InvalidSession.new(MISMATCHED_CLUSTER_ERROR_MSG)
       end
     end

--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -92,7 +92,7 @@ module Mongo
       @server_session = server_session
       options = options.dup
 
-      @client = client.use(:admin)
+      @client = client
       @options = options.dup.freeze
       @cluster_time = nil
       @state = NO_TRANSACTION_STATE
@@ -1023,7 +1023,7 @@ module Mongo
     # @since 2.5.0
     # @api private
     def validate!(client)
-      check_matching_cluster!(client)
+      check_matching_client!(client)
       check_if_ended!
       self
     end
@@ -1199,8 +1199,8 @@ module Mongo
       raise Mongo::Error::InvalidSession.new(SESSION_ENDED_ERROR_MSG) if ended?
     end
 
-    def check_matching_cluster!(client)
-      if @client.cluster != client.cluster
+    def check_matching_client!(client)
+      if @client != client
         raise Mongo::Error::InvalidSession.new(MISMATCHED_CLUSTER_ERROR_MSG)
       end
     end


### PR DESCRIPTION
This isn't the complete solution (yet), but this is a step towards it.

The `Mongo::Session` class was previously setting the session instance's `@client` variable to `client.use(:admin)` for some reason. I suspect it is because the spec requires certain commands (`startSession` and `endSessions`) to be executed against the admin database. However, we don't ever issue those commands; `startSession` is only needed if you want the server to generate session IDs (and we do it ourselves), and `endSessions`...well...I don't know why that's not present.

So, the point is: the session doesn't need a handle to the `admin` database. And even if it needed one to execute those commands, the session's client shouldn't be changed in any way from the client that initialized it.