### PR TITLE
RUBY-3768 Fix secondaryPreferred non-compliance with server selection spec

### DIFF
--- a/lib/mongo/server_selector/secondary_preferred.rb
+++ b/lib/mongo/server_selector/secondary_preferred.rb
@@ -101,7 +101,10 @@ module Mongo
       #
       # @since 2.0.0
       def select_in_replica_set(candidates)
-        near_servers(secondaries(candidates)) + primary(candidates)
+        eligible = secondaries(candidates)
+        return near_servers(eligible) unless eligible.empty?
+
+        primary(candidates)
       end
 
       def max_staleness_allowed?

--- a/spec/mongo/server_selector/secondary_preferred_spec.rb
+++ b/spec/mongo/server_selector/secondary_preferred_spec.rb
@@ -147,19 +147,17 @@ describe Mongo::ServerSelector::SecondaryPreferred do
 
     context 'primary and secondary candidates' do
       let(:candidates) { [ primary, secondary ] }
-      let(:expected) { [ secondary, primary ] }
 
-      it 'returns array with secondary first, then primary' do
-        expect(selector.send(:select_in_replica_set, candidates)).to eq(expected)
+      it 'returns array with secondary only' do
+        expect(selector.send(:select_in_replica_set, candidates)).to eq([ secondary ])
       end
     end
 
     context 'secondary and primary candidates' do
       let(:candidates) { [ secondary, primary ] }
-      let(:expected) { [ secondary, primary ] }
 
-      it 'returns array with secondary and primary' do
-        expect(selector.send(:select_in_replica_set, candidates)).to eq(expected)
+      it 'returns array with secondary only' do
+        expect(selector.send(:select_in_replica_set, candidates)).to eq([ secondary ])
       end
     end
 
@@ -222,28 +220,26 @@ describe Mongo::ServerSelector::SecondaryPreferred do
         context 'one matching secondary' do
           let(:candidates) { [ primary, matching_secondary ] }
 
-          it 'returns an array of the matching secondary, then primary' do
-            expect(selector.send(:select_in_replica_set, candidates)).to eq(
-              [ matching_secondary, primary ]
-            )
+          it 'returns an array with the matching secondary only' do
+            expect(selector.send(:select_in_replica_set, candidates)).to eq([ matching_secondary ])
           end
         end
 
         context 'two matching secondaries' do
           let(:candidates) { [ primary, matching_secondary, matching_secondary ] }
-          let(:expected) { [ matching_secondary, matching_secondary, primary ] }
 
-          it 'returns an array of the matching secondaries, then primary' do
-            expect(selector.send(:select_in_replica_set, candidates)).to eq(expected)
+          it 'returns an array of the matching secondaries only' do
+            expect(selector.send(:select_in_replica_set, candidates)).to eq(
+              [ matching_secondary, matching_secondary ]
+            )
           end
         end
 
         context 'one matching secondary and one matching primary' do
           let(:candidates) { [ matching_primary, matching_secondary ] }
-          let(:expected) { [ matching_secondary, matching_primary ] }
 
-          it 'returns an array of the matching secondary, then the primary' do
-            expect(selector.send(:select_in_replica_set, candidates)).to eq(expected)
+          it 'returns an array with the matching secondary only' do
+            expect(selector.send(:select_in_replica_set, candidates)).to eq([ matching_secondary ])
           end
         end
       end
@@ -275,53 +271,49 @@ describe Mongo::ServerSelector::SecondaryPreferred do
         context 'local primary, local secondary' do
           let(:candidates) { [ primary, secondary ] }
 
-          it 'returns an array with secondary, then primary' do
-            expect(selector.send(:select_in_replica_set, candidates)).to eq([ secondary, primary ])
+          it 'returns an array with secondary only' do
+            expect(selector.send(:select_in_replica_set, candidates)).to eq([ secondary ])
           end
         end
 
         context 'local primary, far secondary' do
           let(:candidates) { [ primary, far_secondary ] }
 
-          it 'returns an array with the secondary, then primary' do
-            expect(selector.send(:select_in_replica_set, candidates)).to eq([ far_secondary, primary ])
+          it 'returns an array with the secondary only' do
+            expect(selector.send(:select_in_replica_set, candidates)).to eq([ far_secondary ])
           end
         end
 
         context 'local secondary' do
           let(:candidates) { [ far_primary, secondary ] }
-          let(:expected) { [ secondary, far_primary ] }
 
-          it 'returns an array with secondary, then primary' do
-            expect(selector.send(:select_in_replica_set, candidates)).to eq(expected)
+          it 'returns an array with secondary only' do
+            expect(selector.send(:select_in_replica_set, candidates)).to eq([ secondary ])
           end
         end
 
         context 'far primary, far secondary' do
           let(:candidates) { [ far_primary, far_secondary ] }
-          let(:expected) { [ far_secondary, far_primary ] }
 
-          it 'returns an array with secondary, then primary' do
-            expect(selector.send(:select_in_replica_set, candidates)).to eq(expected)
+          it 'returns an array with secondary only' do
+            expect(selector.send(:select_in_replica_set, candidates)).to eq([ far_secondary ])
           end
         end
 
         context 'two near servers, one far secondary' do
           context 'near primary, near secondary, far secondary' do
             let(:candidates) { [ primary, secondary, far_secondary ] }
-            let(:expected) { [ secondary, primary ] }
 
-            it 'returns an array with near secondary, then primary' do
-              expect(selector.send(:select_in_replica_set, candidates)).to eq(expected)
+            it 'returns an array with near secondary only' do
+              expect(selector.send(:select_in_replica_set, candidates)).to eq([ secondary ])
             end
           end
 
           context 'two near secondaries, one far primary' do
             let(:candidates) { [ far_primary, secondary, secondary ] }
-            let(:expected) { [ secondary, secondary, far_primary ] }
 
-            it 'returns an array with secondaries, then primary' do
-              expect(selector.send(:select_in_replica_set, candidates)).to eq(expected)
+            it 'returns an array with secondaries only' do
+              expect(selector.send(:select_in_replica_set, candidates)).to contain_exactly(secondary, secondary)
             end
           end
         end

--- a/spec/runners/server_selection.rb
+++ b/spec/runners/server_selection.rb
@@ -214,7 +214,7 @@ def define_server_selection_spec_tests(test_paths, skipped_tests = {})
                 server['avg_rtt_ms'] / 1000.0
               end
             end
-            allow(s).to receive(:tags).and_return(server['tags'])
+            allow(s).to receive(:tags).and_return(server['tags'] || {})
             allow(s).to receive(:secondary?).and_return(server['type'] == 'RSSecondary')
             allow(s).to receive(:primary?).and_return(server['type'] == 'RSPrimary')
             allow(s).to receive(:mongos?).and_return(server['type'] == 'Mongos')
@@ -338,22 +338,6 @@ def define_server_selection_spec_tests(test_paths, skipped_tests = {})
 
           let(:actual_addresses) do
             servers = server_selector.send(:suitable_servers, cluster, deprioritized_servers)
-
-            # The tests expect that only secondaries are "suitable" for
-            # server selection with secondary preferred read preference.
-            # In actuality, primaries are also suitable, and the driver
-            # returns the primaries also. Remove primaries from the
-            # actual set when read preference is secondary preferred.
-            # HOWEVER, if a test ends up selecting a primary, then it
-            # includes that primary into its suitable servers. Therefore
-            # only remove primaries when the number of suitable servers
-            # is greater than 1.
-            servers.delete_if do |server|
-              server_selector.is_a?(Mongo::ServerSelector::SecondaryPreferred) &&
-                server.primary? &&
-                servers.length > 1
-            end
-
             # Since we remove the latency requirement, the servers
             # may be returned in arbitrary order.
             servers.map(&:address).map(&:seed).sort

--- a/spec/spec_tests/data/server_selection/ReplicaSetWithPrimary/read/SecondaryPreferred_empty_tags.yml
+++ b/spec/spec_tests/data/server_selection/ReplicaSetWithPrimary/read/SecondaryPreferred_empty_tags.yml
@@ -1,0 +1,27 @@
+# Attempt to select the secondary using an empty tag set. Expect empty tag set to match.
+# This is a regression test for RUST-2363.
+---
+topology_description:
+  type: ReplicaSetWithPrimary
+  servers:
+  - &1
+    address: a:27017
+    avg_rtt_ms: 5
+    type: RSPrimary
+    # No "tags".
+  - &2
+    address: b:27017
+    avg_rtt_ms: 5
+    type: RSSecondary
+    # No "tags"
+operation: read
+read_preference:
+  mode: SecondaryPreferred
+  tag_sets:
+  - data_center: nyc # Does not match.
+  - {} # Empty tag set.
+suitable_servers:
+- *2
+in_latency_window:
+- *2
+


### PR DESCRIPTION
## Motivation

The `secondaryPreferred` read preference was non-compliant with the [server selection spec](https://github.com/mongodb/specifications/blob/master/source/server-selection/server-selection.md#L350):

> If there is at least one eligible secondary, only eligible secondaries are suitable. Otherwise, when there are no eligible secondaries, the primary is suitable.

The driver always appended the primary to the candidate list alongside secondaries, regardless of secondary availability.

## Changes

**`lib/mongo/server_selector/secondary_preferred.rb`**

Fixed `select_in_replica_set` to mirror the `primaryPreferred` pattern: return eligible secondaries when present, fall back to primary only when none exist.

**`spec/mongo/server_selector/secondary_preferred_spec.rb`**

Updated 11 unit tests whose expected values wrongly included the primary alongside available secondaries.

**`spec/runners/server_selection.rb`**

- Removed the workaround that stripped primaries from `SecondaryPreferred` results to paper over the non-compliance.
- Fixed the server mock to return `{}` instead of `nil` for servers with no `tags:` key, matching the production contract of `Description#tags`.

**`spec/spec_tests/data/server_selection/ReplicaSetWithPrimary/read/SecondaryPreferred_empty_tags.yml`**

Added the missing spec fixture from the specifications repo (regression test for empty tag set matching).

## Test plan

- [x] `bundle exec rspec spec/mongo/server_selector/secondary_preferred_spec.rb` — 46 examples, 0 failures
- [x] `bundle exec rspec spec/spec_tests/server_selection_spec.rb` — 142 examples, 0 failures
- [x] `bundle exec rubocop lib/mongo/server_selector/secondary_preferred.rb spec/mongo/server_selector/secondary_preferred_spec.rb spec/runners/server_selection.rb` — no offenses

RUBY-3768: https://jira.mongodb.org/browse/RUBY-3768