### PR TITLE
RUBY-3514 pointer to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ To build API documentation for the master branch, check out the
 repository locally and run `rake docs`.
 
 High-level driver documentation including tutorials and the reference that were in the docs folder can now be found
-[here](https://github.com/mongodb/docs-ruby/tree/master/source)
+at the docs-ruby repository, [here](https://github.com/mongodb/docs-ruby)
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ API documentation for the most recent release can be found
 To build API documentation for the master branch, check out the
 repository locally and run `rake docs`.
 
+High-level driver documentation including tutorials and the reference that were in the docs folder can now be found
+[here](https://github.com/mongodb/docs-ruby/tree/master/source)
+
 ## Support
 
 Commercial support for the driver is available through the

--- a/lib/mongo/server/description/features.rb
+++ b/lib/mongo/server/description/features.rb
@@ -83,7 +83,7 @@ module Mongo
         # The wire protocol versions that this version of the driver supports.
         #
         # @since 2.0.0
-        DRIVER_WIRE_VERSIONS = (6..21).freeze
+        DRIVER_WIRE_VERSIONS = (6..25).freeze
 
         # Create the methods for each mapping to tell if they are supported.
         #


### PR DESCRIPTION
Modified the README.md to indicate the docs folder that was in the Ruby Driver can now be found in docs-ruby