### PR TITLE
Fix 'occured' -> 'occurred' typos in response_handling.rb retry comments

### DIFF
--- a/lib/mongo/operation/shared/response_handling.rb
+++ b/lib/mongo/operation/shared/response_handling.rb
@@ -113,8 +113,8 @@ module Mongo
       # AND the server does not support adding the RetryableWriteError label OR
       #   the error is a network error (i.e. the driver must add the label)
       #
-      # AND the error occured during a commitTransaction or abortTransaction
-      #   OR the error occured during a write outside of a transaction on a
+      # AND the error occurred during a commitTransaction or abortTransaction
+      #   OR the error occurred during a write outside of a transaction on a
       #   client that has retry writes enabled.
       #
       # If these conditions are met, the original error will be mutated.


### PR DESCRIPTION
Two adjacent inline comments in `lib/mongo/operation/shared/response_handling.rb` (lines 116 and 117) describing the retry decision conditions used `the error occured during ...`. Doc-only Ruby change; `ruby -c` stays clean.