### PR TITLE
fix(Mongo::Socket::SSL#verify_ocsp_endpoint!): use leaf cert instead of last one

### DIFF
--- a/lib/mongo/socket/ssl.rb
+++ b/lib/mongo/socket/ssl.rb
@@ -368,7 +368,9 @@ module Mongo
         end
 
         cert = socket.peer_cert
-        ca_cert = socket.peer_cert_chain.last
+        # In the case where the leaf certificate and CA are the same, the chain may only contain one certificate.
+        # If the chain has multiple certificates, the one directly after the leaf should be the issuer.
+        ca_cert = socket.peer_cert_chain.length > 1 ? socket.peer_cert_chain[1] : cert
 
         verifier = OcspVerifier.new(@host_name, cert, ca_cert, context.cert_store,
           **Utils.shallow_symbolize_keys(options))


### PR DESCRIPTION
Summary:
The MongoDB Ruby driver incorrectly handles the OCSP certificate chain by using the last certificate in the chain as the issuer. The correct behavior should be to use the certificate directly after the leaf certificate. This issue causes OCSP verification to fail when the chain contains multiple certificates.

Details:
In the current implementation of the MongoDB Ruby driver, the OCSP verification uses the last certificate in the peer_cert_chain as the issuer certificate. However, according to the correct practice and as implemented in the [official MongoDB Go driver](https://github.com/mongodb/mongo-go-driver/blob/v1/x/mongo/driver/ocsp/config.go#L47), the certificate directly after the leaf certificate should be used as the issuer.