### PR TITLE
Release candidate for 2.24.0

### DIFF
--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -5,5 +5,5 @@ module Mongo
   #
   # Note that this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file will be overwritten by that rake task.
-  VERSION = '2.23.0'
+  VERSION = '2.24.0'
 end

--- a/product.yml
+++ b/product.yml
@@ -5,5 +5,5 @@ description: a pure-Ruby driver for connecting to, querying, and manipulating Mo
 package: mongo
 jira: https://jira.mongodb.org/projects/RUBY
 version:
-  number: 2.23.0
+  number: 2.24.0
   file: lib/mongo/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 2.24.0 of the `mongo` gem - a pure-Ruby driver for connecting to, querying, and manipulating MongoDB databases. This is a new minor release in the 2.x series of MongoDB Ruby Driver.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 2.24.0 mongo
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'mongo', '2.24.0'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/RUBY) to let us know what's on your mind 🧠.

# New Features

* Added support for [MongoDB's Intelligent Workload Management (IWM)](https://www.mongodb.com/docs/atlas/intelligent-workload-management/) and ingress connection rate limiting features. The driver now gracefully handles write-blocking scenarios and optimizes connection establishment during high-load conditions to maintain application availability.
  * Supported on all commands.
  * Custom application retry logic may need to be adjusted to avoid retrying too long.
  * Upgrade is recommended to avoid impacts of server changes related to overload errors.
    * If not upgrading, custom application retry logic may need to be adjusted to handle higher rates of overload errors. See [Overload Errors](https://www.mongodb.com/docs/atlas/overload-errors/?interface=driver&language=c).
  * Add URI option maxAdaptiveRetries to configure the maximum number of retries for operations that fail with a SystemOverloadedError (default: 2).
  * Add URI option enableOverloadRetargeting to control whether retries of SystemOverloadedError will attempt to use a different server (default: false).

* Added serverMonitoringMode option configures which server monitoring protocol to use. Valid modes are
"stream", "poll", or "auto". The default value is "auto":
  - With "stream" mode, the client use the streaming protocol when the server supports it or fall back to the polling protocol otherwise.
  - With "poll" mode, the client  use the polling protocol.
  - With "auto" mode, the client behave the same as "poll" mode when running on a FaaS platform or the same as "stream" mode otherwise. The client detects that it's running on a FaaS platform via the same rules for generating the ``client.env`` handshake metadata field in the `MongoDB Handshake spec`.

* [RUBY-3381](https://jira.mongodb.org/browse/RUBY-3381) RUBY-3640 Remove support for server versions 3.6 and 4.0 ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/2986))

# Bug Fixes

* [RUBY-3771](https://jira.mongodb.org/browse/RUBY-3771) Update db.system attribute ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/2985))
* [RUBY-3669](https://jira.mongodb.org/browse/RUBY-3669) Fix memory leak when iterating cursors ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/2995))
* [RUBY-3685](https://jira.mongodb.org/browse/RUBY-3685) Fix insert_many in transaction with csot ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/2996))
* [RUBY-3616](https://jira.mongodb.org/browse/RUBY-3616) Fix load balanced implementation ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/3013))
