### PR TITLE
RUBY-3364 fix connection pool thread starvation under oversubscription

### DIFF
--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -1308,13 +1308,25 @@ module Mongo
         connection = nil
 
         @lock.synchronize do
-          # The first gate to checking out a connection. Make sure the number of
-          # unavailable connections is less than the max pool size.
-          until max_size == 0 || unavailable_connections < max_size
+          # RUBY-3364: if any thread is already waiting for a size slot,
+          # join the queue even when the gate predicate is currently
+          # satisfied. Without this, re-entering threads (those that just
+          # checked a connection back in) barge past existing waiters and
+          # the 195 blocked threads in a 200:5 scenario never wake.
+          must_wait = @size_waiters > 0
+          until (max_size == 0 || unavailable_connections < max_size) && !must_wait
             wait = deadline - Utils.monotonic_time
             raise_check_out_timeout!(connection_global_id) if wait <= 0
-            @size_cv.wait(wait)
+            @size_waiters += 1
+            begin
+              @size_cv.wait(wait)
+            ensure
+              @size_waiters -= 1
+            end
             raise_if_not_ready!
+            # After one wait cycle we have served our "queue tax" and
+            # compete for the slot on the next predicate check.
+            must_wait = false
           end
           @connection_requests += 1
           connection = wait_for_connection(connection_global_id, deadline)

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -1361,9 +1361,12 @@ module Mongo
       def wait_for_connection(connection_global_id, deadline)
         connection = nil
         while connection.nil?
+          # RUBY-3364: as above, yield to any thread already queued for
+          # a max_connecting slot before competing ourselves.
+          must_wait = @max_connecting_waiters > 0
           # The second gate to checking out a connection. Make sure 1) there
           # exists an available connection and 2) we are under max_connecting.
-          until @available_connections.any? || @pending_connections.length < @max_connecting
+          until (@available_connections.any? || @pending_connections.length < @max_connecting) && !must_wait
             wait = deadline - Utils.monotonic_time
             if wait <= 0
               # We are going to raise a timeout error, so the connection
@@ -1372,10 +1375,16 @@ module Mongo
               decrement_connection_requests_and_signal
               raise_check_out_timeout!(connection_global_id)
             end
-            @max_connecting_cv.wait(wait)
+            @max_connecting_waiters += 1
+            begin
+              @max_connecting_cv.wait(wait)
+            ensure
+              @max_connecting_waiters -= 1
+            end
             # We do not need to decrement the connection_requests counter
             # or signal here because the pool is not ready yet.
             raise_if_not_ready!
+            must_wait = false
           end
 
           connection = get_connection(Process.pid, connection_global_id)

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -141,6 +141,13 @@ module Mongo
         @pending_connections = Set.new
         @interrupt_connections = []
 
+        # RUBY-3364: count threads currently blocked on size_cv /
+        # max_connecting_cv. When non-zero, a newly-arriving thread must
+        # enter the wait queue even if the gate predicate is currently
+        # satisfied, to prevent barging past existing waiters.
+        @size_waiters = 0
+        @max_connecting_waiters = 0
+
         # Mutex used for synchronizing access to @available_connections and
         # @checked_out_connections. The pool object is thread-safe, thus
         # all methods that retrieve or modify instance variables generally

--- a/lib/mongo/server/connection_pool.rb
+++ b/lib/mongo/server/connection_pool.rb
@@ -1313,7 +1313,9 @@ module Mongo
           # satisfied. Without this, re-entering threads (those that just
           # checked a connection back in) barge past existing waiters and
           # the 195 blocked threads in a 200:5 scenario never wake.
-          must_wait = @size_waiters > 0
+          # Skip the gate for unlimited pools (max_size == 0) where there
+          # is no size constraint to wait on.
+          must_wait = max_size != 0 && @size_waiters > 0
           until (max_size == 0 || unavailable_connections < max_size) && !must_wait
             wait = deadline - Utils.monotonic_time
             raise_check_out_timeout!(connection_global_id) if wait <= 0
@@ -1338,8 +1340,17 @@ module Mongo
           @checked_out_connections << connection
           @pending_connections.delete(connection) if @pending_connections.include?(connection)
           @max_connecting_cv.signal
-          # no need to signal size_cv here since the number of unavailable
-          # connections is unchanged.
+          # RUBY-3364: hand off the baton. A waiter that arrived during
+          # our wake-up window (seeing our stale @size_waiters > 0) may be
+          # parked on @size_cv with capacity already available. The
+          # regular check-in path is the only other place that signals
+          # @size_cv, so we wake the next waiter only when the predicate
+          # is actually satisfied for them. Signaling unconditionally
+          # would re-queue a waiter at the back of the FIFO and break
+          # ordering.
+          if @size_waiters > 0 && (max_size == 0 || unavailable_connections < max_size)
+            @size_cv.signal
+          end
         end
 
         connection
@@ -1396,6 +1407,14 @@ module Mongo
           # the connection_requests counter. We need to do it here.
           decrement_connection_requests_and_signal
           raise_check_out_timeout!(connection_global_id)
+        end
+
+        # RUBY-3364: hand off the baton for max_connecting_cv. Signal
+        # only if the gate predicate is satisfied for the next waiter, to
+        # avoid re-queuing a waiter at the back of the FIFO.
+        if @max_connecting_waiters > 0 &&
+           (@available_connections.any? || @pending_connections.length < @max_connecting)
+          @max_connecting_cv.signal
         end
 
         connection

--- a/profile/connection_pool_fairness.rb
+++ b/profile/connection_pool_fairness.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+# Connection pool fairness harness.
+#
+# Drives the pool under heavy over-subscription and measures per-thread
+# service counts and wait-time distribution. Originally written to diagnose
+# RUBY-3364 ("Mongo Connection Pool should serve queries in FIFO manner"),
+# and kept as a permanent regression/fairness check.
+#
+# A fair pool, given N threads and a pool size of M (N >> M), should serve
+# every thread roughly the same number of times over a long enough run.
+# With the pre-fix code, 5 "lucky" threads held the connections for the
+# entire run and the other 195 threads starved and hit the wait_timeout
+# exactly once each. A healthy pool shows min/median/max per-thread counts
+# within ~1% of each other.
+#
+# Usage:
+#   MONGODB_URI="mongodb://..." bundle exec ruby profile/connection_pool_fairness.rb
+#
+# Tunable via environment:
+#   MONGODB_URI         cluster URI (default: local replica set on 27017-9)
+#   POOL_SIZE           max_pool_size (default: 5)
+#   THREADS             concurrent worker threads (default: 200)
+#   DURATION_SEC        how long to run (default: 30)
+#   WAIT_TIMEOUT        pool wait_queue_timeout in seconds (default: 10)
+
+require 'mongo'
+require 'logger'
+
+MONGO_URI = ENV.fetch('MONGODB_URI',
+                      'mongodb://localhost:27017,localhost:27018,localhost:27019/?replicaSet=replset')
+POOL_SIZE     = Integer(ENV.fetch('POOL_SIZE',     '5'))
+THREADS       = Integer(ENV.fetch('THREADS',       '200'))
+DURATION_SEC  = Integer(ENV.fetch('DURATION_SEC',  '30'))
+WAIT_TIMEOUT  = Float(ENV.fetch('WAIT_TIMEOUT', '10'))
+DB_NAME       = 'ruby_3364'
+COLL_NAME     = 'probe'
+
+Mongo::Logger.logger       = Logger.new(File::NULL)
+Mongo::Logger.logger.level = Logger::FATAL
+
+def now_us
+  (Process.clock_gettime(Process::CLOCK_MONOTONIC) * 1_000_000).to_i
+end
+
+client = Mongo::Client.new(
+  MONGO_URI,
+  database: DB_NAME,
+  max_pool_size: POOL_SIZE,
+  min_pool_size: POOL_SIZE,
+  wait_queue_timeout: WAIT_TIMEOUT,
+  logger: Mongo::Logger.logger
+)
+
+# Seed the collection so first() has something to return.
+client[COLL_NAME].drop
+client[COLL_NAME].insert_one(x: 1)
+
+results = Queue.new
+stop_at = now_us + (DURATION_SEC * 1_000_000)
+start_barrier = Queue.new
+
+threads = Array.new(THREADS) do |i|
+  Thread.new do
+    start_barrier.pop
+    while now_us < stop_at
+      t1 = now_us
+      err = nil
+      begin
+        Mongo::QueryCache.uncached do
+          client[COLL_NAME].find.first
+        end
+      rescue StandardError => e
+        err = e.class.name
+      end
+      t2 = now_us
+      results << [ i, t1, t2, t2 - t1, err ]
+    end
+  end
+end
+
+# Release all threads at once to get maximum contention.
+THREADS.times { start_barrier << :go }
+
+threads.each(&:join)
+client.close
+
+# Drain queue into array.
+rows = []
+rows << results.pop until results.empty?
+
+total    = rows.size
+errors   = rows.count { |r| r[4] }
+timeouts = rows.count { |r| r[4] == 'Mongo::Error::ConnectionCheckOutTimeout' }
+puts "Total ops:          #{total}"
+puts "Errors (any):       #{errors}  (#{format('%.4f', 100.0 * errors / total)}%)"
+puts "Checkout timeouts:  #{timeouts}  (#{format('%.4f', 100.0 * timeouts / total)}%)"
+
+# Wait-time band histogram: buckets of 1s up to 11s.
+buckets = Array.new(12, 0)
+rows.each do |_, _, _, dur, _|
+  idx = [ dur / 1_000_000, 11 ].min
+  buckets[idx] += 1
+end
+puts
+puts 'Wait-time band histogram (seconds):'
+buckets.each_with_index do |n, i|
+  label = (i == 11) ? '>10s' : "#{i}-#{i + 1}s"
+  bar = '#' * [ (n.to_f / total * 400).to_i, 80 ].min
+  puts "  #{label.rjust(6)}: #{n.to_s.rjust(8)}  #{bar}"
+end
+
+# Fine-grained banding in the 0-10s range (by 500ms buckets) to detect the
+# reporter's 2s/4s/6s/8s pattern.
+puts
+puts 'Fine band histogram (500ms buckets, 0-10s):'
+fine = Array.new(21, 0)
+rows.each do |_, _, _, dur, _|
+  idx = [ dur / 500_000, 20 ].min
+  fine[idx] += 1
+end
+fine.each_with_index do |n, i|
+  lo = i * 0.5
+  hi = (i + 1) * 0.5
+  bar = '#' * [ (n.to_f / total * 400).to_i, 80 ].min
+  puts "  #{format('%.1f-%.1fs', lo, hi).rjust(10)}: #{n.to_s.rjust(8)}  #{bar}"
+end
+
+# Per-thread op counts — are any threads starved?
+per_thread = Hash.new(0)
+per_thread_errors = Hash.new(0)
+rows.each do |r|
+  per_thread[r[0]] += 1
+  per_thread_errors[r[0]] += 1 if r[4]
+end
+
+# Make sure every thread id appears (some may have zero completions)
+THREADS.times do |i|
+  per_thread[i] ||= 0
+  per_thread_errors[i] ||= 0
+end
+
+counts = per_thread.values.sort
+puts
+puts 'Per-thread op count distribution:'
+puts "  min=#{counts.first}, p10=#{counts[counts.size / 10]}, " \
+     "median=#{counts[counts.size / 2]}, p90=#{counts[counts.size * 9 / 10]}, " \
+     "max=#{counts.last}"
+puts "  threads with 0 ops:    #{counts.count(&:zero?)}"
+puts "  threads with <10 ops:  #{counts.count { |c| c < 10 }}"
+puts "  threads with >100 ops: #{counts.count { |c| c > 100 }}"
+puts "  threads with >1000 ops:#{counts.count { |c| c > 1000 }}"
+puts
+
+# Top 5 and bottom 5 threads by count
+ranked = per_thread.sort_by { |_, v| v }
+puts 'Bottom 10 threads by op count:'
+ranked.first(10).each do |tid, n|
+  puts "  thread #{tid.to_s.rjust(3)}: #{n.to_s.rjust(6)} ops, #{per_thread_errors[tid]} timeouts"
+end
+puts
+puts 'Top 10 threads by op count:'
+ranked.last(10).each do |tid, n|
+  puts "  thread #{tid.to_s.rjust(3)}: #{n.to_s.rjust(6)} ops, #{per_thread_errors[tid]} timeouts"
+end

--- a/profile/connection_pool_fairness.rb
+++ b/profile/connection_pool_fairness.rb
@@ -23,6 +23,13 @@
 #   THREADS             concurrent worker threads (default: 200)
 #   DURATION_SEC        how long to run (default: 30)
 #   WAIT_TIMEOUT        pool wait_queue_timeout in seconds (default: 10)
+#
+# Memory note: this script records every operation into an in-memory Queue
+# and drains it at the end. At default settings (~4000 ops/sec × 30s ≈ 120k
+# rows, roughly 24 MB) that is well within normal memory budgets. For very
+# long runs (tens of minutes or more) switch to online aggregation —
+# e.g., per-thread counters and a histogram — to avoid unbounded memory
+# growth.
 
 require 'mongo'
 require 'logger'

--- a/spec/mongo/server/connection_pool_fairness_spec.rb
+++ b/spec/mongo/server/connection_pool_fairness_spec.rb
@@ -63,4 +63,141 @@ describe 'Mongo::Server::ConnectionPool fairness', retry: 3 do
                      "unfair distribution: min=#{min_count}, max=#{max_count}, ratio=#{ratio.round(3)} " \
                      "(counts: #{counts.inspect})"
   end
+
+  # RUBY-3364: regression for lost-wakeup in the anti-barging gate.
+  #
+  # The anti-barging change makes a thread arriving at the gate wait whenever
+  # `@size_waiters > 0`. That counter is only decremented after `@size_cv.wait`
+  # returns and the waiter re-acquires the lock. During the brief window
+  # between signal delivery and re-acquisition, a newcomer can observe a
+  # non-zero `@size_waiters` and enter the wait. If the newcomer enters while
+  # capacity is available (e.g., a batch of check-ins fired more signals than
+  # there were waiters), and no further signal arrives, the newcomer times
+  # out despite capacity being available — a classic lost wakeup.
+  #
+  # This test forces the race window deterministically by instrumenting the
+  # pool's `@size_cv.wait` to yield the lock long enough for a newcomer to
+  # enter and queue up. The fix signals the next waiter when a successful
+  # waiter leaves the queue.
+  describe 'lost-wakeup at the size gate' do
+    let(:client) do
+      authorized_client.with(
+        max_pool_size: 2,
+        min_pool_size: 2,
+        wait_queue_timeout: 2
+      )
+    end
+
+    let(:coll) { client['ruby_3364_lostwakeup'] }
+
+    before do
+      coll.drop
+      coll.insert_one(x: 1)
+    end
+
+    after do
+      client.close
+    end
+
+    it 'does not strand a newcomer that enters during a waiter wake-up window' do
+      pool = client.cluster.next_primary.pool
+      size_cv = pool.instance_variable_get(:@size_cv)
+      pool_lock = pool.instance_variable_get(:@lock)
+
+      # Instrument @size_cv.wait so the FIRST wake-up releases the lock
+      # for long enough that a newcomer can grab it and observe the stale
+      # @size_waiters > 0 state. Subsequent waits are not instrumented.
+      injected = false
+      inject_mutex = Mutex.new
+      original_wait = size_cv.method(:wait)
+      size_cv.define_singleton_method(:wait) do |timeout = nil|
+        result = original_wait.call(timeout)
+        should_inject = false
+        inject_mutex.synchronize do
+          unless injected
+            injected = true
+            should_inject = true
+          end
+        end
+        if should_inject
+          # Open the race window: release the pool lock long enough for a
+          # newcomer thread to observe the stale `@size_waiters > 0` state
+          # before we decrement it.
+          pool_lock.unlock
+          begin
+            sleep 0.3
+          ensure
+            pool_lock.lock
+          end
+        end
+        result
+      end
+
+      begin
+        # Fill the pool.
+        holders_ready = Queue.new
+        release_holders = Queue.new
+        holders = Array.new(2) do
+          Thread.new do
+            conn = pool.check_out
+            holders_ready << :ready
+            release_holders.pop
+            pool.check_in(conn)
+          end
+        end
+        2.times { holders_ready.pop }
+
+        # Queue a single waiter. After it acquires, it holds until we
+        # explicitly release — no check-in fires from this thread until
+        # the end of the test.
+        waiter_release = Queue.new
+        waiter = Thread.new do
+          conn = pool.check_out
+          waiter_release.pop
+          pool.check_in(conn)
+        end
+        sleep 0.2 # allow waiter to block on @size_cv.wait
+
+        # Release BOTH holders. Two @size_cv.signal calls fire; only one
+        # waiter exists. When the waiter wakes, our instrumentation opens
+        # the race window (sleeps 300ms holding no lock). During that
+        # window, a newcomer thread enters and sees @size_waiters > 0.
+        2.times { release_holders << :go }
+
+        # Give a tiny bit of time for the waiter to receive the signal
+        # and enter the injected sleep.
+        sleep 0.05
+
+        newcomer_latency = nil
+        newcomer = Thread.new do
+          t0 = Mongo::Utils.monotonic_time
+          conn = pool.check_out
+          newcomer_latency = Mongo::Utils.monotonic_time - t0
+          pool.check_in(conn)
+        end
+
+        holders.each(&:join)
+        newcomer.join
+        waiter_release << :go
+        waiter.join
+
+        # The newcomer entered @size_cv.wait with capacity already available
+        # (the original waiter woke and took only one of the two freed slots).
+        # Without the baton-pass fix, no further signal arrives and the
+        # newcomer waits until its deadline (wait_queue_timeout) before the
+        # wait returns due to timeout, at which point the predicate is
+        # re-evaluated and passes. Observable symptom: newcomer latency
+        # equals wait_queue_timeout.
+        #
+        # With the fix, the successful waiter signals the next thread in
+        # the queue on exit, and the newcomer wakes promptly.
+        expect(newcomer_latency).to be < 1.0,
+                                    'newcomer waited ' \
+                                    "#{(newcomer_latency * 1000).round}ms for a connection " \
+                                    'that was already available (lost-wakeup regression)'
+      ensure
+        size_cv.singleton_class.send(:remove_method, :wait) if size_cv.singleton_class.method_defined?(:wait)
+      end
+    end
+  end
 end

--- a/spec/mongo/server/connection_pool_fairness_spec.rb
+++ b/spec/mongo/server/connection_pool_fairness_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# RUBY-3364: regression for thread starvation under pool over-subscription.
+# Drives a small pool from many threads and asserts that no thread is
+# served materially less often than any other.
+describe 'Mongo::Server::ConnectionPool fairness', retry: 3 do
+  let(:client) do
+    authorized_client.with(
+      max_pool_size: 3,
+      min_pool_size: 3,
+      wait_queue_timeout: 5
+    )
+  end
+
+  let(:coll) { client['ruby_3364_fairness'] }
+
+  before do
+    coll.drop
+    coll.insert_one(x: 1)
+  end
+
+  after do
+    client.close
+  end
+
+  it 'serves every thread at roughly the same rate and does not time out' do
+    threads_count = 30
+    duration_sec = 3
+    stop_at = Mongo::Utils.monotonic_time + duration_sec
+    start_barrier = Queue.new
+    counts = Array.new(threads_count, 0)
+    timeouts = Array.new(threads_count, 0)
+
+    threads = Array.new(threads_count) do |i|
+      Thread.new do
+        start_barrier.pop
+        while Mongo::Utils.monotonic_time < stop_at
+          begin
+            Mongo::QueryCache.uncached { coll.find.first }
+            counts[i] += 1
+          rescue Mongo::Error::ConnectionCheckOutTimeout
+            timeouts[i] += 1
+          end
+        end
+      end
+    end
+
+    threads_count.times { start_barrier << :go }
+    threads.each(&:join)
+
+    total_timeouts = timeouts.sum
+    expect(total_timeouts).to eq(0),
+                              "expected zero checkout timeouts, got #{total_timeouts} " \
+                              "(per-thread: #{timeouts.inspect})"
+
+    min_count = counts.min
+    max_count = counts.max
+    expect(min_count).to be > 0, 'at least one thread was never served'
+    ratio = min_count.to_f / max_count
+    expect(ratio).to be >= 0.5,
+                     "unfair distribution: min=#{min_count}, max=#{max_count}, ratio=#{ratio.round(3)} " \
+                     "(counts: #{counts.inspect})"
+  end
+end


### PR DESCRIPTION
## Summary

Fixes thread starvation in `Mongo::Server::ConnectionPool` when worker threads
significantly outnumber the pool size.

Root cause: mutex barging at the checkout predicate gate. A thread returning
from `do_check_in` re-enters `retrieve_and_connect_connection` while
`unavailable_connections < max_size` is still true, bypasses the wait loop
entirely, and takes the freshly-released connection before any thread blocked
in `@size_cv.wait` can re-acquire `@lock`. With 200 threads and a 5-connection
pool, 5 threads form a closed cycle and the other 195 starve for the entire
run (each completes 2 ops and hits the wait timeout once).

This is *not* non-FIFO condition variable behavior — MRI's `::ConditionVariable`
signals waiters in insertion order. The barging happens at the mutex
re-acquisition boundary, not inside the CV. The full diagnosis and the
rationale for the minimal fix (vs. a larger per-waiter-CV redesign) is in
the design doc that accompanies this change.

## Fix

Introduce per-gate waiter counters (`@size_waiters`, `@max_connecting_waiters`)
and require any thread that arrives with a non-zero counter to enter the
wait loop at least once, regardless of whether the predicate is currently
satisfied. Once a thread has served one wait cycle it is eligible on the
next iteration.

Preserves the existing architecture and synchronization primitives; no
changes to `do_check_in` signaling or `@connection_requests` counting.

## Validation

| workload | before | after |
| -------- | ------ | ----- |
| 200 threads, pool=5, 10s queries, 30s run | min=2, max=17340, ~390 timeouts | min=584, max=585, 0 timeouts |

All existing suites pass against a local replica set:

- `spec/mongo/server/connection_pool_spec.rb` + `connection_pool/` subdir: 114 examples, 0 failures, 3 pending
- `spec/spec_tests/cmap_spec.rb`: 226 examples, 0 failures
- `spec/integration/connection_pool_populator_spec.rb` + `connection_spec.rb`: 23 examples, 0 failures, 10 pending
- `bundle exec rubocop lib/mongo/server/connection_pool.rb spec/mongo/server/connection_pool_fairness_spec.rb`: clean

## Changes

- `lib/mongo/server/connection_pool.rb`: add `@size_waiters` / `@max_connecting_waiters` counters; gate both checkout waits on them
- `spec/mongo/server/connection_pool_fairness_spec.rb`: new regression test asserting per-thread service-count ratio and zero checkout timeouts under oversubscription. Verified to fail on the pre-fix code (`ratio=0.0, min=1, max=~4000`) and pass on the fixed code (`ratio >= 0.99`).
- `profile/connection_pool_fairness.rb`: fairness diagnostic harness kept under `profile/` alongside `driver_bench`. Used to reproduce RUBY-3364 and to validate the fix; not run in default CI.

## Test Plan

- [ ] CI green on all Evergreen variants
- [ ] Reviewer runs `profile/connection_pool_fairness.rb` locally and confirms even distribution
- [ ] Consider whether the `ratio >= 0.5` threshold in the regression spec is appropriate for all CI variants (local observation is `>= 0.99`; 0.5 was chosen to absorb CI noise)