### PR TITLE
RUBY-3383 Support delegated protocol for CSFLE/QE KMIP

### DIFF
--- a/lib/mongo/crypt/kms/kmip/master_document.rb
+++ b/lib/mongo/crypt/kms/kmip/master_document.rb
@@ -31,8 +31,12 @@ module Mongo
           # @return [ String | nil ] KMIP KMS endpoint with optional port.
           attr_reader :endpoint
 
+          # @return [ true | false | nil ] Whether the KMIP server performs
+          #   encryption and decryption of the data key.
+          attr_reader :delegated
+
           FORMAT_HINT = 'KMIP KMS key document must be in the format: ' +
-                        "{ key_id: 'KEY-ID', endpoint: 'ENDPOINT' }"
+                        "{ key_id: 'KEY-ID', endpoint: 'ENDPOINT', delegated: true|false }"
 
           # Creates a master key document object form a parameters hash.
           #
@@ -42,6 +46,9 @@ module Mongo
           #   a 96 byte KMIP Secret Data managed object, optional. If key_id
           #   is omitted, the driver creates a random 96 byte identifier.
           # @option opts [ String | nil ] :endpoint KMIP endpoint, optional.
+          # @option opts [ true | false | nil ] :delegated If true, the KMIP
+          #   server performs encryption and decryption of the data key,
+          #   optional. Defaults to false.
           #
           # @raise [ ArgumentError ] If required options are missing or incorrectly
           #   formatted.
@@ -52,6 +59,7 @@ module Mongo
             @endpoint = validate_param(
               :endpoint, opts, FORMAT_HINT, required: false
             )
+            @delegated = validate_delegated(opts)
           end
 
           # Convert master key document object to a BSON document in libmongocrypt format.
@@ -63,7 +71,28 @@ module Mongo
                                }).tap do |bson|
               bson.update({ endpoint: endpoint }) unless endpoint.nil?
               bson.update({ keyId: key_id }) unless key_id.nil?
+              bson.update({ delegated: delegated }) unless delegated.nil?
             end
+          end
+
+          private
+
+          # Validate the optional :delegated KMIP master key option.
+          #
+          # @param [ Hash ] opts Master key options.
+          #
+          # @return [ true | false | nil ] The delegated value, or nil if absent.
+          #
+          # @raise [ ArgumentError ] If delegated is present but not a boolean.
+          def validate_delegated(opts)
+            return nil unless opts.key?(:delegated)
+
+            value = opts[:delegated]
+            return value if value == true || value == false || value.nil?
+
+            raise ArgumentError.new(
+              "The delegated option must be a boolean; currently have #{value}"
+            )
           end
         end
       end

--- a/spec/mongo/crypt/kms/kmip/master_document_spec.rb
+++ b/spec/mongo/crypt/kms/kmip/master_document_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'mongo'
+require 'lite_spec_helper'
+
+describe Mongo::Crypt::KMS::KMIP::MasterKeyDocument do
+  let(:document) do
+    described_class.new(options).to_document
+  end
+
+  context 'with key_id and endpoint' do
+    let(:options) do
+      { key_id: '1', endpoint: 'localhost:5698' }
+    end
+
+    it 'builds the libmongocrypt document' do
+      expect(document).to eq(
+        BSON::Document.new(provider: 'kmip', endpoint: 'localhost:5698', keyId: '1')
+      )
+    end
+
+    it 'does not include delegated' do
+      expect(document).not_to have_key(:delegated)
+    end
+  end
+
+  context 'with delegated set to true' do
+    let(:options) do
+      { delegated: true }
+    end
+
+    it 'includes delegated in the document' do
+      expect(document[:delegated]).to be true
+    end
+
+    it 'does not require key_id or endpoint' do
+      expect(document).to eq(
+        BSON::Document.new(provider: 'kmip', delegated: true)
+      )
+    end
+  end
+
+  context 'with delegated set to false' do
+    let(:options) do
+      { key_id: '1', delegated: false }
+    end
+
+    it 'includes delegated false in the document' do
+      expect(document[:delegated]).to be false
+    end
+  end
+
+  context 'without delegated' do
+    let(:options) do
+      { key_id: '1' }
+    end
+
+    it 'omits delegated from the document' do
+      expect(document).not_to have_key(:delegated)
+    end
+  end
+
+  context 'with a non-boolean delegated' do
+    let(:options) do
+      { delegated: 'yes' }
+    end
+
+    it 'raises an error' do
+      expect do
+        described_class.new(options)
+      end.to raise_error(ArgumentError, /delegated/)
+    end
+  end
+end

--- a/spec/spec_tests/data/client_side_encryption/unified/createDataKey.yml
+++ b/spec/spec_tests/data/client_side_encryption/unified/createDataKey.yml
@@ -44,7 +44,7 @@ tests:
           kmsProvider: aws
           opts:
             masterKey: &new_aws_masterkey
-              key: arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+              key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
               region: us-east-1
         expectResult: { $$type: binData }
     expectEvents:
@@ -148,6 +148,35 @@ tests:
                     masterKey:
                       provider: kmip
                       keyId: { $$type: string }
+                writeConcern: { w: majority }
+
+  - description: create datakey with KMIP delegated KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: kmip
+          opts:
+            masterKey: &new_kmip_masterkey
+              delegated: true
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: kmip
+                      keyId: { $$type: string }
+                      delegated: true
                 writeConcern: { w: majority }
 
   - description: create datakey with local KMS provider
@@ -274,7 +303,14 @@ tests:
           kmsProvider: local
           opts:
             # "key_material" repeated 8 times.
-            keyMaterial: &custom_key_material { $binary: { base64: a2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFs, subType: "00" } }
+            keyMaterial:
+              &custom_key_material {
+                $binary:
+                  {
+                    base64: a2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFs,
+                    subType: "00",
+                  },
+              }
         expectResult: { $$type: binData }
     expectEvents:
       - client: *client0
@@ -301,7 +337,14 @@ tests:
           kmsProvider: local
           opts:
             # "key_material" repeated only 7 times (key material length == 84).
-            keyMaterial: { $binary: { base64: a2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFs, subType: "00" } }
+            keyMaterial:
+              {
+                $binary:
+                  {
+                    base64: a2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFsa2V5X21hdGVyaWFs,
+                    subType: "00",
+                  },
+              }
         expectError:
           isClientError: true
     expectEvents:

--- a/spec/spec_tests/data/client_side_encryption/unified/rewrapManyDataKey.yml
+++ b/spec/spec_tests/data/client_side_encryption/unified/rewrapManyDataKey.yml
@@ -40,17 +40,31 @@ initialData:
     documents:
       - _id: &aws_key_id { $binary: { base64: YXdzYXdzYXdzYXdzYXdzYQ==, subType: "04" } }
         keyAltNames: ["aws_key"]
-        keyMaterial: { $binary: { base64: AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gFXJqbF0Fy872MD7xl56D/2AAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDO7HPisPUlGzaio9vgIBEIB7/Qow46PMh/8JbEUbdXgTGhLfXPE+KIVW7T8s6YEMlGiRvMu7TV0QCIUJlSHPKZxzlJ2iwuz5yXeOag+EdY+eIQ0RKrsJ3b8UTisZYzGjfzZnxUKLzLoeXremtRCm3x47wCuHKd1dhh6FBbYt5TL2tDaj+vL2GBrKat2L, subType: "00" } }
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gFXJqbF0Fy872MD7xl56D/2AAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDO7HPisPUlGzaio9vgIBEIB7/Qow46PMh/8JbEUbdXgTGhLfXPE+KIVW7T8s6YEMlGiRvMu7TV0QCIUJlSHPKZxzlJ2iwuz5yXeOag+EdY+eIQ0RKrsJ3b8UTisZYzGjfzZnxUKLzLoeXremtRCm3x47wCuHKd1dhh6FBbYt5TL2tDaj+vL2GBrKat2L,
+                subType: "00",
+              },
+          }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
         masterKey: &aws_masterkey
           provider: aws
-          key: arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0
+          key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
           region: us-east-1
       - _id: &azure_key_id { $binary: { base64: YXp1cmVhenVyZWF6dXJlYQ==, subType: "04" } }
         keyAltNames: ["azure_key"]
-        keyMaterial: { $binary: { base64: pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==, subType: "00" } }
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==,
+                subType: "00",
+              },
+          }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
@@ -60,7 +74,14 @@ initialData:
           keyName: key-name-csfle
       - _id: &gcp_key_id { $binary: { base64: Z2NwZ2NwZ2NwZ2NwZ2NwZw==, subType: "04" } }
         keyAltNames: ["gcp_key"]
-        keyMaterial: { $binary: { base64: CiQAIgLj0USbQtof/pYRLQO96yg/JEtZbD1UxKueaC37yzT5tTkSiQEAhClWB5ZCSgzHgxv8raWjNB4r7e8ePGdsmSuYTYmLC5oHHS/BdQisConzNKFaobEQZHamTCjyhy5NotKF8MWoo+dyfQApwI29+vAGyrUIQCXzKwRnNdNQ+lb3vJtS5bqvLTvSxKHpVca2kqyC9nhonV+u4qru5Q2bAqUgVFc8fL4pBuvlowZFTQ==, subType: "00" } }
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: CiQAIgLj0USbQtof/pYRLQO96yg/JEtZbD1UxKueaC37yzT5tTkSiQEAhClWB5ZCSgzHgxv8raWjNB4r7e8ePGdsmSuYTYmLC5oHHS/BdQisConzNKFaobEQZHamTCjyhy5NotKF8MWoo+dyfQApwI29+vAGyrUIQCXzKwRnNdNQ+lb3vJtS5bqvLTvSxKHpVca2kqyC9nhonV+u4qru5Q2bAqUgVFc8fL4pBuvlowZFTQ==,
+                subType: "00",
+              },
+          }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
@@ -72,7 +93,14 @@ initialData:
           keyName: key-name-csfle
       - _id: &kmip_key_id { $binary: { base64: a21pcGttaXBrbWlwa21pcA==, subType: "04" } }
         keyAltNames: ["kmip_key"]
-        keyMaterial: { $binary: { base64: CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==, subType: "00" } }
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==,
+                subType: "00",
+              },
+          }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
@@ -81,12 +109,36 @@ initialData:
           keyId: "1"
       - _id: &local_key_id { $binary: { base64: bG9jYWxrZXlsb2NhbGtleQ==, subType: "04" } }
         keyAltNames: ["local_key"]
-        keyMaterial: { $binary: { base64: ABKBldDEoDW323yejOnIRk6YQmlD9d3eQthd16scKL75nz2LjNL9fgPDZWrFFOlqlhMCFaSrNJfGrFUjYk5JFDO7soG5Syb50k1niJoKg4ilsj0L4mpimFUtTpOr2nzZOeQtvAksEXc7gsFgq8gV7t/U3lsaXPY7I0t42DfSE8EGlPdxRjFdHnxh+OR8h7U9b8Qs5K5UuhgyeyxaBZ1Hgw==, subType: "00" } }
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: ABKBldDEoDW323yejOnIRk6YQmlD9d3eQthd16scKL75nz2LjNL9fgPDZWrFFOlqlhMCFaSrNJfGrFUjYk5JFDO7soG5Syb50k1niJoKg4ilsj0L4mpimFUtTpOr2nzZOeQtvAksEXc7gsFgq8gV7t/U3lsaXPY7I0t42DfSE8EGlPdxRjFdHnxh+OR8h7U9b8Qs5K5UuhgyeyxaBZ1Hgw==,
+                subType: "00",
+              },
+          }
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
         masterKey: &local_masterkey
           provider: local
+      - _id: &kmip_delegated_key_id { $uuid: "7411e9af-c688-4df7-8143-5e60ae96cba5" }
+        keyAltNames: ["kmip_delegated_key"]
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: 5TLMFWlguBWe5GUESTvOVtkdBsCrynhnV72XRyZ66/nk+EP9/1oEp1t1sg0+vwCTqULHjBiUE6DRx2mYD/Eup1+u2Jgz9/+1sV1drXeOPALNPkSgiZiDbIb67zRi+wTABEcKcegJH+FhmSGxwUoQAiHCsCbcvia5P8tN1lt98YQ=,
+                subType: "00",
+              },
+          }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &kmip_delegated_masterkey
+          provider: kmip
+          keyId: "11"
+          delegated: true
 
 tests:
   - description: "no keys to rewrap due to no filter matches"
@@ -120,16 +172,17 @@ tests:
             provider: aws
             # Different key: 89fcc2c4-08b0-4bd9-9f25-e30687b580d0 -> 061334ae-07a8-4ceb-a813-8135540e837d.
             masterKey: &new_aws_masterkey
-              key: arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d
+              key: "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d"
               region: us-east-1
         expectResult:
           bulkWriteResult:
             insertedCount: 0
-            matchedCount: 4
-            modifiedCount: 4
+            matchedCount: 5
+            modifiedCount: 5
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -146,19 +199,48 @@ tests:
                 ordered: true
                 updates:
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: aws, <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: aws, <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: aws, <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: aws, <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: aws, <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: aws, <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: aws, <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: aws, <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: aws, <<: *new_aws_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                 writeConcern: { w: majority }
@@ -177,11 +259,12 @@ tests:
         expectResult:
           bulkWriteResult:
             insertedCount: 0
-            matchedCount: 4
-            modifiedCount: 4
+            matchedCount: 5
+            modifiedCount: 5
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -198,19 +281,63 @@ tests:
                 ordered: true
                 updates:
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: azure, <<: *new_azure_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: azure, <<: *new_azure_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: azure, <<: *new_azure_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: azure, <<: *new_azure_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: azure, <<: *new_azure_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: azure, <<: *new_azure_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: azure, <<: *new_azure_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: azure, <<: *new_azure_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: azure, <<: *new_azure_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                 writeConcern: { w: majority }
@@ -231,11 +358,12 @@ tests:
         expectResult:
           bulkWriteResult:
             insertedCount: 0
-            matchedCount: 4
-            modifiedCount: 4
+            matchedCount: 5
+            modifiedCount: 5
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -252,19 +380,48 @@ tests:
                 ordered: true
                 updates:
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: gcp, <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: gcp, <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: gcp, <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: gcp, <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: gcp, <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: gcp, <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: gcp, <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: gcp, <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          { masterKey: { provider: gcp, <<: *new_gcp_masterkey }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                 writeConcern: { w: majority }
@@ -280,11 +437,12 @@ tests:
         expectResult:
           bulkWriteResult:
             insertedCount: 0
-            matchedCount: 4
-            modifiedCount: 4
+            matchedCount: 5
+            modifiedCount: 5
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -301,19 +459,159 @@ tests:
                 ordered: true
                 updates:
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: kmip, keyId: { $$type: string } }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: kmip, keyId: { $$type: string } }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: kmip, keyId: { $$type: string } }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: kmip, keyId: { $$type: string } }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap with new KMIP delegated KMS provider"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: kmip_delegated_key } }
+          opts:
+            provider: kmip
+            masterKey:
+              delegated: true
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 5
+            modifiedCount: 5
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: kmip_delegated_key } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, delegated: true, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, delegated: true, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, delegated: true, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, delegated: true, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: kmip, delegated: true, keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                 writeConcern: { w: majority }
@@ -329,11 +627,12 @@ tests:
         expectResult:
           bulkWriteResult:
             insertedCount: 0
-            matchedCount: 4
-            modifiedCount: 4
+            matchedCount: 5
+            modifiedCount: 5
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
     expectEvents:
       - client: *client0
         events:
@@ -350,19 +649,43 @@ tests:
                 ordered: true
                 updates:
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: local }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: local }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: local }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: local }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: local }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: local }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { provider: local }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: local }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: local }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                 writeConcern: { w: majority }
@@ -376,11 +699,12 @@ tests:
         expectResult:
           bulkWriteResult:
             insertedCount: 0
-            matchedCount: 5
-            modifiedCount: 5
+            matchedCount: 6
+            modifiedCount: 6
             deletedCount: 0
             upsertedCount: 0
             upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
       - name: find
         object: *collection0
         arguments:
@@ -391,6 +715,7 @@ tests:
           - { _id: *aws_key_id, masterKey: *aws_masterkey }
           - { _id: *azure_key_id, masterKey: *azure_masterkey }
           - { _id: *gcp_key_id, masterKey: *gcp_masterkey }
+          - { _id: *kmip_delegated_key_id, masterKey: *kmip_delegated_masterkey }
           - { _id: *kmip_key_id, masterKey: *kmip_masterkey }
           - { _id: *local_key_id, masterKey: *local_masterkey }
     expectEvents:
@@ -409,23 +734,51 @@ tests:
                 ordered: true
                 updates:
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                   - q: { _id: { $$type: binData } }
-                    u: { $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } }, $currentDate: { updateDate: true } }
+                    u:
+                      {
+                        $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set: { masterKey: { $$type: object }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
                     multi: { $$unsetOrMatches: false }
                     upsert: { $$unsetOrMatches: false }
                 writeConcern: { w: majority }


### PR DESCRIPTION
## What

Add support for the KMIP `delegated` protocol option for CSFLE/QE, per
[DRIVERS-2732](https://jira.mongodb.org/browse/RUBY-3383). When `delegated`
is `true`, the KMIP server performs encryption and decryption of the data
key, so the key encryption key never leaves the server.

The cryptographic work is handled entirely by libmongocrypt (>= 1.10; the
driver pins 1.12.0). Unlike Python, which passes `master_key` straight
through, the Ruby driver builds the KMIP master key document explicitly, so
it must carry the new field through and validate it.

## Changes

Code:
- `lib/mongo/crypt/kms/kmip/master_document.rb` — add the optional boolean
  `delegated` attribute. It is validated as `true`/`false` (raises
  `ArgumentError` otherwise) and included in the libmongocrypt document only
  when provided. `key_id` and `endpoint` remain optional, so
  `{ delegated: true }` alone is valid.

Tests:
- `spec/mongo/crypt/kms/kmip/master_document_spec.rb` — new unit spec for the
  document building and validation (runnable without a KMIP server).
- `spec/spec_tests/data/client_side_encryption/unified/createDataKey.yml` and
  `rewrapManyDataKey.yml` — refreshed from the specifications repo to pick up
  the `delegated` test cases.

## Test plan

- [x] `bundle exec rspec spec/mongo/crypt/kms/kmip/master_document_spec.rb` — 7 examples, 0 failures
- [x] `bundle exec rspec spec/mongo/crypt/kms_spec.rb spec/mongo/crypt/kms/credentials_spec.rb` — no regressions
- [x] `bundle exec rubocop` on changed files — no offenses
- [ ] Unified KMIP `delegated` integration cases (createDataKey / rewrapManyDataKey) require a pykmip test server, which is not part of the local replica set. These run in Evergreen CI.

Jira: https://jira.mongodb.org/browse/RUBY-3383
