### PR TITLE
RUBY-3461 Enable tests that require failCommand with appName on initial handshake before 4.9

### DIFF
--- a/spec/spec_tests/data/client_side_operations_timeout/command-execution.yml
+++ b/spec/spec_tests/data/client_side_operations_timeout/command-execution.yml
@@ -3,9 +3,8 @@ description: "timeoutMS behaves correctly during command execution"
 schemaVersion: "1.9"
 
 runOnRequirements:
-  # The appName filter cannot be used to set a fail point on connection handshakes until server version 4.9 due to
-  # SERVER-49220/SERVER-49336.
-  - minServerVersion: "4.9"
+  # Require SERVER-49336 for failCommand + appName on the initial handshake.
+  - minServerVersion: "4.4.7"
     # Skip load-balanced and serverless which do not support RTT measurements.
     topologies: [ single, replicaset, sharded ]
     serverless: forbid

--- a/spec/spec_tests/data/sdam_unified/hello-command-error.yml
+++ b/spec/spec_tests/data/sdam_unified/hello-command-error.yml
@@ -1,11 +1,11 @@
 ---
 description: hello-command-error
 
-schemaVersion: "1.10"
+schemaVersion: "1.4"
 
 runOnRequirements:
-    # failCommand appName requirements
-  - minServerVersion: "4.9"
+  # Require SERVER-49336 for failCommand + appName on the initial handshake.
+  - minServerVersion: "4.4.7"
     serverless: forbid
     topologies: [ single, replicaset, sharded ]
 

--- a/spec/spec_tests/data/sdam_unified/hello-network-error.yml
+++ b/spec/spec_tests/data/sdam_unified/hello-network-error.yml
@@ -1,11 +1,11 @@
 ---
 description: hello-network-error
 
-schemaVersion: "1.10"
+schemaVersion: "1.4"
 
 runOnRequirements:
-    # failCommand appName requirements
-  - minServerVersion: "4.9"
+  # Require SERVER-49336 for failCommand + appName on the initial handshake.
+  - minServerVersion: "4.4.7"
     serverless: forbid
     topologies: [ single, replicaset, sharded ]
 
@@ -140,7 +140,6 @@ tests:
       # network error. Use "times: 4" to increase the probability that the
       # Monitor check fails since the RTT hello may trigger this failpoint one
       # or many times as well.
-      # The ruby driver only needs to fail twice because the RTT updates topology.
       - name: failPoint
         object: testRunner
         arguments:

--- a/spec/spec_tests/data/sdam_unified/interruptInUse-pool-clear.yml
+++ b/spec/spec_tests/data/sdam_unified/interruptInUse-pool-clear.yml
@@ -5,7 +5,7 @@ schemaVersion: "1.11"
 
 runOnRequirements:
   # failCommand appName requirements
-  - minServerVersion: "4.9"
+  - minServerVersion: "4.4"
     serverless: forbid
     topologies: [ replicaset, sharded ]
 
@@ -338,3 +338,4 @@ tests:
         databaseName: *databaseName
         documents:
           - { _id: 1, a : bar }
+

--- a/spec/spec_tests/data/sdam_unified/minPoolSize-error.yml
+++ b/spec/spec_tests/data/sdam_unified/minPoolSize-error.yml
@@ -1,11 +1,11 @@
 ---
 description: minPoolSize-error
 
-schemaVersion: "1.10"
+schemaVersion: "1.4"
 
 runOnRequirements:
-    # failCommand appName requirements
-  - minServerVersion: "4.9"
+  # Require SERVER-49336 for failCommand + appName on the initial handshake.
+  - minServerVersion: "4.4.7"
     serverless: forbid
     topologies:
       - single


### PR DESCRIPTION
This syncs a few specs from DRIVERS-1725 to enable some tests on earlier server versions.

Note that one test from the original ticket (source/load-balancers/tests/sdam-error-handling.yml) was not synced; the Ruby driver does not have most of the load-balancers specs, and adding that one introduced numerous failures. There is probably an earlier spec that needs to be addressed there.