### PR TITLE
RUBY-1933 Add debug level logging around initial DNS seed list query

### DIFF
--- a/lib/mongo/uri/srv_protocol.rb
+++ b/lib/mongo/uri/srv_protocol.rb
@@ -147,6 +147,8 @@ module Mongo
         validate_srv_hostname(hostname)
         @query_hostname = hostname
 
+        log_debug "attempting to resolve #{hostname}"
+
         @srv_result = resolver.get_records(hostname, uri_options[:srv_service_name], uri_options[:srv_max_hosts])
         if srv_result.empty?
           raise Error::NoSRVRecords.new(NO_SRV_RECORDS % hostname)

--- a/spec/mongo/uri/srv_protocol_spec.rb
+++ b/spec/mongo/uri/srv_protocol_spec.rb
@@ -2,6 +2,7 @@
 # rubocop:todo all
 
 require 'lite_spec_helper'
+require 'support/recording_logger'
 
 describe Mongo::URI::SRVProtocol do
   require_external_connectivity
@@ -18,6 +19,18 @@ describe Mongo::URI::SRVProtocol do
   shared_examples "roundtrips string" do
     it "returns the correct string for the uri" do
       expect(uri.to_s).to eq(URI::DEFAULT_PARSER.unescape(string))
+    end
+  end
+
+  describe 'logging' do
+    let(:logger) { RecordingLogger.new }
+    let(:uri) { described_class.new(string, logger: logger) }
+    let(:host) { 'test5.test.build.10gen.cc' }
+    let(:string) { "#{scheme}#{host}" }
+
+    it 'logs when resolving the address' do
+      expect { uri }.not_to raise_error
+      expect(logger.contents).to include("attempting to resolve #{host}")
     end
   end
 
@@ -228,7 +241,6 @@ describe Mongo::URI::SRVProtocol do
   end
 
   describe 'valid uris' do
-    require_external_connectivity
 
     describe 'invalid query results' do
 


### PR DESCRIPTION
When a `mongodb+srv` URI is parsed, it attempts to resolve the hostname and fetch the DNS records associated with it. This occurs synchronously, which can cause the application to seem to pause at that point if there is any delay in fetching the DNS records. That pause can be difficult to troubleshot, because no logging was done to indicate that the DNS records were being queried.

This PR adds a debug line just before fetching the DNS records for the given hostname, which will hopefully add some transparency when debugging network issues.