### PR TITLE
Fixing the Dockerfile used for releasing gems

### DIFF
--- a/release/mri/Dockerfile
+++ b/release/mri/Dockerfile
@@ -1,9 +1,9 @@
-FROM debian:10
+FROM debian:12
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-  apt-get -y install git ruby-bundler make gcc ruby-dev
+  apt-get -y install git ruby-bundler make gcc ruby-dev zlib1g-dev
 
 WORKDIR /app
 


### PR DESCRIPTION
The `bundle` step was failing during the release process, because it needed libz for libxml, for nokogiri, etc.

Also bumping to debian:12 for grins.