### PR TITLE
RUBY-3824 Restore conditional skip logic in transactions spec runner

### DIFF
--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -936,6 +936,13 @@ module Mongo
     #
     # @api private
     def unpin(connection = nil)
+      # Idempotent: if there is no pinned state to clear, do nothing. Nested
+      # unpin_maybe handlers (e.g. in BulkWrite#execute_operation wrapping an
+      # OpMsg execution that already calls unpin_maybe in its own do_execute)
+      # can call this method twice for the same error; checking the connection
+      # back into the pool a second time would raise from the pool.
+      return if @pinned_server.nil? && @pinned_connection.nil? && @pinned_connection_global_id.nil?
+
       @pinned_server = nil
       @pinned_connection_global_id = nil
       conn = connection || @pinned_connection

--- a/spec/mongo/session_spec.rb
+++ b/spec/mongo/session_spec.rb
@@ -340,4 +340,26 @@ describe Mongo::Session do
       session.session_id.should be_a(BSON::Document)
     end
   end
+
+  describe '#unpin' do
+    context 'when called twice with the same connection' do
+      # Nested unpin_maybe handlers in the bulk_write code path can trigger
+      # Session#unpin to be invoked twice for the same network error: once
+      # from Operation::Executable#do_execute and once from
+      # BulkWrite#execute_operation. The second call must be a no-op rather
+      # than raising "Trying to check in a connection which is not currently
+      # checked out" from the pool.
+      it 'does not raise on the second call' do
+        server = authorized_client.cluster.next_primary
+        server.with_connection do |connection|
+          session.pin_to_server(server)
+          session.unpin(connection)
+
+          expect do
+            session.unpin(connection)
+          end.not_to raise_error
+        end
+      end
+    end
+  end
 end

--- a/spec/runners/transactions.rb
+++ b/spec/runners/transactions.rb
@@ -25,7 +25,7 @@ def define_transactions_spec_tests(test_paths, expectations_bson_types: true)
     spec = Mongo::Transactions::Spec.new(file)
 
     context(spec.description) do
-      define_spec_tests_with_requirements(spec) do |_req|
+      define_spec_tests_with_requirements(spec) do |req|
         spec.tests(expectations_bson_types: expectations_bson_types).each do |test|
           context(test.description) do
             before(:all) do
@@ -38,9 +38,8 @@ def define_transactions_spec_tests(test_paths, expectations_bson_types: true)
                   skip 'Test does not specify multiple mongoses'
                 end
               end
-              skip test.skip_reason
-
-              skip 'Requirements not satisfied'
+              skip test.skip_reason if test.skip_reason
+              skip 'Requirements not satisfied' unless req.satisfied?
 
               test.setup_test
             end


### PR DESCRIPTION
A rubocop autocorrect in commit
[8db64312b](https://github.com/mongodb/mongo-ruby-driver/commit/8db64312b8ca53d2e564e59250c079a38baf3ad3)
(\"Enable rubocop on all files, with exceptions\" — #3005) flattened
the original `if test.skip_reason` and `unless req.satisfied?` guards
in `spec/runners/transactions.rb` into bare `skip` calls inside a
single `before(:all)` block:

```ruby
before(:all) do
  ...
  skip test.skip_reason            # always skips, even when nil
  skip 'Requirements not satisfied' # always skips
  test.setup_test                   # never reached
end
```

Effect: every `transactions_spec.rb` and `transactions_api_spec.rb`
example reports as `PENDING` regardless of topology or actual
requirements. The transactions spec test suite has not run locally on
master since that commit (2026-03-27).

The fix restores the conditional checks and passes `req` through to
the block (it was renamed to `_req` because it had become unused after
the regression).

## Test plan

Against a local 3-node replica set (`replicaSet=replset`):

- [x] `bundle exec rspec spec/spec_tests/transactions_spec.rb` — 1809 examples, 0 failures, 965 pending (sharded-only). Before: all pending.
- [x] `bundle exec rspec spec/spec_tests/transactions_api_spec.rb` — 370 examples, 0 failures, 185 pending (sharded-only). Before: all pending.
- [x] `bundle exec rubocop spec/runners/transactions.rb` — clean