### PR TITLE
RUBY-3330 sync sdam specs for too_old/too_new

### DIFF
--- a/spec/spec_tests/data/sdam/rs/too_old.yml
+++ b/spec/spec_tests/data/sdam/rs/too_old.yml
@@ -10,7 +10,7 @@ phases: [
                     setName: "rs",
                     hosts: ["a:27017", "b:27017"],
                     minWireVersion: 0,
-                    maxWireVersion: 6
+                    maxWireVersion: 21
                 }],
                 ["b:27017", {
                     ok: 1,
@@ -18,7 +18,9 @@ phases: [
                     isWritablePrimary: false,
                     secondary: true,
                     setName: "rs",
-                    hosts: ["a:27017", "b:27017"]
+                    hosts: ["a:27017", "b:27017"],
+                    minWireVersion: 999,
+                    maxWireVersion: 1000
                 }]
         ],
         outcome: {

--- a/spec/spec_tests/data/sdam/sharded/too_new.yml
+++ b/spec/spec_tests/data/sdam/sharded/too_new.yml
@@ -15,7 +15,9 @@ phases: [
                     ok: 1,
                     helloOk: true,
                     isWritablePrimary: true,
-                    msg: "isdbgrid"
+                    msg: "isdbgrid",
+                    minWireVersion: 7,
+                    maxWireVersion: 900
                 }]
         ],
         outcome: {


### PR DESCRIPTION
No user facing changes. Syncs the specs that were changed in DRIVERS-2250.