### PR TITLE
RUBY-3611 Support $lookup in CSFLE/QE

### DIFF
--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -1666,7 +1666,9 @@ module Mongo
       # @param [ Mongo::Crypt::Handle ] handle
       # @return [ Boolean ] Whether the option was set successfully.
       def self.setopt_enable_multiple_collinfo(handle)
-        mongocrypt_setopt_enable_multiple_collinfo(handle.ref)
+        check_status(handle) do
+          mongocrypt_setopt_enable_multiple_collinfo(handle.ref)
+        end
       end
 
       # @!method self.mongocrypt_setopt_use_need_mongo_collinfo_with_db_state(crypt)

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -1706,9 +1706,12 @@ module Mongo
       # Get the database name for the current collinfo operation.
       #
       # @param [ Mongo::Crypt::Context ] context
-      # @return [ String, nil ] The database name.
+      # @return [ String ] The database name.
       def self.ctx_mongo_db(context)
-        mongocrypt_ctx_mongo_db(context.ctx_p)
+        db_name = mongocrypt_ctx_mongo_db(context.ctx_p)
+        return db_name if db_name
+
+        check_ctx_status(context)
       end
 
       # @!method self.mongocrypt_ctx_provide_kms_providers(ctx, kms_providers)

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -823,14 +823,15 @@ module Mongo
 
       # An enum labeling different libmognocrypt state machine states
       enum :mongocrypt_ctx_state, [
-        :error,                 0,
-        :need_mongo_collinfo,   1,
-        :need_mongo_markings,   2,
-        :need_mongo_keys,       3,
-        :need_kms,              4,
-        :ready,                 5,
-        :done,                  6,
-        :need_kms_credentials,  7,
+        :error,                        0,
+        :need_mongo_collinfo,          1,
+        :need_mongo_markings,          2,
+        :need_mongo_keys,              3,
+        :need_kms,                     4,
+        :ready,                        5,
+        :done,                         6,
+        :need_kms_credentials,         7,
+        :need_mongo_collinfo_with_db,  8,
       ]
 
       # @!method self.mongocrypt_ctx_state(ctx)

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -1647,6 +1647,68 @@ module Mongo
         mongocrypt_setopt_use_need_kms_credentials_state(handle.ref)
       end
 
+      # @!method self.mongocrypt_setopt_enable_multiple_collinfo(crypt)
+      #   @api private
+      #
+      # Enable support for multiple collection schemas. Required to support $lookup.
+      #
+      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      # @pre mongocrypt_init has not been called on crypt.
+      # @return [ Boolean ] Whether the option was set successfully.
+      attach_function(
+        :mongocrypt_setopt_enable_multiple_collinfo,
+        [ :pointer ],
+        :bool
+      )
+
+      # Enable support for multiple collection schemas. Required to support $lookup.
+      #
+      # @param [ Mongo::Crypt::Handle ] handle
+      # @return [ Boolean ] Whether the option was set successfully.
+      def self.setopt_enable_multiple_collinfo(handle)
+        mongocrypt_setopt_enable_multiple_collinfo(handle.ref)
+      end
+
+      # @!method self.mongocrypt_setopt_use_need_mongo_collinfo_with_db_state(crypt)
+      #   @api private
+      #
+      # Opt into handling the MONGOCRYPT_CTX_NEED_MONGO_COLLINFO_WITH_DB state.
+      # A context enters this state when processing a bulkWrite command whose
+      # target database differs from the command database ("admin").
+      #
+      # @param [ FFI::Pointer ] crypt A pointer to a mongocrypt_t object.
+      attach_function(
+        :mongocrypt_setopt_use_need_mongo_collinfo_with_db_state,
+        [ :pointer ],
+        :void
+      )
+
+      # Opt into handling the MONGOCRYPT_CTX_NEED_MONGO_COLLINFO_WITH_DB state.
+      #
+      # @param [ Mongo::Crypt::Handle ] handle
+      def self.setopt_use_need_mongo_collinfo_with_db_state(handle)
+        mongocrypt_setopt_use_need_mongo_collinfo_with_db_state(handle.ref)
+      end
+
+      # @!method self.mongocrypt_ctx_mongo_db(ctx)
+      #   @api private
+      #
+      # Get the database name for the current collinfo operation. Used in the
+      # MONGOCRYPT_CTX_NEED_MONGO_COLLINFO_WITH_DB state to determine which
+      # database to run listCollections against.
+      #
+      # @param [ FFI::Pointer ] ctx A pointer to a mongocrypt_ctx_t object.
+      # @return [ String, nil ] The database name, or nil on error.
+      attach_function :mongocrypt_ctx_mongo_db, [ :pointer ], :string
+
+      # Get the database name for the current collinfo operation.
+      #
+      # @param [ Mongo::Crypt::Context ] context
+      # @return [ String, nil ] The database name.
+      def self.ctx_mongo_db(context)
+        mongocrypt_ctx_mongo_db(context.ctx_p)
+      end
+
       # @!method self.mongocrypt_ctx_provide_kms_providers(ctx, kms_providers)
       #   @api private
       #

--- a/lib/mongo/crypt/context.rb
+++ b/lib/mongo/crypt/context.rb
@@ -131,18 +131,15 @@ module Mongo
       end
 
       def provide_collection_info(timeout_ms)
-        filter = Binding.ctx_mongo_op(self)
-
-        @encryption_io.collection_info(@db_name, filter, timeout_ms: timeout_ms).each do |result|
-          mongocrypt_feed(result)
-        end
-
-        mongocrypt_done
+        feed_collection_info(@db_name, timeout_ms)
       end
 
       def provide_collection_info_with_db(timeout_ms)
+        feed_collection_info(Binding.ctx_mongo_db(self), timeout_ms)
+      end
+
+      def feed_collection_info(db_name, timeout_ms)
         filter = Binding.ctx_mongo_op(self)
-        db_name = Binding.ctx_mongo_db(self)
 
         @encryption_io.collection_info(db_name, filter, timeout_ms: timeout_ms).each do |result|
           mongocrypt_feed(result)

--- a/lib/mongo/crypt/context.rb
+++ b/lib/mongo/crypt/context.rb
@@ -90,6 +90,8 @@ module Mongo
             provide_keys(timeout_ms)
           when :need_mongo_collinfo
             provide_collection_info(timeout_ms)
+          when :need_mongo_collinfo_with_db
+            provide_collection_info_with_db(timeout_ms)
           when :need_mongo_markings
             provide_markings(timeout_ms)
           when :need_kms
@@ -131,8 +133,20 @@ module Mongo
       def provide_collection_info(timeout_ms)
         filter = Binding.ctx_mongo_op(self)
 
-        result = @encryption_io.collection_info(@db_name, filter, timeout_ms: timeout_ms)
-        mongocrypt_feed(result) if result
+        @encryption_io.collection_info(@db_name, filter, timeout_ms: timeout_ms).each do |result|
+          mongocrypt_feed(result)
+        end
+
+        mongocrypt_done
+      end
+
+      def provide_collection_info_with_db(timeout_ms)
+        filter = Binding.ctx_mongo_op(self)
+        db_name = Binding.ctx_mongo_db(self)
+
+        @encryption_io.collection_info(db_name, filter, timeout_ms: timeout_ms).each do |result|
+          mongocrypt_feed(result)
+        end
 
         mongocrypt_done
       end

--- a/lib/mongo/crypt/encryption_io.rb
+++ b/lib/mongo/crypt/encryption_io.rb
@@ -97,7 +97,7 @@ module Mongo
       #    Must be a non-negative integer. An explicit value of 0 means infinite.
       #    The default value is unset which means the feature is not enabled.
       #
-      # @return [ Hash ] The collection information
+      # @return [ Array<BSON::Document> ] The collection information documents
       def collection_info(db_name, filter, timeout_ms: nil)
         unless @metadata_client
           raise ArgumentError,
@@ -108,7 +108,7 @@ module Mongo
           .use(db_name)
           .database
           .list_collections(filter: filter, deserialize_as_bson: true, timeout_ms: timeout_ms)
-          .first
+          .to_a
       end
 
       # Send the command to mongocryptd to be marked with intent-to-encrypt markings

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -74,6 +74,8 @@ module Mongo
           Binding.method(:mongocrypt_destroy)
         )
         Binding.kms_ctx_setopt_retry_kms(self, true)
+        Binding.setopt_enable_multiple_collinfo(self)
+        Binding.setopt_use_need_mongo_collinfo_with_db_state(self)
         @kms_providers = kms_providers
         @kms_tls_options = kms_tls_options
 

--- a/spec/integration/client_side_encryption/lookup_prose_spec.rb
+++ b/spec/integration/client_side_encryption/lookup_prose_spec.rb
@@ -98,7 +98,7 @@ describe 'Prose Test 25: $lookup support with CSFLE and QE' do
         auto_encryption_options: {
           key_vault_namespace: 'db.keyvault',
           kms_providers: { local: { key: local_master_key } },
-          extra_options: extra_options
+          extra_options: Crypt.extra_options
         },
         database: 'db'
       )

--- a/spec/integration/client_side_encryption/lookup_prose_spec.rb
+++ b/spec/integration/client_side_encryption/lookup_prose_spec.rb
@@ -98,7 +98,13 @@ describe 'Prose Test 25: $lookup support with CSFLE and QE' do
         auto_encryption_options: {
           key_vault_namespace: 'db.keyvault',
           kms_providers: { local: { key: local_master_key } },
-          extra_options: Crypt.extra_options
+          extra_options: Crypt.extra_options,
+
+          # MongoDB 8.3.2 complains about "non_csfle_schema" having a JSON schema defined, and
+          # recommends this as a workaround.
+          encrypted_fields_map: {
+            non_csfle_schema: { fields: [] }
+          },
         },
         database: 'db'
       )

--- a/spec/integration/client_side_encryption/lookup_prose_spec.rb
+++ b/spec/integration/client_side_encryption/lookup_prose_spec.rb
@@ -296,6 +296,7 @@ describe 'Prose Test 25: $lookup support with CSFLE and QE' do
 
   context 'Case 10: QE collection $lookup from collection with non-CSFLE schema' do
     min_server_version '8.2'
+    min_libmongocrypt_version '1.18.0'
 
     it 'decrypts both collections correctly' do
       client = new_encrypted_client

--- a/spec/integration/client_side_encryption/lookup_prose_spec.rb
+++ b/spec/integration/client_side_encryption/lookup_prose_spec.rb
@@ -16,10 +16,7 @@ describe 'Prose Test 25: $lookup support with CSFLE and QE' do
     {
       key_vault_namespace: 'db.keyvault',
       kms_providers: { local: { key: local_master_key } },
-      extra_options: {
-        mongocryptd_spawn_args: [ "--port=#{SpecConfig.instance.mongocryptd_port}" ],
-        mongocryptd_uri: "mongodb://localhost:#{SpecConfig.instance.mongocryptd_port}",
-      }
+      extra_options: extra_options
     }
   end
 

--- a/spec/integration/client_side_encryption/lookup_prose_spec.rb
+++ b/spec/integration/client_side_encryption/lookup_prose_spec.rb
@@ -1,0 +1,310 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Prose Test 25: $lookup support with CSFLE and QE' do
+  require_libmongocrypt
+  require_enterprise
+  require_topology :replica_set
+  min_server_version '7.0'
+
+  include_context 'define shared FLE helpers'
+
+  let(:local_master_key) { Base64.decode64(Crypt::LOCAL_MASTER_KEY_B64) }
+
+  let(:auto_encryption_options) do
+    {
+      key_vault_namespace: 'db.keyvault',
+      kms_providers: { local: { key: local_master_key } },
+      extra_options: {
+        mongocryptd_spawn_args: [ "--port=#{SpecConfig.instance.mongocryptd_port}" ],
+        mongocryptd_uri: "mongodb://localhost:#{SpecConfig.instance.mongocryptd_port}",
+      }
+    }
+  end
+
+  def new_encrypted_client
+    ClientRegistry.instance.new_local_client(
+      SpecConfig.instance.addresses,
+      SpecConfig.instance.test_options.merge(
+        auto_encryption_options: auto_encryption_options,
+        database: 'db'
+      )
+    )
+  end
+
+  before(:all) do
+    key_doc = BSON::ExtJSON.parse(File.read('spec/support/crypt/lookup/key-doc.json'))
+    schema_csfle = BSON::ExtJSON.parse(File.read('spec/support/crypt/lookup/schema-csfle.json'))
+    schema_csfle2 = BSON::ExtJSON.parse(File.read('spec/support/crypt/lookup/schema-csfle2.json'))
+    schema_qe = BSON::ExtJSON.parse(File.read('spec/support/crypt/lookup/schema-qe.json'))
+    schema_qe2 = BSON::ExtJSON.parse(File.read('spec/support/crypt/lookup/schema-qe2.json'))
+    schema_non_csfle = BSON::ExtJSON.parse(File.read('spec/support/crypt/lookup/schema-non-csfle.json'))
+
+    local_master_key = Base64.decode64(Crypt::LOCAL_MASTER_KEY_B64)
+
+    setup_client = ClientRegistry.instance.new_local_client(
+      SpecConfig.instance.addresses,
+      SpecConfig.instance.test_options
+    )
+
+    # Set up key vault
+    setup_client.use('db')['keyvault'].drop
+    setup_client.use('db')['keyvault', write_concern: { w: :majority }].insert_one(key_doc)
+
+    # Drop and recreate CSFLE collections
+    setup_client.use('db')['csfle'].drop
+    setup_client.use('db').command(
+      create: 'csfle',
+      validator: { '$jsonSchema' => schema_csfle }
+    )
+
+    setup_client.use('db')['csfle2'].drop
+    setup_client.use('db').command(
+      create: 'csfle2',
+      validator: { '$jsonSchema' => schema_csfle2 }
+    )
+
+    # Drop and recreate QE collections
+    begin
+      setup_client.use('db').command(drop: 'qe')
+    rescue StandardError
+      nil
+    end
+    setup_client.use('db').command(create: 'qe', encryptedFields: schema_qe)
+
+    begin
+      setup_client.use('db').command(drop: 'qe2')
+    rescue StandardError
+      nil
+    end
+    setup_client.use('db').command(create: 'qe2', encryptedFields: schema_qe2)
+
+    # Drop and recreate plain collections
+    setup_client.use('db')['no_schema'].drop
+    setup_client.use('db')['no_schema'].create
+
+    setup_client.use('db')['no_schema2'].drop
+    setup_client.use('db')['no_schema2'].create
+
+    # Drop and recreate non-CSFLE schema collection
+    setup_client.use('db')['non_csfle_schema'].drop
+    setup_client.use('db').command(
+      create: 'non_csfle_schema',
+      validator: { '$jsonSchema' => schema_non_csfle }
+    )
+
+    # Insert test data using encrypted client (so fields get encrypted)
+    encrypted_client = ClientRegistry.instance.new_local_client(
+      SpecConfig.instance.addresses,
+      SpecConfig.instance.test_options.merge(
+        auto_encryption_options: {
+          key_vault_namespace: 'db.keyvault',
+          kms_providers: { local: { key: local_master_key } },
+          extra_options: {
+            mongocryptd_spawn_args: [ "--port=#{SpecConfig.instance.mongocryptd_port}" ],
+            mongocryptd_uri: "mongodb://localhost:#{SpecConfig.instance.mongocryptd_port}",
+          }
+        },
+        database: 'db'
+      )
+    )
+
+    encrypted_client['csfle'].insert_one(csfle: 'csfle')
+    encrypted_client['csfle2'].insert_one(csfle2: 'csfle2')
+    encrypted_client['qe'].insert_one(qe: 'qe')
+    encrypted_client['qe2'].insert_one(qe2: 'qe2')
+    encrypted_client['no_schema'].insert_one(no_schema: 'no_schema')
+    encrypted_client['no_schema2'].insert_one(no_schema2: 'no_schema2')
+    encrypted_client['non_csfle_schema'].insert_one(non_csfle_schema: 'non_csfle_schema')
+
+    # Verify csfle and qe fields are encrypted at rest
+    csfle_doc = setup_client.use('db')['csfle'].find.first
+    raise 'Expected csfle field to be encrypted' unless csfle_doc['csfle'].is_a?(BSON::Binary)
+
+    qe_doc = setup_client.use('db')['qe'].find.first
+    raise 'Expected qe field to be encrypted' unless qe_doc['qe'].is_a?(BSON::Binary)
+  end
+
+  def lookup_pipeline(from:, project_out: nil)
+    inner_project = { '_id' => 0 }
+    inner_project[project_out] = 0 if project_out
+
+    [
+      { '$match' => {} },
+      {
+        '$lookup' => {
+          'from' => from,
+          'pipeline' => [
+            { '$match' => {} },
+            { '$project' => inner_project }
+          ],
+          'as' => 'matched'
+        }
+      },
+      { '$project' => { '_id' => 0 } }
+    ]
+  end
+
+  def lookup_pipeline_with_outer_project(from:, outer_project_out:, inner_project_out: nil)
+    inner_project = { '_id' => 0 }
+    inner_project[inner_project_out] = 0 if inner_project_out
+
+    outer_project = { '_id' => 0, outer_project_out => 0 }
+
+    [
+      { '$match' => {} },
+      {
+        '$lookup' => {
+          'from' => from,
+          'pipeline' => [
+            { '$match' => {} },
+            { '$project' => inner_project }
+          ],
+          'as' => 'matched'
+        }
+      },
+      { '$project' => outer_project }
+    ]
+  end
+
+  context 'Case 1: CSFLE collection $lookup from unencrypted collection' do
+    min_server_version '8.1'
+
+    it 'decrypts both collections correctly' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline(from: 'no_schema')
+      result = client['csfle'].aggregate(pipeline).to_a
+
+      expect(result.length).to eq(1)
+      expect(result.first['csfle']).to eq('csfle')
+      expect(result.first['matched']).to eq([ { 'no_schema' => 'no_schema' } ])
+    end
+  end
+
+  context 'Case 2: QE collection $lookup from unencrypted collection' do
+    min_server_version '8.1'
+
+    it 'decrypts both collections correctly' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline_with_outer_project(from: 'no_schema', outer_project_out: '__safeContent__')
+      result = client['qe'].aggregate(pipeline).to_a
+
+      expect(result.length).to eq(1)
+      expect(result.first['qe']).to eq('qe')
+      expect(result.first['matched']).to eq([ { 'no_schema' => 'no_schema' } ])
+    end
+  end
+
+  context 'Case 3: Unencrypted collection $lookup from CSFLE collection' do
+    min_server_version '8.1'
+
+    it 'decrypts the inner collection correctly' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline(from: 'csfle')
+      result = client['no_schema'].aggregate(pipeline).to_a
+
+      expect(result.length).to eq(1)
+      expect(result.first['no_schema']).to eq('no_schema')
+      expect(result.first['matched']).to eq([ { 'csfle' => 'csfle' } ])
+    end
+  end
+
+  context 'Case 4: Unencrypted collection $lookup from QE collection' do
+    min_server_version '8.1'
+
+    it 'decrypts the inner collection correctly' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline(from: 'qe', project_out: '__safeContent__')
+      result = client['no_schema'].aggregate(pipeline).to_a
+
+      expect(result.length).to eq(1)
+      expect(result.first['no_schema']).to eq('no_schema')
+      expect(result.first['matched']).to eq([ { 'qe' => 'qe' } ])
+    end
+  end
+
+  context 'Case 5: CSFLE collection $lookup from another CSFLE collection' do
+    min_server_version '8.1'
+
+    it 'decrypts both collections correctly' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline(from: 'csfle2')
+      result = client['csfle'].aggregate(pipeline).to_a
+
+      expect(result.length).to eq(1)
+      expect(result.first['csfle']).to eq('csfle')
+      expect(result.first['matched']).to eq([ { 'csfle2' => 'csfle2' } ])
+    end
+  end
+
+  context 'Case 6: QE collection $lookup from another QE collection' do
+    min_server_version '8.1'
+
+    it 'decrypts both collections correctly' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline_with_outer_project(
+        from: 'qe2',
+        outer_project_out: '__safeContent__',
+        inner_project_out: '__safeContent__'
+      )
+      result = client['qe'].aggregate(pipeline).to_a
+
+      expect(result.length).to eq(1)
+      expect(result.first['qe']).to eq('qe')
+      expect(result.first['matched']).to eq([ { 'qe2' => 'qe2' } ])
+    end
+  end
+
+  context 'Case 7: Unencrypted collection $lookup from another unencrypted collection' do
+    min_server_version '8.1'
+
+    it 'works without encryption' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline(from: 'no_schema2')
+      result = client['no_schema'].aggregate(pipeline).to_a
+
+      expect(result.length).to eq(1)
+      expect(result.first['no_schema']).to eq('no_schema')
+      expect(result.first['matched']).to eq([ { 'no_schema2' => 'no_schema2' } ])
+    end
+  end
+
+  context 'Case 8: CSFLE collection $lookup from QE collection raises error' do
+    min_server_version '8.1'
+
+    it 'raises an error' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline(from: 'qe')
+      expect do
+        client['csfle'].aggregate(pipeline).to_a
+      end.to raise_error(Mongo::Error, /not supported|Cannot specify both encryptionInformation/)
+    end
+  end
+
+  context 'Case 9: CSFLE $lookup on server version < 8.1 raises upgrade error' do
+    max_server_version '8.0.99'
+
+    it 'raises an error suggesting upgrade' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline(from: 'no_schema')
+      expect do
+        client['csfle'].aggregate(pipeline).to_a
+      end.to raise_error(Mongo::Error, /Upgrade/)
+    end
+  end
+
+  context 'Case 10: QE collection $lookup from collection with non-CSFLE schema' do
+    min_server_version '8.2'
+
+    it 'decrypts both collections correctly' do
+      client = new_encrypted_client
+      pipeline = lookup_pipeline_with_outer_project(from: 'non_csfle_schema', outer_project_out: '__safeContent__')
+      result = client['qe'].aggregate(pipeline).to_a
+
+      expect(result.length).to eq(1)
+      expect(result.first['qe']).to eq('qe')
+      expect(result.first['matched']).to eq([ { 'non_csfle_schema' => 'non_csfle_schema' } ])
+    end
+  end
+end

--- a/spec/integration/client_side_encryption/lookup_prose_spec.rb
+++ b/spec/integration/client_side_encryption/lookup_prose_spec.rb
@@ -98,13 +98,7 @@ describe 'Prose Test 25: $lookup support with CSFLE and QE' do
         auto_encryption_options: {
           key_vault_namespace: 'db.keyvault',
           kms_providers: { local: { key: local_master_key } },
-          extra_options: Crypt.extra_options,
-
-          # MongoDB 8.3.2 complains about "non_csfle_schema" having a JSON schema defined, and
-          # recommends this as a workaround.
-          encrypted_fields_map: {
-            non_csfle_schema: { fields: [] }
-          },
+          extra_options: Crypt.extra_options
         },
         database: 'db'
       )

--- a/spec/integration/client_side_encryption/lookup_prose_spec.rb
+++ b/spec/integration/client_side_encryption/lookup_prose_spec.rb
@@ -98,10 +98,7 @@ describe 'Prose Test 25: $lookup support with CSFLE and QE' do
         auto_encryption_options: {
           key_vault_namespace: 'db.keyvault',
           kms_providers: { local: { key: local_master_key } },
-          extra_options: {
-            mongocryptd_spawn_args: [ "--port=#{SpecConfig.instance.mongocryptd_port}" ],
-            mongocryptd_uri: "mongodb://localhost:#{SpecConfig.instance.mongocryptd_port}",
-          }
+          extra_options: extra_options
         },
         database: 'db'
       )

--- a/spec/mongo/crypt/binding/context_spec.rb
+++ b/spec/mongo/crypt/binding/context_spec.rb
@@ -302,4 +302,12 @@ describe 'Mongo::Crypt::Binding' do
       end
     end
   end
+
+  describe 'mongocrypt_ctx_state enum' do
+    it 'includes need_mongo_collinfo_with_db as value 8' do
+      expect(
+        Mongo::Crypt::Binding.enum_type(:mongocrypt_ctx_state)[:need_mongo_collinfo_with_db]
+      ).to eq(8)
+    end
+  end
 end

--- a/spec/mongo/crypt/binding/context_spec.rb
+++ b/spec/mongo/crypt/binding/context_spec.rb
@@ -304,6 +304,9 @@ describe 'Mongo::Crypt::Binding' do
   end
 
   describe 'mongocrypt_ctx_state enum' do
+    require_libmongocrypt
+    fails_on_jruby
+
     it 'includes need_mongo_collinfo_with_db as value 8' do
       expect(
         Mongo::Crypt::Binding.enum_type(:mongocrypt_ctx_state)[:need_mongo_collinfo_with_db]

--- a/spec/mongo/crypt/binding/mongocrypt_spec.rb
+++ b/spec/mongo/crypt/binding/mongocrypt_spec.rb
@@ -108,5 +108,25 @@ describe 'Mongo::Crypt::Binding' do
         end
       end
     end
+
+    describe '#mongocrypt_setopt_enable_multiple_collinfo' do
+      let(:mongocrypt) { Mongo::Crypt::Binding.mongocrypt_new }
+
+      it 'returns true when called before init' do
+        expect(
+          Mongo::Crypt::Binding.mongocrypt_setopt_enable_multiple_collinfo(mongocrypt)
+        ).to be true
+      end
+    end
+
+    describe '#mongocrypt_setopt_use_need_mongo_collinfo_with_db_state' do
+      let(:mongocrypt) { Mongo::Crypt::Binding.mongocrypt_new }
+
+      it 'does not raise' do
+        expect do
+          Mongo::Crypt::Binding.mongocrypt_setopt_use_need_mongo_collinfo_with_db_state(mongocrypt)
+        end.not_to raise_error
+      end
+    end
   end
 end

--- a/spec/mongo/crypt/encryption_io_spec.rb
+++ b/spec/mongo/crypt/encryption_io_spec.rb
@@ -84,6 +84,50 @@ describe Mongo::Crypt::EncryptionIO do
     end
   end
 
+  describe '#collection_info' do
+    let(:subject) do
+      described_class.new(
+        key_vault_namespace: 'foo.bar',
+        key_vault_client: authorized_client,
+        metadata_client: authorized_client,
+        mongocryptd_options: {}
+      )
+    end
+
+    let(:db_name) { 'collection_info_test' }
+    let(:test_client) { authorized_client }
+
+    before do
+      test_client.use(db_name)['col_a'].drop
+      test_client.use(db_name)['col_b'].drop
+      test_client.use(db_name).command(create: 'col_a')
+      test_client.use(db_name).command(create: 'col_b')
+    end
+
+    after do
+      test_client.use(db_name)['col_a'].drop
+      test_client.use(db_name)['col_b'].drop
+    end
+
+    it 'returns an array of all matching collection documents' do
+      results = subject.collection_info(db_name, {}, timeout_ms: nil)
+      names = results.map { |doc| doc['name'] }
+      expect(names).to include('col_a', 'col_b')
+    end
+
+    it 'returns an empty array when no collections match' do
+      results = subject.collection_info(db_name, { name: 'nonexistent' }, timeout_ms: nil)
+      expect(results).to eq([])
+    end
+
+    it 'returns an array even when only one collection matches' do
+      results = subject.collection_info(db_name, { name: 'col_a' }, timeout_ms: nil)
+      expect(results).to be_an(Array)
+      expect(results.length).to eq(1)
+      expect(results.first['name']).to eq('col_a')
+    end
+  end
+
   describe '#mark_command' do
     let(:mock_client) do
       double('mongocryptd client').tap do |client|

--- a/spec/mongo/crypt/handle_spec.rb
+++ b/spec/mongo/crypt/handle_spec.rb
@@ -182,6 +182,20 @@ describe Mongo::Crypt::Handle do
       end
     end
 
+    context 'with local KMS providers' do
+      include_context 'with local kms_providers'
+
+      it 'calls setopt_enable_multiple_collinfo' do
+        expect(Mongo::Crypt::Binding).to receive(:setopt_enable_multiple_collinfo).and_call_original
+        handle
+      end
+
+      it 'calls setopt_use_need_mongo_collinfo_with_db_state' do
+        expect(Mongo::Crypt::Binding).to receive(:setopt_use_need_mongo_collinfo_with_db_state).and_call_original
+        handle
+      end
+    end
+
     context 'local' do
       context 'with invalid local kms master key' do
         let(:kms_providers) do

--- a/spec/support/crypt.rb
+++ b/spec/support/crypt.rb
@@ -20,6 +20,25 @@ module Crypt
 
   LOCAL_MASTER_KEY = Base64.decode64(LOCAL_MASTER_KEY_B64)
 
+  def self.extra_options
+    opts = {
+      mongocryptd_spawn_args: [ "--port=#{SpecConfig.instance.mongocryptd_port}" ],
+      mongocryptd_uri: "mongodb://localhost:#{SpecConfig.instance.mongocryptd_port}",
+    }
+    if SpecConfig.instance.crypt_shared_lib_path
+      # Always use the explicit path when available so that every Handle in
+      # the process uses the same load mechanism and libmongocrypt does not
+      # raise "An existing crypt_shared library is loaded" errors.
+      opts[:crypt_shared_lib_path] = SpecConfig.instance.crypt_shared_lib_path
+    elsif SpecConfig.instance.suppress_crypt_shared_lib_search?
+      # Inside without_crypt_shared_lib_path: skip the "$SYSTEM" search
+      # entirely so we don't conflict with any library already loaded by a
+      # previous Handle via a path override.
+      opts[:disable_crypt_shared_lib_search] = true
+    end
+    opts
+  end
+
   # For all FLE-related tests
   shared_context 'define shared FLE helpers' do
     # 96-byte binary string, base64-encoded local master key
@@ -94,24 +113,7 @@ module Crypt
       )[key_vault_coll]
     end
 
-    let(:extra_options) do
-      opts = {
-        mongocryptd_spawn_args: [ "--port=#{SpecConfig.instance.mongocryptd_port}" ],
-        mongocryptd_uri: "mongodb://localhost:#{SpecConfig.instance.mongocryptd_port}",
-      }
-      if SpecConfig.instance.crypt_shared_lib_path
-        # Always use the explicit path when available so that every Handle in
-        # the process uses the same load mechanism and libmongocrypt does not
-        # raise "An existing crypt_shared library is loaded" errors.
-        opts[:crypt_shared_lib_path] = SpecConfig.instance.crypt_shared_lib_path
-      elsif SpecConfig.instance.suppress_crypt_shared_lib_search?
-        # Inside without_crypt_shared_lib_path: skip the "$SYSTEM" search
-        # entirely so we don't conflict with any library already loaded by a
-        # previous Handle via a path override.
-        opts[:disable_crypt_shared_lib_search] = true
-      end
-      opts
-    end
+    let(:extra_options) { Crypt.extra_options }
 
     let(:kms_tls_options) do
       {}

--- a/spec/support/crypt/lookup/key-doc.json
+++ b/spec/support/crypt/lookup/key-doc.json
@@ -1,0 +1,30 @@
+{
+    "_id": {
+        "$binary": {
+            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+            "subType": "04"
+        }
+    },
+    "keyMaterial": {
+        "$binary": {
+            "base64": "sHe0kz57YW7v8g9VP9sf/+K1ex4JqKc5rf/URX3n3p8XdZ6+15uXPaSayC6adWbNxkFskuMCOifDoTT+rkqMtFkDclOy884RuGGtUysq3X7zkAWYTKi8QAfKkajvVbZl2y23UqgVasdQu3OVBQCrH/xY00nNAs/52e958nVjBuzQkSb1T8pKJAyjZsHJ60+FtnfafDZSTAIBJYn7UWBCwQ==",
+            "subType": "00"
+        }
+    },
+    "creationDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "updateDate": {
+        "$date": {
+            "$numberLong": "1648914851981"
+        }
+    },
+    "status": {
+        "$numberInt": "0"
+    },
+    "masterKey": {
+        "provider": "local"
+    }
+}

--- a/spec/support/crypt/lookup/schema-csfle.json
+++ b/spec/support/crypt/lookup/schema-csfle.json
@@ -1,0 +1,19 @@
+{
+    "properties": {
+        "csfle": {
+            "encrypt": {
+                "keyId": [
+                    {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    }
+                ],
+                "bsonType": "string",
+                "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+        }
+    },
+    "bsonType": "object"
+}

--- a/spec/support/crypt/lookup/schema-csfle2.json
+++ b/spec/support/crypt/lookup/schema-csfle2.json
@@ -1,0 +1,19 @@
+{
+    "properties": {
+        "csfle2": {
+            "encrypt": {
+                "keyId": [
+                    {
+                        "$binary": {
+                            "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                            "subType": "04"
+                        }
+                    }
+                ],
+                "bsonType": "string",
+                "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+            }
+        }
+    },
+    "bsonType": "object"
+}

--- a/spec/support/crypt/lookup/schema-non-csfle.json
+++ b/spec/support/crypt/lookup/schema-non-csfle.json
@@ -1,0 +1,3 @@
+{
+   "bsonType": "object"
+}

--- a/spec/support/crypt/lookup/schema-qe.json
+++ b/spec/support/crypt/lookup/schema-qe.json
@@ -1,0 +1,20 @@
+{
+    "escCollection": "enxcol_.qe.esc",
+    "ecocCollection": "enxcol_.qe.ecoc",
+    "fields": [
+        {
+            "keyId": {
+                "$binary": {
+                    "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                    "subType": "04"
+                }
+            },
+            "path": "qe",
+            "bsonType": "string",
+            "queries": {
+                "queryType": "equality",
+                "contention": 0
+            }
+        }
+    ]
+}

--- a/spec/support/crypt/lookup/schema-qe2.json
+++ b/spec/support/crypt/lookup/schema-qe2.json
@@ -1,0 +1,20 @@
+{
+    "escCollection": "enxcol_.qe2.esc",
+    "ecocCollection": "enxcol_.qe2.ecoc",
+    "fields": [
+        {
+            "keyId": {
+                "$binary": {
+                    "base64": "EjRWeBI0mHYSNBI0VniQEg==",
+                    "subType": "04"
+                }
+            },
+            "path": "qe2",
+            "bsonType": "string",
+            "queries": {
+                "queryType": "equality",
+                "contention": 0
+            }
+        }
+    ]
+}

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -724,6 +724,8 @@ class SpecConfig
         { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'ci-tests' },
         { role: Mongo::Auth::Roles::READ_WRITE, db: 'papi-tests' },
         { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'papi-tests' },
+        { role: Mongo::Auth::Roles::READ_WRITE, db: 'collection_info_test' },
+        { role: Mongo::Auth::Roles::DATABASE_ADMIN, db: 'collection_info_test' },
       ]
     )
   end


### PR DESCRIPTION
## Summary

You can now use `$lookup` in aggregation pipelines that reference CSFLE- and QE-enabled collections.