### PR TITLE
Release candidate for 2.23.1

### DIFF
--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -5,5 +5,5 @@ module Mongo
   #
   # Note that this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file will be overwritten by that rake task.
-  VERSION = '2.23.0'
+  VERSION = '2.23.1'
 end

--- a/product.yml
+++ b/product.yml
@@ -5,5 +5,5 @@ description: a pure-Ruby driver for connecting to, querying, and manipulating Mo
 package: mongo
 jira: https://jira.mongodb.org/projects/RUBY
 version:
-  number: 2.23.0
+  number: 2.23.1
   file: lib/mongo/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 2.23.1 of the `mongo` gem - a pure-Ruby driver for connecting to, querying, and manipulating MongoDB databases. This is a new patch release in the 2.23.x series of MongoDB Ruby Driver.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 2.23.1 mongo
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'mongo', '2.23.1'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/RUBY) to let us know what's on your mind 🧠.

# Bug Fixes

* [RUBY-3831](https://jira.mongodb.org/browse/RUBY-3831) Skip OpenTelemetry command spans ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/3042))
