### PR TITLE
RUBY-3628 Deprecate hedged reads option

### DIFF
--- a/lib/mongo/error/invalid_server_preference.rb
+++ b/lib/mongo/error/invalid_server_preference.rb
@@ -33,6 +33,9 @@ module Mongo
       # Error message when hedge is specified for a read preference that does not support it.
       #
       # @api private
+      #
+      # @deprecated Hedged reads are deprecated in MongoDB Server 8.0 and will
+      #   be removed in a future version.
       NO_HEDGE_SUPPORT = 'The hedge option cannot be set for this read preference'
 
       # Error message for when the max staleness is not at least twice the heartbeat frequency.

--- a/lib/mongo/server_selector/base.rb
+++ b/lib/mongo/server_selector/base.rb
@@ -37,6 +37,8 @@ module Mongo
       #   reads on the server. Hedged reads are not enabled by default. When
       #   specifying this option, it must be in the format: { enabled: true },
       #   where the value of the :enabled key is a boolean value.
+      #   @deprecated Hedged reads are deprecated in MongoDB Server 8.0 and will
+      #     be removed in a future version.
       #
       # @raise [ Error::InvalidServerPreference ] If tag sets are specified
       #   but not allowed.
@@ -51,6 +53,14 @@ module Mongo
         @hedge = options[:hedge]
 
         validate!
+
+        return if @hedge.nil?
+
+        Mongo::Deprecations.warn(
+          :hedge_read_preference,
+          'The hedge read preference option is deprecated. Hedged reads are ' \
+          'deprecated in MongoDB Server 8.0 and will be removed in a future version.'
+        )
       end
 
       # @return [ Hash ] options The options.
@@ -67,6 +77,9 @@ module Mongo
 
       # @return [ Hash | nil ] hedge The document specifying whether to enable
       #   hedged reads.
+      #
+      # @deprecated Hedged reads are deprecated in MongoDB Server 8.0 and will
+      #   be removed in a future version.
       attr_reader :hedge
 
       # Get the timeout for server selection.

--- a/lib/mongo/server_selector/nearest.rb
+++ b/lib/mongo/server_selector/nearest.rb
@@ -59,6 +59,9 @@ module Mongo
       # Whether the hedge option is allowed to be defined for this server preference.
       #
       # @return [ true ] true
+      #
+      # @deprecated Hedged reads are deprecated in MongoDB Server 8.0 and will
+      #   be removed in a future version.
       def hedge_allowed?
         true
       end

--- a/lib/mongo/server_selector/primary.rb
+++ b/lib/mongo/server_selector/primary.rb
@@ -59,6 +59,9 @@ module Mongo
       # Whether the hedge option is allowed to be defined for this server preference.
       #
       # @return [ false ] false
+      #
+      # @deprecated Hedged reads are deprecated in MongoDB Server 8.0 and will
+      #   be removed in a future version.
       def hedge_allowed?
         false
       end

--- a/lib/mongo/server_selector/primary_preferred.rb
+++ b/lib/mongo/server_selector/primary_preferred.rb
@@ -59,6 +59,9 @@ module Mongo
       # Whether the hedge option is allowed to be defined for this server preference.
       #
       # @return [ true ] true
+      #
+      # @deprecated Hedged reads are deprecated in MongoDB Server 8.0 and will
+      #   be removed in a future version.
       def hedge_allowed?
         true
       end

--- a/lib/mongo/server_selector/secondary.rb
+++ b/lib/mongo/server_selector/secondary.rb
@@ -59,6 +59,9 @@ module Mongo
       # Whether the hedge option is allowed to be defined for this server preference.
       #
       # @return [ true ] true
+      #
+      # @deprecated Hedged reads are deprecated in MongoDB Server 8.0 and will
+      #   be removed in a future version.
       def hedge_allowed?
         true
       end

--- a/lib/mongo/server_selector/secondary_preferred.rb
+++ b/lib/mongo/server_selector/secondary_preferred.rb
@@ -59,6 +59,9 @@ module Mongo
       # Whether the hedge option is allowed to be defined for this server preference.
       #
       # @return [ true ] true
+      #
+      # @deprecated Hedged reads are deprecated in MongoDB Server 8.0 and will
+      #   be removed in a future version.
       def hedge_allowed?
         true
       end


### PR DESCRIPTION
## Description

[RUBY-3628](https://jira.mongodb.org/browse/RUBY-3628). Implements the [server-selection spec change](https://github.com/mongodb/specifications/commit/75027a8e91ff50778aed2ad5a67c005f2694705f) for [DRIVERS-2929](https://jira.mongodb.org/browse/DRIVERS-2929).

Hedged reads are deprecated in MongoDB Server 8.0 and will be removed in a future version. The spec requires that "Driver APIs related to the `hedge` parameter SHOULD be annotated and documented as deprecated. If static annotations are not used, drivers MUST emit a runtime deprecation warning if a `hedge` parameter is specified."

Ruby has no static deprecation annotation, so this PR does both: it adds YARD `@deprecated` tags everywhere `hedge` is exposed, and it emits a one-time runtime warning via the existing `Mongo::Deprecations` helper (same pattern as `:map_reduce`).

## Changes

- `lib/mongo/server_selector/base.rb` — annotate the `:hedge` option, the `hedge` attr_reader, and emit a runtime `Mongo::Deprecations.warn(:hedge_read_preference, ...)` when a selector is constructed with a non-nil `hedge`.
- `lib/mongo/server_selector/{primary,secondary,primary_preferred,secondary_preferred,nearest}.rb` — annotate the per-selector `hedge_allowed?` methods.
- `lib/mongo/error/invalid_server_preference.rb` — annotate the `NO_HEDGE_SUPPORT` constant.

No behavioral change. The `hedge` option still serializes to the wire and the existing validation still raises `Error::InvalidServerPreference` for invalid shapes.

## Cross-driver references

- Python: mongodb/mongo-python-driver#2213 (PYTHON-5169) — runtime `DeprecationWarning`, no static annotations available.
- Java: mongodb/mongo-java-driver#1655 (JAVA-5804) — `@Deprecated` annotation only.
- Go: mongodb/mongo-go-driver#2100 (GODRIVER-3494) — `Deprecated:` doc-comment only.

## Test plan

This change is annotation + a one-line runtime warning. No new specs added; per the spec change there is no behavioral surface to assert.

- [x] `bundle exec rubocop` clean on all modified files.
- [x] `MONGODB_URI=... bundle exec rspec spec/mongo/server_selector/{primary,primary_preferred,secondary,secondary_preferred,nearest}_spec.rb` — 200 examples, 0 failures.
- [x] `MONGODB_URI=... bundle exec rspec spec/mongo/operation/read_preference_op_msg_spec.rb` — 41 examples, 0 failures.
- [x] Deprecation warning observed once per process when constructing a selector with `hedge: { ... }`.