### PR TITLE
RUBY-3812 Don't use the legacy datasets for bson benchmarks

### DIFF
--- a/profile/driver_bench/rake/tasks.rake
+++ b/profile/driver_bench/rake/tasks.rake
@@ -25,6 +25,8 @@ namespace :driver_bench do
     mkdir_p DRIVER_BENCH_DATA
 
     Dir.glob(File.join(SPECS_PATH, 'source/benchmarking/data/*.tgz')) do |archive|
+      next if archive.include?('legacy') # skip the legacy data sets
+
       Dir.chdir(DRIVER_BENCH_DATA) do
         sh 'tar', 'xzf', archive
       end


### PR DESCRIPTION
The legacy data sets were being unpacked on top of the recent data sets, and so the recent data sets were never being used by the benchmarks. This PR explicitly skips the legacy data sets so they don't clobber the recent ones.