### PR TITLE
RUBY-2467 Remove specs from packaged gem

### DIFF
--- a/mongo.gemspec
+++ b/mongo.gemspec
@@ -28,9 +28,8 @@ Gem::Specification.new do |s|
     'source_code_uri' => 'https://github.com/mongodb/mongo-ruby-driver',
   }
 
-  s.files             = Dir.glob('{bin,lib,spec}/**/*')
-  s.files             += %w[mongo.gemspec LICENSE README.md CONTRIBUTING.md Rakefile]
-  s.test_files        = Dir.glob('spec/**/*')
+  s.files             = Dir.glob('{bin,lib}/**/*')
+  s.files             += %w[mongo.gemspec LICENSE README.md CONTRIBUTING.md]
 
   s.executables       = ['mongo_console']
   s.require_paths     = ['lib']


### PR DESCRIPTION
TL;DR: let's not bundle specs with the packaged gem, because the specs as presented in the gem are not runnable anyway.

The `mongo` gem currently includes the spec files, presumably so that users can run the specs to ensure correctness. However, the `mongo-ruby-spec-shared` and `drivers-evergreen-tools` submodules are *not* included, which means (1) a symbolic link in `spec/support` that points into `.mod/drivers-evergreen-tools` causes a warning when installing the gem, and (2) the specs can't run anyway, because the submodules are missing.

Further, the specs require dependencies from the `testing` group in the Gemfile, which are not installed by default when the gem is installed, further complicating the running of specs from an installed gem.

So, because the specs cannot currently be run from the gem anyway, and the warning about the dangling symlink is alarming to some users, it seems cleaner and less confusing to make sure the `spec` directory is omitted entirely from the packaged gem. Users interested in running the specs should refer to either (a) the corresponding release on GitHub, which includes an archive of the source code for that release, or (b) the repository itself.