### PR TITLE
RUBY-3811 deprecate server version 4.2

### DIFF
--- a/lib/mongo/server/description/features.rb
+++ b/lib/mongo/server/description/features.rb
@@ -74,7 +74,7 @@ module Mongo
         #
         # If there are no currently-deprecated wire versions, this should be
         # set to an empty range (e.g. the EMPTY_RANGE constant).
-        DEPRECATED_WIRE_VERSIONS = EMPTY_RANGE
+        DEPRECATED_WIRE_VERSIONS = 8..8
 
         # make sure the deprecated versions are valid
         if DEPRECATED_WIRE_VERSIONS.min && (DRIVER_WIRE_VERSIONS.min > DEPRECATED_WIRE_VERSIONS.max)


### PR DESCRIPTION
## Summary

MongoDB server version 4.2 is EOL, and support for it will be **removed from the driver** in a future driver release. If you are using MongoDB server version 4.2, please upgrade to a newer version soon.