### PR TITLE
RUBY-3622 - Use SessionEnded error consistently

### DIFF
--- a/lib/mongo/error/session_ended.rb
+++ b/lib/mongo/error/session_ended.rb
@@ -21,9 +21,9 @@ module Mongo
     # Session was previously ended.
     #
     # @since 2.7.0
-    class SessionEnded < Error
+    class SessionEnded < InvalidSession
       def initialize
-        super("The session was ended and cannot be used")
+        super('The session was ended and cannot be used. Please create a new session.')
       end
     end
   end

--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -297,11 +297,6 @@ module Mongo
         'of the client owning this operation. Please only use this session for operations through its parent ' +
         'client.'.freeze
 
-    # Error message describing that the session cannot be used because it has already been ended.
-    #
-    # @since 2.5.0
-    SESSION_ENDED_ERROR_MSG = 'This session has ended and cannot be used. Please create a new one.'.freeze
-
     # Error message describing that sessions are not supported by the server version.
     #
     # @since 2.5.0
@@ -1251,7 +1246,7 @@ module Mongo
     end
 
     def check_if_ended!
-      raise Mongo::Error::InvalidSession.new(SESSION_ENDED_ERROR_MSG) if ended?
+      raise Mongo::Error::SessionEnded if ended?
     end
 
     def check_matching_cluster!(client)


### PR DESCRIPTION
In the Ruby driver, there is a case where InvalidSession is raised instead of SessionEnded. In addition, SessionEnded should inherit from InvalidSession, not from just Error.