### PR TITLE
Release candidate for 2.21.3

### DIFF
--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -5,5 +5,5 @@ module Mongo
   #
   # Note that this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file will be overwritten by that rake task.
-  VERSION = '2.21.2'
+  VERSION = '2.21.3'
 end

--- a/product.yml
+++ b/product.yml
@@ -5,5 +5,5 @@ description: a pure-Ruby driver for connecting to, querying, and manipulating Mo
 package: mongo
 jira: https://jira.mongodb.org/projects/RUBY
 version:
-  number: 2.21.2
+  number: 2.21.3
   file: lib/mongo/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 2.21.3 of the `mongo` gem - a pure-Ruby driver for connecting to, querying, and manipulating MongoDB databases. This is a new patch release in the 2.21.x series of the MongoDB Ruby Driver.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 2.21.3 mongo
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'mongo', '2.21.3'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/RUBY) to let us know what's on your mind 🧠.

# Bug Fixes

* [RUBY-3694](https://jira.mongodb.org/browse/RUBY-3694) Use correct CA when verifying OCSP endpoint ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/2944))
