### PR TITLE
RUBY-3672 Use AWS Secrets Manager for AWS auth test credentials

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -157,35 +157,13 @@ functions:
         file: mo-expansion.yml
 
   "export AWS auth credentials":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
-        silent: true
-        working_dir: "src"
-        script: |
-          cat <<EOT > .env.private
-          IAM_AUTH_ASSUME_AWS_ACCOUNT="${iam_auth_assume_aws_account}"
-          IAM_AUTH_ASSUME_AWS_SECRET_ACCESS_KEY="${iam_auth_assume_aws_secret_access_key}"
-          IAM_AUTH_ASSUME_ROLE_NAME="${iam_auth_assume_role_name}"
-          IAM_AUTH_EC2_INSTANCE_ACCOUNT="${iam_auth_ec2_instance_account}"
-          IAM_AUTH_EC2_INSTANCE_PROFILE="${iam_auth_ec2_instance_profile}"
-          IAM_AUTH_EC2_INSTANCE_SECRET_ACCESS_KEY="${iam_auth_ec2_instance_secret_access_key}"
-          IAM_AUTH_ECS_ACCOUNT="${iam_auth_ecs_account}"
-          IAM_AUTH_ECS_ACCOUNT_ARN="${iam_auth_ecs_account_arn}"
-          IAM_AUTH_ECS_CLUSTER="${iam_auth_ecs_cluster}"
-          IAM_AUTH_ECS_SECRET_ACCESS_KEY="${iam_auth_ecs_secret_access_key}"
-          IAM_AUTH_ECS_SECURITY_GROUP="${iam_auth_ecs_security_group}"
-          IAM_AUTH_ECS_SUBNET_A="${iam_auth_ecs_subnet_a}"
-          IAM_AUTH_ECS_SUBNET_B="${iam_auth_ecs_subnet_b}"
-          IAM_AUTH_ECS_TASK_DEFINITION="${iam_auth_ecs_task_definition_ubuntu2004}"
-
-          IAM_WEB_IDENTITY_ISSUER="${iam_web_identity_issuer}"
-          IAM_WEB_IDENTITY_JWKS_URI="${iam_web_identity_jwks_uri}"
-          IAM_WEB_IDENTITY_RSA_KEY="${iam_web_identity_rsa_key}"
-          IAM_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}"
-          IAM_AUTH_ASSUME_WEB_ROLE_NAME="${iam_auth_assume_web_role_name}"
-
-          EOT
+        binary: bash
+        include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, DRIVERS_TOOLS]
+        args:
+          - "${DRIVERS_TOOLS}/.evergreen/auth_aws/setup-secrets.sh"
 
   "run CSOT tests":
     - command: shell.exec

--- a/.evergreen/config/common.yml.erb
+++ b/.evergreen/config/common.yml.erb
@@ -154,35 +154,13 @@ functions:
         file: mo-expansion.yml
 
   "export AWS auth credentials":
-    - command: shell.exec
+    - command: subprocess.exec
       type: test
       params:
-        silent: true
-        working_dir: "src"
-        script: |
-          cat <<EOT > .env.private
-          IAM_AUTH_ASSUME_AWS_ACCOUNT="${iam_auth_assume_aws_account}"
-          IAM_AUTH_ASSUME_AWS_SECRET_ACCESS_KEY="${iam_auth_assume_aws_secret_access_key}"
-          IAM_AUTH_ASSUME_ROLE_NAME="${iam_auth_assume_role_name}"
-          IAM_AUTH_EC2_INSTANCE_ACCOUNT="${iam_auth_ec2_instance_account}"
-          IAM_AUTH_EC2_INSTANCE_PROFILE="${iam_auth_ec2_instance_profile}"
-          IAM_AUTH_EC2_INSTANCE_SECRET_ACCESS_KEY="${iam_auth_ec2_instance_secret_access_key}"
-          IAM_AUTH_ECS_ACCOUNT="${iam_auth_ecs_account}"
-          IAM_AUTH_ECS_ACCOUNT_ARN="${iam_auth_ecs_account_arn}"
-          IAM_AUTH_ECS_CLUSTER="${iam_auth_ecs_cluster}"
-          IAM_AUTH_ECS_SECRET_ACCESS_KEY="${iam_auth_ecs_secret_access_key}"
-          IAM_AUTH_ECS_SECURITY_GROUP="${iam_auth_ecs_security_group}"
-          IAM_AUTH_ECS_SUBNET_A="${iam_auth_ecs_subnet_a}"
-          IAM_AUTH_ECS_SUBNET_B="${iam_auth_ecs_subnet_b}"
-          IAM_AUTH_ECS_TASK_DEFINITION="${iam_auth_ecs_task_definition_ubuntu2004}"
-
-          IAM_WEB_IDENTITY_ISSUER="${iam_web_identity_issuer}"
-          IAM_WEB_IDENTITY_JWKS_URI="${iam_web_identity_jwks_uri}"
-          IAM_WEB_IDENTITY_RSA_KEY="${iam_web_identity_rsa_key}"
-          IAM_WEB_IDENTITY_TOKEN_FILE="${iam_web_identity_token_file}"
-          IAM_AUTH_ASSUME_WEB_ROLE_NAME="${iam_auth_assume_web_role_name}"
-
-          EOT
+        binary: bash
+        include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, DRIVERS_TOOLS]
+        args:
+          - "${DRIVERS_TOOLS}/.evergreen/auth_aws/setup-secrets.sh"
 
   "run CSOT tests":
     - command: shell.exec

--- a/.evergreen/functions-aws.sh
+++ b/.evergreen/functions-aws.sh
@@ -9,9 +9,10 @@ clear_instance_profile() {
   # the main shell environment, which uses different credentials for
   # regular and assume role configurations.
   (
-    # When running in Evergreen, credentials are written to this file.
-    # In Docker they are already in the environment and the file does not exist.
-    if test -f .env.private; then
+    # Source credentials from AWS Secrets Manager (CI) or .env.private (local/Docker).
+    if test -n "${DRIVERS_TOOLS:-}" && test -f "${DRIVERS_TOOLS}/.evergreen/auth_aws/secrets-export.sh"; then
+      . "${DRIVERS_TOOLS}/.evergreen/auth_aws/secrets-export.sh"
+    elif test -f .env.private; then
       . ./.env.private
     fi
     

--- a/.evergreen/run-tests-aws-auth.sh
+++ b/.evergreen/run-tests-aws-auth.sh
@@ -6,9 +6,10 @@ set +x
 
 . `dirname "$0"`/functions.sh
 
-# When running in Evergreen, credentials are written to this file.
-# In Docker they are already in the environment and the file does not exist.
-if test -f .env.private; then
+# Source credentials from AWS Secrets Manager (CI) or .env.private (local/Docker).
+if test -n "${DRIVERS_TOOLS:-}" && test -f "${DRIVERS_TOOLS}/.evergreen/auth_aws/secrets-export.sh"; then
+  . "${DRIVERS_TOOLS}/.evergreen/auth_aws/secrets-export.sh"
+elif test -f .env.private; then
   . ./.env.private
 fi
 


### PR DESCRIPTION
## Changes

Replace the deprecated Evergreen project-variables approach in the
`"export AWS auth credentials"` function with a call to
`drivers-evergreen-tools/.evergreen/auth_aws/setup-secrets.sh`, which
fetches credentials from the AWS Secrets Manager vault `drivers/aws_auth`.

The `pre:` section already assumes the secrets role via
`assume-test-secrets-ec2-role` (added in RUBY-3727), so the temporary
AWS credentials are available as Evergreen expansions when task
commands run. The new function passes those expansions via
`include_expansions_in_env` and invokes `setup-secrets.sh`, which
writes all IAM auth variables to
`$DRIVERS_TOOLS/.evergreen/auth_aws/secrets-export.sh`.

The shell scripts that previously sourced `.env.private` now check for
`secrets-export.sh` first (CI path), falling back to `.env.private`
for local/Docker development.

## Files changed

- `.evergreen/config/common.yml.erb` — replace `"export AWS auth credentials"` body
- `.evergreen/config.yml` — regenerated from ERB template
- `.evergreen/run-tests-aws-auth.sh` — source `secrets-export.sh` in CI
- `.evergreen/functions-aws.sh` — same in `clear_instance_profile`

## Test plan

- [ ] AWS auth tests require Evergreen CI with AWS Secrets Manager access; not runnable locally
- [ ] Verified `config.yml` regenerated correctly from updated template
- [ ] No Ruby source files changed; rubocop not applicable

Jira: https://jira.mongodb.org/browse/RUBY-3672