### PR TITLE
RUBY-3831 Skip OpenTelemetry command spans - backport

### DIFF
--- a/lib/mongo/tracing/open_telemetry/command_tracer.rb
+++ b/lib/mongo/tracing/open_telemetry/command_tracer.rb
@@ -21,6 +21,15 @@ module Mongo
       #
       # @api private
       class CommandTracer
+        include Mongo::Monitoring::Event::Secure
+
+        # Commands for which a span MUST NOT be created. The OpenTelemetry spec
+        # requires drivers to skip command spans for sensitive commands listed in
+        # the Command Logging and Monitoring spec. We additionally skip hello /
+        # legacy hello in all forms — these are handshake/heartbeat traffic and
+        # would only add noise to traces.
+        HELLO_COMMANDS = %w[hello ismaster isMaster].freeze
+
         # Initializes a new CommandTracer.
         #
         # @param otel_tracer [ OpenTelemetry::Trace::Tracer ] the OpenTelemetry tracer.
@@ -57,6 +66,8 @@ module Mongo
         # @return [ Object ] the result of the command.
         # rubocop:disable Lint/RescueException
         def trace_command(message, _operation_context, connection)
+          return yield if skip_tracing?(message)
+
           # Commands should always be nested under their operation span, not directly under
           # the transaction span. Don't pass with_parent to use automatic parent resolution
           # from the currently active span (the operation span).
@@ -75,6 +86,22 @@ module Mongo
         # rubocop:enable Lint/RescueException
 
         private
+
+        # Determines whether the command must not be traced. Sensitive auth
+        # commands carry credentials in their payloads (SCRAM proofs, cleartext
+        # passwords, etc.) and the OpenTelemetry spec requires drivers to skip
+        # command spans for them. Hello / legacy hello are also skipped to keep
+        # handshake traffic out of traces.
+        #
+        # @param message [ Mongo::Protocol::Message ] the command message.
+        #
+        # @return [ Boolean ] true when no command span should be created.
+        def skip_tracing?(message)
+          name = command_name(message)
+          return true if HELLO_COMMANDS.include?(name)
+
+          sensitive?(command_name: name, document: message.documents.first)
+        end
 
         # Creates a span for a command.
         #

--- a/spec/mongo/tracing/open_telemetry/command_tracer_spec.rb
+++ b/spec/mongo/tracing/open_telemetry/command_tracer_spec.rb
@@ -197,6 +197,84 @@ describe Mongo::Tracing::OpenTelemetry::CommandTracer do
         end.to raise_error(error)
       end
     end
+
+    shared_examples 'skipped command' do
+      let(:query_text_max_length) { 1000 }
+
+      it 'does not create a span' do
+        expect(otel_tracer).not_to receive(:start_span)
+        command_tracer.trace_command(message, operation_context, connection) { result }
+      end
+
+      it 'does not enter an OpenTelemetry context' do
+        expect(OpenTelemetry::Trace).not_to receive(:with_span)
+        command_tracer.trace_command(message, operation_context, connection) { result }
+      end
+
+      it 'yields the block' do
+        yielded = false
+        command_tracer.trace_command(message, operation_context, connection) do
+          yielded = true
+          result
+        end
+        expect(yielded).to be true
+      end
+
+      it 'returns the block result' do
+        return_value = command_tracer.trace_command(message, operation_context, connection) { result }
+        expect(return_value).to eq(result)
+      end
+    end
+
+    %w[
+      authenticate
+      saslStart
+      saslContinue
+      getnonce
+      createUser
+      updateUser
+      copydbgetnonce
+      copydbsaslstart
+      copydb
+    ].each do |sensitive_cmd|
+      context "with #{sensitive_cmd} command" do
+        let(:document) do
+          {
+            sensitive_cmd => 1,
+            '$db' => 'admin',
+            'payload' => BSON::Binary.new('secret-credential-bytes')
+          }
+        end
+
+        include_examples 'skipped command'
+      end
+    end
+
+    %w[hello ismaster isMaster].each do |hello_cmd|
+      context "with #{hello_cmd} command without speculativeAuthenticate" do
+        let(:document) do
+          { hello_cmd => 1, '$db' => 'admin' }
+        end
+
+        include_examples 'skipped command'
+      end
+
+      context "with #{hello_cmd} command with speculativeAuthenticate" do
+        let(:document) do
+          {
+            hello_cmd => 1,
+            '$db' => 'admin',
+            'speculativeAuthenticate' => {
+              'saslStart' => 1,
+              'mechanism' => 'SCRAM-SHA-256',
+              'payload' => BSON::Binary.new('secret-handshake-bytes')
+            }
+          }
+        end
+
+        include_examples 'skipped command'
+      end
+    end
   end
 
   describe '#span_attributes' do


### PR DESCRIPTION
This is backport of https://github.com/mongodb/mongo-ruby-driver/pull/3038 to 2.23.x