### PR TITLE
RUBY-3832 Raise on invalid tls/ssl boolean URI option

### DIFF
--- a/lib/mongo/uri.rb
+++ b/lib/mongo/uri.rb
@@ -503,6 +503,12 @@ module Mongo
       # 'tls' and 'ssl'. In order to fulfill this, we parse the values of each instance into an
       # array; assuming all values in the array are the same, we replace the array with that value.
       unless uri_options[:ssl].nil? || uri_options[:ssl].empty?
+        # A nil element means an invalid value (e.g. tls=yes) was supplied.
+        # Refuse it rather than silently connecting over plaintext (RUBY-3832).
+        if uri_options[:ssl].include?(nil)
+          raise_invalid_error_no_fmt!("invalid boolean value for 'tls' or 'ssl'; only 'true' and 'false' are accepted")
+        end
+
         unless uri_options[:ssl].uniq.length == 1
           raise_invalid_error_no_fmt!("all instances of 'tls' and 'ssl' must have the same value")
         end

--- a/lib/mongo/uri/options_mapper.rb
+++ b/lib/mongo/uri/options_mapper.rb
@@ -354,13 +354,25 @@ module Mongo
 
       # Converts the value into a boolean and returns it wrapped in an array.
       #
-      # @param [ String ] name Name of the URI option being processed.
+      # tls and ssl are the only repeated_bool options. An invalid value is
+      # preserved as a nil element rather than warned-and-dropped, so that
+      # URI#validate_uri_options! can detect it and raise instead of silently
+      # falling back to a plaintext connection (RUBY-3832).
+      #
+      # @param [ String ] _name Name of the URI option being processed.
       # @param [ String ] value URI option value.
       #
-      # @return [ Array<true | false> | nil ] The boolean value parsed and wraped
-      #   in an array.
-      def convert_repeated_bool(name, value)
-        [ convert_bool(name, value) ]
+      # @return [ Array<true | false | nil> ] The boolean value parsed and
+      #   wrapped in an array.
+      def convert_repeated_bool(_name, value)
+        case value
+        when true, 'true', 'TRUE'
+          [ true ]
+        when false, 'false', 'FALSE'
+          [ false ]
+        else
+          [ nil ]
+        end
       end
 
       # Reverts a repeated boolean type.

--- a/spec/mongo/uri_option_parsing_spec.rb
+++ b/spec/mongo/uri_option_parsing_spec.rb
@@ -102,6 +102,21 @@ describe Mongo::URI do
     end
   end
 
+  # TLS boolean options must fail loudly on an invalid value: an unrecognized
+  # value such as 'yes' or '1' would otherwise be discarded and the connection
+  # would silently fall back to plaintext (RUBY-3832).
+  shared_examples_for 'a strict boolean option' do
+    it_behaves_like 'a boolean option'
+
+    %w[ yes no 1 0 on off invalid ].each do |bad_value|
+      context "is #{bad_value}" do
+        let(:string) { "mongodb://example.com/?#{uri_option}=#{bad_value}" }
+
+        it_behaves_like 'raises parse error'
+      end
+    end
+  end
+
   shared_examples_for 'an inverted boolean option' do
     let(:string) { "mongodb://example.com/?#{uri_option}=true" }
 
@@ -460,14 +475,14 @@ describe Mongo::URI do
     let(:uri_option) { 'ssl' }
     let(:ruby_option) { :ssl }
 
-    it_behaves_like 'a boolean option'
+    it_behaves_like 'a strict boolean option'
   end
 
   context 'tls' do
     let(:uri_option) { 'tls' }
     let(:ruby_option) { :ssl }
 
-    it_behaves_like 'a boolean option'
+    it_behaves_like 'a strict boolean option'
   end
 
   context 'tlsAllowInvalidCertificates' do


### PR DESCRIPTION
## What

An invalid value for the `tls` or `ssl` URI option (a typo such as `tls=yes`, `tls=1`, `tls=on`) was warned about and discarded, leaving `:ssl` as `nil`. `Address::IPv4#socket` evaluates `if options[:ssl]`, so `nil` is falsy and the driver opened a plaintext TCP socket. Against a server that does not enforce TLS server-side, the application connected successfully over plaintext with only a log line — credentials and traffic exposed. (RUBY-3832)

This now raises `Mongo::Error::InvalidURI` instead of silently downgrading.

## How

- `OptionsMapper#convert_repeated_bool` (used only by `tls`/`ssl`) preserves an invalid value as a `nil` element rather than warning and dropping it.
- `URI#validate_uri_options!` raises `Mongo::Error::InvalidURI` when the parsed `tls`/`ssl` value contains a `nil`, alongside the existing tls/ssl conflict checks.

### Scope decision

Limited to `tls` and `ssl` — the only boolean options that fail **open** (to plaintext). The other TLS boolean options keep the lenient warn-and-default behavior because:

1. They fail **secure** on an invalid value (`tlsInsecure`, `tlsAllowInvalidCertificates`, `tlsAllowInvalidHostnames`, `tlsDisableOCSPEndpointCheck` invalid → `nil` → secure default, verification stays on).
2. The upstream unified spec fixtures (`uri-options/tests/tls-options.yml`) explicitly assert `valid: true, warning: true` for invalid `tlsAllowInvalidCertificates`/`tlsAllowInvalidHostnames`/`tlsInsecure`. Raising for those would diverge from the spec tests. There is no upstream fixture for invalid `tls`/`ssl`, so raising there is spec-safe.

Python and Go also raise on invalid `tls`/`ssl`; pymongo achieves the spec-test warnings via a separate `warn=True` mode, which the Ruby driver does not have.

## Breaking change

Applications currently passing invalid TLS boolean values (`tls=yes`, etc.) connect over plaintext today while believing they have TLS. They will now fail fast at URI parse time. This surfaces a pre-existing misconfiguration; it does not introduce a new failure mode.

## Files changed

- `lib/mongo/uri/options_mapper.rb` — `convert_repeated_bool` preserves invalid value as `nil`
- `lib/mongo/uri.rb` — `validate_uri_options!` raises on invalid `tls`/`ssl`
- `spec/mongo/uri_option_parsing_spec.rb` — new `'a strict boolean option'` shared example covering `tls`/`ssl`

## Test plan

- [x] `bundle exec rspec spec/mongo/uri_option_parsing_spec.rb spec/mongo/uri_spec.rb spec/spec_tests/uri_options_spec.rb` — 730 examples, 0 failures (inverse_bool warn fixtures still pass)
- [x] `bundle exec rspec spec/integration/ssl_uri_options_spec.rb` — passes
- [x] `bundle exec rubocop` on changed files — no offenses
- [x] Manual: `tls=yes` raises `InvalidURI`; `tls=true/false` and absent parse as before; `tlsInsecure=foo` still warns + secure default

[RUBY-3832](https://jira.mongodb.org/browse/RUBY-3832)
