### PR TITLE
RUBY-3164 Use mongosh instead of mongo

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1717,7 +1717,7 @@ buildvariants:
       ruby: "ruby-3.3"
       topology: standalone
       mongodb-version: "7.0"
-      os: ubuntu1804
+      os: ubuntu2204
     display_name: "AWS ${auth-and-ssl} ${mongodb-version} ${ruby}"
     tasks:
       - name: "test-aws-auth"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1524,10 +1524,10 @@ buildvariants:
   - matrix_name: "x509-tests"
     matrix_spec:
       auth-and-ssl: "x509"
-      ruby: 'ruby-3.1'
+      ruby: "ruby-3.3"
       mongodb-version: "7.0"
       topology: standalone
-      os: ubuntu1804
+      os: ubuntu2204
     display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
     tasks:
       - name: "test-mlaunch"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -927,11 +927,6 @@ axes:
         display_name: "6.0"
         variables:
           MONGODB_VERSION: "6.0"
-      - id: "5.3"
-        display_name: "5.3"
-        variables:
-          MONGODB_VERSION: "5.3"
-          CRYPT_SHARED_VERSION: "6.0.5"
       - id: "5.0"
         display_name: "5.0"
         variables:
@@ -1363,7 +1358,7 @@ buildvariants:
   - matrix_name: "mongo-5.x"
     matrix_spec:
       ruby: ["ruby-3.3", "ruby-3.2", "jruby-9.4"]
-      mongodb-version: ['5.3']
+      mongodb-version: ['5.0']
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ubuntu1804
     display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1525,12 +1525,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: "x509"
       ruby: 'ruby-3.1'
-      # needs the latest_5x_mdb because run-tests.sh uses `mongo` to configure
-      # the server for certain auth mechanisms. Once run-tests.sh is made smart
-      # enough to install mongosh, and then use either mongo or mongosh
-      # (depending on server version and what's available), we can bump this to
-      # the latest stable db version.
-      mongodb-version: "5.3"
+      mongodb-version: "7.0"
       topology: standalone
       os: ubuntu1804
     display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
@@ -1721,12 +1716,7 @@ buildvariants:
       auth-and-ssl: [ aws-regular, aws-assume-role, aws-ecs, aws-web-identity ]
       ruby: "ruby-3.3"
       topology: standalone
-      # needs the latest_5x_mdb because run-tests.sh uses `mongo` to configure
-      # the server for certain auth mechanisms. Once run-tests.sh is made smart
-      # enough to install mongosh, and then use either mongo or mongosh
-      # (depending on server version and what's available), we can bump this to
-      # the latest stable db version.
-      mongodb-version: "5.3"
+      mongodb-version: "7.0"
       os: ubuntu1804
     display_name: "AWS ${auth-and-ssl} ${mongodb-version} ${ruby}"
     tasks:

--- a/.evergreen/config/axes.yml.erb
+++ b/.evergreen/config/axes.yml.erb
@@ -30,11 +30,6 @@ axes:
         display_name: "6.0"
         variables:
           MONGODB_VERSION: "6.0"
-      - id: "5.3"
-        display_name: "5.3"
-        variables:
-          MONGODB_VERSION: "5.3"
-          CRYPT_SHARED_VERSION: "6.0.5"
       - id: "5.0"
         display_name: "5.0"
         variables:

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -38,7 +38,7 @@
 
   recent_mdb = %w( 8.0 7.0 )
 
-  all_dbs = %w(latest 8.0 7.0 6.0 5.3 5.0 4.4 4.2 4.0 3.6)
+  all_dbs = %w(latest 8.0 7.0 6.0 5.0 4.4 4.2 4.0 3.6)
 %>
 
 buildvariants:
@@ -86,7 +86,7 @@ buildvariants:
   - matrix_name: "mongo-5.x"
     matrix_spec:
       ruby: <%= recent_rubies %>
-      mongodb-version: ['5.3']
+      mongodb-version: ['5.0']
       topology: <%= topologies %>
       os: ubuntu1804
     display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -247,10 +247,10 @@ buildvariants:
   - matrix_name: "x509-tests"
     matrix_spec:
       auth-and-ssl: "x509"
-      ruby: 'ruby-3.1'
+      ruby: <%= latest_ruby %>
       mongodb-version: <%= latest_stable_mdb %>
       topology: standalone
-      os: ubuntu1804
+      os: ubuntu2204
     display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
     tasks:
       - name: "test-mlaunch"

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -37,7 +37,6 @@
   actual_and_upcoming_mdb = %w( latest 8.0 7.0 )
 
   recent_mdb = %w( 8.0 7.0 )
-  latest_5x_mdb = "5.3".inspect # so it gets quoted as a string
 
   all_dbs = %w(latest 8.0 7.0 6.0 5.3 5.0 4.4 4.2 4.0 3.6)
 %>
@@ -249,12 +248,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: "x509"
       ruby: 'ruby-3.1'
-      # needs the latest_5x_mdb because run-tests.sh uses `mongo` to configure
-      # the server for certain auth mechanisms. Once run-tests.sh is made smart
-      # enough to install mongosh, and then use either mongo or mongosh
-      # (depending on server version and what's available), we can bump this to
-      # the latest stable db version.
-      mongodb-version: <%= latest_5x_mdb %>
+      mongodb-version: <%= latest_stable_mdb %>
       topology: standalone
       os: ubuntu1804
     display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
@@ -390,12 +384,7 @@ buildvariants:
       auth-and-ssl: [ aws-regular, aws-assume-role, aws-ecs, aws-web-identity ]
       ruby: <%= latest_ruby %>
       topology: standalone
-      # needs the latest_5x_mdb because run-tests.sh uses `mongo` to configure
-      # the server for certain auth mechanisms. Once run-tests.sh is made smart
-      # enough to install mongosh, and then use either mongo or mongosh
-      # (depending on server version and what's available), we can bump this to
-      # the latest stable db version.
-      mongodb-version: <%= latest_5x_mdb %>
+      mongodb-version: <%= latest_stable_mdb %>
       os: ubuntu1804
     display_name: "AWS ${auth-and-ssl} ${mongodb-version} ${ruby}"
     tasks:

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -385,7 +385,7 @@ buildvariants:
       ruby: <%= latest_ruby %>
       topology: standalone
       mongodb-version: <%= latest_stable_mdb %>
-      os: ubuntu1804
+      os: ubuntu2204
     display_name: "AWS ${auth-and-ssl} ${mongodb-version} ${ruby}"
     tasks:
       - name: "test-aws-auth"

--- a/.evergreen/functions-kerberos.sh
+++ b/.evergreen/functions-kerberos.sh
@@ -76,8 +76,8 @@ configure_local_kerberos() {
 EOT
   `"
 
-  "$BINDIR"/mongo --eval "$create_user_cmd"
-  "$BINDIR"/mongo --eval 'db.getSiblingDB("kerberos").test.insert({kerberos: true, authenticated: "yeah"})'
+  "$BINDIR"/mongosh --eval "$create_user_cmd"
+  "$BINDIR"/mongosh --eval 'db.getSiblingDB("kerberos").test.insert({kerberos: true, authenticated: "yeah"})'
   pkill mongod
   sleep 1
 

--- a/.evergreen/run-tests-kerberos-integration.sh
+++ b/.evergreen/run-tests-kerberos-integration.sh
@@ -55,7 +55,7 @@ configure_kerberos_ip_addr
 # To test authentication using the mongo shell, note that the host name
 # must be uppercased when it is used in the username.
 # The following call works when using the docker image:
-# /opt/mongodb/bin/mongo --host $SASL_HOST --authenticationMechanism=GSSAPI \
+# /opt/mongodb/bin/mongosh --host $SASL_HOST --authenticationMechanism=GSSAPI \
 #   --authenticationDatabase='$external' --username $SASL_USER@`echo $SASL_HOST |tr a-z A-Z`
 
 echo "Install dependencies"

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -41,7 +41,7 @@ set_env_vars
 set_env_python
 set_env_ruby
 
-prepare_server $arch
+prepare_server
 
 if test "$DOCKER_PRELOAD" != 1; then
   install_mlaunch_venv

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -22,6 +22,10 @@ else
   set -x
 fi
 
+if test -z "$PROJECT_DIRECTORY"; then
+  PROJECT_DIRECTORY=`realpath $(dirname $0)/..`
+fi
+
 MRSS_ROOT=`dirname "$0"`/../spec/shared
 
 . $MRSS_ROOT/shlib/distro.sh

--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -118,7 +118,7 @@ elif test "$AUTH" = x509; then
 EOT
   `"
 
-  "$BINDIR"/mongo --tls \
+  "$BINDIR"/mongosh --tls \
     --tlsCAFile spec/support/certificates/ca.crt \
     --tlsCertificateKeyFile spec/support/certificates/client-x509.pem \
     -u bootstrap -p bootstrap \
@@ -286,7 +286,7 @@ fi
 export MONGODB_URI="mongodb://$hosts/?serverSelectionTimeoutMS=30000$uri_options"
 
 if echo "$AUTH" |grep -q ^aws-assume-role; then
-  $BINDIR/mongo "$MONGODB_URI" --eval 'db.runCommand({serverStatus: 1})' |wc
+  $BINDIR/mongosh "$MONGODB_URI" --eval 'db.runCommand({serverStatus: 1})' | wc
 fi
 
 set_fcv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         os: [ ubuntu-20.04 ]
         ruby: ["2.7", "3.0", "3.1", "3.2"]
-        mongodb: ["3.6", "4.4", "5.0", "6.0", "7.0"]
+        mongodb: ["4.4", "5.0", "6.0", "7.0"]
         topology: [replica_set, sharded_cluster]
         include:
           - os: macos

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,5 @@
 	url = https://github.com/mongodb-labs/drivers-evergreen-tools
 [submodule "spec/shared"]
 	path = spec/shared
-        url = git@github.com:mongodb-labs/mongo-ruby-spec-shared.git
+	url = git@github.com:jamis/mongo-ruby-spec-shared.git
+	branch = install-mongosh

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,5 +3,4 @@
 	url = https://github.com/mongodb-labs/drivers-evergreen-tools
 [submodule "spec/shared"]
 	path = spec/shared
-	url = git@github.com:jamis/mongo-ruby-spec-shared.git
-	branch = install-mongosh
+	url = git@github.com:mongodb-labs/mongo-ruby-spec-shared.git

--- a/spec/README.aws-auth.md
+++ b/spec/README.aws-auth.md
@@ -24,7 +24,7 @@ AWS authentication, and add a bootstrap user:
 
 Then connect as the bootstrap user and create AWS-mapped users:
 
-    mongo mongodb://root:toor@localhost:27017
+    mongosh mongodb://root:toor@localhost:27017
     
     # In the mongo shell:
     use $external
@@ -41,7 +41,7 @@ With the server user created, it is possible to authenticate using AWS.
 The following example uses regular user credentials for an IAM user
 created as described in the next section;
 
-    mongo 'mongodb://AKIAAAAAAAAAAAA:t9t2mawssecretkey@localhost:27017/?authMechanism=MONGODB-AWS&authsource=$external'
+    mongosh 'mongodb://AKIAAAAAAAAAAAA:t9t2mawssecretkey@localhost:27017/?authMechanism=MONGODB-AWS&authsource=$external'
 
 To authenticate, provide the IAM user's access key id as the username and
 secret access key as the password. Note that the username and the password

--- a/spec/README.md
+++ b/spec/README.md
@@ -292,7 +292,7 @@ to a variable as follows:
 
 Use the MongoDB shell to execute this command:
 
-    mongo --tls \
+    mongosh --tls \
       --tlsCAFile `pwd`/spec/support/certificates/ca.crt \
       --tlsCertificateKeyFile `pwd`/spec/support/certificates/client-x509.pem \
       -u bootstrap -p bootstrap \
@@ -301,14 +301,14 @@ Use the MongoDB shell to execute this command:
 Verify that authentication is required by running the following command, which
 should fail:
 
-    mongo --tls \
+    mongosh --tls \
       --tlsCAFile `pwd`/spec/support/certificates/ca.crt \
       --tlsCertificateKeyFile `pwd`/spec/support/certificates/client-x509.pem \
       --eval 'db.serverStatus()'
 
 Verify that X.509 authentication works by running the following command:
 
-    mongo --tls \
+    mongosh --tls \
       --tlsCAFile `pwd`/spec/support/certificates/ca.crt \
       --tlsCertificateKeyFile `pwd`/spec/support/certificates/client-x509.pem \
       --authenticationDatabase '$external' \

--- a/spec/support/certificates/README.md
+++ b/spec/support/certificates/README.md
@@ -81,9 +81,9 @@ To sum up, openssl's command line tools appear to only handle certificate
 chains provided by the client when the server is verifying them, not the
 other way around and not when trying to standalone verify the chain.
 
-## Manual Testing - mongo
+## Manual Testing - mongosh
 
-When it comes to `mongod` and `mongo`, certificate chains are supported in
+When it comes to `mongod` and `mongosh`, certificate chains are supported in
 both directions:
 
     mongod --sslMode requireSSL \
@@ -91,16 +91,16 @@ both directions:
         --sslPEMKeyFile server-second-level-bundle.pem \
         --sslClientCertificate client.pem
 
-    mongo --host localhost --ssl \
+    mongosh --host localhost --ssl \
         --sslCAFile ca.crt \
         --sslPEMKeyFile client-second-level-bundle.pem
 
-The `--host` option needs to be given to `mongo` because the certificates here
+The `--host` option needs to be given to `mongosh` because the certificates here
 do not include 127.0.0.1 in subject alternate name.
 
 If the intermediate certificate is not provided, the connection should fail.
 
     # Expected to fail
-    mongo --host localhost --ssl \
+    mongosh --host localhost --ssl \
         --sslCAFile ca.crt \
         --sslPEMKeyFile client-second-level.pem


### PR DESCRIPTION
Many of the specs in evergreen were still using `mongo` instead of `mongosh` to configure the server. As `mongo` is no longer available with more recent server versions, this limited the server version we could use for some tests. Updating to `mongosh` lets us update those tests.