### PR TITLE
Add MongoDB 8.2 to Evergreen test matrix

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -781,6 +781,10 @@ axes:
         display_name: "Rapid"
         variables:
           MONGODB_VERSION: "rapid"
+      - id: "8.2"
+        display_name: "8.2"
+        variables:
+          MONGODB_VERSION: "8.2"
       - id: "8.0"
         display_name: "8.0"
         variables:
@@ -1183,7 +1187,7 @@ buildvariants:
     matrix_spec:
       auth-and-ssl: ["auth-and-ssl", "noauth-and-nossl"]
       ruby: "ruby-4.0"
-      mongodb-version: ["8.0", "7.0"]
+      mongodb-version: ["8.2", "8.0", "7.0"]
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ubuntu2204
     display_name: ${auth-and-ssl} ${ruby} db-${mongodb-version} ${topology}
@@ -1194,7 +1198,7 @@ buildvariants:
   - matrix_name: "mongo-recent"
     matrix_spec:
       ruby: ["ruby-4.0", "ruby-3.4", "ruby-3.3", "ruby-3.2", "jruby-9.4"]
-      mongodb-version: ["8.0", "7.0"]
+      mongodb-version: ["8.2", "8.0", "7.0"]
       topology: ["standalone", "replica-set", "sharded-cluster"]
       os: ubuntu2204
     display_name: "${mongodb-version} ${os} ${topology} ${auth-and-ssl} ${ruby}"
@@ -1365,7 +1369,7 @@ buildvariants:
     matrix_spec:
       stress: on
       ruby: "ruby-4.0"
-      mongodb-version: ["8.0", "7.0"]
+      mongodb-version: ["8.2", "8.0", "7.0"]
       topology: replica-set
       os: ubuntu2204
     display_name: "${mongodb-version} ${topology} stress ${ruby}"

--- a/.evergreen/config/axes.yml.erb
+++ b/.evergreen/config/axes.yml.erb
@@ -6,6 +6,10 @@ axes:
         display_name: "Rapid"
         variables:
           MONGODB_VERSION: "rapid"
+      - id: "8.2"
+        display_name: "8.2"
+        variables:
+          MONGODB_VERSION: "8.2"
       - id: "8.0"
         display_name: "8.0"
         variables:

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -32,7 +32,7 @@
 
   stable_and_rapid = [ latest_stable_mdb_raw, "rapid" ]
 
-  recent_mdb = %w( 8.0 7.0 )
+  recent_mdb = %w( 8.2 8.0 7.0 )
 %>
 
 buildvariants:

--- a/spec/mongo/session_transaction_prose_spec.rb
+++ b/spec/mongo/session_transaction_prose_spec.rb
@@ -25,37 +25,33 @@ describe Mongo::Session do
     it 'adds measurable delay when jitter is enabled' do
       skip 'failCommand fail point is not available' unless fail_command_available?
 
-      no_backoff_time = with_fixed_jitter(0) do
+      no_backoff_sleeps = []
+      with_fixed_jitter(0) do
         with_commit_failures(13) do
-          measure_with_transaction_time do |session|
-            collection.insert_one({}, session: session)
+          client.start_session do |session|
+            allow(session).to receive(:sleep) { |d| no_backoff_sleeps << d }
+            session.with_transaction { collection.insert_one({}, session: session) }
           end
         end
       end
 
-      with_backoff_time = with_fixed_jitter(1) do
+      with_backoff_sleeps = []
+      with_fixed_jitter(1) do
         with_commit_failures(13) do
-          measure_with_transaction_time do |session|
-            collection.insert_one({}, session: session)
+          client.start_session do |session|
+            allow(session).to receive(:sleep) { |d| with_backoff_sleeps << d }
+            session.with_transaction { collection.insert_one({}, session: session) }
           end
         end
       end
 
-      # Sum of 13 backoffs per spec is approximately 1.8 seconds.
-      expect(with_backoff_time).to be_within(0.5).of(no_backoff_time + 1.8)
+      # With jitter=0 all requested sleeps are zero; with jitter=1 they sum to
+      # approximately 1.8 seconds (sum of 13 exponential backoffs, per spec).
+      expect(no_backoff_sleeps.sum).to eq(0)
+      expect(with_backoff_sleeps.sum).to be_within(0.05).of(1.8)
     end
 
     private
-
-    def measure_with_transaction_time
-      start_time = Mongo::Utils.monotonic_time
-      client.start_session do |session|
-        session.with_transaction do
-          yield(session)
-        end
-      end
-      Mongo::Utils.monotonic_time - start_time
-    end
 
     def with_fixed_jitter(value)
       allow(Random).to receive(:rand).and_return(value)


### PR DESCRIPTION
Adds MongoDB 8.2 (currently at 8.2.7) to the Evergreen CI test matrix.

Changes:
- Add `8.2` axis value to `mongodb-version` in `axes.yml.erb`
- Add `8.2` to `recent_mdb` in `standard.yml.erb`, which includes it in the `mongo-recent`, `auth/ssl`, and `stress` build variants
- Regenerate `config.yml`