### PR TITLE
RUBY-3299 Direct access to `mongocrypt_binary_t` for better decryption performance

### DIFF
--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -108,13 +108,13 @@ module Mongo
 
         # Cannot write a string that's longer than the space currently allocated
         # by the mongocrypt_binary_t object
-        str_p = Binding.mongocrypt_binary_data(ref)
-        len = Binding.mongocrypt_binary_len(ref)
+        str_p = Binding.get_binary_data_direct(ref)
+        len = Binding.get_binary_len_direct(ref)
 
         if len < data.bytesize
           raise ArgumentError.new(
             "Cannot write #{data.bytesize} bytes of data to a Binary object " +
-            "that was initialized with #{Binding.mongocrypt_binary_len(@bin)} bytes."
+            "that was initialized with #{Binding.get_binary_len_direct(@bin)} bytes."
           )
         end
 
@@ -127,8 +127,8 @@ module Mongo
       #
       # @return [ String ] Data stored in the mongocrypt_binary_t as a string
       def to_s
-        str_p = Binding.mongocrypt_binary_data(ref)
-        len = Binding.mongocrypt_binary_len(ref)
+        str_p = Binding.get_binary_data_direct(ref)
+        len = Binding.get_binary_len_direct(ref)
         str_p.read_string(len)
       end
 

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -178,6 +178,14 @@ module Mongo
       #   @return [ Integer ] The length of the data array.
       attach_function :mongocrypt_binary_len, [:pointer], :int
 
+      def self.get_binary_data_direct(mongocrypt_binary_t)
+        mongocrypt_binary_t.get_pointer(0)
+      end
+
+      def self.get_binary_len_direct(mongocrypt_binary_t)
+        mongocrypt_binary_t.get_uint32(FFI::NativeType::POINTER.size)
+      end
+
       # @!method self.mongocrypt_binary_destroy(binary)
       #   @api private
       #

--- a/profile/driver_bench/crypto/decrypt.rb
+++ b/profile/driver_bench/crypto/decrypt.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'mongo'
+require_relative '../base'
+
+module Mongo
+  module DriverBench
+    module Crypto
+      class Decrypt < Mongo::DriverBench::Base
+        ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
+        KEY_VAULT_NAMESPACE = 'encryption.__keyVault'
+        N = 10
+
+        def run
+          data_key_id = client_encryption.create_data_key('local')
+
+          pairs = Array.new(1500) do |i|
+            n = "%04d" % (i + 1)
+            key = "key#{n}"
+            value = "value #{n}"
+
+            encrypted = client_encryption.encrypt(value,
+                                                  key_id: data_key_id,
+                                                  algorithm: ALGORITHM)
+
+            [ key, encrypted ]
+          end
+
+          doc = BSON::Document[pairs]
+
+          # warm up
+          run_test(doc, 1)
+
+          results = []
+          [ 1, 2, 8, 64 ].each do |thread_count|
+            results = []
+
+            N.times do |n|
+              threads = Array.new(thread_count) do
+                Thread.new { Thread.current[:ops_sec] = run_test(doc, 1) }
+              end
+
+              results << threads.each(&:join).sum { |t| t[:ops_sec] }
+            end
+
+            median = results.sort[N / 2]
+            puts "thread_count=#{thread_count}; median ops/sec=#{median}"
+          end
+        end
+
+        private
+
+        def timeout_holder
+          @timeout_holder ||= Mongo::CsotTimeoutHolder.new
+        end
+
+        def encrypter
+          @encrypter ||= Crypt::AutoEncrypter.new(
+            client: new_client,
+            key_vault_client: key_vault_client,
+            key_vault_namespace: KEY_VAULT_NAMESPACE,
+            kms_providers: kms_providers,
+          )
+        end
+
+        def run_test(doc, duration)
+          finish_at = Mongo::Utils.monotonic_time + duration
+          count = 0
+
+          while Mongo::Utils.monotonic_time < finish_at
+            result = encrypter.decrypt(doc, timeout_holder)
+            count += 1
+          end
+
+          count
+        end
+
+        def key_vault_client
+          @key_vault_client ||= new_client
+        end
+
+        def kms_providers
+          @kms_providers ||= { local: { key: SecureRandom.random_bytes(96) } }
+        end
+
+        def client_encryption
+          @client_encryption ||= Mongo::ClientEncryption.new(
+                                   key_vault_client, 
+                                   key_vault_namespace: KEY_VAULT_NAMESPACE,
+                                   kms_providers: kms_providers
+                                 )
+        end
+      end
+    end
+  end
+end

--- a/profile/driver_bench/crypto/decrypt.rb
+++ b/profile/driver_bench/crypto/decrypt.rb
@@ -6,16 +6,46 @@ require_relative '../base'
 module Mongo
   module DriverBench
     module Crypto
+      # Benchmark for reporting the performance of decrypting a document with
+      # a large number of encrypted fields.
       class Decrypt < Mongo::DriverBench::Base
         ALGORITHM = 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic'
         KEY_VAULT_NAMESPACE = 'encryption.__keyVault'
         N = 10
 
         def run
+          doc = build_encrypted_doc
+
+          # warm up
+          run_test(doc, 1)
+
+          [ 1, 2, 8, 64 ].each do |thread_count|
+            run_test_with_thread_count(doc, thread_count)
+          end
+        end
+
+        private
+
+        def run_test_with_thread_count(doc, thread_count)
+          results = []
+
+          N.times do
+            threads = Array.new(thread_count) do
+              Thread.new { Thread.current[:ops_sec] = run_test(doc, 1) }
+            end
+
+            results << threads.each(&:join).sum { |t| t[:ops_sec] }
+          end
+
+          median = results.sort[N / 2]
+          puts "thread_count=#{thread_count}; median ops/sec=#{median}"
+        end
+
+        def build_encrypted_doc
           data_key_id = client_encryption.create_data_key('local')
 
           pairs = Array.new(1500) do |i|
-            n = "%04d" % (i + 1)
+            n = format('%04d', i + 1)
             key = "key#{n}"
             value = "value #{n}"
 
@@ -26,29 +56,8 @@ module Mongo
             [ key, encrypted ]
           end
 
-          doc = BSON::Document[pairs]
-
-          # warm up
-          run_test(doc, 1)
-
-          results = []
-          [ 1, 2, 8, 64 ].each do |thread_count|
-            results = []
-
-            N.times do |n|
-              threads = Array.new(thread_count) do
-                Thread.new { Thread.current[:ops_sec] = run_test(doc, 1) }
-              end
-
-              results << threads.each(&:join).sum { |t| t[:ops_sec] }
-            end
-
-            median = results.sort[N / 2]
-            puts "thread_count=#{thread_count}; median ops/sec=#{median}"
-          end
+          BSON::Document[pairs]
         end
-
-        private
 
         def timeout_holder
           @timeout_holder ||= Mongo::CsotTimeoutHolder.new
@@ -59,7 +68,7 @@ module Mongo
             client: new_client,
             key_vault_client: key_vault_client,
             key_vault_namespace: KEY_VAULT_NAMESPACE,
-            kms_providers: kms_providers,
+            kms_providers: kms_providers
           )
         end
 
@@ -68,7 +77,7 @@ module Mongo
           count = 0
 
           while Mongo::Utils.monotonic_time < finish_at
-            result = encrypter.decrypt(doc, timeout_holder)
+            encrypter.decrypt(doc, timeout_holder)
             count += 1
           end
 
@@ -85,10 +94,10 @@ module Mongo
 
         def client_encryption
           @client_encryption ||= Mongo::ClientEncryption.new(
-                                   key_vault_client, 
-                                   key_vault_namespace: KEY_VAULT_NAMESPACE,
-                                   kms_providers: kms_providers
-                                 )
+            key_vault_client,
+            key_vault_namespace: KEY_VAULT_NAMESPACE,
+            kms_providers: kms_providers
+          )
         end
       end
     end

--- a/profile/driver_bench/rake/tasks.rake
+++ b/profile/driver_bench/rake/tasks.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+$LOAD_PATH.unshift File.expand_path('../../../lib', __dir__)
+
 task driver_bench: %i[ driver_bench:data driver_bench:run ]
 
 SPECS_REPO_URI = 'git@github.com:mongodb/specifications.git'
@@ -34,5 +36,12 @@ namespace :driver_bench do
     require_relative '../suite'
 
     Mongo::DriverBench::Suite.run!
+  end
+
+  desc 'Runs the crypto benchmark'
+  task :crypto do
+    require_relative '../crypto/decrypt'
+
+    Mongo::DriverBench::Crypto::Decrypt.new.run
   end
 end

--- a/profile/driver_bench/rake/tasks.rake
+++ b/profile/driver_bench/rake/tasks.rake
@@ -8,6 +8,7 @@ SPECS_REPO_URI = 'git@github.com:mongodb/specifications.git'
 SPECS_PATH = File.expand_path('../../../specifications', __dir__)
 DRIVER_BENCH_DATA = File.expand_path('../../data/driver_bench', __dir__)
 
+# rubocop:disable Metrics/BlockLength
 namespace :driver_bench do
   desc 'Downloads the DriverBench data files, if necessary'
   task :data do
@@ -45,3 +46,4 @@ namespace :driver_bench do
     Mongo::DriverBench::Crypto::Decrypt.new.run
   end
 end
+# rubocop:enable Metrics/BlockLength

--- a/spec/mongo/crypt/binding/binary_spec.rb
+++ b/spec/mongo/crypt/binding/binary_spec.rb
@@ -43,11 +43,27 @@ describe 'Mongo::Crypt::Binding' do
       end
     end
 
+    describe '#get_binary_data_direct' do
+      let(:binary) { Mongo::Crypt::Binding.mongocrypt_binary_new_from_data(bytes_pointer, bytes.length) }
+
+      it 'returns the pointer to the data' do
+        expect(Mongo::Crypt::Binding.get_binary_data_direct(binary)).to eq(bytes_pointer)
+      end
+    end
+
     describe '#mongocrypt_binary_len' do
       let(:binary) { Mongo::Crypt::Binding.mongocrypt_binary_new_from_data(bytes_pointer, bytes.length) }
 
       it 'returns the length of the data' do
         expect(Mongo::Crypt::Binding.mongocrypt_binary_len(binary)).to eq(bytes.length)
+      end
+    end
+
+    describe '#get_binary_len_direct' do
+      let(:binary) { Mongo::Crypt::Binding.mongocrypt_binary_new_from_data(bytes_pointer, bytes.length) }
+
+      it 'returns the length of the data' do
+        expect(Mongo::Crypt::Binding.get_binary_len_direct(binary)).to eq(bytes.length)
       end
     end
   end

--- a/spec/mongo/crypt/binding/context_spec.rb
+++ b/spec/mongo/crypt/binding/context_spec.rb
@@ -228,8 +228,8 @@ describe 'Mongo::Crypt::Binding' do
         it 'returns a BSON document' do
           expect(result).to be true
 
-          data = Mongo::Crypt::Binding.mongocrypt_binary_data(out_binary)
-          len = Mongo::Crypt::Binding.mongocrypt_binary_len(out_binary)
+          data = Mongo::Crypt::Binding.get_binary_data_direct(out_binary)
+          len = Mongo::Crypt::Binding.get_binary_len_direct(out_binary)
 
           response = data.get_array_of_uint8(0, len).pack('C*')
           expect(response).to be_a_kind_of(String)

--- a/spec/mongo/crypt/helpers/mongo_crypt_spec_helper.rb
+++ b/spec/mongo/crypt/helpers/mongo_crypt_spec_helper.rb
@@ -30,14 +30,14 @@ module MongoCryptSpecHelper
   private
 
   def string_from_binary(binary_p)
-    str_p = Mongo::Crypt::Binding.mongocrypt_binary_data(binary_p)
-    len = Mongo::Crypt::Binding.mongocrypt_binary_len(binary_p)
+    str_p = Mongo::Crypt::Binding.get_binary_data_direct(binary_p)
+    len = Mongo::Crypt::Binding.get_binary_len_direct(binary_p)
     str_p.read_string(len)
   end
   module_function :string_from_binary
 
   def write_to_binary(binary_p, data)
-    str_p = Mongo::Crypt::Binding.mongocrypt_binary_data(binary_p)
+    str_p = Mongo::Crypt::Binding.get_binary_data_direct(binary_p)
     str_p.put_bytes(0, data)
   end
   module_function :write_to_binary


### PR DESCRIPTION
This adds a benchmark for testing the performance of decrypting a document with a large number of encrypted fields (1500), and then changes the implementation so that it accesses the underlying fields of `mongocrypt_binary_t` directly, rather than indirectly.

The resulting performance improvements are marginal, but consistent:

```
with indirect mongocrypt_binary_t access:
  thread_count=1; median ops/sec=44
  thread_count=2; median ops/sec=48
  thread_count=8; median ops/sec=78
  thread_count=64; median ops/sec=327

with direct mongocrypt_binary_t access:
  thread_count=1; median ops/sec=47
  thread_count=2; median ops/sec=52
  thread_count=8; median ops/sec=82
  thread_count=64; median ops/sec=360
```