### PR TITLE
Release candidate for 2.20.2

### DIFF
--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -5,5 +5,5 @@ module Mongo
   #
   # Note that this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file will be overwritten by that rake task.
-  VERSION = '2.20.1'
+  VERSION = '2.20.2'
 end

--- a/product.yml
+++ b/product.yml
@@ -1,8 +1,9 @@
 ---
 name: MongoDB Ruby Driver
-description: a pure-Ruby driver for connecting to, querying, and manipulating MongoDB databases
+description: a pure-Ruby driver for connecting to, querying, and manipulating MongoDB
+  databases
 package: mongo
 jira: https://jira.mongodb.org/projects/RUBY
 version:
-  number: 2.20.1
+  number: 2.20.2
   file: lib/mongo/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 2.20.2 of the `mongo` gem - a pure-Ruby driver for connecting to, querying, and manipulating MongoDB databases. This is a new patch release in the 2.20.x series of the MongoDB Ruby Driver.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 2.20.2 mongo
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'mongo', '2.20.2'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/RUBY) to let us know what's on your mind 🧠.

# Bug Fixes

* [RUBY-3694](https://jira.mongodb.org/browse/RUBY-3694) Use correct CA when verifying OCSP endpoint ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/2945))
