### PR TITLE
DOCSP-48221 Fix 404 in API Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ their applications.
 
 ## Running Tests
 
-Please refer to [spec/README.md](spec/README.md) for instructions on how
+Please refer to [spec/README.md](https://github.com/mongodb/mongo-ruby-driver/blob/master/spec/README.md) for instructions on how
 to run the driver's test suite.
 
 ## Release History


### PR DESCRIPTION
Jira Ticket: https://jira.mongodb.org/browse/DOCSP-48221

This should fix the 404 by replacing the file path with an actual link to the file. Will have to regenerate the API docs as well.