### PR TITLE
RUBY-3623 Rename WriteConcernFailed code name to WriteConcernTimeout

### DIFF
--- a/spec/mongo/auth/user/view_spec.rb
+++ b/spec/mongo/auth/user/view_spec.rb
@@ -473,7 +473,7 @@ describe Mongo::Auth::User::View do
           failCommands: [ failCommand ],
           writeConcernError: {
             code: 64,
-            codeName: 'WriteConcernFailed',
+            codeName: 'WriteConcernTimeout',
             errmsg: 'waiting for replication timed out',
             errInfo: { wtimeout: true }
           }
@@ -494,7 +494,7 @@ describe Mongo::Auth::User::View do
         expect(e.write_concern_error?).to be true
         expect(e.write_concern_error_document).to eq(
           'code' => 64,
-          'codeName' => 'WriteConcernFailed',
+          'codeName' => 'WriteConcernTimeout',
           'errmsg' => 'waiting for replication timed out',
           'errInfo' => { 'wtimeout' => true }
         )

--- a/spec/spec_tests/data/retryable_writes/legacy/insertOne-serverErrors.yml
+++ b/spec/spec_tests/data/retryable_writes/legacy/insertOne-serverErrors.yml
@@ -480,7 +480,7 @@ tests:
                     - { _id: 2, x: 22 }
                     - { _id: 3, x: 33 }  # The write was still applied.
     -
-        description: "InsertOne fails after WriteConcernError WriteConcernFailed"
+        description: "InsertOne fails after WriteConcernError WriteConcernTimeout"
         failPoint:
             configureFailPoint: failCommand
             mode: { times: 1 }
@@ -488,7 +488,6 @@ tests:
                 failCommands: ["insert"]
                 writeConcernError:
                     code: 64
-                    codeName: WriteConcernFailed
                     errmsg: waiting for replication timed out
                     errInfo: {wtimeout: True}
         operation:

--- a/spec/spec_tests/data/transactions/error-labels.yml
+++ b/spec/spec_tests/data/transactions/error-labels.yml
@@ -736,7 +736,7 @@ tests:
       collection:
         data: []
 
-  - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed
+  - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernTimeout
 
     failPoint:
       configureFailPoint: failCommand
@@ -744,7 +744,7 @@ tests:
       data:
           failCommands: ["commitTransaction"]
           writeConcernError:
-            code: 64  # WriteConcernFailed without wtimeout
+            code: 64  # WriteConcernTimeout without wtimeout
             errmsg: multiple errors reported
 
     operations:
@@ -816,7 +816,7 @@ tests:
         data:
           - _id: 1
 
-  - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernFailed with wtimeout
+  - description: add UnknownTransactionCommitResult label to writeConcernError WriteConcernTimeout with wtimeout
 
     failPoint:
       configureFailPoint: failCommand
@@ -825,7 +825,6 @@ tests:
           failCommands: ["commitTransaction"]
           writeConcernError:
             code: 64
-            codeName: WriteConcernFailed
             errmsg: waiting for replication timed out
             errInfo: {wtimeout: True}
 

--- a/spec/spec_tests/data/transactions_api/commit-writeconcernerror.yml
+++ b/spec/spec_tests/data/transactions_api/commit-writeconcernerror.yml
@@ -13,7 +13,7 @@ data: []
 
 tests:
   -
-    description: commitTransaction is retried after WriteConcernFailed timeout error
+    description: commitTransaction is retried after WriteConcernTimeout timeout error
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 2 }
@@ -23,7 +23,6 @@ tests:
           # with writeConcernError (see: SERVER-39292)
           writeConcernError:
             code: 64
-            codeName: WriteConcernFailed
             errmsg: "waiting for replication timed out"
             errInfo: { wtimeout: true }
     operations:
@@ -106,10 +105,10 @@ tests:
           - { _id: 1 }
   -
     # This test configures the fail point to return an error with the
-    # WriteConcernFailed code but without errInfo that would identify it as a
+    # WriteConcernTimeout code but without errInfo that would identify it as a
     # wtimeout error. This tests that drivers do not assume that all
-    # WriteConcernFailed errors are due to a replication timeout.
-    description: commitTransaction is retried after WriteConcernFailed non-timeout error
+    # WriteConcernTimeout errors are due to a replication timeout.
+    description: commitTransaction is retried after WriteConcernTimeout non-timeout error
     failPoint:
       configureFailPoint: failCommand
       mode: { times: 2 }
@@ -119,7 +118,6 @@ tests:
           # with writeConcernError (see: SERVER-39292)
           writeConcernError:
             code: 64
-            codeName: WriteConcernFailed
             errmsg: "multiple errors reported"
     operations:
       - *operation


### PR DESCRIPTION
Sync the spec test fixtures to match [mongodb/specifications@b643abfb](https://github.com/mongodb/specifications/commit/b643abfb05c9b8c799723876bba976d9bc05e555)
(DRIVERS-3007). The server has renamed error code 64's name from
`WriteConcernFailed` to `WriteConcernTimeout`; the numeric code is
unchanged.

The spec change drops `codeName: WriteConcernFailed` from failpoint
configs (so the server returns its version-appropriate name) and
updates test descriptions and surrounding comments. This PR mirrors
those edits in the Ruby driver's local copies of the affected
fixtures.

The driver-specific failpoint test in `spec/mongo/auth/user/view_spec.rb`
sets `codeName` itself and asserts on the echoed value, so both the
failpoint and the assertion are updated to the new name.

## Test plan

- [x] `bundle exec rspec spec/mongo/auth/user/view_spec.rb` — 55 examples, 0 failures (4 unrelated pending)
- [x] `bundle exec rspec spec/spec_tests/retryable_writes_spec.rb -e 'WriteConcernTimeout'` — replica-set examples ran and passed; sharded ones pending as expected
- [x] `bundle exec rubocop spec/mongo/auth/user/view_spec.rb` — clean