### PR TITLE
RUBY-3802 bump max wire version to 29 for upcoming 9.0 release

### DIFF
--- a/lib/mongo/server/description/features.rb
+++ b/lib/mongo/server/description/features.rb
@@ -61,7 +61,7 @@ module Mongo
         # The wire protocol versions that this version of the driver supports.
         #
         # @since 2.0.0
-        DRIVER_WIRE_VERSIONS = 8..25
+        DRIVER_WIRE_VERSIONS = 8..29
 
         # The wire protocol versions that are deprecated in this version of the
         # driver. Support for these versions will be removed in the future.


### PR DESCRIPTION
In preparation for the upcoming 9.0 LTS release, this bumps the max wire version to 29, so the driver can be ready to support it.