### PR TITLE
RUBY-3624 Sync `non-lb-connection-establishment` test

### DIFF
--- a/spec/spec_tests/data/load_balancers/non-lb-connection-establishment.yml
+++ b/spec/spec_tests/data/load_balancers/non-lb-connection-establishment.yml
@@ -42,6 +42,11 @@ tests:
   # If the server is not configured to be behind a load balancer and the URI contains loadBalanced=true, the driver
   # should error during the connection handshake because the server's hello response does not contain a serviceId field.
   - description: operations against non-load balanced clusters fail if URI contains loadBalanced=true
+    runOnRequirements:
+      - maxServerVersion: 8.0.99 # DRIVERS-3108: Skip test on >=8.1 mongod. SERVER-85804 changes a non-LB mongod to close connection.
+        topologies: [ single ]
+      - topologies: [ sharded ]
+
     operations:
       - name: runCommand
         object: *lbTrueDatabase


### PR DESCRIPTION
Sync `non-lb-connection-establishment` test to https://github.com/mongodb/specifications/commit/d05c33e0a6124ee7d1a9de665084d540b2ff06c5

Intended to proactively avoid tests failure once drivers start testing 8.1 builds. See DRIVERS-3108. Drivers are not-yet testing 8.1 (see [slack](https://mongodb.slack.com/archives/C72LB5RPV/p1739884710850709)).
