### PR TITLE
RUBY-3600 Skip aggregate $out test in retryable writes spec on serverless

### DIFF
--- a/spec/spec_tests/data/retryable_writes/unified/aggregate-out-merge.yml
+++ b/spec/spec_tests/data/retryable_writes/unified/aggregate-out-merge.yml
@@ -1,0 +1,67 @@
+description: "aggregate with $out/$merge does not set txnNumber"
+
+schemaVersion: "1.4"
+
+runOnRequirements:
+  - minServerVersion: "3.6"
+    topologies:
+      - replicaset
+      - sharded
+      - load-balanced
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents: [ commandStartedEvent ]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name retryable-writes-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name coll0
+
+initialData:
+  # The output collection must already exist for $merge on a sharded cluster
+  - collectionName: &mergeCollection mergeCollection
+    databaseName: *database0Name
+    documents: []
+
+tests:
+  - description: "aggregate with $out does not set txnNumber"
+    runOnRequirements:
+      - serverless: forbid # $out is not supported on serverless
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline:
+            - { $sort: { x: 1 } }
+            - { $match: { _id: { $gt: 1 } } }
+            - { $out: outCollection }
+    expectEvents:
+      - client: client0
+        events:
+          - commandStartedEvent:
+              commandName: aggregate
+              command:
+                txnNumber: { $$exists: false }
+  - description: "aggregate with $merge does not set txnNumber"
+    runOnRequirements:
+      - minServerVersion: "4.1.11"
+    operations:
+      - object: *collection0
+        name: aggregate
+        arguments:
+          pipeline:
+            - { $sort: { x: 1 } }
+            - { $match: { _id: { $gt: 1 } } }
+            - { $merge: { into: *mergeCollection } }
+    expectEvents:
+      - client: client0
+        events:
+          - commandStartedEvent:
+              commandName: aggregate
+              command:
+                txnNumber: { $$exists: false }


### PR DESCRIPTION
- Syncs the retryable writes unified spec tests with [specifications commit ce9b56b](https://github.com/mongodb/specifications/commit/ce9b56ba3ed76cb4ebca9d4b760260548007dce6)
- Adds `aggregate-out-merge.yml`, which tests that `aggregate` with `$out`/`$merge` does not set `txnNumber`
- The `$out` test carries a `serverless: forbid` requirement since `$out` is not supported on serverless

## Test plan

- [ ] Run `bundle exec rspec spec/spec_tests/retryable_writes_unified_spec.rb` against a local replica set and confirm 0 failures