### PR TITLE
RUBY-3410 Release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,9 @@ run-name: "Gem Release for ${{ github.ref }}"
 on:
   # for auto-deploy when merging a release-candidate PR
   push:
-    - 'master'
-    - '*-stable'
+    branches:
+      - 'master'
+      - '*-stable'
 
   # for manual release
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,66 +2,83 @@ name: "Driver Release"
 run-name: "Driver Release for ${{ github.ref }}"
 
 on:
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: Whether this is a dry run or not
-        required: true
-        default: true
-        type: boolean
+  # for auto-deploy when merging a release-candidate PR
+  pull_request:
+    types: [ closed ]
+
+  # for manual release trigger: "/release" in a comment on a merged
+  # release-candidate PR (useful if the auto-deploy fails)
+  #
+  # Note: this is commented out because it may be more effective to
+  # just retry the failed job in the Actions UI.
+  # issue_comment:
+  #   types: [ created ]
 
 env:
   SILK_ASSET_GROUP: mongodb-ruby-driver
-  RELEASE_MESSAGE_TEMPLATE: |
-    Version {0} of the [MongoDB Ruby Driver](https://rubygems.org/gems/mongo) is now available.
 
-    **Release Highlights**
+permissions:
+  # required for all workflows
+  security-events: write
 
-    TODO: one or more paragraphs describing important changes in this release
+  # required to fetch internal or private CodeQL packs
+  packages: read
 
-    **Documentation**
+  # only required for workflows in private repositories
+  actions: read
+  pull-requests: read
+  contents: write
 
-    Documentation is available at [MongoDB.com](https://www.mongodb.com/docs/ruby-driver/current/).
-
-    **Installation**
-
-    You may install this version via RubyGems, with:
-
-    gem install --version {0} mongo
+  # required by the mongodb-labs/drivers-github-tools/setup@v2 step
+  # also required by `rubygems/release-gem`
+  id-token: write
 
 jobs:
-  release:
-    name: "Driver Release"
+  check:
+    name: "Check Release"
+    runs-on: ubuntu-latest
+    outputs:
+      message: ${{ steps.check.outputs.message }}
+      ref: ${{ steps.check.outputs.ref }}
+    steps:
+      - name: "Run the check action"
+        id: check
+        uses: jamis/drivers-github-tools/ruby/pr-check@ruby-3643-update-release-process
+
+  build:
+    name: "Build Gems"
+    needs: check
+    environment: release
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Run the build action"
+        uses: jamis/drivers-github-tools/ruby/build@ruby-3643-update-release-process
+        with:
+          app_id: ${{ vars.APP_ID }}
+          app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          artifact: mongo-ruby-driver
+          gem_name: mongo
+          ruby_version: 'ruby-3.2'
+          ref: ${{ needs.check.outputs.ref }}
+
+  publish:
+    name: "Publish Gems"
+    needs: [ check, build ]
     environment: release
     runs-on: 'ubuntu-latest'
-
-    permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
-      contents: write
-
-      # required by the mongodb-labs/drivers-github-tools/setup@v2 step
-      # also required by `rubygems/release-gem`
-      id-token: write
-
     steps:
       - name: "Run the publish action"
-        uses: mongodb-labs/drivers-github-tools/ruby/publish@v2
+        uses: jamis/drivers-github-tools/ruby/publish@ruby-3643-update-release-process
         with:
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
           aws_role_arn: ${{ secrets.AWS_ROLE_ARN }}
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
-          dry_run: ${{ inputs.dry_run }}
+          dry_run: false
           gem_name: mongo
           product_name: Ruby Driver
           product_id: mongodb-ruby-driver
-          release_message_template: ${{ env.RELEASE_MESSAGE_TEMPLATE }}
+          release_message: ${{ needs.check.outputs.message }}
           silk_asset_group: ${{ env.SILK_ASSET_GROUP }}
+          ref: ${{ needs.check.outputs.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,21 +1,24 @@
-name: "Driver Release"
-run-name: "Driver Release for ${{ github.ref }}"
+name: "Gem Release"
+run-name: "Gem Release for ${{ github.ref }}"
 
 on:
   # for auto-deploy when merging a release-candidate PR
-  pull_request:
-    types: [ closed ]
+  push:
+    - 'master'
+    - '*-stable'
 
-  # for manual release trigger: "/release" in a comment on a merged
-  # release-candidate PR (useful if the auto-deploy fails)
-  #
-  # Note: this is commented out because it may be more effective to
-  # just retry the failed job in the Actions UI.
-  # issue_comment:
-  #   types: [ created ]
+  # for manual release
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "The number of the merged release candidate PR"
+        required: true
 
 env:
   SILK_ASSET_GROUP: mongodb-ruby-driver
+  GEM_NAME: mongo
+  PRODUCT_NAME: Ruby Driver
+  PRODUCT_ID: mongodb-ruby-driver
 
 permissions:
   # required for all workflows
@@ -56,8 +59,8 @@ jobs:
         with:
           app_id: ${{ vars.APP_ID }}
           app_private_key: ${{ secrets.APP_PRIVATE_KEY }}
-          artifact: mongo-ruby-driver
-          gem_name: mongo
+          artifact: 'ruby-3.2'
+          gem_name: ${{ env.GEM_NAME }}
           ruby_version: 'ruby-3.2'
           ref: ${{ needs.check.outputs.ref }}
 
@@ -76,9 +79,9 @@ jobs:
           aws_region_name: ${{ vars.AWS_REGION_NAME }}
           aws_secret_id: ${{ secrets.AWS_SECRET_ID }}
           dry_run: false
-          gem_name: mongo
-          product_name: Ruby Driver
-          product_id: mongodb-ruby-driver
+          gem_name: ${{ env.GEM_NAME }}
+          product_name: ${{ env.PRODUCT_NAME }}
+          product_id: ${{ env.PRODUCT_ID }}
           release_message: ${{ needs.check.outputs.message }}
           silk_asset_group: ${{ env.SILK_ASSET_GROUP }}
           ref: ${{ needs.check.outputs.ref }}

--- a/Rakefile
+++ b/Rakefile
@@ -38,16 +38,12 @@ end
 
 task :default => ['spec:prepare', :spec]
 
-# stands in for the Bundler-provided `build` task, which builds the
-# gem for this project. Our release process builds the gems in a
-# particular way, in a GitHub action. This task is just to help remind
-# developers of that fact.
+desc 'Build the gem'
 task :build do
-  abort <<~WARNING
-    `rake build` does nothing in this project. The gem must be built via
-    the `Driver Release` action on GitHub, which is triggered manually when
-    a new release is ready.
-  WARNING
+  command = %w[ gem build ]
+  command << "--output=#{ENV['GEM_FILE_NAME']}" if ENV['GEM_FILE_NAME']
+  command << (ENV['GEMSPEC'] || 'mongo.gemspec')
+  system(*command)
 end
 
 # `rake version` is used by the deployment system so get the release version

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,8 @@
 require 'bundler'
 require 'rspec/core/rake_task'
 
+load 'spec/shared/lib/tasks/candidate.rake'
+
 ROOT = File.expand_path(File.join(File.dirname(__FILE__)))
 
 $: << File.join(ROOT, 'spec/shared/lib')

--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,9 @@
 require 'bundler'
 require 'rspec/core/rake_task'
 
-load 'spec/shared/lib/tasks/candidate.rake'
+if File.exist?('./spec/shared/lib/tasks/candidate.rake')
+  load 'spec/shared/lib/tasks/candidate.rake'
+end
 
 ROOT = File.expand_path(File.join(File.dirname(__FILE__)))
 

--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -1,20 +1,9 @@
 # frozen_string_literal: true
 
-# Copyright (C) 2014-2020 MongoDB Inc.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 module Mongo
   # The current version of the driver.
+  #
+  # Note that this file is automatically updated via `rake candidate:create`.
+  # Manual changes to this file will be overwritten by that rake task.
   VERSION = '2.21.1'
 end

--- a/product.yml
+++ b/product.yml
@@ -1,0 +1,8 @@
+---
+name: MongoDB Ruby Driver
+description: a pure-Ruby driver for connecting to, querying, and manipulating MongoDB databases
+package: mongo
+jira: https://jira.mongodb.org/projects/RUBY
+version:
+  number: 2.21.1
+  file: lib/mongo/version.rb


### PR DESCRIPTION
This adds the necessary bits for the new release automation process. Notably:

- Adds new `candidate:*` rake tasks, for previewing and creating candidate pull requests.
- Adds a `product.yml` file, which is used by the new `candidate:*` rake tasks.
- Updates the release workflow to use the new check/build/publish jobs.