### PR TITLE
Support the removal for Fixnum from ruby

### DIFF
--- a/lib/mongo/utils/support.rb
+++ b/lib/mongo/utils/support.rb
@@ -45,7 +45,7 @@ module Mongo
 
     def normalize_seeds(seeds)
       pairs = Array(seeds)
-      pairs = [ seeds ] if pairs.last.is_a?(Fixnum)
+      pairs = [ seeds ] if pairs.last.is_a?(1.class)
       pairs = pairs.collect do |hostport|
         if hostport.is_a?(String)
           if hostport[0,1] == '['


### PR DESCRIPTION
Upgrading from ruby 3.1.3 to Ruby 3.2.x raises error `NameError: uninitialized constant Mongo::Support::Fixnum`


Used 1.class similar to how its used here: https://github.com/rails/rails/pull/27458/files#diff-5a9ceb7949cd32ce2be8451ae0011d4640a2a642b6bf2e5a1eb46c9bba918673L24

Unfortunately we cannot upgrade the gem to 2.x until we upgrade the database version.