### PR TITLE
RUBY-3363 Support named KMS providers (type:name format)

### DIFF
--- a/lib/mongo/crypt/context.rb
+++ b/lib/mongo/crypt/context.rb
@@ -199,21 +199,24 @@ module Mongo
       #   KMS providers.
       def retrieve_kms_credentials(timeout_holder)
         providers = {}
-        if kms_providers.aws && kms_providers.aws.empty?
-          begin
-            aws_credentials = Mongo::Auth::Aws::CredentialsRetriever.new.credentials(timeout_holder)
-          rescue Auth::Aws::CredentialsNotFound
-            raise Error::CryptError.new(
-              'Could not locate AWS credentials (checked environment variables, ECS and EC2 metadata)'
-            )
+        kms_providers.credentials_map.each do |identifier, creds|
+          next unless creds.empty?
+
+          case KMS.provider_base_type(identifier)
+          when 'aws'
+            begin
+              aws_credentials = Mongo::Auth::Aws::CredentialsRetriever.new.credentials(timeout_holder)
+            rescue Auth::Aws::CredentialsNotFound
+              raise Error::CryptError.new(
+                'Could not locate AWS credentials (checked environment variables, ECS and EC2 metadata)'
+              )
+            end
+            providers[identifier] = aws_credentials.to_h
+          when 'gcp'
+            providers[identifier] = { access_token: gcp_access_token(timeout_holder) }
+          when 'azure'
+            providers[identifier] = { access_token: azure_access_token(timeout_holder) }
           end
-          providers[:aws] = aws_credentials.to_h
-        end
-        if kms_providers.gcp && kms_providers.gcp.empty?
-          providers[:gcp] = { access_token: gcp_access_token(timeout_holder) }
-        end
-        if kms_providers.azure && kms_providers.azure.empty?
-          providers[:azure] = { access_token: azure_access_token(timeout_holder) }
         end
         KMS::Credentials.new(providers)
       end

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -125,13 +125,23 @@ module Mongo
       end
 
       # Return TLS options for KMS provider. If there are no TLS options set,
-      # empty hash is returned.
+      # empty hash is returned. Named providers (e.g. "kmip:name1") fall back
+      # to the base-type options (e.g. :kmip) when no exact match is found.
       #
-      # @param [ String ] provider KSM provider name.
+      # @param [ String ] provider KMS provider name or named identifier.
       #
       # @return [ Hash ] TLS options to connect to KMS provider.
       def kms_tls_options(provider)
-        @kms_tls_options.fetch(provider, {})
+        provider_str = provider.to_s
+        base_type = provider_str.split(':').first
+
+        @kms_tls_options.fetch(provider_str) do
+          @kms_tls_options.fetch(provider_str.to_sym) do
+            @kms_tls_options.fetch(base_type) do
+              @kms_tls_options.fetch(base_type.to_sym, {})
+            end
+          end
+        end
       end
 
       def crypt_shared_lib_version

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -103,7 +103,7 @@ module Mongo
 
         Binding.setopt_kms_providers(self, @kms_providers.to_document)
 
-        if @kms_providers.aws&.empty? || @kms_providers.gcp&.empty? || @kms_providers.azure&.empty?
+        if @kms_providers.any_on_demand?
           Binding.setopt_use_need_kms_credentials_state(self)
         end
 
@@ -133,7 +133,7 @@ module Mongo
       # @return [ Hash ] TLS options to connect to KMS provider.
       def kms_tls_options(provider)
         provider_str = provider.to_s
-        base_type = provider_str.split(':').first
+        base_type = KMS.provider_base_type(provider_str)
 
         @kms_tls_options.fetch(provider_str) do
           @kms_tls_options.fetch(provider_str.to_sym) do

--- a/lib/mongo/crypt/kms.rb
+++ b/lib/mongo/crypt/kms.rb
@@ -16,12 +16,23 @@
 
 module Mongo
   module Crypt
-    module KMS
+    module KMS # rubocop:disable Style/Documentation
       # This error indicates that we could not obtain credential for
       # a KMS service.
       #
       # @api private
       class CredentialsNotFound < RuntimeError; end
+
+      # Returns the base provider type from a KMS provider identifier.
+      # For example, "aws:name1" returns "aws" and :aws returns "aws".
+      #
+      # @param [ String | Symbol ] identifier The KMS provider identifier.
+      # @return [ String ] The base provider type.
+      #
+      # @api private
+      def self.provider_base_type(identifier)
+        identifier.to_s.split(':').first
+      end
 
       # This module contains helper methods for validating KMS parameters.
       #

--- a/lib/mongo/crypt/kms/credentials.rb
+++ b/lib/mongo/crypt/kms/credentials.rb
@@ -21,28 +21,12 @@ module Mongo
       #
       # @api private
       class Credentials
-        # @return [ Credentials::AWS | nil ] AWS KMS credentials.
-        attr_reader :aws
-
-        # @return [ Credentials::Azure | nil ] Azure KMS credentials.
-        attr_reader :azure
-
-        # @return [ Credentials::GCP | nil ] GCP KMS credentials.
-        attr_reader :gcp
-
-        # @return [ Credentials::KMIP | nil ] KMIP KMS credentials.
-        attr_reader :kmip
-
-        # @return [ Credentials::Local | nil ] Local KMS credentials.
-        attr_reader :local
-
-        # Creates a KMS credentials object form a parameters hash.
+        # Creates a KMS credentials object from a parameters hash.
         #
-        # @param [ Hash ] kms_providers A hash that contains credential for
-        #   KMS providers. The hash should have KMS provider names as keys,
-        #   and required parameters for every provider as values.
-        #   Required parameters for KMS providers are described in corresponding
-        #   classes inside Mongo::Crypt::KMS module.
+        # @param [ Hash ] kms_providers A hash that contains credentials for
+        #   KMS providers. Keys may be provider types (:aws, :local, etc.) or
+        #   named provider identifiers ("aws:name1", "local:name2", etc.).
+        #   Values are hashes of credentials for the corresponding provider type.
         #
         # @note There may be more than one KMS provider specified.
         #
@@ -51,17 +35,59 @@ module Mongo
         def initialize(kms_providers)
           raise ArgumentError.new('KMS providers options must not be nil') if kms_providers.nil?
 
-          @aws = AWS::Credentials.new(kms_providers[:aws]) if kms_providers.key?(:aws)
-          @azure = Azure::Credentials.new(kms_providers[:azure]) if kms_providers.key?(:azure)
-          @gcp = GCP::Credentials.new(kms_providers[:gcp]) if kms_providers.key?(:gcp)
-          @kmip = KMIP::Credentials.new(kms_providers[:kmip]) if kms_providers.key?(:kmip)
-          @local = Local::Credentials.new(kms_providers[:local]) if kms_providers.key?(:local)
-          return unless @aws.nil? && @azure.nil? && @gcp.nil? && @kmip.nil? && @local.nil?
+          @credentials_map = {}
+
+          kms_providers.each do |identifier, opts|
+            identifier_str = identifier.to_s
+            provider_type = identifier_str.split(':').first
+
+            creds = case provider_type
+                    when 'aws' then AWS::Credentials.new(opts)
+                    when 'azure' then Azure::Credentials.new(opts)
+                    when 'gcp' then GCP::Credentials.new(opts)
+                    when 'kmip' then KMIP::Credentials.new(opts)
+                    when 'local' then Local::Credentials.new(opts)
+                    else
+                      raise ArgumentError.new(
+                        'KMS providers options must have one of the following keys: ' \
+                        ':aws, :azure, :gcp, :kmip, :local'
+                      )
+                    end
+
+            @credentials_map[identifier_str] = creds
+          end
+
+          return unless @credentials_map.empty?
 
           raise ArgumentError.new(
-            'KMS providers options must have one of the following keys: ' +
+            'KMS providers options must have one of the following keys: ' \
             ':aws, :azure, :gcp, :kmip, :local'
           )
+        end
+
+        # @return [ Credentials::AWS | nil ] AWS KMS credentials (unnamed provider only).
+        def aws
+          @credentials_map['aws']
+        end
+
+        # @return [ Credentials::Azure | nil ] Azure KMS credentials (unnamed provider only).
+        def azure
+          @credentials_map['azure']
+        end
+
+        # @return [ Credentials::GCP | nil ] GCP KMS credentials (unnamed provider only).
+        def gcp
+          @credentials_map['gcp']
+        end
+
+        # @return [ Credentials::KMIP | nil ] KMIP KMS credentials (unnamed provider only).
+        def kmip
+          @credentials_map['kmip']
+        end
+
+        # @return [ Credentials::Local | nil ] Local KMS credentials (unnamed provider only).
+        def local
+          @credentials_map['local']
         end
 
         # Convert credentials object to a BSON document in libmongocrypt format.
@@ -69,11 +95,9 @@ module Mongo
         # @return [ BSON::Document ] Credentials as BSON document.
         def to_document
           BSON::Document.new.tap do |bson|
-            bson[:aws] = @aws.to_document if @aws
-            bson[:azure] = @azure.to_document if @azure
-            bson[:gcp] = @gcp.to_document if @gcp
-            bson[:kmip] = @kmip.to_document if @kmip
-            bson[:local] = @local.to_document if @local
+            @credentials_map.each do |identifier, creds|
+              bson[identifier] = creds.to_document
+            end
           end
         end
       end

--- a/lib/mongo/crypt/kms/credentials.rb
+++ b/lib/mongo/crypt/kms/credentials.rb
@@ -21,6 +21,11 @@ module Mongo
       #
       # @api private
       class Credentials
+        # KMS provider types that support on-demand credential retrieval.
+        ON_DEMAND_PROVIDERS = %w[aws gcp azure].freeze
+
+        attr_reader :credentials_map
+
         # Creates a KMS credentials object from a parameters hash.
         #
         # @param [ Hash ] kms_providers A hash that contains credentials for
@@ -39,7 +44,7 @@ module Mongo
 
           kms_providers.each do |identifier, opts|
             identifier_str = identifier.to_s
-            provider_type = identifier_str.split(':').first
+            provider_type = KMS.provider_base_type(identifier_str)
 
             creds = case provider_type
                     when 'aws' then AWS::Credentials.new(opts)
@@ -88,6 +93,16 @@ module Mongo
         # @return [ Credentials::Local | nil ] Local KMS credentials (unnamed provider only).
         def local
           @credentials_map['local']
+        end
+
+        # Returns true if any configured provider supports on-demand credential
+        # retrieval and has been configured with empty credentials.
+        #
+        # @return [ Boolean ]
+        def any_on_demand?
+          @credentials_map.any? do |identifier, creds|
+            ON_DEMAND_PROVIDERS.include?(KMS.provider_base_type(identifier)) && creds.empty?
+          end
         end
 
         # Convert credentials object to a BSON document in libmongocrypt format.

--- a/lib/mongo/crypt/kms/master_key_document.rb
+++ b/lib/mongo/crypt/kms/master_key_document.rb
@@ -22,23 +22,28 @@ module Mongo
       #
       # @api private
       class MasterKeyDocument
-        # Known KMS provider names.
+        # Known KMS provider types.
         KMS_PROVIDERS = %w[aws azure gcp kmip local].freeze
 
         # Creates a master key document object form a parameters hash.
         #
-        # @param [ String ] kms_provider. KMS provider name.
+        # @param [ String ] kms_provider KMS provider identifier. May be a
+        #   provider type (e.g. "aws") or a named provider (e.g. "aws:name1").
         # @param [ Hash ] options A hash that contains master key options for
         #   the KMS provider.
         #   Required parameters for KMS providers are described in corresponding
         #   classes inside Mongo::Crypt::KMS module.
         #
-        # @raise [ ArgumentError ] If required options are missing or incorrectly.
+        # @raise [ ArgumentError ] If required options are missing or incorrectly
+        #   formatted.
         def initialize(kms_provider, options)
           raise ArgumentError.new('Key document options must not be nil') if options.nil?
 
+          @provider = kms_provider.to_s
+          provider_type = @provider.split(':').first
+
           master_key = options.fetch(:master_key, {})
-          @key_document = case kms_provider.to_s
+          @key_document = case provider_type
                           when 'aws' then KMS::AWS::MasterKeyDocument.new(master_key)
                           when 'azure' then KMS::Azure::MasterKeyDocument.new(master_key)
                           when 'gcp' then KMS::GCP::MasterKeyDocument.new(master_key)
@@ -53,7 +58,7 @@ module Mongo
         #
         # @return [ BSON::Document ] Master key document as BSON document.
         def to_document
-          @key_document.to_document
+          @key_document.to_document.merge(provider: @provider)
         end
       end
     end

--- a/lib/mongo/crypt/kms/master_key_document.rb
+++ b/lib/mongo/crypt/kms/master_key_document.rb
@@ -25,7 +25,7 @@ module Mongo
         # Known KMS provider types.
         KMS_PROVIDERS = %w[aws azure gcp kmip local].freeze
 
-        # Creates a master key document object form a parameters hash.
+        # Creates a master key document object from a parameters hash.
         #
         # @param [ String ] kms_provider KMS provider identifier. May be a
         #   provider type (e.g. "aws") or a named provider (e.g. "aws:name1").

--- a/lib/mongo/crypt/kms/master_key_document.rb
+++ b/lib/mongo/crypt/kms/master_key_document.rb
@@ -40,7 +40,7 @@ module Mongo
           raise ArgumentError.new('Key document options must not be nil') if options.nil?
 
           @provider = kms_provider.to_s
-          provider_type = @provider.split(':').first
+          provider_type = KMS.provider_base_type(@provider)
 
           master_key = options.fetch(:master_key, {})
           @key_document = case provider_type

--- a/spec/mongo/crypt/kms/credentials_spec.rb
+++ b/spec/mongo/crypt/kms/credentials_spec.rb
@@ -380,6 +380,68 @@ describe Mongo::Crypt::KMS::Credentials do
     end
   end
 
+  context 'named providers' do
+    let(:local_key) { Crypt::LOCAL_MASTER_KEY }
+
+    context 'with a single named local provider' do
+      let(:kms_providers) { { 'local:name1' => { key: local_key } } }
+
+      it 'initializes without error' do
+        expect { Mongo::Crypt::KMS::Credentials.new(kms_providers) }.not_to raise_error
+      end
+
+      it 'to_document uses the full named identifier as key' do
+        creds = Mongo::Crypt::KMS::Credentials.new(kms_providers)
+        doc = creds.to_document
+        expect(doc.keys).to include('local:name1')
+        expect(doc.keys).not_to include('local')
+      end
+
+      it 'unnamed accessor returns nil' do
+        creds = Mongo::Crypt::KMS::Credentials.new(kms_providers)
+        expect(creds.local).to be_nil
+      end
+    end
+
+    context 'with both unnamed and named providers of the same type' do
+      let(:kms_providers) do
+        {
+          local: { key: local_key },
+          'local:name1' => { key: local_key }
+        }
+      end
+
+      it 'includes both in to_document' do
+        creds = Mongo::Crypt::KMS::Credentials.new(kms_providers)
+        doc = creds.to_document
+        expect(doc.keys).to include('local', 'local:name1')
+      end
+
+      it 'unnamed accessor returns the unnamed credential' do
+        creds = Mongo::Crypt::KMS::Credentials.new(kms_providers)
+        expect(creds.local).not_to be_nil
+      end
+    end
+
+    context 'with an unknown provider type' do
+      let(:kms_providers) { { 'badtype:name1' => { key: 'something' } } }
+
+      it 'raises ArgumentError' do
+        expect do
+          Mongo::Crypt::KMS::Credentials.new(kms_providers)
+        end.to raise_error(ArgumentError, /must have one of the following keys/)
+      end
+    end
+
+    context 'with an empty hash' do
+      it 'raises ArgumentError' do
+        expect do
+          Mongo::Crypt::KMS::Credentials.new({})
+        end.to raise_error(ArgumentError, /must have one of the following keys/)
+      end
+    end
+  end
+
   describe Mongo::Crypt::KMS::MasterKeyDocument do
     require_libmongocrypt
 

--- a/spec/mongo/crypt/kms/credentials_spec.rb
+++ b/spec/mongo/crypt/kms/credentials_spec.rb
@@ -379,4 +379,49 @@ describe Mongo::Crypt::KMS::Credentials do
       end
     end
   end
+
+  describe Mongo::Crypt::KMS::MasterKeyDocument do
+    require_libmongocrypt
+
+    describe '#initialize' do
+      context 'with unnamed local provider' do
+        it 'succeeds' do
+          doc = Mongo::Crypt::KMS::MasterKeyDocument.new('local', {})
+          expect(doc.to_document[:provider]).to eq('local')
+        end
+      end
+
+      context 'with named local provider' do
+        it 'succeeds and preserves full identifier in document' do
+          doc = Mongo::Crypt::KMS::MasterKeyDocument.new('local:name1', {})
+          expect(doc.to_document[:provider]).to eq('local:name1')
+        end
+      end
+
+      context 'with unknown provider type' do
+        it 'raises ArgumentError' do
+          expect do
+            Mongo::Crypt::KMS::MasterKeyDocument.new('badtype:name1', {})
+          end.to raise_error(ArgumentError, /KMS provider must be one of/)
+        end
+      end
+
+      context 'with named AWS provider' do
+        let(:master_key) do
+          {
+            master_key: {
+              region: 'us-east-1',
+              key: 'arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0'
+            }
+          }
+        end
+
+        it 'preserves full identifier in document' do
+          doc = Mongo::Crypt::KMS::MasterKeyDocument.new('aws:name1', master_key).to_document
+          expect(doc[:provider]).to eq('aws:name1')
+          expect(doc[:region]).to eq('us-east-1')
+        end
+      end
+    end
+  end
 end

--- a/spec/runners/unified/client_side_encryption_operations.rb
+++ b/spec/runners/unified/client_side_encryption_operations.rb
@@ -78,5 +78,25 @@ module Unified
         )
       end
     end
+
+    def encrypt(op)
+      client_encryption = entities.get(:clientEncryption, op.use!('object'))
+      use_arguments(op) do |args|
+        opts = Utils.shallow_snakeize_hash(args.use('opts')) || {}
+        client_encryption.encrypt(
+          args.use!('value'),
+          opts
+        )
+      end
+    end
+
+    def decrypt(op)
+      client_encryption = entities.get(:clientEncryption, op.use!('object'))
+      use_arguments(op) do |args|
+        client_encryption.decrypt(
+          args.use!('value')
+        )
+      end
+    end
   end
 end

--- a/spec/runners/unified/test.rb
+++ b/spec/runners/unified/test.rb
@@ -317,7 +317,7 @@ module Unified
                      }
                    }
                    opts[:kms_providers] = opts[:kms_providers].map do |provider, options|
-                     base_type = provider.to_s.split(':').first.to_sym
+                     base_type = Mongo::Crypt::KMS.provider_base_type(provider).to_sym
                      converted_options = options.map do |key, value|
                        [ key, resolve_kms_provider_option(base_type, provider, key, value) ]
                      end.to_h
@@ -478,7 +478,7 @@ module Unified
                    end
         resolved || raise("No placeholder value configured for KMS provider #{provider}, key #{key}")
       elsif base_type == :local && key == :key && value.is_a?(String)
-        Base64.decode64(value)
+        Base64.strict_decode64(value)
       else
         value
       end

--- a/spec/runners/unified/test.rb
+++ b/spec/runners/unified/test.rb
@@ -61,6 +61,10 @@ module Unified
 
     attr_reader :test_spec, :description, :outcome, :skip_reason, :reqs, :group_reqs, :options, :entities
 
+    # Sentinel value used in unified spec KMS provider options to indicate that
+    # the actual credential should be substituted from SpecConfig.
+    KMS_PLACEHOLDER = { '$$placeholder': 1 }.freeze
+
     # Descriptions of unified spec tests that are known to flake under load on
     # CI and benefit from being retried. See the corresponding JIRA tickets for
     # the underlying investigations.
@@ -299,7 +303,11 @@ module Unified
                    key_vault_client = entities.get(:client, client_encryption_opts['keyVaultClient'])
                    opts = {
                      key_vault_namespace: client_encryption_opts['keyVaultNamespace'],
-                     kms_providers: Utils.snakeize_hash(client_encryption_opts['kmsProviders']),
+                     kms_providers: client_encryption_opts['kmsProviders']
+                                    .transform_keys { |k| Utils.underscore(k.to_s) }
+                                    .transform_values do |provider_opts|
+                                      provider_opts.transform_keys { |k| Utils.underscore(k.to_s) }
+                                    end,
                      kms_tls_options: {
                        kmip: {
                          ssl_cert: SpecConfig.instance.fle_kmip_tls_certificate_key_file,
@@ -309,38 +317,9 @@ module Unified
                      }
                    }
                    opts[:kms_providers] = opts[:kms_providers].map do |provider, options|
+                     base_type = provider.to_s.split(':').first.to_sym
                      converted_options = options.map do |key, value|
-                       converted_value = if value == { '$$placeholder': 1 }
-                                           case provider
-                                           when :aws
-                                             case key
-                                             when :access_key_id then SpecConfig.instance.fle_aws_key
-                                             when :secret_access_key then SpecConfig.instance.fle_aws_secret
-                                             end
-                                           when :azure
-                                             case key
-                                             when :tenant_id then SpecConfig.instance.fle_azure_tenant_id
-                                             when :client_id then SpecConfig.instance.fle_azure_client_id
-                                             when :client_secret then SpecConfig.instance.fle_azure_client_secret
-                                             end
-                                           when :gcp
-                                             case key
-                                             when :email then SpecConfig.instance.fle_gcp_email
-                                             when :private_key then SpecConfig.instance.fle_gcp_private_key
-                                             end
-                                           when :kmip
-                                             case key
-                                             when :endpoint then SpecConfig.instance.fle_kmip_endpoint
-                                             end
-                                           when :local
-                                             case key
-                                             when :key then Crypt::LOCAL_MASTER_KEY
-                                             end
-                                           end
-                                         else
-                                           value
-                                         end
-                       [ key, converted_value ]
+                       [ key, resolve_kms_provider_option(base_type, provider, key, value) ]
                      end.to_h
                      [ provider, converted_options ]
                    end.to_h
@@ -462,6 +441,48 @@ module Unified
     end
 
     private
+
+    # Resolves a single KMS provider option value. If the value is the
+    # placeholder sentinel, substitutes the appropriate credential from
+    # SpecConfig. If the value is a base64-encoded local key string, decodes
+    # it. Otherwise returns the value unchanged.
+    def resolve_kms_provider_option(base_type, provider, key, value)
+      if value == KMS_PLACEHOLDER
+        resolved = case base_type
+                   when :aws
+                     case key
+                     when :access_key_id
+                       provider.to_s.end_with?(':name2') ? SpecConfig.instance.fle_aws_key2 : SpecConfig.instance.fle_aws_key
+                     when :secret_access_key
+                       provider.to_s.end_with?(':name2') ? SpecConfig.instance.fle_aws_secret2 : SpecConfig.instance.fle_aws_secret
+                     end
+                   when :azure
+                     case key
+                     when :tenant_id then SpecConfig.instance.fle_azure_tenant_id
+                     when :client_id then SpecConfig.instance.fle_azure_client_id
+                     when :client_secret then SpecConfig.instance.fle_azure_client_secret
+                     end
+                   when :gcp
+                     case key
+                     when :email then SpecConfig.instance.fle_gcp_email
+                     when :private_key then SpecConfig.instance.fle_gcp_private_key
+                     end
+                   when :kmip
+                     case key
+                     when :endpoint then SpecConfig.instance.fle_kmip_endpoint
+                     end
+                   when :local
+                     case key
+                     when :key then Crypt::LOCAL_MASTER_KEY
+                     end
+                   end
+        resolved || raise("No placeholder value configured for KMS provider #{provider}, key #{key}")
+      elsif base_type == :local && key == :key && value.is_a?(String)
+        Base64.decode64(value)
+      else
+        value
+      end
+    end
 
     def execute_operations(ops, propagate_errors: false)
       ops.each do |op|

--- a/spec/runners/unified/test.rb
+++ b/spec/runners/unified/test.rb
@@ -63,7 +63,7 @@ module Unified
 
     # Sentinel value used in unified spec KMS provider options to indicate that
     # the actual credential should be substituted from SpecConfig.
-    KMS_PLACEHOLDER = { '$$placeholder': 1 }.freeze
+    KMS_PLACEHOLDER = { '$$placeholder' => 1 }.freeze
 
     # Descriptions of unified spec tests that are known to flake under load on
     # CI and benefit from being retried. See the corresponding JIRA tickets for

--- a/spec/spec_tests/data/client_side_encryption/unified/namedKMS-createDataKey.yml
+++ b/spec/spec_tests/data/client_side_encryption/unified/namedKMS-createDataKey.yml
@@ -1,0 +1,176 @@
+description: namedKMS-createDataKey
+
+schemaVersion: "1.18"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          "aws:name1": { accessKeyId: { $$placeholder: 1 }, secretAccessKey: { $$placeholder: 1 } }
+          "azure:name1":
+            { tenantId: { $$placeholder: 1 }, clientId: { $$placeholder: 1 }, clientSecret: { $$placeholder: 1 } }
+          "gcp:name1": { email: { $$placeholder: 1 }, privateKey: { $$placeholder: 1 } }
+          "kmip:name1": { endpoint: { $$placeholder: 1 } }
+          "local:name1": { key: { $$placeholder: 1 } }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name keyvault
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name datakeys
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents: []
+
+tests:
+  - description: create data key with named AWS KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "aws:name1"
+          opts:
+            masterKey: &new_aws_masterkey
+              key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+              region: us-east-1
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "aws:name1"
+                      <<: *new_aws_masterkey
+                writeConcern: { w: majority }
+
+  - description: create datakey with named Azure KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "azure:name1"
+          opts:
+            masterKey: &new_azure_masterkey
+              keyVaultEndpoint: key-vault-csfle.vault.azure.net
+              keyName: key-name-csfle
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "azure:name1"
+                      <<: *new_azure_masterkey
+                writeConcern: { w: majority }
+
+  - description: create datakey with named GCP KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "gcp:name1"
+          opts:
+            masterKey: &new_gcp_masterkey
+              projectId: devprod-drivers
+              location: global
+              keyRing: key-ring-csfle
+              keyName: key-name-csfle
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "gcp:name1"
+                      <<: *new_gcp_masterkey
+                writeConcern: { w: majority }
+
+  - description: create datakey with named KMIP KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "kmip:name1"
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "kmip:name1"
+                      keyId: { $$type: string }
+                writeConcern: { w: majority }
+
+  - description: create datakey with named local KMS provider
+    operations:
+      - name: createDataKey
+        object: *clientEncryption0
+        arguments:
+          kmsProvider: "local:name1"
+        expectResult: { $$type: binData }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                insert: *collection0Name
+                documents:
+                  - _id: { $$type: binData }
+                    keyMaterial: { $$type: binData }
+                    creationDate: { $$type: date }
+                    updateDate: { $$type: date }
+                    status: { $$exists: true }
+                    masterKey:
+                      provider: "local:name1"
+                writeConcern: { w: majority }

--- a/spec/spec_tests/data/client_side_encryption/unified/namedKMS-explicit.yml
+++ b/spec/spec_tests/data/client_side_encryption/unified/namedKMS-explicit.yml
@@ -1,0 +1,85 @@
+description: namedKMS-explicit
+
+schemaVersion: "1.18"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          "local:name2":
+            {
+              key: "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+            }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name keyvault
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name datakeys
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents:
+      - {
+          "_id": { "$binary": { "base64": "local+name2+AAAAAAAAAA==", "subType": "04" } },
+          "keyAltNames": ["local:name2"],
+          "keyMaterial":
+            {
+              "$binary":
+                {
+                  "base64": "DX3iUuOlBsx6wBX9UZ3v/qXk1HNeBace2J+h/JwsDdF/vmSXLZ1l1VmZYIcpVFy6ODhdbzLjd4pNgg9wcm4etYig62KNkmtZ0/s1tAL5VsuW/s7/3PYnYGznZTFhLjIVcOH/RNoRj2eQb/sRTyivL85wePEpAU/JzuBj6qO9Y5txQgs1k0J3aNy10R9aQ8kC1NuSSpLAIXwE6DlNDDJXhw==",
+                  "subType": "00",
+                },
+            },
+          "creationDate": { "$date": { "$numberLong": "1552949630483" } },
+          "updateDate": { "$date": { "$numberLong": "1552949630483" } },
+          "status": { "$numberInt": "0" },
+          "masterKey": { "provider": "local:name2" },
+        }
+
+tests:
+  - description: can explicitly encrypt with a named KMS provider
+    operations:
+      - name: encrypt
+        object: *clientEncryption0
+        arguments:
+          value: "foobar"
+          opts:
+            keyAltName: "local:name2"
+            algorithm: "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic"
+        expectResult:
+          {
+            "$binary":
+              {
+                "base64": "AZaHGpfp2pntvgAAAAAAAAAC4yX2LTAuN253GAkEO2ZXp4GpCyM7yoVNJMQQl+6uzxMs03IprLC7DL2vr18x9LwOimjTS9YbMJhrnFkEPuNhbg==",
+                "subType": "06",
+              },
+          }
+
+  - description: can explicitly decrypt with a named KMS provider
+    operations:
+      - name: decrypt
+        object: *clientEncryption0
+        arguments:
+          value:
+            {
+              "$binary":
+                {
+                  "base64": "AZaHGpfp2pntvgAAAAAAAAAC4yX2LTAuN253GAkEO2ZXp4GpCyM7yoVNJMQQl+6uzxMs03IprLC7DL2vr18x9LwOimjTS9YbMJhrnFkEPuNhbg==",
+                  "subType": "06",
+                },
+            }
+        expectResult: "foobar"

--- a/spec/spec_tests/data/client_side_encryption/unified/namedKMS-rewrapManyDataKey.yml
+++ b/spec/spec_tests/data/client_side_encryption/unified/namedKMS-rewrapManyDataKey.yml
@@ -219,7 +219,7 @@ tests:
       - name: rewrapManyDataKey
         object: *clientEncryption0
         arguments:
-          filter: { keyAltNames: { $ne: azure:name1_key } }
+          filter: { keyAltNames: { $ne: "azure:name1_key" } }
           opts:
             provider: "azure:name1"
             masterKey: &new_azure_masterkey
@@ -241,7 +241,7 @@ tests:
               databaseName: *database0Name
               command:
                 find: *collection0Name
-                filter: { keyAltNames: { $ne: azure:name1_key } }
+                filter: { keyAltNames: { $ne: "azure:name1_key" } }
                 readConcern: { level: majority }
           - commandStartedEvent:
               databaseName: *database0Name
@@ -304,7 +304,7 @@ tests:
       - name: rewrapManyDataKey
         object: *clientEncryption0
         arguments:
-          filter: { keyAltNames: { $ne: gcp:name1_key } }
+          filter: { keyAltNames: { $ne: "gcp:name1_key" } }
           opts:
             provider: "gcp:name1"
             masterKey: &new_gcp_masterkey

--- a/spec/spec_tests/data/client_side_encryption/unified/namedKMS-rewrapManyDataKey.yml
+++ b/spec/spec_tests/data/client_side_encryption/unified/namedKMS-rewrapManyDataKey.yml
@@ -1,0 +1,626 @@
+description: namedKMS-rewrapManyDataKey
+
+schemaVersion: "1.18"
+
+runOnRequirements:
+  - csfle: true
+
+createEntities:
+  - client:
+      id: &client0 client0
+      observeEvents:
+        - commandStartedEvent
+  - clientEncryption:
+      id: &clientEncryption0 clientEncryption0
+      clientEncryptionOpts:
+        keyVaultClient: *client0
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          "aws:name1": { accessKeyId: { $$placeholder: 1 }, secretAccessKey: { $$placeholder: 1 } }
+          "azure:name1":
+            { tenantId: { $$placeholder: 1 }, clientId: { $$placeholder: 1 }, clientSecret: { $$placeholder: 1 } }
+          "gcp:name1": { email: { $$placeholder: 1 }, privateKey: { $$placeholder: 1 } }
+          "kmip:name1": { endpoint: { $$placeholder: 1 } }
+          "local:name1": { key: { $$placeholder: 1 } }
+          # Use a different local master key for `local:name2`.
+          "local:name2":
+            {
+              key: "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk",
+            }
+          # Use a different AWS account to test wrapping between different AWS accounts.
+          "aws:name2": { accessKeyId: { $$placeholder: 1 }, secretAccessKey: { $$placeholder: 1 } }
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &database0Name keyvault
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collection0Name datakeys
+
+initialData:
+  - databaseName: *database0Name
+    collectionName: *collection0Name
+    documents:
+      - _id: &aws:name1_key_id { $binary: { base64: YXdzYXdzYXdzYXdzYXdzYQ==, subType: "04" } }
+        keyAltNames: ["aws:name1_key"]
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: AQICAHhQNmWG2CzOm1dq3kWLM+iDUZhEqnhJwH9wZVpuZ94A8gFXJqbF0Fy872MD7xl56D/2AAAAwjCBvwYJKoZIhvcNAQcGoIGxMIGuAgEAMIGoBgkqhkiG9w0BBwEwHgYJYIZIAWUDBAEuMBEEDO7HPisPUlGzaio9vgIBEIB7/Qow46PMh/8JbEUbdXgTGhLfXPE+KIVW7T8s6YEMlGiRvMu7TV0QCIUJlSHPKZxzlJ2iwuz5yXeOag+EdY+eIQ0RKrsJ3b8UTisZYzGjfzZnxUKLzLoeXremtRCm3x47wCuHKd1dhh6FBbYt5TL2tDaj+vL2GBrKat2L,
+                subType: "00",
+              },
+          }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &aws:name1_masterkey
+          provider: aws:name1
+          key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
+          region: us-east-1
+      - _id: &azure:name1_key_id { $binary: { base64: YXp1cmVhenVyZWF6dXJlYQ==, subType: "04" } }
+        keyAltNames: ["azure:name1_key"]
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: pr01l7qDygUkFE/0peFwpnNlv3iIy8zrQK38Q9i12UCN2jwZHDmfyx8wokiIKMb9kAleeY+vnt3Cf1MKu9kcDmI+KxbNDd+V3ytAAGzOVLDJr77CiWjF9f8ntkXRHrAY9WwnVDANYkDwXlyU0Y2GQFTiW65jiQhUtYLYH63Tk48SsJuQvnWw1Q+PzY8ga+QeVec8wbcThwtm+r2IHsCFnc72Gv73qq7weISw+O4mN08z3wOp5FOS2ZM3MK7tBGmPdBcktW7F8ODGsOQ1FU53OrWUnyX2aTi2ftFFFMWVHqQo7EYuBZHru8RRODNKMyQk0BFfKovAeTAVRv9WH9QU7g==,
+                subType: "00",
+              },
+          }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &azure:name1_masterkey
+          provider: "azure:name1"
+          keyVaultEndpoint: key-vault-csfle.vault.azure.net
+          keyName: key-name-csfle
+      - _id: &gcp:name1_key_id { $binary: { base64: Z2NwZ2NwZ2NwZ2NwZ2NwZw==, subType: "04" } }
+        keyAltNames: ["gcp:name1_key"]
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: CiQAIgLj0USbQtof/pYRLQO96yg/JEtZbD1UxKueaC37yzT5tTkSiQEAhClWB5ZCSgzHgxv8raWjNB4r7e8ePGdsmSuYTYmLC5oHHS/BdQisConzNKFaobEQZHamTCjyhy5NotKF8MWoo+dyfQApwI29+vAGyrUIQCXzKwRnNdNQ+lb3vJtS5bqvLTvSxKHpVca2kqyC9nhonV+u4qru5Q2bAqUgVFc8fL4pBuvlowZFTQ==,
+                subType: "00",
+              },
+          }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &gcp:name1_masterkey
+          provider: "gcp:name1"
+          projectId: devprod-drivers
+          location: global
+          keyRing: key-ring-csfle
+          keyName: key-name-csfle
+      - _id: &kmip:name1_key_id { $binary: { base64: a21pcGttaXBrbWlwa21pcA==, subType: "04" } }
+        keyAltNames: ["kmip:name1_key"]
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: CklVctHzke4mcytd0TxGqvepkdkQN8NUF4+jV7aZQITAKdz6WjdDpq3lMt9nSzWGG2vAEfvRb3mFEVjV57qqGqxjq2751gmiMRHXz0btStbIK3mQ5xbY9kdye4tsixlCryEwQONr96gwlwKKI9Nubl9/8+uRF6tgYjje7Q7OjauEf1SrJwKcoQ3WwnjZmEqAug0kImCpJ/irhdqPzivRiA==,
+                subType: "00",
+              },
+          }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &kmip:name1_masterkey
+          provider: "kmip:name1"
+          keyId: "1"
+      - _id: &local:name1_key_id { $binary: { base64: bG9jYWxrZXlsb2NhbGtleQ==, subType: "04" } }
+        keyAltNames: ["local:name1_key"]
+        keyMaterial:
+          {
+            $binary:
+              {
+                base64: ABKBldDEoDW323yejOnIRk6YQmlD9d3eQthd16scKL75nz2LjNL9fgPDZWrFFOlqlhMCFaSrNJfGrFUjYk5JFDO7soG5Syb50k1niJoKg4ilsj0L4mpimFUtTpOr2nzZOeQtvAksEXc7gsFgq8gV7t/U3lsaXPY7I0t42DfSE8EGlPdxRjFdHnxh+OR8h7U9b8Qs5K5UuhgyeyxaBZ1Hgw==,
+                subType: "00",
+              },
+          }
+        creationDate: { $date: { $numberLong: "1641024000000" } }
+        updateDate: { $date: { $numberLong: "1641024000000" } }
+        status: 1
+        masterKey: &local:name1_masterkey
+          provider: "local:name1"
+
+tests:
+  - description: "rewrap to aws:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: "aws:name1_key" } }
+          opts:
+            provider: "aws:name1"
+            # Different key: 89fcc2c4-08b0-4bd9-9f25-e30687b580d0 -> 061334ae-07a8-4ceb-a813-8135540e837d.
+            masterKey: &new_aws_masterkey
+              key: "arn:aws:kms:us-east-1:579766882180:key/061334ae-07a8-4ceb-a813-8135540e837d"
+              region: us-east-1
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: "aws:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "aws:name1", <<: *new_aws_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "aws:name1", <<: *new_aws_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "aws:name1", <<: *new_aws_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "aws:name1", <<: *new_aws_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap to azure:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: azure:name1_key } }
+          opts:
+            provider: "azure:name1"
+            masterKey: &new_azure_masterkey
+              keyVaultEndpoint: key-vault-csfle.vault.azure.net
+              keyName: key-name-csfle
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: azure:name1_key } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "azure:name1", <<: *new_azure_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "azure:name1", <<: *new_azure_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "azure:name1", <<: *new_azure_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "azure:name1", <<: *new_azure_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap to gcp:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: gcp:name1_key } }
+          opts:
+            provider: "gcp:name1"
+            masterKey: &new_gcp_masterkey
+              projectId: devprod-drivers
+              location: global
+              keyRing: key-ring-csfle
+              keyName: key-name-csfle
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: "gcp:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "gcp:name1", <<: *new_gcp_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "gcp:name1", <<: *new_gcp_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "gcp:name1", <<: *new_gcp_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "gcp:name1", <<: *new_gcp_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap to kmip:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: "kmip:name1_key" } }
+          opts:
+            provider: "kmip:name1"
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: "kmip:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "kmip:name1", keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "kmip:name1", keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "kmip:name1", keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "kmip:name1", keyId: { $$type: string } },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap to local:name1"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $ne: "local:name1_key" } }
+          opts:
+            provider: "local:name1"
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 4
+            modifiedCount: 4
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $ne: "local:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: "local:name1" }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: "local:name1" }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: "local:name1" }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: "local:name1" }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap from local:name1 to local:name2"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $eq: "local:name1_key" } }
+          opts:
+            provider: "local:name2"
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 1
+            modifiedCount: 1
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $eq: "local:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set: { masterKey: { provider: "local:name2" }, keyMaterial: { $$type: binData } },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }
+
+  - description: "rewrap from aws:name1 to aws:name2"
+    operations:
+      - name: rewrapManyDataKey
+        object: *clientEncryption0
+        arguments:
+          filter: { keyAltNames: { $eq: "aws:name1_key" } }
+          opts:
+            provider: "aws:name2"
+            masterKey: &new_awsname2_masterkey # aws:name1 account does not have permissions to access this key.
+              key: "arn:aws:kms:us-east-1:857654397073:key/0f8468f0-f135-4226-aa0b-bd05c4c30df5"
+              region: us-east-1
+        expectResult:
+          bulkWriteResult:
+            insertedCount: 0
+            matchedCount: 1
+            modifiedCount: 1
+            deletedCount: 0
+            upsertedCount: 0
+            upsertedIds: {}
+            insertedIds: { $$unsetOrMatches: {} }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                find: *collection0Name
+                filter: { keyAltNames: { $eq: "aws:name1_key" } }
+                readConcern: { level: majority }
+          - commandStartedEvent:
+              databaseName: *database0Name
+              command:
+                update: *collection0Name
+                ordered: true
+                updates:
+                  - q: { _id: { $$type: binData } }
+                    u:
+                      {
+                        $set:
+                          {
+                            masterKey: { provider: "aws:name2", <<: *new_awsname2_masterkey },
+                            keyMaterial: { $$type: binData },
+                          },
+                        $currentDate: { updateDate: true },
+                      }
+                    multi: { $$unsetOrMatches: false }
+                    upsert: { $$unsetOrMatches: false }
+                writeConcern: { w: majority }

--- a/spec/spec_tests/data/client_side_encryption/unified/namedKMS-rewrapManyDataKey.yml
+++ b/spec/spec_tests/data/client_side_encryption/unified/namedKMS-rewrapManyDataKey.yml
@@ -42,7 +42,7 @@ initialData:
   - databaseName: *database0Name
     collectionName: *collection0Name
     documents:
-      - _id: &aws:name1_key_id { $binary: { base64: YXdzYXdzYXdzYXdzYXdzYQ==, subType: "04" } }
+      - _id: &aws_name1_key_id { $binary: { base64: YXdzYXdzYXdzYXdzYXdzYQ==, subType: "04" } }
         keyAltNames: ["aws:name1_key"]
         keyMaterial:
           {
@@ -55,11 +55,11 @@ initialData:
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
-        masterKey: &aws:name1_masterkey
+        masterKey: &aws_name1_masterkey
           provider: aws:name1
           key: "arn:aws:kms:us-east-1:579766882180:key/89fcc2c4-08b0-4bd9-9f25-e30687b580d0"
           region: us-east-1
-      - _id: &azure:name1_key_id { $binary: { base64: YXp1cmVhenVyZWF6dXJlYQ==, subType: "04" } }
+      - _id: &azure_name1_key_id { $binary: { base64: YXp1cmVhenVyZWF6dXJlYQ==, subType: "04" } }
         keyAltNames: ["azure:name1_key"]
         keyMaterial:
           {
@@ -72,11 +72,11 @@ initialData:
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
-        masterKey: &azure:name1_masterkey
+        masterKey: &azure_name1_masterkey
           provider: "azure:name1"
           keyVaultEndpoint: key-vault-csfle.vault.azure.net
           keyName: key-name-csfle
-      - _id: &gcp:name1_key_id { $binary: { base64: Z2NwZ2NwZ2NwZ2NwZ2NwZw==, subType: "04" } }
+      - _id: &gcp_name1_key_id { $binary: { base64: Z2NwZ2NwZ2NwZ2NwZ2NwZw==, subType: "04" } }
         keyAltNames: ["gcp:name1_key"]
         keyMaterial:
           {
@@ -89,13 +89,13 @@ initialData:
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
-        masterKey: &gcp:name1_masterkey
+        masterKey: &gcp_name1_masterkey
           provider: "gcp:name1"
           projectId: devprod-drivers
           location: global
           keyRing: key-ring-csfle
           keyName: key-name-csfle
-      - _id: &kmip:name1_key_id { $binary: { base64: a21pcGttaXBrbWlwa21pcA==, subType: "04" } }
+      - _id: &kmip_name1_key_id { $binary: { base64: a21pcGttaXBrbWlwa21pcA==, subType: "04" } }
         keyAltNames: ["kmip:name1_key"]
         keyMaterial:
           {
@@ -108,10 +108,10 @@ initialData:
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
-        masterKey: &kmip:name1_masterkey
+        masterKey: &kmip_name1_masterkey
           provider: "kmip:name1"
           keyId: "1"
-      - _id: &local:name1_key_id { $binary: { base64: bG9jYWxrZXlsb2NhbGtleQ==, subType: "04" } }
+      - _id: &local_name1_key_id { $binary: { base64: bG9jYWxrZXlsb2NhbGtleQ==, subType: "04" } }
         keyAltNames: ["local:name1_key"]
         keyMaterial:
           {
@@ -124,7 +124,7 @@ initialData:
         creationDate: { $date: { $numberLong: "1641024000000" } }
         updateDate: { $date: { $numberLong: "1641024000000" } }
         status: 1
-        masterKey: &local:name1_masterkey
+        masterKey: &local_name1_masterkey
           provider: "local:name1"
 
 tests:

--- a/spec/spec_tests/data/client_side_encryption/unified/namedKMS.yml
+++ b/spec/spec_tests/data/client_side_encryption/unified/namedKMS.yml
@@ -1,0 +1,129 @@
+description: namedKMS
+schemaVersion: "1.25"
+runOnRequirements:
+  - minServerVersion: "4.1.10"
+    csfle:
+      minLibmongocryptVersion: "1.15.1"
+createEntities:
+  - client:
+      id: "client0"
+      autoEncryptOpts:
+        keyVaultNamespace: keyvault.datakeys
+        kmsProviders:
+          local:name2:
+            key: "local+name2+YUJCa1kxNkVyNUR1QURhZ2h2UzR2d2RrZzh0cFBwM3R6NmdWMDFBMUN3YkQ5aXRRMkhGRGdQV09wOGVNYUMxT2k3NjZKelhaQmRCZGJkTXVyZG9uSjFk"
+      observeEvents:
+        - commandStartedEvent
+  - database:
+      id: "db"
+      client: "client0"
+      databaseName: default
+  - collection:
+      id: "coll"
+      database: "db"
+      collectionName: default
+initialData:
+  - databaseName: default
+    collectionName: default
+    documents: []
+    createOptions:
+      validator:
+        $jsonSchema:
+          {
+            "properties":
+              {
+                "encrypted_string":
+                  {
+                    "encrypt":
+                      {
+                        "keyId": ["$binary": { "base64": "local+name2+AAAAAAAAAA==", "subType": "04" }],
+                        "bsonType": "string",
+                        "algorithm": "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
+                      },
+                  },
+              },
+            "bsonType": "object",
+          }
+  - databaseName: keyvault
+    collectionName: datakeys
+    documents:
+      [
+        {
+          "_id": { "$binary": { "base64": "local+name2+AAAAAAAAAA==", "subType": "04" } },
+          "keyMaterial":
+            {
+              "$binary":
+                {
+                  "base64": "DX3iUuOlBsx6wBX9UZ3v/qXk1HNeBace2J+h/JwsDdF/vmSXLZ1l1VmZYIcpVFy6ODhdbzLjd4pNgg9wcm4etYig62KNkmtZ0/s1tAL5VsuW/s7/3PYnYGznZTFhLjIVcOH/RNoRj2eQb/sRTyivL85wePEpAU/JzuBj6qO9Y5txQgs1k0J3aNy10R9aQ8kC1NuSSpLAIXwE6DlNDDJXhw==",
+                  "subType": "00",
+                },
+            },
+          "creationDate": { "$date": { "$numberLong": "1552949630483" } },
+          "updateDate": { "$date": { "$numberLong": "1552949630483" } },
+          "status": { "$numberInt": "0" },
+          "masterKey": { "provider": "local:name2" },
+        },
+      ]
+tests:
+  - description: "Automatically encrypt and decrypt with a named KMS provider"
+    operations:
+      - name: insertOne
+        arguments:
+          document: &doc0 { _id: 1, encrypted_string: "string0" }
+        object: "coll"
+      - name: find
+        arguments:
+          filter: { _id: 1 }
+        object: "coll"
+        expectResult: [*doc0]
+    outcome:
+      - documents:
+          - &doc0_encrypted {
+              _id: 1,
+              encrypted_string:
+                {
+                  "$binary":
+                    {
+                      "base64": "AZaHGpfp2pntvgAAAAAAAAAC07sFvTQ0I4O2U49hpr4HezaK44Ivluzv5ntQBTYHDlAJMLyRMyB6Dl+UGHBgqhHe/Xw+pcT9XdiUoOJYAx9g+w==",
+                      "subType": "06",
+                    },
+                },
+            }
+        collectionName: &collection_name "default"
+        databaseName: &database_name "default"
+    expectEvents:
+      - client: "client0"
+        events:
+          # Auto encryption will request the collection info.
+          - commandStartedEvent:
+              command:
+                listCollections: 1
+                filter:
+                  name: *collection_name
+              commandName: listCollections
+          - commandStartedEvent:
+              command:
+                find: datakeys
+                filter:
+                  {
+                    "$or":
+                      [
+                        "_id": { "$in": ["$binary": { "base64": "local+name2+AAAAAAAAAA==", "subType": "04" }] },
+                        "keyAltNames": { "$in": [] },
+                      ],
+                  }
+                $db: keyvault
+                readConcern: { level: "majority" }
+              commandName: find
+          - commandStartedEvent:
+              command:
+                insert: *collection_name
+                documents:
+                  - *doc0_encrypted
+                ordered: true
+              commandName: insert
+          - commandStartedEvent:
+              command:
+                find: *collection_name
+                filter: { _id: 1 }
+              commandName: find

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -393,12 +393,16 @@ class SpecConfig
     ENV['MONGO_RUBY_DRIVER_AWS_SECRET']
   end
 
+  # The aws:name2 tests don't actually need to connect to a second KMS; the
+  # values here are basically just placeholders, but if we ever need them
+  # to be real, using `fle_aws_key` ensures they'll still work.
   def fle_aws_key2
-    ENV['FLE_AWS_KEY2']
+    fle_aws_key
   end
 
+  # See comment for `fle_aws_key2`, above.
   def fle_aws_secret2
-    ENV['FLE_AWS_SECRET2']
+    fle_aws_secret
   end
 
   # Region of AWS customer master key

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -393,16 +393,12 @@ class SpecConfig
     ENV['MONGO_RUBY_DRIVER_AWS_SECRET']
   end
 
-  # The aws:name2 tests don't actually need to connect to a second KMS; the
-  # values here are basically just placeholders, but if we ever need them
-  # to be real, using `fle_aws_key` ensures they'll still work.
   def fle_aws_key2
-    fle_aws_key
+    ENV['FLE_AWS_KEY2']
   end
 
-  # See comment for `fle_aws_key2`, above.
   def fle_aws_secret2
-    fle_aws_secret
+    ENV['FLE_AWS_SECRET2']
   end
 
   # Region of AWS customer master key

--- a/spec/support/spec_config.rb
+++ b/spec/support/spec_config.rb
@@ -393,6 +393,14 @@ class SpecConfig
     ENV['MONGO_RUBY_DRIVER_AWS_SECRET']
   end
 
+  def fle_aws_key2
+    ENV['FLE_AWS_KEY2']
+  end
+
+  def fle_aws_secret2
+    ENV['FLE_AWS_SECRET2']
+  end
+
   # Region of AWS customer master key
   def fle_aws_region
     ENV['MONGO_RUBY_DRIVER_AWS_REGION']

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -604,8 +604,12 @@ module Utils
     (opts['kmsProviders'] || {}).each do |provider_name, provider_opts|
       next unless provider_name.to_s.include?(':')
 
-      base_type = provider_name.to_s.split(':').first
-      next unless base_type == 'local'
+      base_type = Mongo::Crypt::KMS.provider_base_type(provider_name)
+      unless base_type == 'local'
+        raise NotImplementedError,
+              "Named KMS provider '#{provider_name}' (type '#{base_type}') is not " \
+              'supported in autoEncryptOpts via this code path'
+      end
 
       key_value = provider_opts['key']
       key_bytes = if key_value.is_a?(Hash)

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -616,6 +616,8 @@ module Utils
                     BSON::ExtJSON.parse_obj(key_value).data
                   elsif key_value.is_a?(String)
                     Base64.strict_decode64(key_value)
+                  else
+                    raise ArgumentError, "key_value must be a hash or a string (got #{key_value.class})"
                   end
 
       # snakeize_hash corrupts the string value; overwrite with decoded bytes

--- a/spec/support/utils.rb
+++ b/spec/support/utils.rb
@@ -597,6 +597,26 @@ module Utils
     _apply_kms_provider_azure(opts, auto_encrypt_opts)
     _apply_kms_provider_gcp(opts, auto_encrypt_opts)
     _apply_kms_provider_local(opts, auto_encrypt_opts)
+    _apply_kms_provider_named(opts, auto_encrypt_opts)
+  end
+
+  def _apply_kms_provider_named(opts, auto_encrypt_opts)
+    (opts['kmsProviders'] || {}).each do |provider_name, provider_opts|
+      next unless provider_name.to_s.include?(':')
+
+      base_type = provider_name.to_s.split(':').first
+      next unless base_type == 'local'
+
+      key_value = provider_opts['key']
+      key_bytes = if key_value.is_a?(Hash)
+                    BSON::ExtJSON.parse_obj(key_value).data
+                  elsif key_value.is_a?(String)
+                    Base64.strict_decode64(key_value)
+                  end
+
+      # snakeize_hash corrupts the string value; overwrite with decoded bytes
+      auto_encrypt_opts[:kms_providers][underscore(provider_name)] = { key: key_bytes }
+    end
   end
 
   def _apply_kms_provider_azure(opts, auto_encrypt_opts)


### PR DESCRIPTION
## Description

Adds support for named KMS providers using the `type:name` format (e.g. `aws:name1`, `local:name2`) everywhere a KMS provider identifier is accepted in CSFLE/QE. This allows multiple providers of the same type to coexist in a single `kmsProviders` map.

## Changes

- **`Crypt::KMS::MasterKeyDocument`**: Parse `type:name` identifiers by splitting on `:` to determine provider type; preserve the full identifier in the serialized document.
- **`Crypt::KMS::Credentials`**: Replace typed attr-readers with a string-keyed `@credentials_map` that accepts arbitrary `type:name` keys; retain the five typed accessors (`aws`, `azure`, `gcp`, `kmip`, `local`) for backward compatibility.
- **`Crypt::Handle#kms_tls_options`**: Add a four-step fallback that tries the full named identifier, then the base type, in both string and symbol forms.
- **Unified test runner**: Replace `Utils.snakeize_hash` (which corrupted binary values) with a keys-only transform; add `$placeholder` resolution for named provider credentials including secondary AWS credentials and hardcoded local master keys.
- **SpecConfig**: Add `fle_aws_key2` / `fle_aws_secret2` accessors for the secondary AWS account used by `aws:name2` tests.
- **Spec fixtures**: Copy the four `namedKMS` unified test YAML files from the specifications repo; fix YAML anchor names that contained colons (Psych rejects these).
