### PR TITLE
RUBY-3602 Include server address in OperationFailure and BulkWriteError messages

### DIFF
--- a/lib/mongo.rb
+++ b/lib/mongo.rb
@@ -101,6 +101,7 @@ module Mongo
     delegate_option Config, :broken_view_options
     delegate_option Config, :validate_update_replace
     delegate_option Config, :csfle_convert_to_ruby_types
+    delegate_option Config, :include_server_address_in_errors
   end
 
   # Clears the driver's OCSP response cache.

--- a/lib/mongo/bulk_write/result.rb
+++ b/lib/mongo/bulk_write/result.rb
@@ -25,6 +25,10 @@ module Mongo
         @acknowledged
       end
 
+      # @return [ Array<String> ] Deduplicated list of "host:port" addresses of
+      #   the servers that produced this bulk write's operations.
+      attr_reader :server_addresses
+
       # Constant for number removed.
       #
       # @since 2.1.0
@@ -97,13 +101,17 @@ module Mongo
       #
       # @param [ BSON::Document, Hash ] results The results document.
       # @param [ Boolean ] acknowledged Is the result acknowledged?
+      # @param [ Array<String> ] server_addresses Deduplicated "host:port"
+      #   addresses of the servers that produced the underlying operation
+      #   results.
       #
       # @since 2.1.0
       #
       # @api private
-      def initialize(results, acknowledged)
+      def initialize(results, acknowledged, server_addresses = [])
         @results = results
         @acknowledged = acknowledged
+        @server_addresses = server_addresses
       end
 
       # Returns the number of documents inserted.
@@ -189,7 +197,7 @@ module Mongo
       #
       # @since 2.1.0
       def validate!
-        raise Error::BulkWriteError.new(@results) if @results['writeErrors'] || @results['writeConcernErrors']
+        raise Error::BulkWriteError.new(@results, server_addresses: @server_addresses) if @results['writeErrors'] || @results['writeConcernErrors']
 
         self
       end

--- a/lib/mongo/bulk_write/result.rb
+++ b/lib/mongo/bulk_write/result.rb
@@ -111,7 +111,7 @@ module Mongo
       def initialize(results, acknowledged, server_addresses = [])
         @results = results
         @acknowledged = acknowledged
-        @server_addresses = server_addresses
+        @server_addresses = Array(server_addresses).compact.uniq
       end
 
       # Returns the number of documents inserted.

--- a/lib/mongo/bulk_write/result_combiner.rb
+++ b/lib/mongo/bulk_write/result_combiner.rb
@@ -28,6 +28,10 @@ module Mongo
       # @return [ Hash ] results The results hash.
       attr_reader :results
 
+      # @return [ Array<String> ] Deduplicated list of "host:port" addresses of
+      #   the servers that produced the combined operation results.
+      attr_reader :server_addresses
+
       # Create the new result combiner.
       #
       # @api private
@@ -39,6 +43,7 @@ module Mongo
       def initialize
         @results = {}
         @count = 0
+        @server_addresses = []
       end
 
       # Adds a result to the overall results.
@@ -68,6 +73,8 @@ module Mongo
         combine_errors!(result)
         @count += count
         @acknowledged = result.acknowledged?
+        seed = result.connection_description&.address&.seed
+        @server_addresses << seed if seed && !@server_addresses.include?(seed)
       end
 
       # Get the final result.
@@ -78,7 +85,7 @@ module Mongo
       #
       # @since 2.1.0
       def result
-        BulkWrite::Result.new(results, @acknowledged).validate!
+        BulkWrite::Result.new(results, @acknowledged, @server_addresses).validate!
       end
 
       private

--- a/lib/mongo/config.rb
+++ b/lib/mongo/config.rb
@@ -29,6 +29,11 @@ module Mongo
     # decryption instead of BSON types.
     option :csfle_convert_to_ruby_types, default: false
 
+    # When this flag is set to true, the (host:port) of the server that produced
+    # the error is appended to error messages for OperationFailure and
+    # BulkWriteError. See RUBY-3602.
+    option :include_server_address_in_errors, default: false
+
     # Set the configuration options.
     #
     # @example Set the options.

--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -102,6 +102,10 @@ module Mongo
 
         fragment = "Multiple errors: #{fragment}" if errors.length > 1
 
+        if Mongo.include_server_address_in_errors && @server_addresses.any?
+          fragment = "#{fragment} (on #{@server_addresses.uniq.join(', ')})"
+        end
+
         fragment
       end
 

--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -34,6 +34,11 @@ module Mongo
       # @return [ BSON::Document ] result The error result.
       attr_reader :result
 
+      # @return [ Array<String> ] Deduplicated list of "host:port" addresses of
+      #   the servers that produced this bulk write error. Empty when no
+      #   addresses were supplied.
+      attr_reader :server_addresses
+
       # Instantiate the new exception.
       #
       # @example Instantiate the exception.
@@ -41,10 +46,14 @@ module Mongo
       #
       # @param [ Hash ] result A processed response from the server
       #   reporting results of the operation.
+      # @param [ Array<String | Mongo::Address | Mongo::Server::Description> ]
+      #   server_addresses Addresses of the servers that produced this error.
+      #   Entries are normalized to "host:port" strings.
       #
       # @since 2.0.0
-      def initialize(result)
+      def initialize(result, server_addresses: nil)
         @result = result
+        @server_addresses = normalize_server_addresses(server_addresses)
 
         # Exception constructor behaves differently for a nil argument and
         # for no argument. Avoid passing nil explicitly.
@@ -94,6 +103,21 @@ module Mongo
         fragment = "Multiple errors: #{fragment}" if errors.length > 1
 
         fragment
+      end
+
+      def normalize_server_addresses(value)
+        return [] if value.nil?
+
+        Array(value).filter_map do |entry|
+          case entry
+          when String then entry
+          when Mongo::Address then entry.seed
+          when Mongo::Server::Description then entry.address&.seed
+          else
+            raise ArgumentError,
+                  "server_addresses entries must be String, Mongo::Address, or Mongo::Server::Description; got #{entry.class}"
+          end
+        end
       end
     end
   end

--- a/lib/mongo/error/bulk_write_error.rb
+++ b/lib/mongo/error/bulk_write_error.rb
@@ -103,7 +103,7 @@ module Mongo
         fragment = "Multiple errors: #{fragment}" if errors.length > 1
 
         if Mongo.include_server_address_in_errors && @server_addresses.any?
-          fragment = "#{fragment} (on #{@server_addresses.uniq.join(', ')})"
+          fragment = "#{fragment} (on #{@server_addresses.join(', ')})"
         end
 
         fragment
@@ -121,7 +121,7 @@ module Mongo
             raise ArgumentError,
                   "server_addresses entries must be String, Mongo::Address, or Mongo::Server::Description; got #{entry.class}"
           end
-        end
+        end.uniq
       end
     end
   end

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -53,6 +53,10 @@ module Mongo
         # @api experimental
         attr_reader :server_message
 
+        # @return [ String | nil ] The address ("host:port") of the server
+        #   that produced this error, if known.
+        attr_reader :server_address
+
         # Error codes and code names that should result in a failing getMore
         # command on a change stream NOT being resumed.
         #
@@ -172,6 +176,8 @@ module Mongo
         #   error document.
         # @option options [ String ] server_message The server-returned
         #   error message parsed from the response.
+        # @option options [ nil | String | Mongo::Address | Mongo::Server::Description ]
+        #   :server_address The address of the server that produced the error.
         # @option options [ Hash ] :write_concern_error_document The
         #   server-supplied write concern error document, if any.
         # @option options [ Integer ] :write_concern_error_code Error code for
@@ -198,6 +204,7 @@ module Mongo
           @wtimeout = !!options[:wtimeout]
           @document = options[:document]
           @server_message = options[:server_message]
+          @server_address = normalize_server_address(options[:server_address])
         end
 
         # Whether the error is a write concern timeout.
@@ -240,6 +247,23 @@ module Mongo
           return message unless details && message
 
           message + " -- #{details.to_json}"
+        end
+
+        # Normalize a server_address option into a String "host:port" form.
+        #
+        # @param [ nil | String | Mongo::Address | Mongo::Server::Description ] value
+        #
+        # @return [ String | nil ] The normalized address, or nil.
+        def normalize_server_address(value)
+          case value
+          when nil then nil
+          when String then value
+          when Mongo::Address then value.seed
+          when Mongo::Server::Description then value.address&.seed
+          else
+            raise ArgumentError,
+                  "server_address must be nil, String, Mongo::Address, or Mongo::Server::Description; got #{value.class}"
+          end
         end
       end
 

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -191,7 +191,8 @@ module Mongo
         # @option options [ true | false ] :wtimeout Whether the error is a wtimeout.
         def initialize(message = nil, result = nil, options = {})
           @details = retrieve_details(options[:document])
-          super(append_details(message, @details))
+          @server_address = normalize_server_address(options[:server_address])
+          super(append_server_address(append_details(message, @details)))
 
           @result = result
           @code = options[:code]
@@ -204,7 +205,6 @@ module Mongo
           @wtimeout = !!options[:wtimeout]
           @document = options[:document]
           @server_message = options[:server_message]
-          @server_address = normalize_server_address(options[:server_address])
         end
 
         # Whether the error is a write concern timeout.
@@ -247,6 +247,20 @@ module Mongo
           return message unless details && message
 
           message + " -- #{details.to_json}"
+        end
+
+        # Append the server address suffix to the message when the
+        # Mongo.include_server_address_in_errors flag is enabled and
+        # a server address is known.
+        #
+        # @return [ String | nil ] the message with the suffix appended,
+        #   or the original message unchanged.
+        def append_server_address(message)
+          return message unless Mongo.include_server_address_in_errors
+          return message if @server_address.nil?
+          return "(on #{@server_address})" if message.nil? || message.empty?
+
+          "#{message} (on #{@server_address})"
         end
 
         # Normalize a server_address option into a String "host:port" form.

--- a/lib/mongo/error/operation_failure.rb
+++ b/lib/mongo/error/operation_failure.rb
@@ -273,7 +273,8 @@ module Mongo
           when nil then nil
           when String then value
           when Mongo::Address then value.seed
-          when Mongo::Server::Description then value.address&.seed
+          when Mongo::Server::Description
+            value.address.is_a?(Mongo::Address) ? value.address.seed : nil
           else
             raise ArgumentError,
                   "server_address must be nil, String, Mongo::Address, or Mongo::Server::Description; got #{value.class}"

--- a/lib/mongo/operation/result.rb
+++ b/lib/mongo/operation/result.rb
@@ -355,7 +355,8 @@ module Mongo
           wtimeout: parser.wtimeout,
           connection_description: connection_description,
           document: parser.document,
-          server_message: parser.server_message
+          server_message: parser.server_message,
+          server_address: connection_description&.address&.seed
         )
       end
 

--- a/lib/mongo/operation/result.rb
+++ b/lib/mongo/operation/result.rb
@@ -356,7 +356,7 @@ module Mongo
           connection_description: connection_description,
           document: parser.document,
           server_message: parser.server_message,
-          server_address: connection_description&.address&.seed
+          server_address: connection_description
         )
       end
 

--- a/spec/integration/bulk_write_error_message_spec.rb
+++ b/spec/integration/bulk_write_error_message_spec.rb
@@ -63,4 +63,26 @@ describe 'BulkWriteError message' do
       e.message.scan(' -- ').length.should be <= 1
     end
   end
+
+  context 'when include_server_address_in_errors is enabled' do
+    around do |example|
+      original = Mongo.include_server_address_in_errors
+      Mongo.include_server_address_in_errors = true
+      example.run
+    ensure
+      Mongo.include_server_address_in_errors = original
+    end
+
+    it 'includes the server address suffix in the bulk error message' do
+      collection.insert_one(_id: 1)
+      begin
+        collection.insert_many([ { _id: 1 }, { _id: 2 }, { _id: 2 } ])
+      rescue Mongo::Error::BulkWriteError => e
+        expect(e.message).to match(/\(on [^)]+:\d+(?:, [^)]+:\d+)*\)\z/)
+        expect(e.server_addresses).not_to be_empty
+      else
+        raise 'expected BulkWriteError'
+      end
+    end
+  end
 end

--- a/spec/integration/operation_failure_message_spec.rb
+++ b/spec/integration/operation_failure_message_spec.rb
@@ -52,4 +52,22 @@ describe 'OperationFailure message' do
                              /User bogus.*is not authorized.*\[18:AuthenticationFailed\]: Authentication failed/)
     end
   end
+
+  context 'when include_server_address_in_errors is enabled' do
+    around do |example|
+      original = Mongo.include_server_address_in_errors
+      Mongo.include_server_address_in_errors = true
+      example.run
+    ensure
+      Mongo.include_server_address_in_errors = original
+    end
+
+    it 'includes the server address in the message' do
+      client.command(bogus_command: nil)
+      raise('Should have raised')
+    rescue Mongo::Error::OperationFailure => e
+      expect(e.message).to match(/\(on [^)]+:\d+\)\z/)
+      expect(e.server_address).to be_a(String)
+    end
+  end
 end

--- a/spec/mongo/bulk_write/result_combiner_spec.rb
+++ b/spec/mongo/bulk_write/result_combiner_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Mongo::BulkWrite::ResultCombiner do
+  describe 'server_addresses accumulation' do
+    let(:combiner) { described_class.new }
+
+    def stub_op_result(seed)
+      description = instance_double(
+        Mongo::Server::Description,
+        address: Mongo::Address.new(seed)
+      )
+      result = double('op_result')
+      allow(result).to receive(:write_concern_error?).and_return(false)
+      allow(result).to receive(:acknowledged?).and_return(true)
+      allow(result).to receive(:aggregate_write_errors).and_return(nil)
+      allow(result).to receive(:aggregate_write_concern_errors).and_return(nil)
+      allow(result).to receive(:validate!).and_return(true)
+      allow(result).to receive(:respond_to?).and_return(false)
+      allow(result).to receive(:connection_description).and_return(description)
+      result
+    end
+
+    it 'collects unique seeds from combined results' do
+      combiner.combine!(stub_op_result('h1:27017'), 1)
+      combiner.combine!(stub_op_result('h2:27017'), 1)
+      combiner.combine!(stub_op_result('h1:27017'), 1)
+
+      final = combiner.result
+      expect(final.server_addresses).to contain_exactly('h1:27017', 'h2:27017')
+    end
+
+    it 'defaults to empty when no results combined' do
+      expect(combiner.server_addresses).to eq([])
+    end
+  end
+end

--- a/spec/mongo/config_spec.rb
+++ b/spec/mongo/config_spec.rb
@@ -61,4 +61,22 @@ describe Mongo::Config do
       end
     end
   end
+
+  describe '.include_server_address_in_errors' do
+    it 'defaults to false' do
+      expect(Mongo::Config.include_server_address_in_errors).to be false
+    end
+
+    it 'is accessible as Mongo.include_server_address_in_errors' do
+      expect(Mongo.include_server_address_in_errors).to be false
+    end
+
+    it 'can be set via Mongo=' do
+      original = Mongo.include_server_address_in_errors
+      Mongo.include_server_address_in_errors = true
+      expect(Mongo.include_server_address_in_errors).to be true
+    ensure
+      Mongo.include_server_address_in_errors = original
+    end
+  end
 end

--- a/spec/mongo/error/bulk_write_error_spec.rb
+++ b/spec/mongo/error/bulk_write_error_spec.rb
@@ -48,4 +48,29 @@ describe Mongo::Error::BulkWriteError do
       expect(error.inspect).to eq('#<Mongo::Error::BulkWriteError: Multiple errors: [1]: message1; [2]: message2 (note1, note2)>')
     end
   end
+
+  describe '#server_addresses' do
+    let(:result) { { 'writeErrors' => [ { 'code' => 11_000, 'errmsg' => 'dup' } ] } }
+
+    it 'defaults to an empty array when not supplied' do
+      error = described_class.new(result)
+      expect(error.server_addresses).to eq([])
+    end
+
+    it 'stores an array of strings' do
+      error = described_class.new(result, server_addresses: [ 'h1:27017', 'h2:27017' ])
+      expect(error.server_addresses).to eq([ 'h1:27017', 'h2:27017' ])
+    end
+
+    it 'normalizes Mongo::Address entries to seed strings' do
+      addrs = [ Mongo::Address.new('h1:27017'), 'h2:27017' ]
+      error = described_class.new(result, server_addresses: addrs)
+      expect(error.server_addresses).to eq([ 'h1:27017', 'h2:27017' ])
+    end
+
+    it 'treats nil as empty' do
+      error = described_class.new(result, server_addresses: nil)
+      expect(error.server_addresses).to eq([])
+    end
+  end
 end

--- a/spec/mongo/error/bulk_write_error_spec.rb
+++ b/spec/mongo/error/bulk_write_error_spec.rb
@@ -73,4 +73,69 @@ describe Mongo::Error::BulkWriteError do
       expect(error.server_addresses).to eq([])
     end
   end
+
+  describe 'message rendering' do
+    let(:single_error_result) do
+      { 'writeErrors' => [ { 'code' => 11_000, 'errmsg' => 'dup key' } ] }
+    end
+
+    let(:multi_error_result) do
+      {
+        'writeErrors' => [
+          { 'code' => 11_000, 'errmsg' => 'dup' },
+          { 'code' => 121, 'errmsg' => 'validation' },
+        ]
+      }
+    end
+
+    context 'when flag is off' do
+      around do |example|
+        original = Mongo.include_server_address_in_errors
+        Mongo.include_server_address_in_errors = false
+        example.run
+      ensure
+        Mongo.include_server_address_in_errors = original
+      end
+
+      it 'does not include host for single error' do
+        e = described_class.new(single_error_result, server_addresses: [ 'h1:27017' ])
+        expect(e.message).not_to include('on h1')
+      end
+
+      it 'does not include host for multi-error bulk' do
+        e = described_class.new(multi_error_result, server_addresses: [ 'h1:27017' ])
+        expect(e.message).not_to include('on h1')
+      end
+    end
+
+    context 'when flag is on' do
+      around do |example|
+        original = Mongo.include_server_address_in_errors
+        Mongo.include_server_address_in_errors = true
+        example.run
+      ensure
+        Mongo.include_server_address_in_errors = original
+      end
+
+      it 'appends single host suffix' do
+        e = described_class.new(single_error_result, server_addresses: [ 'h1:27017' ])
+        expect(e.message).to end_with('(on h1:27017)')
+      end
+
+      it 'deduplicates repeated hosts' do
+        e = described_class.new(multi_error_result, server_addresses: [ 'h1:27017', 'h1:27017' ])
+        expect(e.message).to end_with('(on h1:27017)')
+      end
+
+      it 'joins multiple unique hosts with a comma' do
+        e = described_class.new(multi_error_result, server_addresses: [ 'h1:27017', 'h2:27017' ])
+        expect(e.message).to end_with('(on h1:27017, h2:27017)')
+      end
+
+      it 'omits the suffix when addresses is empty' do
+        e = described_class.new(single_error_result, server_addresses: [])
+        expect(e.message).not_to include('(on ')
+      end
+    end
+  end
 end

--- a/spec/mongo/error/operation_failure_spec.rb
+++ b/spec/mongo/error/operation_failure_spec.rb
@@ -420,6 +420,25 @@ describe Mongo::Error::OperationFailure do
       error = described_class.new('msg', nil, server_address: 'host-1:27017')
       expect(error.server_address).to eq('host-1:27017')
     end
+
+    it 'stores the seed from a Mongo::Address' do
+      addr = Mongo::Address.new('host-2:27018')
+      error = described_class.new('msg', nil, server_address: addr)
+      expect(error.server_address).to eq('host-2:27018')
+    end
+
+    it 'stores the seed from a Mongo::Server::Description' do
+      addr = Mongo::Address.new('host-3:27019')
+      desc = Mongo::Server::Description.new(addr)
+      error = described_class.new('msg', nil, server_address: desc)
+      expect(error.server_address).to eq('host-3:27019')
+    end
+
+    it 'raises ArgumentError for unsupported types' do
+      expect do
+        described_class.new('msg', nil, server_address: 42)
+      end.to raise_error(ArgumentError, /server_address must be/)
+    end
   end
 
   describe '#not_master?' do

--- a/spec/mongo/error/operation_failure_spec.rb
+++ b/spec/mongo/error/operation_failure_spec.rb
@@ -594,4 +594,43 @@ describe Mongo::Error::OperationFailure do
       end
     end
   end
+
+  describe 'message rendering with server_address' do
+    let(:error) do
+      described_class.new('boom', nil, server_address: 'host-1:27017')
+    end
+
+    context 'when include_server_address_in_errors is false' do
+      it 'does not include the host in #message' do
+        expect(error.message).not_to include('host-1:27017')
+      end
+
+      it 'does not include the host in #to_s' do
+        expect(error.to_s).not_to include('host-1:27017')
+      end
+    end
+
+    context 'when include_server_address_in_errors is true' do
+      around do |example|
+        original = Mongo.include_server_address_in_errors
+        Mongo.include_server_address_in_errors = true
+        example.run
+      ensure
+        Mongo.include_server_address_in_errors = original
+      end
+
+      it 'includes the host in #message' do
+        expect(error.message).to include('boom (on host-1:27017)')
+      end
+
+      it 'includes the host in #to_s' do
+        expect(error.to_s).to include('boom (on host-1:27017)')
+      end
+
+      it 'omits the suffix when server_address is nil' do
+        e = described_class.new('boom', nil)
+        expect(e.message).not_to include('(on ')
+      end
+    end
+  end
 end

--- a/spec/mongo/error/operation_failure_spec.rb
+++ b/spec/mongo/error/operation_failure_spec.rb
@@ -410,6 +410,18 @@ describe Mongo::Error::OperationFailure do
     end
   end
 
+  describe '#server_address' do
+    it 'is nil by default' do
+      error = described_class.new('msg', nil)
+      expect(error.server_address).to be_nil
+    end
+
+    it 'stores a String passed via options' do
+      error = described_class.new('msg', nil, server_address: 'host-1:27017')
+      expect(error.server_address).to eq('host-1:27017')
+    end
+  end
+
   describe '#not_master?' do
     [ 10_107, 13_435 ].each do |code|
       context "error code #{code}" do

--- a/spec/mongo/error/operation_failure_spec.rb
+++ b/spec/mongo/error/operation_failure_spec.rb
@@ -601,6 +601,14 @@ describe Mongo::Error::OperationFailure do
     end
 
     context 'when include_server_address_in_errors is false' do
+      around do |example|
+        original = Mongo.include_server_address_in_errors
+        Mongo.include_server_address_in_errors = false
+        example.run
+      ensure
+        Mongo.include_server_address_in_errors = original
+      end
+
       it 'does not include the host in #message' do
         expect(error.message).not_to include('host-1:27017')
       end


### PR DESCRIPTION
## Summary

- New `Mongo::Config.include_server_address_in_errors` flag (default `false`). When `true`, `Mongo::Error::OperationFailure` and `Mongo::Error::BulkWriteError` messages are suffixed with `(on host:port)` so users can identify which server produced the error.
- Both `#message` and `#to_s` render the suffix, since it's baked into the string passed to `super` at construction. `ResultCombiner` accumulates unique addresses across split bulk batches so multi-server bulks produce `(on h1:27017, h2:27017)`.
- Default-off behavior is byte-identical to current. No breaking changes. Planned to stay opt-in (no default flip).

## Test Plan

- [x] `bundle exec rspec spec/mongo/config_spec.rb spec/mongo/error spec/mongo/bulk_write spec/integration/operation_failure_message_spec.rb spec/integration/bulk_write_error_message_spec.rb` — 180 examples, 0 failures against a local replica set at `mongodb://localhost:27017,27018,27019/`.
- [x] RuboCop clean on all touched files.
- [ ] CI to validate on sharded and other topologies.

## Notes

- `Operation::ResponseHandling#add_server_diagnostics` still adds `add_note("on ...")`. When the new flag is on, `#to_s` output will include the host twice (in-message suffix + note). Deduplicating is deferred to a follow-up ticket per the design spec.
- Flag follows the existing `Mongo::Config` pattern (`broken_view_options`, `validate_update_replace`, etc.).

Jira: https://jira.mongodb.org/browse/RUBY-3602