### PR TITLE
Prepare for 2.21.1

### DIFF
--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -16,5 +16,5 @@
 
 module Mongo
   # The current version of the driver.
-  VERSION = '2.21.0'
+  VERSION = '2.21.1'
 end


### PR DESCRIPTION
Release candidate for 2.21.1.

## Proposed Release Notes

Version 2.21.1 of the MongoDB Ruby Driver is now available. This is the latest patch release in the 2.21 series.

Install it via RubyGems at the command line:

```
$ gem install -v 2.21.1 mongo
```

Or via Bundler, in a Gemfile:

```
gem 'mongo', '2.21.1'
```

It includes the following bug fixes:

- RUBY-3604 Fix a race condition in the authentication flow that could cause authentication to fail incorrectly when multiple simultaneous threads are attempting to authenticate. ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/2912) by @jteich)
- RUBY-3658 When a timeout is specified on the client, database, or operation, partial writes to the server are never completed, resulting in timeouts. ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/2927))