### PR TITLE
RUBY-3694 Gracefully handle the case where the issuer can't be found

### DIFF
--- a/lib/mongo/socket/ssl.rb
+++ b/lib/mongo/socket/ssl.rb
@@ -23,6 +23,7 @@ module Mongo
     # @since 2.0.0
     class SSL < Socket
       include OpenSSL
+      include Loggable
 
       # Initializes a new TLS socket.
       #
@@ -455,12 +456,15 @@ module Mongo
       end
 
       def verify_ocsp_endpoint!(socket, timeout = nil)
-        unless verify_ocsp_endpoint?
-          return
-        end
+        return unless verify_ocsp_endpoint?
 
         cert = socket.peer_cert
         ca_cert = find_issuer(cert, socket.peer_cert_chain)
+
+        unless ca_cert
+          log_warn("TLS certificate of '#{host_name}' could not be definitively verified via OCSP: issuer certificate not found in the chain.")
+          return
+        end
 
         verifier = OcspVerifier.new(@host_name, cert, ca_cert, context.cert_store,
           **Utils.shallow_symbolize_keys(options).merge(timeout: timeout))


### PR DESCRIPTION
One more issue related to the OCSP stuff -- just a warning if the issuer certificate cannot be found. Copilot caught the lack of this check, and upon checking other drivers, Python (at least) takes the "warn and return" approach.