### PR TITLE
RUBY-3712 Expose atClusterTime in snapshot sessions

### DIFF
--- a/lib/mongo/operation/shared/executable.rb
+++ b/lib/mongo/operation/shared/executable.rb
@@ -59,7 +59,7 @@ module Mongo
                       end
                     end
 
-                    if session.snapshot? && !session.snapshot_timestamp
+                    if session.snapshot?
                       session.snapshot_timestamp = result.snapshot_timestamp
                     end
                   end

--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -74,12 +74,22 @@ module Mongo
     #     and *:nearest*.
     # @option options [ true | false ] :snapshot Set up the session for
     #   snapshot reads.
+    # @option options [ BSON::Timestamp ] :snapshot_time The desired snapshot
+    #   time for snapshot reads. Only valid when :snapshot is true.
     #
     # @since 2.5.0
     # @api private
     def initialize(server_session, client, options = {})
       if options[:causal_consistency] && options[:snapshot]
         raise ArgumentError, ':causal_consistency and :snapshot options cannot be both set on a session'
+      end
+
+      if options[:snapshot_time] && !options[:snapshot]
+        raise ArgumentError, ':snapshot_time can only be set when :snapshot is true'
+      end
+
+      if options[:snapshot_time] && !options[:snapshot_time].is_a?(BSON::Timestamp)
+        raise ArgumentError, ':snapshot_time must be a BSON::Timestamp'
       end
 
       if options[:implicit]
@@ -104,6 +114,7 @@ module Mongo
       @with_transaction_deadline = nil
       @with_transaction_timeout_ms = nil
       @inside_with_transaction = false
+      @snapshot_timestamp = options[:snapshot_time]
     end
 
     # @return [ Hash ] The options for this session.
@@ -1273,8 +1284,23 @@ module Mongo
       @server_session.txn_num
     end
 
+    # @return [ BSON::Timestamp | nil ] The snapshot time for this session.
+    #   nil if the session is not a snapshot session, or if it is a snapshot
+    #   session for which no :snapshot_time option was provided and no read
+    #   has yet captured atClusterTime from the server.
+    attr_reader :snapshot_timestamp
+
+    # Sets the snapshot time for the session. Once set, subsequent
+    # assignments are ignored: snapshotTime is established at most once per
+    # session, either from the :snapshot_time option at construction or from
+    # the atClusterTime returned by the first find/aggregate/distinct
+    # response. This keeps the property effectively read-only for callers,
+    # per the snapshot-sessions spec rationale.
+    #
     # @api private
-    attr_accessor :snapshot_timestamp
+    def snapshot_timestamp=(value)
+      @snapshot_timestamp ||= value
+    end
 
     # @return [ Integer | nil ] The deadline for the current transaction, if any.
     # @api private

--- a/spec/mongo/session_spec.rb
+++ b/spec/mongo/session_spec.rb
@@ -32,6 +32,53 @@ describe Mongo::Session do
     it 'sets the cluster' do
       expect(session.cluster).to be(authorized_client.cluster)
     end
+
+    context 'when :snapshot_time is set without :snapshot' do
+      let(:options) do
+        { snapshot_time: BSON::Timestamp.new(0, 1) }
+      end
+
+      it 'raises ArgumentError' do
+        expect { session }.to raise_error(
+          ArgumentError, /:snapshot_time can only be set when :snapshot is true/
+        )
+      end
+    end
+
+    context 'when :snapshot_time is not a BSON::Timestamp' do
+      let(:options) do
+        { snapshot: true, snapshot_time: 12_345 }
+      end
+
+      it 'raises ArgumentError' do
+        expect { session }.to raise_error(
+          ArgumentError, /:snapshot_time must be a BSON::Timestamp/
+        )
+      end
+    end
+
+    context 'when :snapshot_time is set with :snapshot' do
+      let(:timestamp) { BSON::Timestamp.new(42, 7) }
+
+      let(:options) do
+        { snapshot: true, snapshot_time: timestamp }
+      end
+
+      it 'exposes the timestamp via snapshot_timestamp' do
+        expect(session.snapshot_timestamp).to eq(timestamp)
+      end
+    end
+  end
+
+  describe '#snapshot_timestamp=' do
+    let(:initial_timestamp) { BSON::Timestamp.new(1, 1) }
+    let(:later_timestamp) { BSON::Timestamp.new(2, 2) }
+    let(:options) { { snapshot: true, snapshot_time: initial_timestamp } }
+
+    it 'is a no-op once a snapshot timestamp is set' do
+      session.snapshot_timestamp = later_timestamp
+      expect(session.snapshot_timestamp).to eq(initial_timestamp)
+    end
   end
 
   describe '#inspect' do

--- a/spec/runners/unified/support_operations.rb
+++ b/spec/runners/unified/support_operations.rb
@@ -68,6 +68,11 @@ module Unified
       session.end_session
     end
 
+    def get_snapshot_time(op)
+      session = entities.get(:session, op.use!('object'))
+      session.snapshot_timestamp
+    end
+
     def assert_session_dirty(op)
       consume_test_runner(op)
       use_arguments(op) do |args|

--- a/spec/runners/unified/test.rb
+++ b/spec/runners/unified/test.rb
@@ -285,12 +285,7 @@ module Unified
                    database.fs
                  when 'session'
                    client = entities.get(:client, spec.use!('client'))
-
-                   opts = if smc_opts = spec.use('sessionOptions')
-                            ::Utils.underscore_hash(smc_opts)
-                          else
-                            {}
-                          end
+                   opts = build_session_options(spec)
 
                    client.start_session(**opts).tap do |session|
                      session.advance_cluster_time(@cluster_time)
@@ -378,6 +373,20 @@ module Unified
         entities.set(type.to_sym, id, entity)
       end
       @entities_created = true
+    end
+
+    # Builds the keyword options for Client#start_session from a session
+    # entity spec. When sessionOptions contains snapshotTime, the value is the
+    # name of a previously saved entity holding the actual BSON::Timestamp.
+    def build_session_options(spec)
+      smc_opts = spec.use('sessionOptions')
+      return {} unless smc_opts
+
+      opts = ::Utils.underscore_hash(smc_opts)
+      if opts[:snapshot_time].is_a?(String)
+        opts[:snapshot_time] = entities.get(:result, opts[:snapshot_time])
+      end
+      opts
     end
 
     def set_initial_data

--- a/spec/spec_tests/data/sessions_unified/snapshot-sessions.yml
+++ b/spec/spec_tests/data/sessions_unified/snapshot-sessions.yml
@@ -378,7 +378,7 @@ tests:
       fieldName: x
       filter: {}
       session: session0
-    expectResult: [ 11 ] 
+    expectResult: [ 11 ]
   expectEvents:
   - client: client0
     events:
@@ -480,3 +480,406 @@ tests:
       isError: true
       isClientError: true
       errorContains: Transactions are not supported in snapshot sessions
+
+- description: Find operation with snapshot and snapshot time
+  operations:
+    - name: find
+      object: collection0
+      arguments:
+        session: session0
+        filter: {}
+      expectResult:
+        - { _id: 1, x: 11 }
+        - { _id: 2, x: 11 }
+    - name: getSnapshotTime
+      object: session0
+      saveResultAsEntity: &savedSnapshotTime savedSnapshotTime
+    - name: insertOne
+      object: collection0
+      arguments:
+        document: { _id: 3, x: 33 }
+    - name: createEntities
+      object: testRunner
+      arguments:
+        entities:
+          - session:
+              id: session2
+              client: client0
+              sessionOptions:
+                snapshot: true
+                snapshotTime: *savedSnapshotTime
+    - name: find
+      object: collection0
+      arguments:
+        session: session2
+        filter: {}
+      expectResult:
+        - { _id: 1, x: 11 }
+        - { _id: 2, x: 11 }
+    ## Calling the operation again to verify that atClusterTime/snapshotTime has not been modified after the first query
+    - name: find
+      object: collection0
+      arguments:
+        session: session2
+        filter: {}
+      expectResult:
+        - { _id: 1, x: 11 }
+        - { _id: 2, x: 11 }
+    - name: find
+      object: collection0
+      arguments:
+        filter: {}
+      expectResult:
+        - { _id: 1, x: 11 }
+        - { _id: 2, x: 11 }
+        - { _id: 3, x: 33 }
+  expectEvents:
+    - client: client0
+      events:
+        - commandStartedEvent:
+            command:
+              find: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime:
+                  "$$exists": false
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              find: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime: { $$matchesEntity: *savedSnapshotTime }
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              find: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime: { $$matchesEntity: *savedSnapshotTime }
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              find: collection0
+              readConcern:
+                "$$exists": false
+            databaseName: database0
+
+- description: Distinct operation with snapshot and snapshot time
+  operations:
+    - name: distinct
+      object: collection0
+      arguments:
+        session: session0
+        filter: {}
+        fieldName: x
+      expectResult: [11]
+    - name: getSnapshotTime
+      object: session0
+      saveResultAsEntity: &savedSnapshotTime savedSnapshotTime
+    - name: insertOne
+      object: collection0
+      arguments:
+        document: { _id: 3, x: 33 }
+    - name: createEntities
+      object: testRunner
+      arguments:
+        entities:
+          - session:
+              id: session2
+              client: client0
+              sessionOptions:
+                snapshot: true
+                snapshotTime: *savedSnapshotTime
+    - name: distinct
+      object: collection0
+      arguments:
+        session: session2
+        filter: {}
+        fieldName: x
+      expectResult: [11]
+    ## Calling the operation again to verify that atClusterTime/snapshotTime has not been modified after the first query
+    - name: distinct
+      object: collection0
+      arguments:
+        session: session2
+        filter: {}
+        fieldName: x
+      expectResult: [11]
+    - name: distinct
+      object: collection0
+      arguments:
+        filter: {}
+        fieldName: x
+      expectResult: [11, 33]
+  expectEvents:
+    - client: client0
+      events:
+        - commandStartedEvent:
+            command:
+              distinct: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime:
+                  "$$exists": false
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              distinct: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime: { $$matchesEntity: *savedSnapshotTime }
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              distinct: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime: { $$matchesEntity: *savedSnapshotTime }
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              distinct: collection0
+              readConcern:
+                "$$exists": false
+            databaseName: database0
+
+- description: Aggregate operation with snapshot and snapshot time
+  operations:
+    - name: aggregate
+      object: collection0
+      arguments:
+        session: session0
+        pipeline:
+        - "$match": { _id: 1 }
+      expectResult:
+      - { _id: 1, x: 11 }
+    - name: getSnapshotTime
+      object: session0
+      saveResultAsEntity: &savedSnapshotTime savedSnapshotTime
+    - name: findOneAndUpdate
+      object: collection0
+      arguments:
+        filter: { _id: 1 }
+        update: { $inc: { x: 1 } }
+        returnDocument: After
+      expectResult: { _id: 1, x: 12 }
+    - name: createEntities
+      object: testRunner
+      arguments:
+        entities:
+          - session:
+              id: session2
+              client: client0
+              sessionOptions:
+                snapshot: true
+                snapshotTime: *savedSnapshotTime
+    - name: aggregate
+      object: collection0
+      arguments:
+        session: session2
+        pipeline:
+        - "$match": { _id: 1 }
+      expectResult:
+      - { _id: 1, x: 11 }
+    ## Calling the operation again to verify that atClusterTime/snapshotTime has not been modified after the first query
+    - name: aggregate
+      object: collection0
+      arguments:
+        session: session2
+        pipeline:
+        - "$match": { _id: 1 }
+      expectResult:
+      - { _id: 1, x: 11 }
+    - name: aggregate
+      object: collection0
+      arguments:
+        pipeline:
+        - "$match": { _id: 1 }
+      expectResult:
+      - { _id: 1, x: 12 }
+  expectEvents:
+    - client: client0
+      events:
+        - commandStartedEvent:
+            command:
+              aggregate: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime:
+                  "$$exists": false
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              aggregate: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime: { $$matchesEntity: *savedSnapshotTime }
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              aggregate: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime: { $$matchesEntity: *savedSnapshotTime }
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              aggregate: collection0
+              readConcern:
+                "$$exists": false
+            databaseName: database0
+
+- description: countDocuments operation with snapshot and snapshot time
+  operations:
+    - name: countDocuments
+      object: collection0
+      arguments:
+        session: session0
+        filter: {}
+      expectResult: 2
+    - name: getSnapshotTime
+      object: session0
+      saveResultAsEntity: &savedSnapshotTime savedSnapshotTime
+    - name: insertOne
+      object: collection0
+      arguments:
+        document: { _id: 3, x: 33 }
+    - name: createEntities
+      object: testRunner
+      arguments:
+        entities:
+          - session:
+              id: session2
+              client: client0
+              sessionOptions:
+                snapshot: true
+                snapshotTime: *savedSnapshotTime
+    - name: countDocuments
+      object: collection0
+      arguments:
+        session: session2
+        filter: {}
+      expectResult: 2
+    ## Calling the operation again to verify that atClusterTime/snapshotTime has not been modified after the first query
+    - name: countDocuments
+      object: collection0
+      arguments:
+        session: session2
+        filter: {}
+      expectResult: 2
+    - name: countDocuments
+      object: collection0
+      arguments:
+        filter: {}
+      expectResult: 3
+  expectEvents:
+    - client: client0
+      events:
+        - commandStartedEvent:
+            command:
+              aggregate: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime:
+                  "$$exists": false
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              aggregate: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime: { $$matchesEntity: *savedSnapshotTime }
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              aggregate: collection0
+              readConcern:
+                level: snapshot
+                atClusterTime: { $$matchesEntity: *savedSnapshotTime }
+            databaseName: database0
+        - commandStartedEvent:
+            command:
+              aggregate: collection0
+              readConcern:
+                "$$exists": false
+            databaseName: database0
+
+- description: Mixed operation with snapshot and snapshotTime
+  operations:
+  - name: find
+    object: collection0
+    arguments:
+      session: session0
+      filter: { _id: 1 }
+    expectResult:
+    - { _id: 1, x: 11 }
+  - name: getSnapshotTime
+    object: session0
+    saveResultAsEntity: &savedSnapshotTime savedSnapshotTime
+  - name: findOneAndUpdate
+    object: collection0
+    arguments:
+      filter: { _id: 1 }
+      update: { $inc: { x: 1 } }
+      returnDocument: After
+    expectResult: { _id: 1, x: 12 }
+  - name: createEntities
+    object: testRunner
+    arguments:
+      entities:
+        - session:
+            id: session2
+            client: client0
+            sessionOptions:
+              snapshot: true
+              snapshotTime: *savedSnapshotTime
+  - name: find
+    object: collection0
+    arguments:
+      filter: { _id: 1 }
+    expectResult:
+    - { _id: 1, x: 12 }
+  - name: aggregate
+    object: collection0
+    arguments:
+      pipeline:
+      - "$match":
+          _id: 1
+      session: session2
+    expectResult:
+    - { _id: 1, x: 11 }
+  - name: distinct
+    object: collection0
+    arguments:
+      fieldName: x
+      filter: {}
+      session: session2
+    expectResult: [ 11 ]
+  expectEvents:
+  - client: client0
+    events:
+    - commandStartedEvent:
+        command:
+          find: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime:
+              "$$exists": false
+    - commandStartedEvent:
+        command:
+          find: collection0
+          readConcern:
+            "$$exists": false
+    - commandStartedEvent:
+        command:
+          aggregate: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime: { $$matchesEntity: *savedSnapshotTime }
+    - commandStartedEvent:
+        command:
+          distinct: collection0
+          readConcern:
+            level: snapshot
+            atClusterTime: { $$matchesEntity: *savedSnapshotTime }


### PR DESCRIPTION
Adds the ability to read and pre-seed the snapshot timestamp on a snapshot session, per the [snapshot-sessions spec](https://github.com/mongodb/specifications/blob/master/source/sessions/snapshot-sessions.md) and the unified-test-format addition for `getSnapshotTime`.

## Changes

- `Mongo::Session#snapshot_timestamp` is now public and returns the BSON::Timestamp captured for the session, or `nil` for a non-snapshot session and for snapshot sessions that haven't yet performed a read.
- `Client#start_session(snapshot: true, snapshot_time: ts)` accepts a pre-set snapshot time. Validates that `:snapshot_time` requires `:snapshot: true` and that the value is a `BSON::Timestamp`.
- The writer is idempotent (`@snapshot_timestamp ||= value`), enforcing the spec's "snapshotTime must be read-only" rationale at the source of truth rather than at one call site. Removed the now-redundant guard in `executable.rb`.
- Unified test runner: added `getSnapshotTime` operation handler and entity-reference resolution for `snapshotTime` in `sessionOptions`, per unified-test-format.md §getSnapshotTime.
- Refreshed `snapshot-sessions.yml` fixtures from the spec repo.

## Test plan

- [x] `bundle exec rubocop` clean on all changed files
- [x] `MONGODB_URI=... bundle exec rspec spec/spec_tests/sessions_unified_spec.rb spec/mongo/session_spec.rb spec/integration/snapshot_query_examples_spec.rb` — 78 examples, 0 failures, 7 pre-existing pending
- [x] New unit specs cover the validation paths (`:snapshot_time` without `:snapshot`, non-Timestamp value) that aren't expressible in the unified test format
- [x] New YAML fixtures (Find/Distinct/Aggregate/countDocuments/Mixed with `snapshot_time`) all pass

## Jira

[RUBY-3712](https://jira.mongodb.org/browse/RUBY-3712) (split from DRIVERS-2782)