### PR TITLE
RUBY-3750 Clarify NoWritesPerformed error label

### DIFF
--- a/lib/mongo/retryable/write_worker.rb
+++ b/lib/mongo/retryable/write_worker.rb
@@ -109,6 +109,7 @@ module Mongo
 
         if options[:retry_writes]
           error_count = 0
+          error_to_raise = nil
           begin
             result = server.with_connection(connection_global_id: context.connection_global_id) do |connection|
               yield connection, nil, context
@@ -120,8 +121,12 @@ module Mongo
           rescue *retryable_exceptions, Error::PoolError, Error::OperationFailure::Family => e
             if retryable_overload_error?(e)
               error_count += 1
+              error_to_raise ||= e
+              unless e.respond_to?(:label?) && e.label?('NoWritesPerformed')
+                error_to_raise = e
+              end
               delay = retry_policy.backoff_delay(error_count)
-              raise e unless retry_policy.should_retry_overload?(error_count, delay, context: context)
+              raise error_to_raise unless retry_policy.should_retry_overload?(error_count, delay, context: context)
 
               log_retry(e, message: 'Write retry (overload backoff)')
               sleep(delay)
@@ -131,8 +136,8 @@ module Mongo
                   error: e, timeout: context.remaining_timeout_sec
                 )
               rescue Error, Error::AuthError => select_err
-                e.add_note("later retry failed: #{select_err.class}: #{select_err}")
-                raise e
+                error_to_raise.add_note("later retry failed: #{select_err.class}: #{select_err}")
+                raise error_to_raise
               end
               retry
             else
@@ -375,9 +380,14 @@ module Mongo
       # Retry loop for overload write errors with exponential backoff.
       def overload_write_retry(last_error, session, txn_num, context:, failed_server:, error_count:,
                                was_starting_transaction: false)
+        # Track the error to return per the NoWritesPerformed spec rules:
+        # - first error is always saved
+        # - only update when a new error does NOT have NoWritesPerformed
+        error_to_raise = last_error
+
         loop do
           delay = retry_policy.backoff_delay(error_count)
-          raise last_error unless retry_policy.should_retry_overload?(error_count, delay, context: context)
+          raise error_to_raise unless retry_policy.should_retry_overload?(error_count, delay, context: context)
 
           log_retry(last_error, message: 'Write retry (overload backoff)')
           sleep(delay)
@@ -389,13 +399,13 @@ module Mongo
               timeout: context.remaining_timeout_sec
             )
           rescue Error, Error::AuthError => e
-            last_error.add_note("later retry failed: #{e.class}: #{e}")
-            raise last_error
+            error_to_raise.add_note("later retry failed: #{e.class}: #{e}")
+            raise error_to_raise
           end
 
           unless server.retry_writes?
-            last_error.add_note('did not retry because server does not support retryable writes')
-            raise last_error
+            error_to_raise.add_note('did not retry because server does not support retryable writes')
+            raise error_to_raise
           end
 
           begin
@@ -417,13 +427,16 @@ module Mongo
             else
               raise e unless is_overload || e.write_retryable?
             end
+            unless e.respond_to?(:label?) && e.label?('NoWritesPerformed')
+              error_to_raise = e
+            end
             retry_policy.record_non_overload_retry_failure unless is_overload
             context = context.with(overload_only_retry: false) unless is_overload
             failed_server = server
             last_error = e
           rescue Error, Error::AuthError => e
-            last_error.add_note("later retry failed: #{e.class}: #{e}")
-            raise last_error
+            error_to_raise.add_note("later retry failed: #{e.class}: #{e}")
+            raise error_to_raise
           end
         end
       end

--- a/spec/mongo/retryable/retryable_writes_error_propagation_prose_spec.rb
+++ b/spec/mongo/retryable/retryable_writes_error_propagation_prose_spec.rb
@@ -1,0 +1,183 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Retryable Writes Prose Test 6: Test error propagation after
+# encountering multiple errors.
+#
+# Spec reference:
+#   specifications/source/retryable-writes/tests/README.md
+#   "6. Test error propagation after encountering multiple errors."
+describe 'Retryable writes prose test 6: error propagation' do
+  require_topology :replica_set
+  min_server_version '6.0'
+
+  let(:client) do
+    authorized_client.with(retry_writes: true)
+  end
+
+  let(:admin_client) { client.use(:admin) }
+
+  let(:collection) { client['error-propagation-prose-test'] }
+
+  after do
+    admin_client.command(configureFailPoint: 'failCommand', mode: 'off')
+  rescue Mongo::Error
+    # Ignore cleanup failures.
+  end
+
+  # Case 1: Test that drivers return the correct error when receiving
+  # only errors without NoWritesPerformed.
+  context 'Case 1: only errors without NoWritesPerformed' do
+    it 'returns the most recent error (10107)' do
+      # Step 2: Configure a fail point with error code 91 and
+      # RetryableError + SystemOverloadedError labels.
+      admin_client.command(
+        configureFailPoint: 'failCommand',
+        mode: { times: 1 },
+        data: {
+          failCommands: [ 'insert' ],
+          errorCode: 91,
+          errorLabels: %w[RetryableError SystemOverloadedError]
+        }
+      )
+
+      # Step 3: Via CommandFailedEvent, configure a fail point with
+      # error code 10107 once the 91 error is observed.
+      failpoint_set = false
+      subscriber = Mrss::EventSubscriber.new
+      client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+
+      allow(subscriber).to receive(:failed).and_wrap_original do |m, event|
+        m.call(event)
+        if !failpoint_set && event.command_name == 'insert'
+          failpoint_set = true
+          admin_client.command(
+            configureFailPoint: 'failCommand',
+            mode: 'alwaysOn',
+            data: {
+              failCommands: [ 'insert' ],
+              errorCode: 10_107,
+              errorLabels: %w[RetryableError SystemOverloadedError]
+            }
+          )
+        end
+      end
+
+      # Step 4: Attempt an insertOne. Assert error code is 10107.
+      error = nil
+      begin
+        collection.insert_one(x: 1)
+      rescue Mongo::Error::OperationFailure => e
+        error = e
+      end
+
+      expect(error).not_to be_nil
+      expect(error.code).to eq(10_107)
+    end
+  end
+
+  # Case 2: Test that drivers return the correct error when receiving
+  # only errors with NoWritesPerformed.
+  context 'Case 2: only errors with NoWritesPerformed' do
+    it 'returns the first error (91)' do
+      # Step 2: Configure a fail point with error code 91 and
+      # RetryableError + SystemOverloadedError + NoWritesPerformed labels.
+      admin_client.command(
+        configureFailPoint: 'failCommand',
+        mode: { times: 1 },
+        data: {
+          failCommands: [ 'insert' ],
+          errorCode: 91,
+          errorLabels: %w[RetryableError SystemOverloadedError NoWritesPerformed]
+        }
+      )
+
+      # Step 3: Via CommandFailedEvent, configure a fail point with
+      # error code 10107 and NoWritesPerformed once the 91 error is observed.
+      failpoint_set = false
+      subscriber = Mrss::EventSubscriber.new
+      client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+
+      allow(subscriber).to receive(:failed).and_wrap_original do |m, event|
+        m.call(event)
+        if !failpoint_set && event.command_name == 'insert'
+          failpoint_set = true
+          admin_client.command(
+            configureFailPoint: 'failCommand',
+            mode: 'alwaysOn',
+            data: {
+              failCommands: [ 'insert' ],
+              errorCode: 10_107,
+              errorLabels: %w[RetryableError SystemOverloadedError NoWritesPerformed]
+            }
+          )
+        end
+      end
+
+      # Step 4: Attempt an insertOne. Assert error code is 91.
+      error = nil
+      begin
+        collection.insert_one(x: 1)
+      rescue Mongo::Error::OperationFailure => e
+        error = e
+      end
+
+      expect(error).not_to be_nil
+      expect(error.code).to eq(91)
+    end
+  end
+
+  # Case 3: Test that drivers return the correct error when receiving
+  # some errors with NoWritesPerformed and some without.
+  context 'Case 3: mixed errors with and without NoWritesPerformed' do
+    it 'returns the error without NoWritesPerformed (91)' do
+      # Step 2: Via CommandFailedEvent, configure a fail point with
+      # error code 91 and NoWritesPerformed for subsequent retries.
+      failpoint_set = false
+      subscriber = Mrss::EventSubscriber.new
+      client.subscribe(Mongo::Monitoring::COMMAND, subscriber)
+
+      allow(subscriber).to receive(:failed).and_wrap_original do |m, event|
+        m.call(event)
+        if !failpoint_set && event.command_name == 'insert'
+          failpoint_set = true
+          admin_client.command(
+            configureFailPoint: 'failCommand',
+            mode: 'alwaysOn',
+            data: {
+              failCommands: [ 'insert' ],
+              errorCode: 91,
+              errorLabels: %w[RetryableError SystemOverloadedError NoWritesPerformed]
+            }
+          )
+        end
+      end
+
+      # Step 3: Configure initial fail point with error code 91
+      # WITHOUT NoWritesPerformed.
+      admin_client.command(
+        configureFailPoint: 'failCommand',
+        mode: { times: 1 },
+        data: {
+          failCommands: [ 'insert' ],
+          errorCode: 91,
+          errorLabels: %w[RetryableError SystemOverloadedError]
+        }
+      )
+
+      # Step 4: Attempt an insertOne. Assert error code is 91 and
+      # error does NOT contain NoWritesPerformed label.
+      error = nil
+      begin
+        collection.insert_one(x: 1)
+      rescue Mongo::Error::OperationFailure => e
+        error = e
+      end
+
+      expect(error).not_to be_nil
+      expect(error.code).to eq(91)
+      expect(error.label?('NoWritesPerformed')).to be false
+    end
+  end
+end


### PR DESCRIPTION
When the overload retry loop encounters multiple errors, the driver now returns the correct error based on NoWritesPerformed labels per the DRIVERS-3326 spec clarification. If all errors indicate no write was attempted, the first error is returned; if mixed, the most recent write-attempted error is returned. Adds three new retryable writes prose tests (spec test 6, cases 1-3).
