### PR TITLE
RUBY-3902 Indicate that the IWM options are for DB version 9.0+

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -265,6 +265,11 @@ module Mongo
     # @option options [ Float ] :connect_timeout The timeout, in seconds, to
     #   attempt a connection.
     # @option options [ String ] :database The database to connect to.
+    # @option options [ true | false ] :enable_overload_retargeting Whether
+    #   the driver deprioritizes a server that returns an overload error,
+    #   reducing the likelihood of retrying on the same overloaded server.
+    #   This option works with MongoDB Server Version 9.0 and above.
+    #   Default: false.
     # @option options [ Float ] :heartbeat_frequency The interval, in seconds,
     #   for the server monitor to refresh its description via hello.
     # @option options [ Object ] :id_generator A custom object to generate ids
@@ -277,6 +282,9 @@ module Mongo
     # @option options [ String ] :log_prefix A custom log prefix to use when
     #   logging. This option is experimental and subject to change in a future
     #   version of the driver.
+    # @option options [ Integer ] :max_adaptive_retries The maximum number of
+    #   retries to attempt when the driver encounters overload errors. This
+    #   option works with MongoDB Server Version 9.0 and above. Default: 2.
     # @option options [ Integer ] :max_connecting The maximum number of
     #  connections that can be connecting simultaneously. The default is 2.
     #  This option should be increased if there are many threads that share


### PR DESCRIPTION
The Intelligent Workflow Management (IWM) options (e.g. `:enable_overload_retargeting` and `:max_adaptive_retries`) are for database version 9.0+ only, per RUBY-3902.