### PR TITLE
RUBY-3705 Skip tests that fail on latest

### DIFF
--- a/spec/mongo/index/view_spec.rb
+++ b/spec/mongo/index/view_spec.rb
@@ -38,6 +38,8 @@ describe Mongo::Index::View do
 
   describe '#drop_one' do
 
+    max_server_version '8.2.99'
+
     let(:spec) do
       { another: -1 }
     end

--- a/spec/mongo/operation/drop_index_spec.rb
+++ b/spec/mongo/operation/drop_index_spec.rb
@@ -5,6 +5,7 @@ require 'spec_helper'
 
 describe Mongo::Operation::DropIndex do
   require_no_required_api_version
+  max_server_version '8.2.99'
 
   before do
     authorized_collection.indexes.drop_all


### PR DESCRIPTION
The following tests fails on the `latest` server version constantly:

rspec ./spec/mongo/index/view_spec.rb[1:1:1:2:1:1] # Mongo::Index::View#drop_one when provided a session behaves like a failed operation using a session when the operation fails raises an error

rspec ./spec/mongo/operation/drop_index_spec.rb:54 # Mongo::Operation::DropIndex#execute when the index does not exist raises an exception

Since the `latest` is still in `alpha` stage, we disable the tests for now, and investigate when a more stable version is available.