### PR TITLE
RUBY-3840 Keep MemoryPointer alive in Binary.wrap_string

### DIFF
--- a/lib/mongo/crypt/binary.rb
+++ b/lib/mongo/crypt/binary.rb
@@ -139,14 +139,17 @@ module Mongo
       # Wraps a String with a mongocrypt_binary_t, yielding an FFI::Pointer
       # to the wrapped struct.
       def self.wrap_string(str)
-        binary_p = Binding.mongocrypt_binary_new_from_data(
-          FFI::MemoryPointer.from_string(str),
-          str.bytesize
-        )
+        # mongocrypt_binary_new_from_data does not copy the buffer, so the
+        # MemoryPointer must outlive the mongocrypt_binary_t. Hold it in a
+        # local so it stays referenced for the whole method frame; otherwise
+        # GC can free the buffer while libmongocrypt still points into it.
+        data_p = FFI::MemoryPointer.from_string(str)
+        binary_p = Binding.mongocrypt_binary_new_from_data(data_p, str.bytesize)
         begin
           yield binary_p
         ensure
           Binding.mongocrypt_binary_destroy(binary_p)
+          data_p # rubocop:disable Lint/Void -- keep the buffer alive past destroy
         end
       end
     end

--- a/spec/mongo/crypt/binary_spec.rb
+++ b/spec/mongo/crypt/binary_spec.rb
@@ -80,6 +80,35 @@ describe Mongo::Crypt::Binary do
     end
   end
 
+  describe '#self.wrap_string' do
+    it 'yields a binary that reads back the original data' do
+      described_class.wrap_string(data) do |binary_p|
+        str_p = Mongo::Crypt::Binding.get_binary_data_direct(binary_p)
+        len = Mongo::Crypt::Binding.get_binary_len_direct(binary_p)
+        expect(str_p.read_string(len)).to eq(data)
+      end
+    end
+
+    it 'keeps the wrapped buffer valid under GC pressure' do
+      # mongocrypt_binary_new_from_data does not copy the buffer, so the
+      # MemoryPointer backing the wrapped binary must stay referenced for the
+      # whole block. If it is collected, GC frees the buffer and the bytes
+      # libmongocrypt sees get corrupted. Force GC and allocation churn inside
+      # the block to surface a use-after-free.
+      100.times do |i|
+        str = "wrap-string-payload-#{i}-#{'x' * 64}"
+        described_class.wrap_string(str) do |binary_p|
+          GC.start(full_mark: true, immediate_sweep: true)
+          # Allocate garbage to reuse any freed buffer in this tick.
+          Array.new(1000) { 'y' * 64 }
+          str_p = Mongo::Crypt::Binding.get_binary_data_direct(binary_p)
+          len = Mongo::Crypt::Binding.get_binary_len_direct(binary_p)
+          expect(str_p.read_string(len)).to eq(str)
+        end
+      end
+    end
+  end
+
   describe '#write' do
     # Binary must have enough space pre-allocated
     let(:binary) { described_class.from_data("\00" * data.length) }


### PR DESCRIPTION
## Problem

`Mongo::Crypt::Binary.wrap_string` passed `FFI::MemoryPointer.from_string(str)` directly into `mongocrypt_binary_new_from_data` as an anonymous temporary. That C API does **not** copy the buffer — the binding doc states "the data is not copied and must outlive the mongocrypt_binary_t object". With no Ruby-side reference, the `MemoryPointer` became GC-eligible the moment the call returned. If GC ran during the `yield`, its finalizer freed the buffer while libmongocrypt still pointed into it — a use-after-free.

Impact is intermittent (GC-timing dependent under MRI): crashes under GC pressure, garbled BSON / spurious libmongocrypt errors, or silent local corruption of the BSON fed to libmongocrypt (KMS providers, schema maps, key IDs/material, KMS network bytes). Not attacker-controlled, so a reliability bug rather than a security vulnerability.

## Fix

Hold the `MemoryPointer` in a local for the lifetime of the method frame, mirroring how `Binary#initialize` retains its pointer in `@data_p`.

## Files changed

- `lib/mongo/crypt/binary.rb` — retain the pointer in a local across the wrapped binary's lifetime.
- `spec/mongo/crypt/binary_spec.rb` — add a `.wrap_string` group, including a GC-pressure regression test that reads the wrapped buffer back through libmongocrypt.

## Test plan

- [x] `spec/mongo/crypt/binary_spec.rb` — new GC-pressure test fails on the old code (libmongocrypt reads freed/reused bytes), passes with the fix. 11 examples, 0 failures.
- [x] `spec/mongo/crypt/handle_spec.rb` + `binary_spec.rb` — 81 examples, 0 failures (cloud-KMS cases pending without credentials).
- [x] CSFLE integration (`data_key_spec.rb`, `explicit_encryption_spec.rb`) — remaining failures are pre-existing and environment-only (AWS credentials / KMIP mock server); identical with and without this change.
- [x] `bundle exec rubocop` — clean.

[RUBY-3840](https://jira.mongodb.org/browse/RUBY-3840)