### PR TITLE
RUBY-3820 Send afterClusterTime on writes in causally-consistent sessions

### DIFF
--- a/lib/mongo/index/view.rb
+++ b/lib/mongo/index/view.rb
@@ -350,7 +350,9 @@ module Mongo
       private
 
       def drop_by_name(name, opts = {})
-        client.send(:with_session, @options) do |session|
+        session_options = @options.dup
+        session_options[:session] = opts[:session] if opts[:session]
+        client.send(:with_session, session_options) do |session|
           spec = {
             db_name: database.name,
             coll_name: collection.name,

--- a/lib/mongo/operation/create/op_msg.rb
+++ b/lib/mongo/operation/create/op_msg.rb
@@ -24,6 +24,7 @@ module Mongo
       # @since 2.5.2
       class OpMsg < OpMsgBase
         include ExecutableTransactionLabel
+        include CausalConsistencySupported
 
         private
 

--- a/lib/mongo/operation/create_index/op_msg.rb
+++ b/lib/mongo/operation/create_index/op_msg.rb
@@ -24,6 +24,7 @@ module Mongo
       # @since 2.5.2
       class OpMsg < OpMsgBase
         include ExecutableTransactionLabel
+        include CausalConsistencySupported
 
         private
 

--- a/lib/mongo/operation/delete/op_msg.rb
+++ b/lib/mongo/operation/delete/op_msg.rb
@@ -27,6 +27,7 @@ module Mongo
         include ExecutableNoValidate
         include ExecutableTransactionLabel
         include PolymorphicResult
+        include CausalConsistencySupported
 
         private
 

--- a/lib/mongo/operation/drop/op_msg.rb
+++ b/lib/mongo/operation/drop/op_msg.rb
@@ -24,6 +24,7 @@ module Mongo
       # @since 2.5.2
       class OpMsg < OpMsgBase
         include ExecutableTransactionLabel
+        include CausalConsistencySupported
       end
     end
   end

--- a/lib/mongo/operation/drop_database/op_msg.rb
+++ b/lib/mongo/operation/drop_database/op_msg.rb
@@ -24,6 +24,7 @@ module Mongo
       # @since 2.5.2
       class OpMsg < OpMsgBase
         include ExecutableTransactionLabel
+        include CausalConsistencySupported
       end
     end
   end

--- a/lib/mongo/operation/drop_index/op_msg.rb
+++ b/lib/mongo/operation/drop_index/op_msg.rb
@@ -24,6 +24,7 @@ module Mongo
       # @since 2.5.2
       class OpMsg < OpMsgBase
         include ExecutableTransactionLabel
+        include CausalConsistencySupported
 
         private
 

--- a/lib/mongo/operation/insert/op_msg.rb
+++ b/lib/mongo/operation/insert/op_msg.rb
@@ -28,6 +28,7 @@ module Mongo
         include ExecutableNoValidate
         include ExecutableTransactionLabel
         include PolymorphicResult
+        include CausalConsistencySupported
 
         private
 

--- a/lib/mongo/operation/shared/causal_consistency_supported.rb
+++ b/lib/mongo/operation/shared/causal_consistency_supported.rb
@@ -28,8 +28,10 @@ module Mongo
       #
       # This method overrides the causal consistency addition logic of
       # SessionsSupported and is meant to be used with operations classified
-      # as "read operations accepting a read concern", as these are defined
-      # in the causal consistency spec.
+      # as "read and write operations accepting a read concern", as these are
+      # defined in the causal consistency spec. For write operations this
+      # attaches only afterClusterTime (no read concern level) so that causal
+      # ordering is preserved across writes in a causally consistent session.
       #
       # In order for the override to work correctly the
       # CausalConsistencySupported module must be included after

--- a/lib/mongo/operation/update/op_msg.rb
+++ b/lib/mongo/operation/update/op_msg.rb
@@ -27,6 +27,7 @@ module Mongo
         include ExecutableNoValidate
         include ExecutableTransactionLabel
         include PolymorphicResult
+        include CausalConsistencySupported
 
         private
 

--- a/lib/mongo/operation/write_command/op_msg.rb
+++ b/lib/mongo/operation/write_command/op_msg.rb
@@ -21,6 +21,8 @@ module Mongo
       #
       # @api private
       class OpMsg < OpMsgBase
+        include CausalConsistencySupported
+
         private
 
         def selector(connection)

--- a/spec/runners/unified/crud_operations.rb
+++ b/spec/runners/unified/crud_operations.rb
@@ -216,6 +216,9 @@ module Unified
           timeout_ms: args.use('timeoutMS'),
           max_time_ms: args.use('maxTimeMS')
         }
+        if session = args.use('session')
+          opts[:session] = entities.get(:session, session)
+        end
         collection.update_many(args.use!('filter'), args.use!('update'), **opts)
       end
     end
@@ -223,9 +226,7 @@ module Unified
     def replace_one(op)
       collection = entities.get(:collection, op.use!('object'))
       use_arguments(op) do |args|
-        collection.replace_one(
-          args.use!('filter'),
-          args.use!('replacement'),
+        opts = {
           comment: args.use('comment'),
           upsert: args.use('upsert'),
           let: args.use('let'),
@@ -233,6 +234,14 @@ module Unified
           timeout_ms: args.use('timeoutMS'),
           max_time_ms: args.use('maxTimeMS'),
           sort: args.use('sort')
+        }
+        if session = args.use('session')
+          opts[:session] = entities.get(:session, session)
+        end
+        collection.replace_one(
+          args.use!('filter'),
+          args.use!('replacement'),
+          **opts
         )
       end
     end
@@ -264,6 +273,9 @@ module Unified
           timeout_ms: args.use('timeoutMS'),
           max_time_ms: args.use('maxTimeMS')
         }
+        if session = args.use('session')
+          opts[:session] = entities.get(:session, session)
+        end
         collection.delete_many(args.use!('filter'), **opts)
       end
     end
@@ -276,6 +288,9 @@ module Unified
         end
         opts = {}
         opts[:ordered] = args.use!('ordered') if args.key?('ordered')
+        if session = args.use('session')
+          opts[:session] = entities.get(:session, session)
+        end
         if comment = args.use('comment')
           opts[:comment] = comment
         end

--- a/spec/runners/unified/ddl_operations.rb
+++ b/spec/runners/unified/ddl_operations.rb
@@ -97,8 +97,23 @@ module Unified
     def drop_collection(op)
       database = entities.get(:database, op.use!('object'))
       use_arguments(op) do |args|
+        opts = {}
+        if session = args.use('session')
+          opts[:session] = entities.get(:session, session)
+        end
         collection = database[args.use!('collection')]
-        collection.drop
+        collection.drop(**opts)
+      end
+    end
+
+    def drop_database(op)
+      client = entities.get(:client, op.use!('object'))
+      use_arguments(op) do |args|
+        opts = {}
+        if session = args.use('session')
+          opts[:session] = entities.get(:session, session)
+        end
+        client.use(args.use!('database')).database.drop(**opts)
       end
     end
 
@@ -158,6 +173,9 @@ module Unified
       collection = entities.get(:collection, op.use!('object'))
       use_arguments(op) do |args|
         opts = extract_options(args, 'maxTimeMS', 'timeoutMS', allow_extra: true)
+        if session = args.use('session')
+          opts[:session] = entities.get(:session, session)
+        end
         collection.indexes.drop_all(**opts)
       end
     end

--- a/spec/spec_tests/causal_consistency_unified_spec.rb
+++ b/spec/spec_tests/causal_consistency_unified_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'runners/unified'
+
+base = "#{CURRENT_PATH}/spec_tests/data/causal_consistency_unified"
+CAUSAL_CONSISTENCY_UNIFIED_TESTS = Dir.glob("#{base}/**/*.yml").sort
+
+describe 'Causal consistency unified spec tests' do
+  define_unified_spec_tests(base, CAUSAL_CONSISTENCY_UNIFIED_TESTS)
+end

--- a/spec/spec_tests/data/causal_consistency_unified/causal-consistency-clientBulkWrite.yml
+++ b/spec/spec_tests/data/causal_consistency_unified/causal-consistency-clientBulkWrite.yml
@@ -1,0 +1,75 @@
+description: "causal consistency bulkWrite include afterClusterTime"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - minServerVersion: "8.0"
+    topologies: [replicaset, sharded, load-balanced]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      uriOptions:
+        retryWrites: false
+      observeEvents: [commandStartedEvent]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName causal-consistency-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName test
+  - session:
+      id: &session0 session0
+      client: *client0
+      sessionOptions:
+        causalConsistency: true
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+# In a causally consistent session, once an operationTime has been established by a prior
+# operation, subsequent write commands MUST include readConcern.afterClusterTime so the
+# server can apply the write causally after the previously-observed data.
+
+tests:
+  - description: "clientBulkWrite includes afterClusterTime in causally consistent session"
+    operations:
+      - name: find
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+        expectResult: [{ _id: 1, x: 11 }]
+      - name: clientBulkWrite
+        object: *client0
+        arguments:
+          session: *session0
+          models:
+          - insertOne:
+              namespace: causal-consistency-tests.test
+              document: { _id: 4 }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: find
+              command:
+                find: *collectionName
+                readConcern: { $$exists: false }
+                lsid: { $$sessionLsid: *session0 }
+          - commandStartedEvent:
+              commandName: bulkWrite
+              command:
+                bulkWrite: 1
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }

--- a/spec/spec_tests/data/causal_consistency_unified/causal-consistency-write-commands.yml
+++ b/spec/spec_tests/data/causal_consistency_unified/causal-consistency-write-commands.yml
@@ -1,0 +1,472 @@
+description: "causal consistency write commands include afterClusterTime"
+
+schemaVersion: "1.3"
+
+runOnRequirements:
+  - topologies: [replicaset, sharded, load-balanced]
+
+createEntities:
+  - client:
+      id: &client0 client0
+      useMultipleMongoses: false
+      uriOptions:
+        retryWrites: false
+      observeEvents: [commandStartedEvent]
+  - database:
+      id: &database0 database0
+      client: *client0
+      databaseName: &databaseName causal-consistency-tests
+  - collection:
+      id: &collection0 collection0
+      database: *database0
+      collectionName: &collectionName test
+  - session:
+      id: &session0 session0
+      client: *client0
+      sessionOptions:
+        causalConsistency: true
+
+initialData:
+  - collectionName: *collectionName
+    databaseName: *databaseName
+    documents:
+      - { _id: 1, x: 11 }
+      - { _id: 2, x: 22 }
+      - { _id: 3, x: 33 }
+
+# In a causally consistent session, once an operationTime has been established by a prior
+# operation, subsequent write commands MUST include readConcern.afterClusterTime so the
+# server can apply the write causally after the previously-observed data.
+
+tests:
+  - description: "insertOne includes afterClusterTime in causally consistent session"
+    operations:
+      - &find
+        name: find
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+        expectResult: [{ _id: 1, x: 11 }]
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 4 }
+        expectResult:
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 4 } }
+    expectEvents:
+      - client: *client0
+        events:
+          - &findEvent
+            commandStartedEvent:
+              commandName: find
+              command:
+                find: *collectionName
+                readConcern: { $$exists: false }
+                lsid: { $$sessionLsid: *session0 }
+          - commandStartedEvent:
+              commandName: insert
+              command:
+                insert: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "insertMany includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: insertMany
+        object: *collection0
+        arguments:
+          session: *session0
+          documents:
+            - { _id: 4 }
+            - { _id: 5 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: insert
+              command:
+                insert: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "updateOne includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: updateOne
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+          update: { $set: { x: 100 } }
+        expectResult:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: update
+              command:
+                update: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "updateMany includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: updateMany
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: { $gt: 0 } }
+          update: { $set: { updated: true } }
+        expectResult:
+          matchedCount: 3
+          modifiedCount: 3
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: update
+              command:
+                update: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "replaceOne includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: replaceOne
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+          replacement: { x: 100 }
+        expectResult:
+          matchedCount: 1
+          modifiedCount: 1
+          upsertedCount: 0
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: update
+              command:
+                update: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "deleteOne includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: deleteOne
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+        expectResult:
+          deletedCount: 1
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: delete
+              command:
+                delete: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "deleteMany includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: deleteMany
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: { $gt: 0 } }
+        expectResult:
+          deletedCount: 3
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: delete
+              command:
+                delete: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "findOneAndUpdate includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: findOneAndUpdate
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+          update: { $set: { x: 100 } }
+        expectResult: { _id: 1, x: 11 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: findAndModify
+              command:
+                findAndModify: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "findOneAndDelete includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: findOneAndDelete
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+        expectResult: { _id: 1, x: 11 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: findAndModify
+              command:
+                findAndModify: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "findOneAndReplace includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: findOneAndReplace
+        object: *collection0
+        arguments:
+          session: *session0
+          filter: { _id: 1 }
+          replacement: { x: 100 }
+        expectResult: { _id: 1, x: 11 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: findAndModify
+              command:
+                findAndModify: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "bulkWrite includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: bulkWrite
+        object: *collection0
+        arguments:
+          session: *session0
+          requests:
+            - insertOne:
+                document: { _id: 4 }
+            - updateOne:
+                filter: { _id: 2 }
+                update: { $set: { x: 100 } }
+            - deleteOne:
+                filter: { _id: 3 }
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: insert
+              command:
+                insert: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+          - commandStartedEvent:
+              commandName: update
+              command:
+                update: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+          - commandStartedEvent:
+              commandName: delete
+              command:
+                delete: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "create includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      # Drop the collection first to make sure there's no name conflict during
+      # createCollection.
+      - name: dropCollection
+        object: *database0
+        arguments:
+          session: *session0
+          collection: &newCollectionName causal-consistency-createCollection-test
+      - name: createCollection
+        object: *database0
+        arguments:
+          session: *session0
+          collection: *newCollectionName
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: drop
+              command:
+                drop: *newCollectionName
+                lsid: { $$sessionLsid: *session0 }
+          - commandStartedEvent:
+              commandName: create
+              command:
+                create: *newCollectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "createIndexes includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: createIndex
+        object: *collection0
+        arguments:
+          session: *session0
+          keys: { x: 1 }
+          name: x_1
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: createIndexes
+              command:
+                createIndexes: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "drop includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: dropCollection
+        object: *database0
+        arguments:
+          session: *session0
+          collection: *collectionName
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: drop
+              command:
+                drop: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "dropDatabase includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: dropDatabase
+        object: *client0
+        arguments:
+          session: *session0
+          database: causal-consistency-dropDatabase-test
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: dropDatabase
+              command:
+                dropDatabase: 1
+                $db: causal-consistency-dropDatabase-test
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  - description: "dropIndexes includes afterClusterTime in causally consistent session"
+    operations:
+      - *find
+      - name: dropIndexes
+        object: *collection0
+        arguments:
+          session: *session0
+    expectEvents:
+      - client: *client0
+        events:
+          - *findEvent
+          - commandStartedEvent:
+              commandName: dropIndexes
+              command:
+                dropIndexes: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern:
+                  afterClusterTime: { $$exists: true }
+                  level: { $$exists: false }
+
+  # Covers the same condition as Causal Consistency prose test #2, but for a write operation.
+  - description: "first write command in a causally consistent session does not include afterClusterTime"
+    operations:
+      - name: insertOne
+        object: *collection0
+        arguments:
+          session: *session0
+          document: { _id: 4 }
+        expectResult:
+          $$unsetOrMatches: { insertedId: { $$unsetOrMatches: 4 } }
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              commandName: insert
+              command:
+                insert: *collectionName
+                lsid: { $$sessionLsid: *session0 }
+                readConcern: { $$exists: false }

--- a/spec/spec_tests/data/transactions/commit.yml
+++ b/spec/spec_tests/data/transactions/commit.yml
@@ -509,7 +509,10 @@ tests:
             documents:
               - _id: 2
             ordered: true
+            # This write follows an ended transaction in the same causally
+            # consistent session, so it carries afterClusterTime.
             readConcern:
+              afterClusterTime: 42
             lsid: session0
             txnNumber:
             startTransaction:
@@ -589,7 +592,10 @@ tests:
             documents:
               - _id: 2
             ordered: true
+            # This write follows an ended transaction in the same causally
+            # consistent session, so it carries afterClusterTime.
             readConcern:
+              afterClusterTime: 42
             lsid: session0
             txnNumber:
             startTransaction:

--- a/spec/spec_tests/data/transactions/retryable-writes.yml
+++ b/spec/spec_tests/data/transactions/retryable-writes.yml
@@ -96,7 +96,10 @@ tests:
             documents:
               - _id: 2
             ordered: true
+            # This retryable write follows an ended transaction in the same
+            # causally consistent session, so it carries afterClusterTime.
             readConcern:
+              afterClusterTime: 42
             lsid: session0
             txnNumber:
               $numberLong: "2"
@@ -139,7 +142,10 @@ tests:
               - _id: 4
               - _id: 5
             ordered: true
+            # This retryable write follows an ended transaction in the same
+            # causally consistent session, so it carries afterClusterTime.
             readConcern:
+              afterClusterTime: 42
             lsid: session0
             txnNumber:
               $numberLong: "4"

--- a/spec/spec_tests/data/transactions_api/callback-aborts.yml
+++ b/spec/spec_tests/data/transactions_api/callback-aborts.yml
@@ -159,7 +159,10 @@ tests:
             lsid: session0
             # omitted fields
             autocommit: ~
-            readConcern: ~
+            # This write follows a committed/aborted transaction in the same
+            # causally consistent session, so it carries afterClusterTime.
+            readConcern:
+              afterClusterTime: 42
             startTransaction: ~
             writeConcern: ~
           command_name: insert

--- a/spec/spec_tests/data/transactions_api/callback-commits.yml
+++ b/spec/spec_tests/data/transactions_api/callback-commits.yml
@@ -191,7 +191,10 @@ tests:
             lsid: session0
             # omitted fields
             autocommit: ~
-            readConcern: ~
+            # This write follows a committed/aborted transaction in the same
+            # causally consistent session, so it carries afterClusterTime.
+            readConcern:
+              afterClusterTime: 42
             startTransaction: ~
             writeConcern: ~
           command_name: insert


### PR DESCRIPTION
## Description

Writes performed in a causally consistent session now attach `afterClusterTime`, matching the updated causal consistency spec (split from DRIVERS-3274). Previously only reads carried it.

The write operation op_msg classes (`insert`, `update`, `delete`, `create`, `create_index`, `drop`, `drop_database`, `drop_index`, and `write_command`) now `include CausalConsistencySupported`. That override always applies the causal consistency document (rather than only for `startTransaction`), so writes emit `afterClusterTime` when the session is causally consistent and has an operation time. For writes this attaches only `afterClusterTime` with no read concern level, since write specs never populate a read concern.

## Testing and runner changes

- Added the causal consistency unified spec suite (`spec/spec_tests/causal_consistency_unified_spec.rb` plus fixtures).
- Threaded an explicit `:session` through `Index::View#drop_by_name` so a session passed to `drop`/`drop_all` is honored.
- Added `session` argument support to the affected unified runner operations, including a new `drop_database` handler.
- The `clientBulkWrite` fixture is skipped at runtime pending RUBY-2964, since the driver does not yet implement the `bulkWrite` command.

## Fixture updates

Existing transaction fixtures (`transactions/commit.yml`, `transactions/retryable-writes.yml`, `transactions_api/callback-aborts.yml`, `transactions_api/callback-commits.yml`) were updated: post-transaction writes in the same causally consistent session now expect `afterClusterTime`.

## Verification

- `causal_consistency_unified_spec.rb`: 18 examples, 0 failures, 1 pending (clientBulkWrite).
- Combined with `transactions_spec.rb` and `transactions_api_spec.rb`: 2197 examples, 0 failures.
- RuboCop clean.