### PR TITLE
Fix multithread auth race condition

### DIFF
--- a/lib/mongo/auth/credential_cache.rb
+++ b/lib/mongo/auth/credential_cache.rb
@@ -22,19 +22,24 @@ module Mongo
     #
     # @api private
     module CredentialCache
+      MUTEX = Mutex.new
 
       class << self
         attr_reader :store
       end
 
       module_function def get(key)
-        @store ||= {}
-        @store[key]
+        MUTEX.synchronize do
+          @store ||= {}
+          @store[key]
+        end
       end
 
       module_function def set(key, value)
-        @store ||= {}
-        @store[key] = value
+        MUTEX.synchronize do
+          @store ||= {}
+          @store[key] = value
+        end
       end
 
       module_function def cache(key)
@@ -47,7 +52,9 @@ module Mongo
       end
 
       module_function def clear
-        @store = {}
+        MUTEX.synchronize do
+          @store = {}
+        end
       end
     end
   end


### PR DESCRIPTION
This PR fixes a race-condition that we occasionally see when multiple threads are simultaneously authenticating with the database. 

Details of the failure:
While the cache is being written to, the value will go through a phase, such that if it is retrieved a particular moment, it will return `false` (value is never actually set to false by the code, somehow the underlying Ruby code behaves this way). The cache code does check if the value is `nil`, but will consider the value `false` to be a cache hit. As a result, The methods `client_key` and `server_key` in scram_conversion_base.rb may incorrectly return `false` instead of the value from the block. This will result in an error "no implicit conversion of false into String" when attempting to use the "false" value for authentication. 

In our testing, we found that protecting the cache with a mutex resolves this problem.

Of note is that the two other caches in this library are already made theadsafe. These are Mongo::Auth::Aws::CredentialsCache (auth/aws/credentials_cache.rb) [not to be confused with Mongo::Auth::CredentialCache] which is protected with a Mutex and Mongo::QueryCache (query_cache.rb) which is protected with a ThreadLocal variable.