### PR TITLE
Release candidate for 2.24.1

### DIFF
--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -5,5 +5,5 @@ module Mongo
   #
   # Note that this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file will be overwritten by that rake task.
-  VERSION = '2.24.0'
+  VERSION = '2.24.1'
 end

--- a/product.yml
+++ b/product.yml
@@ -5,5 +5,5 @@ description: a pure-Ruby driver for connecting to, querying, and manipulating Mo
 package: mongo
 jira: https://jira.mongodb.org/projects/RUBY
 version:
-  number: 2.24.0
+  number: 2.24.1
   file: lib/mongo/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 2.24.1 of the `mongo` gem - a pure-Ruby driver for connecting to, querying, and manipulating MongoDB databases. This is a new patch release in the 2.24.x series of MongoDB Ruby Driver.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 2.24.1 mongo
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'mongo', '2.24.1'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/RUBY) to let us know what's on your mind 🧠.

# Bug Fixes

* [RUBY-3831](https://jira.mongodb.org/browse/RUBY-3831) Skip OpenTelemetry command spans for sensitive commands ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/3038))
* [RUBY-3456](https://jira.mongodb.org/browse/RUBY-3456) Suppress no-op SDAM debug log lines ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/3030))

# New Features

### [RUBY-3602](https://jira.mongodb.org/browse/RUBY-3602) Include server address in OperationFailure and BulkWriteError messages ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/3027))

- New `Mongo::Config.include_server_address_in_errors` flag (default `false`). When `true`, `Mongo::Error::OperationFailure` and `Mongo::Error::BulkWriteError` messages are suffixed with `(on host:port)` so users can identify which server produced the error.
- Both `#message` and `#to_s` render the suffix, since it's baked into the string passed to `super` at construction. `ResultCombiner` accumulates unique addresses across split bulk batches so multi-server bulks produce `(on h1:27017, h2:27017)`.
- Default-off behavior is byte-identical to current. No breaking changes. Planned to stay opt-in (no default flip).

### [RUBY-3220](https://jira.mongodb.org/browse/RUBY-3220) Add databaseName property to command events ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/3031))

- Sync `find.yml` from the command-logging-and-monitoring spec so `commandSucceededEvent` and `commandFailedEvent` expectations include `databaseName`. Schema bumped from 1.1 to 1.15.
- The Ruby driver's event classes already exposed `database_name` on `CommandStarted`, `CommandSucceeded`, and `CommandFailed`, and the unified runner already supports asserting `databaseName` on any command event — this change exercises that path through the unified spec tests.

* [RUBY-3712](https://jira.mongodb.org/browse/RUBY-3712) Expose atClusterTime in snapshot sessions ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/3035))

