### PR TITLE
RUBY-3731 Run ruby-dev build on a bi-weekly schedule

### DIFF
--- a/.evergreen/README.md
+++ b/.evergreen/README.md
@@ -4,6 +4,42 @@ This directory contains configuration and scripts used to run the driver's
 test suite in Evergreen, MongoDB's continuous integration system.
 
 
+## Scheduled ruby-dev build (RUBY-3731)
+
+The `ruby-dev` build variant runs the main test suite against the upcoming,
+in-development Ruby version (`ruby-dev`, provided by `mongo-ruby-toolchain`).
+This catches incompatibilities with the next Ruby release before it ships.
+
+The variant is defined in `config/standard.yml.erb`. Two properties matter:
+
+- It is not tagged `pr`, so it never runs on pull requests. It only runs on
+  the `master` waterfall.
+- Its task carries `batchtime: 20160` (14 days), so Evergreen activates it at
+  most once every two weeks instead of on every commit.
+
+### Failure notification
+
+Failures of the scheduled run should open a Jira issue in the `RUBY` project.
+This is not expressed in `config.yml`; it is an Evergreen project
+notification, configured once by a project admin in the Evergreen UI:
+
+1. Open the `mongo-ruby-driver` project in Evergreen, go to
+   **Settings -> Notifications** (project subscriptions).
+2. Add a subscription:
+   - **Event**: a task finishes -> the task fails.
+   - **Scope**: limit to the build variant, using a regex that matches the
+     `ruby-dev` variant display name (it contains `ruby-dev`).
+   - **Action**: Create a Jira issue.
+   - **Project**: `RUBY`; pick an appropriate issue type (e.g. `Task`/`Bug`).
+3. Evergreen fills the issue with the failing task, the build variant (which
+   names the Ruby version), the version/commit, and links to the failed
+   tasks, so the report includes the Ruby version, commit hash, and the list
+   of failures.
+
+Because this lives in project settings rather than the repository, it must be
+recreated if the project is reconfigured.
+
+
 ## Testing In Docker
 
 It is possible to run the test suite in Docker. This executes all of the

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -1062,6 +1062,9 @@ axes:
         display_name: No
 
 buildvariants:
+  # RUBY-3731: test master against the upcoming Ruby (ruby-dev). Runs off-PR
+  # (no "pr" tag) on a ~2-week cadence. Failures are reported as RUBY Jira
+  # issues via an Evergreen project notification; see .evergreen/README.md.
   - matrix_name: "ruby-dev"
     matrix_spec:
       ruby: "ruby-dev"
@@ -1072,6 +1075,7 @@ buildvariants:
     display_name: "${mongodb-version} ${os} ${topology} ${auth-and-ssl} ${ruby}"
     tasks:
       - name: "run-main-test-suite"
+        batchtime: 20160 # run at most once every 14 days
 
   - matrix_name: DriverBench
     matrix_spec:

--- a/.evergreen/config/standard.yml.erb
+++ b/.evergreen/config/standard.yml.erb
@@ -36,6 +36,9 @@
 %>
 
 buildvariants:
+  # RUBY-3731: test master against the upcoming Ruby (ruby-dev). Runs off-PR
+  # (no "pr" tag) on a ~2-week cadence. Failures are reported as RUBY Jira
+  # issues via an Evergreen project notification; see .evergreen/README.md.
   - matrix_name: "ruby-dev"
     matrix_spec:
       ruby: "ruby-dev"
@@ -46,6 +49,7 @@ buildvariants:
     display_name: "${mongodb-version} ${os} ${topology} ${auth-and-ssl} ${ruby}"
     tasks:
       - name: "run-main-test-suite"
+        batchtime: 20160 # run at most once every 14 days
 
   - matrix_name: DriverBench
     matrix_spec:


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/RUBY-3731

## What

Make the `ruby-dev` build variant test `master` against the upcoming Ruby
version on a regular schedule, instead of on every commit, and document how
failures are reported to Jira.

The `ruby-dev` variant already existed and already runs off pull requests (it
carries no `pr` tag, so the PR alias skips it). The only gap was the cadence
and the failure-reporting story.

## Changes

Scheduling:
- `.evergreen/config/standard.yml.erb` — add `batchtime: 20160` (14 days) to
  the `ruby-dev` variant's task, so Evergreen activates it at most once every
  two weeks. This matches the repo's existing 14-day convention.
- `.evergreen/config.yml` — regenerated from the ERB templates (`rake eg`).
  Do not edit by hand.

Failure reporting (docs only):
- `.evergreen/README.md` — new "Scheduled ruby-dev build" section. The
  Jira-issue-on-failure requirement is an Evergreen project notification, not
  repo config, so it is documented for a project admin to configure once:
  task-failure scoped to the `ruby-dev` variant, action "Create a Jira issue"
  in project `RUBY`. Evergreen populates the issue with the variant (Ruby
  version), version/commit, and links to the failed tasks.

## Test plan

- [x] `rake eg` regenerates `config.yml`; diff is only the `batchtime` line
      plus the explanatory comment.
- [x] `evergreen validate .evergreen/config.yml` -> "valid with warnings"
      (the warnings are pre-existing, for commented-out gcpkms/azurekms/lambda
      tasks).
- [n/a] No RSpec specs: this is Evergreen CI configuration with no Ruby code
      or runtime behavior change, so there is nothing in `spec/` to exercise.

## Follow-up (manual, not in this PR)

A project admin must create the Evergreen notification described in the
README. It cannot be committed because it lives in project settings.
