### PR TITLE
RUBY-3424 Prep for 2.20

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1008,22 +1008,10 @@ axes:
         display_name: ruby-2.7
         variables:
           RVM_RUBY: "ruby-2.7"
-      - id: "ruby-2.6"
-        display_name: ruby-2.6
-        variables:
-          RVM_RUBY: "ruby-2.6"
-      - id: "ruby-2.5"
-        display_name: ruby-2.5
-        variables:
-          RVM_RUBY: "ruby-2.5"
       - id: "ruby-head"
         display_name: ruby-head
         variables:
           RVM_RUBY: "ruby-head"
-      - id: "jruby-9.2"
-        display_name: jruby-9.2
-        variables:
-          RVM_RUBY: "jruby-9.2"
       - id: "jruby-9.3"
         display_name: jruby-9.3
         variables:
@@ -1257,7 +1245,6 @@ axes:
       - id: no
         display_name: No
 
-
 buildvariants:
   - matrix_name: DriverBench
     matrix_spec:
@@ -1317,7 +1304,7 @@ buildvariants:
 
   - matrix_name: "mongo-4.x"
     matrix_spec:
-      ruby: ["ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5"]
+      ruby: ["ruby-3.0", "ruby-2.7"]
       mongodb-version: ['4.4', '4.2', '4.0']
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1327,7 +1314,7 @@ buildvariants:
 
   - matrix_name: "mongo-3.6"
     matrix_spec:
-      ruby: "ruby-2.5"
+      ruby: "ruby-2.7"
       mongodb-version: ['3.6']
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1392,7 +1379,7 @@ buildvariants:
 
   - matrix_name: mmapv1
     matrix_spec:
-      ruby: "ruby-2.5"
+      ruby: "ruby-2.7"
       mongodb-version: ['3.6', '4.0']
       topology: ["standalone", "replica-set", "sharded-cluster"]
       storage-engine: mmapv1
@@ -1426,7 +1413,7 @@ buildvariants:
   - matrix_name: "solo"
     matrix_spec:
       solo: on
-      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
+      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.3"]
       mongodb-version: "7.0"
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1609,7 +1596,7 @@ buildvariants:
     matrix_spec:
       ocsp-verifier: true
       # No JRuby due to https://github.com/jruby/jruby-openssl/issues/210
-      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5"]
+      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7"]
       topology: standalone
       mongodb-version: "7.0"
       os: rhel8
@@ -1825,7 +1812,7 @@ buildvariants:
 
   - matrix_name: "atlas"
     matrix_spec:
-      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
+      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.3"]
       os: rhel8
     display_name: "Atlas tests ${ruby}"
     tasks:
@@ -1835,8 +1822,8 @@ buildvariants:
 #  - matrix_name: "serverless"
 #    matrix_spec:
 #      # https://jira.mongodb.org/browse/RUBY-3217
-#      # ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
-#      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5"]
+#      # ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.3"]
+#      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7"]
 #      fle: path
 #      os: rhel8
 #    display_name: "Atlas serverless ${ruby}"
@@ -1846,8 +1833,8 @@ buildvariants:
 #  - matrix_name: "serverless-next"
 #    matrix_spec:
 #      # https://jira.mongodb.org/browse/RUBY-3217
-#      # ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5", "jruby-9.3", "jruby-9.2"]
-#      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "ruby-2.6", "ruby-2.5"]
+#      # ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.3"]
+#      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7"]
 #      fle: path
 #      os: rhel8
 #    display_name: "Atlas serverless-next ${ruby}"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1249,7 +1249,7 @@ buildvariants:
   - matrix_name: DriverBench
     matrix_spec:
       ruby: "ruby-3.2"
-      mongodb-version: latest
+      mongodb-version: "7.0"
       topology: standalone
     run_on: rhel80-large
     display_name: DriverBench

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1269,7 +1269,7 @@ buildvariants:
 
   - matrix_name: "mongo-recent"
     matrix_spec:
-      ruby: ["ruby-3.2", "ruby-3.1", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-3.1", "jruby-9.4"]
       mongodb-version: ["latest", "7.0", "6.0"]
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ['rhel8']
@@ -1294,7 +1294,7 @@ buildvariants:
 
   - matrix_name: "mongo-5.x"
     matrix_spec:
-      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.4"]
       mongodb-version: ['5.3', '5.0']
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1413,7 +1413,7 @@ buildvariants:
   - matrix_name: "solo"
     matrix_spec:
       solo: on
-      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.4", "jruby-9.3"]
       mongodb-version: "7.0"
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1462,7 +1462,7 @@ buildvariants:
   - matrix_name: "jruby-auth"
     matrix_spec:
       auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
-      ruby: jruby-9.3
+      ruby: jruby-9.4
       mongodb-version: "7.0"
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: rhel8
@@ -1473,7 +1473,7 @@ buildvariants:
   - matrix_name: "zlib"
     matrix_spec:
       auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
-      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.4"]
       mongodb-version: "7.0"
       topology: "replica-set"
       compressor: 'zlib'
@@ -1485,7 +1485,7 @@ buildvariants:
   - matrix_name: "snappy"
     matrix_spec:
       auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
-      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.4"]
       mongodb-version: "7.0"
       topology: "replica-set"
       compressor: 'snappy'
@@ -1512,7 +1512,7 @@ buildvariants:
 
   - matrix_name: "activesupport"
     matrix_spec:
-      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.4"]
       mongodb-version: "7.0"
       topology: replica-set
       as: as
@@ -1523,7 +1523,7 @@ buildvariants:
 
   - matrix_name: "bson"
     matrix_spec:
-      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.4"]
       mongodb-version: "7.0"
       topology: replica-set
       bson: "*"
@@ -1535,7 +1535,7 @@ buildvariants:
   # kerberos integration tests are broken (RUBY-3266)
   # - matrix_name: "kerberos-integration"
   #   matrix_spec:
-  #     ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.3"]
+  #     ruby: ["ruby-3.2", "ruby-2.7", "jruby-9.4"]
   #     os: rhel8
   #   display_name: "Kerberos integration ${os} ${ruby}"
   #   tasks:
@@ -1770,7 +1770,7 @@ buildvariants:
       ocsp-status: [valid, unknown]
       ocsp-delegate: '*'
       ocsp-connectivity: pass
-      ruby: jruby-9.3
+      ruby: jruby-9.4
       topology: standalone
       mongodb-version: "7.0"
       os: rhel8
@@ -1812,7 +1812,7 @@ buildvariants:
 
   - matrix_name: "atlas"
     matrix_spec:
-      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.3"]
+      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.4", "jruby-9.3"]
       os: rhel8
     display_name: "Atlas tests ${ruby}"
     tasks:
@@ -1822,7 +1822,7 @@ buildvariants:
 #  - matrix_name: "serverless"
 #    matrix_spec:
 #      # https://jira.mongodb.org/browse/RUBY-3217
-#      # ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.3"]
+#      # ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.4", "jruby-9.3"]
 #      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7"]
 #      fle: path
 #      os: rhel8
@@ -1833,7 +1833,7 @@ buildvariants:
 #  - matrix_name: "serverless-next"
 #    matrix_spec:
 #      # https://jira.mongodb.org/browse/RUBY-3217
-#      # ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.3"]
+#      # ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7", "jruby-9.4", "jruby-9.3"]
 #      ruby: ["ruby-3.2", "ruby-3.1", "ruby-3.0", "ruby-2.7"]
 #      fle: path
 #      os: rhel8

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1,5 +1,5 @@
 # GENERATED FILE - DO NOT EDIT.
-# Run ./.evergreen/update-evergreen-configs to regenerate this file.
+# Run `rake eg` to regenerate this file.
 
 # When a task that used to pass starts to fail, go through all versions that
 # may have been skipped to detect when the task started failing.
@@ -1279,9 +1279,6 @@ buildvariants:
     tasks:
       - name: "test-mlaunch"
 
-  # Only JRuby-9.4 is built for arm in the current toolchain, but 9.4 has other
-  # issues. Either we fix those issues, or we build 9.3 for arm in the toolchain,
-  # and hope it fixes the issues... Until then, we can only test MRI ruby on arm.
   - matrix_name: "mongo-recent-arm"
     matrix_spec:
       ruby: "ruby-3.2"

--- a/.evergreen/config/axes.yml.erb
+++ b/.evergreen/config/axes.yml.erb
@@ -162,22 +162,10 @@ axes:
         display_name: ruby-2.7
         variables:
           RVM_RUBY: "ruby-2.7"
-      - id: "ruby-2.6"
-        display_name: ruby-2.6
-        variables:
-          RVM_RUBY: "ruby-2.6"
-      - id: "ruby-2.5"
-        display_name: ruby-2.5
-        variables:
-          RVM_RUBY: "ruby-2.5"
       - id: "ruby-head"
         display_name: ruby-head
         variables:
           RVM_RUBY: "ruby-head"
-      - id: "jruby-9.2"
-        display_name: jruby-9.2
-        variables:
-          RVM_RUBY: "jruby-9.2"
       - id: "jruby-9.3"
         display_name: jruby-9.3
         variables:
@@ -405,4 +393,3 @@ axes:
           API_VERSION_REQUIRED: 1
       - id: no
         display_name: No
-

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -69,9 +69,6 @@ buildvariants:
     tasks:
       - name: "test-mlaunch"
 
-  # Only JRuby-9.4 is built for arm in the current toolchain, but 9.4 has other
-  # issues. Either we fix those issues, or we build 9.3 for arm in the toolchain,
-  # and hope it fixes the issues... Until then, we can only test MRI ruby on arm.
   - matrix_name: "mongo-recent-arm"
     matrix_spec:
       ruby: <%= latest_ruby %>

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -45,7 +45,7 @@ buildvariants:
   - matrix_name: DriverBench
     matrix_spec:
       ruby: <%= latest_ruby %>
-      mongodb-version: latest
+      mongodb-version: <%= latest_stable_mdb %>
       topology: standalone
     run_on: rhel80-large
     display_name: DriverBench

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -21,13 +21,13 @@
   sample_rubies = sample_mri_rubies + %w( jruby-9.3 )
 
   # older Ruby versions provided by 10gen/mongo-ruby-toolchain
-  older_rubies = %w( ruby-3.0 ruby-2.7 ruby-2.6 ruby-2.5 )
+  older_rubies = %w( ruby-3.0 ruby-2.7  )
 
   # all supported JRuby versions provided by 10gen/mongo-ruby-toolchain
-  jrubies = %w( jruby-9.3 jruby-9.2 )
+  jrubies = %w( jruby-9.3 )
 
   supported_mri_rubies = %w( ruby-3.2 ruby-3.1 ruby-3.0
-                             ruby-2.7 ruby-2.6 ruby-2.5 )
+                             ruby-2.7 )
 
   supported_rubies = supported_mri_rubies + jrubies
 
@@ -110,7 +110,7 @@ buildvariants:
 
   - matrix_name: "mongo-3.6"
     matrix_spec:
-      ruby: "ruby-2.5"
+      ruby: "ruby-2.7"
       mongodb-version: ['3.6']
       topology: <%= topologies %>
       os: rhel8
@@ -175,7 +175,7 @@ buildvariants:
 
   - matrix_name: mmapv1
     matrix_spec:
-      ruby: "ruby-2.5"
+      ruby: "ruby-2.7"
       mongodb-version: ['3.6', '4.0']
       topology: <%= topologies %>
       storage-engine: mmapv1

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -1,30 +1,24 @@
 <%
   topologies = %w( standalone replica-set sharded-cluster )
 
-  # jruby-9.4 is available in the toolchain, but tests break. It will
-  # require some investigation. Once available:
-  #  1. replace jruby-9.3 with jruby-9.4 in `recent_rubies` and
-  #     `sample_rubies`.
-  #  2. add jruby-9.4 to the front of `jrubies`.
-
   # latest_ruby = the most recently released, stable version of Ruby
   #    (make sure this version is being built by 10gen/mongo-ruby-toolchain)
   latest_ruby = "ruby-3.2".inspect # so it gets quoted as a string
 
   # these are used for testing against a few recent ruby versions
-  recent_rubies = %w( ruby-3.2 ruby-3.1 jruby-9.3 )
+  recent_rubies = %w( ruby-3.2 ruby-3.1 jruby-9.4 )
 
   # this is a list of the most most recent 3.x and 2.x MRI ruby versions
   sample_mri_rubies = %w( ruby-3.2 ruby-2.7 )
 
   # as above, but including the most recent JRuby release
-  sample_rubies = sample_mri_rubies + %w( jruby-9.3 )
+  sample_rubies = sample_mri_rubies + %w( jruby-9.4 )
 
   # older Ruby versions provided by 10gen/mongo-ruby-toolchain
   older_rubies = %w( ruby-3.0 ruby-2.7  )
 
   # all supported JRuby versions provided by 10gen/mongo-ruby-toolchain
-  jrubies = %w( jruby-9.3 )
+  jrubies = %w( jruby-9.4 jruby-9.3 )
 
   supported_mri_rubies = %w( ruby-3.2 ruby-3.1 ruby-3.0
                              ruby-2.7 )

--- a/.evergreen/update-evergreen-configs
+++ b/.evergreen/update-evergreen-configs
@@ -13,7 +13,7 @@ class Runner
   def transform(output_file_name)
     contents = <<-EOT
 # GENERATED FILE - DO NOT EDIT.
-# Run ./.evergreen/update-evergreen-configs to regenerate this file.
+# Run `rake eg` to regenerate this file.
 
 EOT
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,24 +16,16 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-20.04 ]
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
-        mongodb: ["3.6", "4.4", "5.0"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
+        mongodb: ["3.6", "4.4", "5.0", "6.0", "7.0"]
         topology: [replica_set, sharded_cluster]
         include:
-          - os: macos
-            ruby: "2.6"
-            mongodb: "5.0"
-            topology: server
           - os: macos
             ruby: "2.7"
             mongodb: "5.0"
             topology: server
           - os: macos
             ruby: "3.0"
-            mongodb: "5.0"
-            topology: server
-          - os: ubuntu-latest
-            ruby: "2.6"
             mongodb: "5.0"
             topology: server
           - os: ubuntu-latest
@@ -48,10 +40,6 @@ jobs:
             ruby: "3.2"
             mongodb: "5.0"
             topology: server
-          - os: ubuntu-18.04
-            ruby: "2.5"
-            mongodb: "3.6"
-            topology: replica_set
           - os: ubuntu-latest
             ruby: "3.2"
             mongodb: "6.0"

--- a/docs/reference/driver-compatibility.txt
+++ b/docs/reference/driver-compatibility.txt
@@ -305,6 +305,7 @@ for that Ruby version is deprecated.
      - Ruby 2.1
      - Ruby 2.0
      - Ruby 1.9
+     - JRuby 9.4
      - JRuby 9.3
      - JRuby 9.2
      - JRuby 9.1
@@ -323,6 +324,7 @@ for that Ruby version is deprecated.
      -
      -
      - |checkmark|
+     - |checkmark|
      - D
      -
 
@@ -333,6 +335,7 @@ for that Ruby version is deprecated.
      - |checkmark|
      - D
      - D
+     -
      -
      -
      -
@@ -350,6 +353,7 @@ for that Ruby version is deprecated.
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      -
      -
@@ -374,6 +378,7 @@ for that Ruby version is deprecated.
      -
      -
      -
+     -
      - |checkmark|
      -
 
@@ -385,6 +390,7 @@ for that Ruby version is deprecated.
      - |checkmark|
      - |checkmark|
      - D
+     -
      -
      -
      -
@@ -408,6 +414,7 @@ for that Ruby version is deprecated.
      -
      -
      -
+     -
      - |checkmark|
      -
 
@@ -420,6 +427,7 @@ for that Ruby version is deprecated.
      - |checkmark|
      - D
      - D
+     -
      -
      -
      -
@@ -442,6 +450,7 @@ for that Ruby version is deprecated.
      -
      -
      -
+     -
      - |checkmark|
      -
 
@@ -454,6 +463,7 @@ for that Ruby version is deprecated.
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      -
      -
@@ -476,6 +486,7 @@ for that Ruby version is deprecated.
      -
      -
      -
+     -
      - |checkmark|
      -
 
@@ -492,6 +503,7 @@ for that Ruby version is deprecated.
      - D
      - D
      - D
+     -
      -
      - |checkmark|
      - |checkmark|
@@ -510,6 +522,7 @@ for that Ruby version is deprecated.
      - D
      - D
      -
+     -
      - |checkmark|
      - |checkmark|
 
@@ -526,6 +539,7 @@ for that Ruby version is deprecated.
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      - |checkmark|
      - |checkmark|
@@ -544,6 +558,7 @@ for that Ruby version is deprecated.
      - |checkmark|
      - |checkmark|
      -
+     -
      - |checkmark|
      - |checkmark|
 
@@ -560,6 +575,7 @@ for that Ruby version is deprecated.
      - |checkmark|
      - |checkmark|
      - |checkmark|
+     -
      -
      - |checkmark|
      - |checkmark|

--- a/docs/reference/driver-compatibility.txt
+++ b/docs/reference/driver-compatibility.txt
@@ -57,6 +57,19 @@ version.
      - MongoDB 3.0
      - MongoDB 2.6
 
+   * - 2.20
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+     -
+     -
+
    * - 2.19
      - |checkmark|
      - |checkmark|
@@ -295,6 +308,23 @@ for that Ruby version is deprecated.
      - JRuby 9.3
      - JRuby 9.2
      - JRuby 9.1
+
+   * - 2.20
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - D
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     -
+     - |checkmark|
+     - D
+     -
 
    * - 2.19
      - |checkmark|

--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -27,6 +27,7 @@ This release includes the following new features:
 
 - Support for Ruby 2.5 and 2.6 has been discontinued. Support for Ruby 2.7 has
   been deprecated, and will be discontinued in the next minor driver version.
+- Support for the newly-released Ruby-BSON version 5.0.
 - Connection strings no longer require a slash between the hosts and the
   options. E.g., "mongodb://example.com?w=1" and "mongodb://example.com/?w=1"
   are both valid connection strings now.

--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -18,6 +18,21 @@ for the complete list of changes, including those internal to the driver and
 its test suite.
 
 
+.. _release-notes-2.20:
+
+2.20
+====
+
+This release includes the following new features:
+
+- Support for Ruby 2.5 and 2.6 has been discontinued. Support for Ruby 2.7 has
+  been deprecated, and will be discontinued in the next minor driver version.
+- Connection strings no longer require a slash between the hosts and the
+  options. E.g., "mongodb://example.com?w=1" and "mongodb://example.com/?w=1"
+  are both valid connection strings now.
+- Container runtime and orchestration metadata for the client environment are
+  now sent to the server for analytics purposes.
+
 .. _release-notes-2.19:
 
 2.19

--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -34,6 +34,11 @@ This release includes the following new features:
   are both valid connection strings now.
 - Container runtime and orchestration metadata for the client environment are
   now sent to the server for analytics purposes.
+- A warning message is now written to the log when the host is detected to be
+  a CosmosDB (Azure) or DocumentDB (Amazon) instance.
+- When attempting a retry of a read or write operation in a sharded topology,
+  the retry will be attempted on a different mongos instance, if possible.
+
 
 .. _release-notes-2.19:
 

--- a/docs/release-notes.txt
+++ b/docs/release-notes.txt
@@ -25,8 +25,9 @@ its test suite.
 
 This release includes the following new features:
 
-- Support for Ruby 2.5 and 2.6 has been discontinued. Support for Ruby 2.7 has
-  been deprecated, and will be discontinued in the next minor driver version.
+- Support for Ruby 2.5 and 2.6 has been discontinued. Support for Ruby 2.7 and
+  JRuby 9.2 has been deprecated, and will be discontinued in the next minor
+  driver version. Support for JRuby 9.4 has been added.
 - Support for the newly-released Ruby-BSON version 5.0.
 - Connection strings no longer require a slash between the hosts and the
   options. E.g., "mongodb://example.com?w=1" and "mongodb://example.com/?w=1"

--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -20,5 +20,5 @@ module Mongo
   # The current version of the driver.
   #
   # @since 2.0.0
-  VERSION = '2.19.1'.freeze
+  VERSION = '2.20.0'.freeze
 end


### PR DESCRIPTION
Preparing for the 2.20 release. I probably did not need to deprecate 2.7 and JRuby 9.2, and add JRuby 9.4, in this release, but I did it anyway. :) The effort involved was minimal.

N.B.: The two failing specs are known and will be addressed in RUBY-3423 (related to `rangePreview` on latest server).

Proposed release announcement:

> Ruby Driver 2.20.0 Released
> 
> Version 2.20.0 of the Ruby driver for MongoDB is released. This adds the following new features:
> 
> * Connection strings no longer require a slash between the hosts and the options. E.g., "mongodb://example.com?w=1" and "mongodb://example.com/?w=1" are both valid connection strings now. (https://jira.mongodb.org/browse/RUBY-3329)
> * Container runtime and orchestration metadata for the client environment are now sent to the server for analytics purposes. (https://jira.mongodb.org/browse/RUBY-3298)
> * When connecting to a CosmosDB (Azure) or DocumentDB (Amazon) instance, a warning message will now be logged. (https://jira.mongodb.org/browse/RUBY-3296)
> * When attempting a retry of a read or write operation in a sharded topology, the retry will be attempted on a different mongos instance, if possible. (https://jira.mongodb.org/browse/RUBY-2748)
> * Add support for the newly-released Ruby-BSON version 5.0.
> * Support for Ruby 2.5 and 2.6 has been discontinued. Support for Ruby 2.7 and JRuby 9.2 has been deprecated, and will be discontinued in a future driver version. Support for JRuby 9.4 has been added.
> 
> This release also fixes the following user-facing issues:
> 
> * The driver will now raise an error if `start_transaction` is invoked and the server deployment does not support transactions. (https://jira.mongodb.org/browse/RUBY-1791)
> * Encountering a network error when a session is live will mark the session dirty and discard it, preventing the session from being reused when it is likely to fail. (https://jira.mongodb.org/browse/RUBY-1813)
> * Tailable cursors would terminate early, after reading existing documents, instead of waiting for more. (https://jira.mongodb.org/browse/RUBY-3332)
> * There was an issue where writes could fail with an exception if no session was active. (https://jira.mongodb.org/browse/RUBY-3358)
> 