### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @mongodb/dbx-ruby


### PR DESCRIPTION
With the new code ownership initiative, we're required to have ownership for all files in the repository. This adds the corresponding code ownership file from PHPLIB