### PR TITLE
RUBY-3806 Stabilize flaky CI tests and variants

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1161,7 +1161,8 @@ buildvariants:
   - matrix_name: "ruby-dev"
     matrix_spec:
       ruby: "ruby-dev"
-      mongodb-version: ["8.0", "7.0"]
+      # MongoDB 7.0 enterprise archive is not published for ubuntu2404.
+      mongodb-version: "8.0"
       topology: "replica-set"
       os: ubuntu2404
     display_name: "${mongodb-version} ${os} ${topology} ${auth-and-ssl} ${ruby}"
@@ -1382,17 +1383,19 @@ buildvariants:
 #    tasks:
 #      - name: "test-mlaunch"
 
-  - matrix_name: "jruby-auth"
-    matrix_spec:
-      auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
-      ruby: jruby-9.4
-      mongodb-version: "8.0"
-      topology: ["standalone", "replica-set", "sharded-cluster"]
-      os: ubuntu2204
-    display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-    tags: ["pr"]
-    tasks:
-      - name: "run-main-test-suite"
+  # RUBY-3808: disabled — widespread TLS/EBADF failures on jruby-openssl.
+  # Re-enable once the jruby + TLS stack is investigated.
+  # - matrix_name: "jruby-auth"
+  #   matrix_spec:
+  #     auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
+  #     ruby: <%= jrubies.first %>
+  #     mongodb-version: <%= latest_stable_mdb %>
+  #     topology: <%= topologies %>
+  #     os: ubuntu2204
+  #   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  #   tags: ["pr"]
+  #   tasks:
+  #     - name: "run-main-test-suite"
 
   - matrix_name: zlib-"ruby-4.0"
     matrix_spec:

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -39,7 +39,8 @@ buildvariants:
   - matrix_name: "ruby-dev"
     matrix_spec:
       ruby: "ruby-dev"
-      mongodb-version: <%= recent_mdb %>
+      # MongoDB 7.0 enterprise archive is not published for ubuntu2404.
+      mongodb-version: <%= latest_stable_mdb %>
       topology: "replica-set"
       os: ubuntu2404
     display_name: "${mongodb-version} ${os} ${topology} ${auth-and-ssl} ${ruby}"
@@ -260,17 +261,19 @@ buildvariants:
 #    tasks:
 #      - name: "test-mlaunch"
 
-  - matrix_name: "jruby-auth"
-    matrix_spec:
-      auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
-      ruby: <%= jrubies.first %>
-      mongodb-version: <%= latest_stable_mdb %>
-      topology: <%= topologies %>
-      os: ubuntu2204
-    display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
-    tags: ["pr"]
-    tasks:
-      - name: "run-main-test-suite"
+  # RUBY-3808: disabled — widespread TLS/EBADF failures on jruby-openssl.
+  # Re-enable once the jruby + TLS stack is investigated.
+  # - matrix_name: "jruby-auth"
+  #   matrix_spec:
+  #     auth-and-ssl: [ "auth-and-ssl", "noauth-and-nossl" ]
+  #     ruby: <%%= jrubies.first %>
+  #     mongodb-version: <%%= latest_stable_mdb %>
+  #     topology: <%%= topologies %>
+  #     os: ubuntu2204
+  #   display_name: "${mongodb-version} ${topology} ${auth-and-ssl} ${ruby}"
+  #   tags: ["pr"]
+  #   tasks:
+  #     - name: "run-main-test-suite"
 
  <% [
       [latest_ruby, stable_and_rapid, 'ubuntu2204'],

--- a/spec/integration/client_side_operations_timeout/encryption_prose_spec.rb
+++ b/spec/integration/client_side_operations_timeout/encryption_prose_spec.rb
@@ -49,7 +49,7 @@ describe 'CSOT for encryption' do
     let(:key_vault_client) do
       ClientRegistry.instance.new_local_client(
         SpecConfig.instance.addresses,
-        SpecConfig.instance.test_options.merge(timeout_ms: 20)
+        SpecConfig.instance.test_options.merge(timeout_ms: 50)
       )
     end
 
@@ -73,7 +73,7 @@ describe 'CSOT for encryption' do
                                                 data: {
                                                   failCommands: [ 'insert' ],
                                                   blockConnection: true,
-                                                  blockTimeMS: 30
+                                                  blockTimeMS: 200
                                                 }
                                               })
       end
@@ -107,7 +107,7 @@ describe 'CSOT for encryption' do
                                                 data: {
                                                   failCommands: [ 'find' ],
                                                   blockConnection: true,
-                                                  blockTimeMS: 30
+                                                  blockTimeMS: 200
                                                 }
                                               })
       end

--- a/spec/runners/unified/test.rb
+++ b/spec/runners/unified/test.rb
@@ -61,8 +61,23 @@ module Unified
 
     attr_reader :test_spec, :description, :outcome, :skip_reason, :reqs, :group_reqs, :options, :entities
 
+    # Descriptions of unified spec tests that are known to flake under load on
+    # CI and benefit from being retried. See the corresponding JIRA tickets for
+    # the underlying investigations.
+    RETRY_PATTERNS = Regexp.union(
+      /KMS/i,
+      # RUBY-3809: CSOT deprecated-options "maxTimeMS is ignored if timeoutMS
+      # is set" operations occasionally observe a drifted maxTimeMS on the
+      # wire when the CI host is loaded.
+      /maxTimeMS is ignored if timeoutMS is set/i,
+      # RUBY-3810: sharded mongos-pin-auto "remain pinned after non-transient"
+      # tests flake when the server injects its own transient transaction
+      # condition around the failCommand-injected error.
+      /remain pinned after non-transient/i
+    ).freeze
+
     def retry?
-      @description =~ /KMS/i
+      @description =~ RETRY_PATTERNS
     end
 
     def skip?
@@ -424,6 +439,13 @@ module Unified
       entities[:client]&.each do |_id, client|
         client.close
       end
+
+      # Reset entity state so that retry_test re-runs (RUBY-3809, RUBY-3810)
+      # build fresh clients/sessions instead of reusing the closed ones
+      # produced by the previous attempt. Without this, retried transactional
+      # tests hit TRANSACTION_ALREADY_IN_PROGRESS on the stale session.
+      @entities = EntityMap.new
+      @entities_created = false
     end
 
     private

--- a/spec/spec_tests/data/unified/valid-pass/poc-transactions-convenient-api.yml
+++ b/spec/spec_tests/data/unified/valid-pass/poc-transactions-convenient-api.yml
@@ -2,11 +2,13 @@ description: "poc-transactions-convenient-api"
 
 schemaVersion: "1.0"
 
+# RUBY-3806: all tests in this file are flaky on sharded clusters due to
+# MigrationConflict during catalog changes forcing a withTransaction retry
+# that violates the strict expectEvents assertions. Restrict to replicaset
+# until the spec or the runner can tolerate transient-transaction retries.
 runOnRequirements:
   - minServerVersion: "4.0"
     topologies: [ replicaset ]
-  - minServerVersion: "4.1.8"
-    topologies: [ sharded ]
 
 createEntities:
   - client:


### PR DESCRIPTION
## Summary

Fix or skip the recurring flaky test failures that have been blocking patch builds.

- **RUBY-3806** — `poc-transactions-convenient-api.yml` unified tests flake on sharded clusters via `MigrationConflict` → `withTransaction` retry → extra commandStartedEvents violate strict `expectEvents`. Restrict the file-level `runOnRequirements` to replicaset.
- **RUBY-3808** — `jruby-auth` Evergreen matrix fails wholesale with `TLS/EBADF` socket errors on jruby-openssl (4411 failed tests of 24286). Matrix disabled with a comment pointing to the follow-up.
- **RUBY-3809** — CSOT `deprecated-options.yml` "maxTimeMS is ignored if timeoutMS is set" tests flake intermittently on loaded CI. Added to `Unified::Test#retry?` regex so `retry_test` wraps them with 3 attempts.
- **RUBY-3810** — Sharded `poc-transactions-mongos-pin-auto.yml` "remain pinned after non-transient" tests flake similarly; also added to `retry?`. Fixed a retry state leak in `Test#cleanup`: entity map and `@entities_created` now reset after each attempt, so retries rebuild fresh clients/sessions instead of reusing the closed ones (previously hit `TRANSACTION_ALREADY_IN_PROGRESS`).
- CSOT encryption prose tests — bumped `timeout_ms` (20 → 50) and `blockTimeMS` (30 → 200) in `encryption_prose_spec.rb`; the previous values barely passed on Evergreen.
- `.evergreen/config/standard.yml.erb` — `ruby-dev` / `ubuntu2404` matrix now uses `latest_stable_mdb` (8.0 only) since MongoDB 7.0 enterprise archive is not published for ubuntu2404.
