### PR TITLE
RUBY-3831 Skip OpenTelemetry command spans for sensitive commands

### DIFF
--- a/lib/mongo/tracing/open_telemetry/command_tracer.rb
+++ b/lib/mongo/tracing/open_telemetry/command_tracer.rb
@@ -21,6 +21,15 @@ module Mongo
       #
       # @api private
       class CommandTracer
+        include Mongo::Monitoring::Event::Secure
+
+        # Commands for which a span MUST NOT be created. The OpenTelemetry spec
+        # requires drivers to skip command spans for sensitive commands listed in
+        # the Command Logging and Monitoring spec. We additionally skip hello /
+        # legacy hello in all forms — these are handshake/heartbeat traffic and
+        # would only add noise to traces.
+        HELLO_COMMANDS = %w[hello ismaster isMaster].freeze
+
         # Initializes a new CommandTracer.
         #
         # @param otel_tracer [ OpenTelemetry::Trace::Tracer ] the OpenTelemetry tracer.
@@ -57,6 +66,8 @@ module Mongo
         # @return [ Object ] the result of the command.
         # rubocop:disable Lint/RescueException
         def trace_command(message, _operation_context, connection)
+          return yield if skip_tracing?(message)
+
           # Commands should always be nested under their operation span, not directly under
           # the transaction span. Don't pass with_parent to use automatic parent resolution
           # from the currently active span (the operation span).
@@ -75,6 +86,22 @@ module Mongo
         # rubocop:enable Lint/RescueException
 
         private
+
+        # Determines whether the command must not be traced. Sensitive auth
+        # commands carry credentials in their payloads (SCRAM proofs, cleartext
+        # passwords, etc.) and the OpenTelemetry spec requires drivers to skip
+        # command spans for them. Hello / legacy hello are also skipped to keep
+        # handshake traffic out of traces.
+        #
+        # @param message [ Mongo::Protocol::Message ] the command message.
+        #
+        # @return [ Boolean ] true when no command span should be created.
+        def skip_tracing?(message)
+          name = command_name(message)
+          return true if HELLO_COMMANDS.include?(name)
+
+          sensitive?(command_name: name, document: message.documents.first)
+        end
 
         # Creates a span for a command.
         #

--- a/spec/mongo/tracing/open_telemetry/command_tracer_spec.rb
+++ b/spec/mongo/tracing/open_telemetry/command_tracer_spec.rb
@@ -196,6 +196,84 @@ describe Mongo::Tracing::OpenTelemetry::CommandTracer do
         end.to raise_error(error)
       end
     end
+
+    shared_examples 'skipped command' do
+      let(:query_text_max_length) { 1000 }
+
+      it 'does not create a span' do
+        expect(otel_tracer).not_to receive(:start_span)
+        command_tracer.trace_command(message, operation_context, connection) { result }
+      end
+
+      it 'does not enter an OpenTelemetry context' do
+        expect(OpenTelemetry::Trace).not_to receive(:with_span)
+        command_tracer.trace_command(message, operation_context, connection) { result }
+      end
+
+      it 'yields the block' do
+        yielded = false
+        command_tracer.trace_command(message, operation_context, connection) do
+          yielded = true
+          result
+        end
+        expect(yielded).to be true
+      end
+
+      it 'returns the block result' do
+        return_value = command_tracer.trace_command(message, operation_context, connection) { result }
+        expect(return_value).to eq(result)
+      end
+    end
+
+    %w[
+      authenticate
+      saslStart
+      saslContinue
+      getnonce
+      createUser
+      updateUser
+      copydbgetnonce
+      copydbsaslstart
+      copydb
+    ].each do |sensitive_cmd|
+      context "with #{sensitive_cmd} command" do
+        let(:document) do
+          {
+            sensitive_cmd => 1,
+            '$db' => 'admin',
+            'payload' => BSON::Binary.new('secret-credential-bytes')
+          }
+        end
+
+        include_examples 'skipped command'
+      end
+    end
+
+    %w[hello ismaster isMaster].each do |hello_cmd|
+      context "with #{hello_cmd} command without speculativeAuthenticate" do
+        let(:document) do
+          { hello_cmd => 1, '$db' => 'admin' }
+        end
+
+        include_examples 'skipped command'
+      end
+
+      context "with #{hello_cmd} command with speculativeAuthenticate" do
+        let(:document) do
+          {
+            hello_cmd => 1,
+            '$db' => 'admin',
+            'speculativeAuthenticate' => {
+              'saslStart' => 1,
+              'mechanism' => 'SCRAM-SHA-256',
+              'payload' => BSON::Binary.new('secret-handshake-bytes')
+            }
+          }
+        end
+
+        include_examples 'skipped command'
+      end
+    end
   end
 
   describe '#span_attributes' do


### PR DESCRIPTION
## Description

[RUBY-3831](https://jira.mongodb.org/browse/RUBY-3831).

The OpenTelemetry command tracer JSON-serialized the entire command body into the `db.query.text` span attribute (excluding only `lsid`, `$db`, `$clusterTime`, `signature`). Auth commands (`saslStart`, `saslContinue`, `createUser`, `updateUser`, …) carry SCRAM proofs and cleartext passwords, so enabling `OTEL_RUBY_INSTRUMENTATION_MONGODB_QUERY_TEXT_MAX_LENGTH > 0` would have leaked credentials to any tracing backend.

Per the OpenTelemetry tracing spec (`specifications/source/open-telemetry/open-telemetry.md` lines 216-217 and the *Security Implication* section), drivers MUST NOT create a command span for sensitive commands at all — attribute-level redaction is not enough. The sensitive list is the same one already enforced by `Mongo::Monitoring::Event::Secure`.

## Changes

- `lib/mongo/tracing/open_telemetry/command_tracer.rb`: include `Mongo::Monitoring::Event::Secure` and short-circuit `trace_command` when the command is sensitive (no span is created, the block still runs and its return value is propagated). Also skip `hello` / legacy `hello` regardless of `speculativeAuthenticate` — handshake/heartbeat traffic does not belong in traces.
- `spec/mongo/tracing/open_telemetry/command_tracer_spec.rb`: add coverage asserting that `start_span` and `OpenTelemetry::Trace.with_span` are NOT invoked for each sensitive command, for `hello`/`ismaster`/`isMaster` with and without `speculativeAuthenticate`, while the block still runs and its result is returned.

## Test plan

- [x] `bundle exec rubocop lib/mongo/tracing/open_telemetry/command_tracer.rb spec/mongo/tracing/open_telemetry/command_tracer_spec.rb` — clean
- [x] `MONGODB_URI=mongodb://localhost:27017,localhost:27018,localhost:27019/ bundle exec rspec spec/mongo/tracing/open_telemetry/command_tracer_spec.rb` — 115 examples, 0 failures
- [x] `MONGODB_URI=… bundle exec rspec spec/mongo/tracing/open_telemetry/operation_tracer_spec.rb` — 45 examples, 0 failures (regression check)