### PR TITLE
RUBY-3507 Prep for 2.20.1

### DIFF
--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-# rubocop:todo all
 
 # Copyright (C) 2014-2020 MongoDB Inc.
 #
@@ -16,9 +15,6 @@
 # limitations under the License.
 
 module Mongo
-
   # The current version of the driver.
-  #
-  # @since 2.0.0
-  VERSION = '2.20.0'.freeze
+  VERSION = '2.20.1'
 end


### PR DESCRIPTION
Prepping for 2.20.1. Proposed release notes follow; please edit as needed.

---

Version 2.20.1 of the [MongoDB Ruby Driver](https://rubygems.org/gems/mongo) is now available.

**Release Highlights**

This patch release includes one bug fix, and one documentation update:

* [RUBY-3496](https://jira.mongodb.org/browse/RUBY-3496) Certain retryable errors were not being retried when legacy retries were enabled. Thank you to Joe Lim for the PR!
* [RUBY-3434](https://jira.mongodb.org/browse/RUBY-3434) Documentation was added/improved to suggest how to configure Mongoid for use with forking web servers. Thank you to Johnny Shields for the PR!

Other changes (not user-visible):

* [RUBY-3396](https://jira.mongodb.org/browse/RUBY-3396) Added a test to ensure that no error is raised when the `saslSupportedMechs` attribute of the initial handshake contains an unknown mechanism.

**Documentation**

Documentation is available at [MongoDB.com](https://www.mongodb.com/docs/ruby-driver/current/).

**Installation**

You may install this version via RubyGems, with:

```
gem install --version 2.20.1 mongo
```