### PR TITLE
RUBY-3816 Remove core driver antipatterns

### DIFF
--- a/lib/mongo/auth/user/view.rb
+++ b/lib/mongo/auth/user/view.rb
@@ -152,7 +152,7 @@ module Mongo
         end
 
         def execute_operation(options)
-          client.send(:with_session, options) do |session|
+          client.with_session(options) do |session|
             op = yield session
             op.execute(next_primary(nil, session), context: Operation::Context.new(client: client, session: session))
           end

--- a/lib/mongo/bulk_write/result_combiner.rb
+++ b/lib/mongo/bulk_write/result_combiner.rb
@@ -92,7 +92,7 @@ module Mongo
 
       def combine_counts!(result)
         Result::FIELDS.each do |field|
-          if result.respond_to?(field) && (value = result.send(field))
+          if result.respond_to?(field) && (value = result.public_send(field))
             results.merge!(field => (results[field] || 0) + value)
           end
         end

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -172,7 +172,6 @@ module Mongo
         @monitoring
       end
     end
-    private :monitoring
 
     # Determine if this client is equivalent to another object.
     #

--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -796,10 +796,10 @@ module Mongo
     def with(new_options = nil)
       clone.tap do |client|
         opts = client.update_options(new_options || Options::Redacted.new)
-        Database.create(client)
+        client.reset_database!
         # We can't use the same cluster if some options that would affect it
         # have changed.
-        Cluster.create(client, monitoring: opts[:monitoring]) if cluster_modifying?(opts)
+        client.reset_cluster!(monitoring: opts[:monitoring]) if cluster_modifying?(opts)
       end
     end
 
@@ -853,6 +853,31 @@ module Mongo
         validate_options!
         validate_authentication_options!
       end
+    end
+
+    # Replaces this client's database with a fresh instance built from the
+    # client's current options. Used by #with so a reconfigured client does
+    # not share its database with the client it was cloned from.
+    #
+    # @api private
+    def reset_database!
+      @database = Database.new(self, options[:database], options)
+    end
+
+    # Replaces this client's cluster with a fresh instance built from the
+    # client's current options. Used by #with so a reconfigured client does
+    # not share its cluster with the client it was cloned from.
+    #
+    # @param [ Monitoring | nil ] monitoring The monitoring instance to use
+    #   with the new cluster. If nil, a new instance of Monitoring is created.
+    #
+    # @api private
+    def reset_cluster!(monitoring: nil)
+      @cluster = Cluster.new(
+        cluster.addresses.map(&:to_s),
+        monitoring || Monitoring.new,
+        cluster_options
+      )
     end
 
     # Get the read concern for this client.

--- a/lib/mongo/cluster.rb
+++ b/lib/mongo/cluster.rb
@@ -269,30 +269,6 @@ module Mongo
       start_stop_srv_monitor
     end
 
-    # Create a cluster for the provided client, for use when we don't want the
-    # client's original cluster instance to be the same.
-    #
-    # @example Create a cluster for the client.
-    #   Cluster.create(client)
-    #
-    # @param [ Client ] client The client to create on.
-    # @param [ Monitoring | nil ] monitoring. The monitoring instance to use
-    #   with the new cluster. If nil, a new instance of Monitoring will be
-    #   created.
-    #
-    # @return [ Cluster ] The cluster.
-    #
-    # @since 2.0.0
-    # @api private
-    def self.create(client, monitoring: nil)
-      cluster = Cluster.new(
-        client.cluster.addresses.map(&:to_s),
-        monitoring || Monitoring.new,
-        client.cluster_options
-      )
-      client.instance_variable_set(:@cluster, cluster)
-    end
-
     # @return [ Hash ] The options hash.
     attr_reader :options
 

--- a/lib/mongo/cluster/sdam_flow.rb
+++ b/lib/mongo/cluster/sdam_flow.rb
@@ -385,7 +385,7 @@ class Mongo::Cluster
     def add_servers_from_desc(updated_desc)
       added_servers = []
       %w[hosts passives arbiters].each do |m|
-        updated_desc.send(m).each do |address_str|
+        updated_desc.public_send(m).each do |address_str|
           if (server = cluster.add(address_str, monitor: false))
             added_servers << server
           end
@@ -402,7 +402,7 @@ class Mongo::Cluster
     # good primary).
     def remove_servers_not_in_desc(updated_desc)
       updated_desc_address_strs = %w[hosts passives arbiters].map do |m|
-        updated_desc.send(m)
+        updated_desc.public_send(m)
       end.flatten
       servers_list.each do |server|
         next if updated_desc_address_strs.include?(address_str = server.address.to_s)

--- a/lib/mongo/collection.rb
+++ b/lib/mongo/collection.rb
@@ -393,7 +393,7 @@ module Mongo
       operation = { create: name }.merge(options)
       operation.delete(:write)
       operation.delete(:write_concern)
-      client.send(:with_session, opts) do |session|
+      client.with_session(opts) do |session|
         write_concern = if opts[:write_concern]
                           WriteConcern.get(opts[:write_concern])
                         else

--- a/lib/mongo/collection/view.rb
+++ b/lib/mongo/collection/view.rb
@@ -236,6 +236,14 @@ module Mongo
         end
       end
 
+      # Executes the provided block within the context of a session, using
+      # this view's options merged with the given ones.
+      #
+      # @api private
+      def with_session(opts = {}, &block)
+        client.with_session(@options.merge(opts), &block)
+      end
+
       private
 
       def initialize_copy(other)
@@ -251,10 +259,6 @@ module Mongo
 
       def view
         self
-      end
-
-      def with_session(opts = {}, &block)
-        client.with_session(@options.merge(opts), &block)
       end
     end
   end

--- a/lib/mongo/collection/view/aggregation/behavior.rb
+++ b/lib/mongo/collection/view/aggregation/behavior.rb
@@ -85,7 +85,7 @@ module Mongo
           end
 
           def server_selector
-            @view.send(:server_selector)
+            @view.server_selector
           end
 
           def aggregate_spec(session, read_preference = nil)

--- a/lib/mongo/collection/view/map_reduce.rb
+++ b/lib/mongo/collection/view/map_reduce.rb
@@ -241,7 +241,7 @@ module Mongo
         OUT_ACTIONS = %i[replace merge reduce].freeze
 
         def server_selector
-          @view.send(:server_selector)
+          @view.server_selector
         end
 
         def inline?

--- a/lib/mongo/collection/view/map_reduce.rb
+++ b/lib/mongo/collection/view/map_reduce.rb
@@ -227,7 +227,7 @@ module Mongo
         #
         # @since 2.5.0
         def execute
-          view.send(:with_session, @options) do |session|
+          view.with_session(@options) do |session|
             write_concern = view.write_concern_with_session(session)
             context = Operation::Context.new(client: client, session: session)
             nro_write_with_retry(write_concern, context: context) do |connection, _txn_num, context|

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -678,7 +678,7 @@ module Mongo
         # @api private
         def read_concern
           if options[:session] && options[:session].in_transaction?
-            options[:session].send(:txn_read_concern) || collection.client.read_concern
+            options[:session].txn_read_concern || collection.client.read_concern
           else
             collection.read_concern
           end

--- a/lib/mongo/collection/view/readable.rb
+++ b/lib/mongo/collection/view/readable.rb
@@ -749,18 +749,22 @@ module Mongo
           end
         end
 
-        private
-
-        def collation(doc = nil)
-          configure(:collation, doc)
-        end
-
+        # The server selector for this view, derived from its read
+        # preference (or the collection/client default).
+        #
+        # @api private
         def server_selector
           @server_selector ||= if options[:session] && options[:session].in_transaction?
                                  ServerSelector.get(read_preference || client.server_selector)
                                else
                                  ServerSelector.get(read_preference || collection.server_selector)
                                end
+        end
+
+        private
+
+        def collation(doc = nil)
+          configure(:collation, doc)
         end
 
         def validate_doc!(doc)

--- a/lib/mongo/crypt/auto_encrypter.rb
+++ b/lib/mongo/crypt/auto_encrypter.rb
@@ -287,7 +287,7 @@ module Mongo
         @internal_client ||= client.with(
           auto_encryption_options: nil,
           min_pool_size: 0,
-          monitoring: client.send(:monitoring)
+          monitoring: client.monitoring
         )
       end
     end

--- a/lib/mongo/crypt/handle.rb
+++ b/lib/mongo/crypt/handle.rb
@@ -203,7 +203,7 @@ module Mongo
       # Send the logs from libmongocrypt to the Mongo::Logger
       def set_logger_callback
         @log_callback = proc do |level, msg|
-          @logger.send(level, msg)
+          @logger.public_send(level, msg)
         end
 
         Binding.setopt_log_handler(@mongocrypt, @log_callback)

--- a/lib/mongo/cursor.rb
+++ b/lib/mongo/cursor.rb
@@ -507,7 +507,7 @@ module Mongo
     end
 
     def limit
-      @view.send(:limit)
+      @view.limit
     end
 
     def register

--- a/lib/mongo/database.rb
+++ b/lib/mongo/database.rb
@@ -644,24 +644,6 @@ module Mongo
       )
     end
 
-    # Create a database for the provided client, for use when we don't want the
-    # client's original database instance to be the same.
-    #
-    # @api private
-    #
-    # @example Create a database for the client.
-    #   Database.create(client)
-    #
-    # @param [ Client ] client The client to create on.
-    #
-    # @return [ Database ] The database.
-    #
-    # @since 2.0.0
-    def self.create(client)
-      database = Database.new(client, client.options[:database], client.options)
-      client.instance_variable_set(:@database, database)
-    end
-
     # @return [ Integer | nil ] Operation timeout that is for this database or
     #   for the corresponding client.
     #

--- a/lib/mongo/database/cursor_command_view.rb
+++ b/lib/mongo/database/cursor_command_view.rb
@@ -84,9 +84,9 @@ module Mongo
         database.operation_timeouts(opts)
       end
 
-      private
-
       # Cursors do not support a limit when built from a command response.
+      #
+      # @api private
       def limit
         nil
       end

--- a/lib/mongo/grid/fs_bucket.rb
+++ b/lib/mongo/grid/fs_bucket.rb
@@ -494,6 +494,32 @@ module Mongo
         chunks_collection.drop(timeout_ms: context.remaining_timeout_ms)
       end
 
+      # Ensures the files and chunks collections have their required indexes,
+      # creating any that are missing.
+      #
+      # @param [ CsotTimeoutHolder | nil ] timeout_holder The timeout holder.
+      #
+      # @api private
+      def ensure_indexes!(timeout_holder = nil)
+        fc_idx = files_collection.find(
+          {},
+          limit: 1,
+          projection: { _id: 1 },
+          timeout_ms: timeout_holder&.remaining_timeout_ms
+        ).first
+        create_index_if_missing!(files_collection, FSBucket::FILES_INDEX) if fc_idx.nil?
+
+        cc_idx = chunks_collection.find(
+          {},
+          limit: 1,
+          projection: { _id: 1 },
+          timeout_ms: timeout_holder&.remaining_timeout_ms
+        ).first
+        return unless cc_idx.nil?
+
+        create_index_if_missing!(chunks_collection, FSBucket::CHUNKS_INDEX, unique: true)
+      end
+
       private
 
       # @param [ Hash ] opts The options.
@@ -514,26 +540,6 @@ module Mongo
 
       def files_name
         "#{prefix}.#{Grid::File::Info::COLLECTION}"
-      end
-
-      def ensure_indexes!(timeout_holder = nil)
-        fc_idx = files_collection.find(
-          {},
-          limit: 1,
-          projection: { _id: 1 },
-          timeout_ms: timeout_holder&.remaining_timeout_ms
-        ).first
-        create_index_if_missing!(files_collection, FSBucket::FILES_INDEX) if fc_idx.nil?
-
-        cc_idx = chunks_collection.find(
-          {},
-          limit: 1,
-          projection: { _id: 1 },
-          timeout_ms: timeout_holder&.remaining_timeout_ms
-        ).first
-        return unless cc_idx.nil?
-
-        create_index_if_missing!(chunks_collection, FSBucket::CHUNKS_INDEX, unique: true)
       end
 
       def create_index_if_missing!(collection, index_spec, options = {})

--- a/lib/mongo/grid/stream/write.rb
+++ b/lib/mongo/grid/stream/write.rb
@@ -212,7 +212,7 @@ module Mongo
           end
 
           def ensure_indexes!
-            fs.send(:ensure_indexes!, @timeout_holder)
+            fs.ensure_indexes!(@timeout_holder)
           end
 
           def ensure_open!

--- a/lib/mongo/index/view.rb
+++ b/lib/mongo/index/view.rb
@@ -347,12 +347,20 @@ module Mongo
         end
       end
 
+      # The query limit for an index view. Always -1; present so a Cursor
+      # can treat an index view like a collection view.
+      #
+      # @api private
+      def limit
+        -1
+      end
+
       private
 
       def drop_by_name(name, opts = {})
         session_options = @options.dup
         session_options[:session] = opts[:session] if opts[:session]
-        client.send(:with_session, session_options) do |session|
+        client.with_session(session_options) do |session|
           spec = {
             db_name: database.name,
             coll_name: collection.name,
@@ -394,10 +402,6 @@ module Mongo
 
       def initial_query_op(session)
         Operation::Indexes.new(indexes_spec(session))
-      end
-
-      def limit
-        -1
       end
 
       def normalize_keys(spec)

--- a/lib/mongo/operation/shared/sessions_supported.rb
+++ b/lib/mongo/operation/shared/sessions_supported.rb
@@ -61,7 +61,7 @@ module Mongo
       def apply_causal_consistency_if_possible(selector, connection)
         return if connection.description.standalone?
 
-        cc_doc = session.send(:causal_consistency_doc)
+        cc_doc = session.causal_consistency_doc
         return unless cc_doc
 
         rc_doc = (selector[:readConcern] || read_concern || {}).merge(cc_doc)

--- a/lib/mongo/options/redacted.rb
+++ b/lib/mongo/options/redacted.rb
@@ -143,14 +143,14 @@ module Mongo
 
       def redacted_string(method)
         '{' + reduce([]) do |list, (k, v)|
-          list << "#{k.send(method)}=>#{redact(k, v, method)}"
+          list << "#{k.public_send(method)}=>#{redact(k, v, method)}"
         end.join(', ') + '}'
       end
 
       def redact(k, v, method)
         return STRING_REPLACEMENT if SENSITIVE_OPTIONS.include?(k.to_sym)
 
-        v.send(method)
+        v.public_send(method)
       end
     end
   end

--- a/lib/mongo/protocol/compressed.rb
+++ b/lib/mongo/protocol/compressed.rb
@@ -95,9 +95,9 @@ module Mongo
 
         message.send(:fields).each do |field|
           if field[:multi]
-            Message.deserialize_array(message, buf, field)
+            message.deserialize_array(buf, field)
           else
-            Message.deserialize_field(message, buf, field)
+            message.deserialize_field(buf, field)
           end
         end
         message.fix_after_deserialization if message.is_a?(Msg)

--- a/lib/mongo/protocol/compressed.rb
+++ b/lib/mongo/protocol/compressed.rb
@@ -93,7 +93,7 @@ module Mongo
         message = Registry.get(@original_op_code).allocate
         buf = decompress(@compressed_message)
 
-        message.send(:fields).each do |field|
+        message.fields.each do |field|
           if field[:multi]
             message.deserialize_array(buf, field)
           else
@@ -114,6 +114,15 @@ module Mongo
       # @since 2.5.0
       def replyable?
         @original_message.replyable?
+      end
+
+      # @api private
+      def serialize_fields(buffer, max_bson_size)
+        buf = BSON::ByteBuffer.new
+        @original_message.serialize_fields(buf, max_bson_size)
+        @uncompressed_size = buf.length
+        @compressed_message = compress(buf)
+        super
       end
 
       private
@@ -139,14 +148,6 @@ module Mongo
       # @!attribute
       # @return [ String ] The actual compressed message bytes.
       field :compressed_message, Bytes
-
-      def serialize_fields(buffer, max_bson_size)
-        buf = BSON::ByteBuffer.new
-        @original_message.send(:serialize_fields, buf, max_bson_size)
-        @uncompressed_size = buf.length
-        @compressed_message = compress(buf)
-        super
-      end
 
       def compress(buffer)
         if @compressor_id == NOOP_BYTE

--- a/lib/mongo/protocol/message.rb
+++ b/lib/mongo/protocol/message.rb
@@ -270,9 +270,9 @@ module Mongo
         message = Registry.get(_op_code).allocate
         message.send(:fields).each do |field|
           if field[:multi]
-            deserialize_array(message, buf, field, options)
+            message.deserialize_array(buf, field, options)
           else
-            deserialize_field(message, buf, field, options)
+            message.deserialize_field(buf, field, options)
           end
         end
         message.fix_after_deserialization if message.is_a?(Msg)
@@ -369,7 +369,6 @@ module Mongo
       # deserialized field specified in the class by the field dsl under
       # the key +:multi+
       #
-      # @param message [Message] Message to contain the deserialized array.
       # @param io [IO] Stream containing the array to deserialize.
       # @param field [Hash] Hash representing a field.
       # @param options [ Hash ]
@@ -377,18 +376,17 @@ module Mongo
       # @option options [ Boolean ] :deserialize_as_bson Whether to deserialize
       #   each of the elements in this array using BSON types wherever possible.
       #
-      # @return [Message] Message with deserialized array.
+      # @return [Array] The deserialized array.
       # @api private
-      def self.deserialize_array(message, io, field, options = {})
+      def deserialize_array(io, field, options = {})
         elements = []
-        count = message.instance_variable_get(field[:multi])
+        count = instance_variable_get(field[:multi])
         count.times { elements << field[:type].deserialize(io, options) }
-        message.instance_variable_set(field[:name], elements)
+        instance_variable_set(field[:name], elements)
       end
 
-      # Deserializes a single field in a message
+      # Deserializes a single field into this message.
       #
-      # @param message [Message] Message to contain the deserialized field.
       # @param io [IO] Stream containing the field to deserialize.
       # @param field [Hash] Hash representing a field.
       # @param options [ Hash ]
@@ -396,10 +394,10 @@ module Mongo
       # @option options [ Boolean ] :deserialize_as_bson Whether to deserialize
       #   this field using BSON types wherever possible.
       #
-      # @return [Message] Message with deserialized field.
+      # @return [Object] The deserialized field value.
       # @api private
-      def self.deserialize_field(message, io, field, options = {})
-        message.instance_variable_set(
+      def deserialize_field(io, field, options = {})
+        instance_variable_set(
           field[:name],
           field[:type].deserialize(io, options)
         )

--- a/lib/mongo/protocol/message.rb
+++ b/lib/mongo/protocol/message.rb
@@ -405,7 +405,7 @@ module Mongo
 
       # A method for getting the fields for a message class
       #
-      # @return [Integer] the fields for the message class
+      # @return [Array<Hash>] The fields for the message class
       # @api private
       def fields
         self.class.fields

--- a/lib/mongo/protocol/message.rb
+++ b/lib/mongo/protocol/message.rb
@@ -268,7 +268,7 @@ module Mongo
         buf = BSON::ByteBuffer.new(chunk)
 
         message = Registry.get(_op_code).allocate
-        message.send(:fields).each do |field|
+        message.fields.each do |field|
           if field[:multi]
             message.deserialize_array(buf, field, options)
           else
@@ -403,11 +403,10 @@ module Mongo
         )
       end
 
-      private
-
       # A method for getting the fields for a message class
       #
       # @return [Integer] the fields for the message class
+      # @api private
       def fields
         self.class.fields
       end
@@ -416,6 +415,7 @@ module Mongo
       #
       # @param buffer [String] buffer to receive the field
       # @return [String] buffer with serialized field
+      # @api private
       def serialize_fields(buffer, max_bson_size = nil)
         fields.each do |field|
           value = instance_variable_get(field[:name])
@@ -434,6 +434,8 @@ module Mongo
           end
         end
       end
+
+      private
 
       # Serializes the header of the message consisting of 4 32bit integers
       #

--- a/lib/mongo/server/connection_common.rb
+++ b/lib/mongo/server/connection_common.rb
@@ -99,6 +99,14 @@ module Mongo
         end
       end
 
+      # Closes the underlying socket, if one is open, to interrupt an
+      # in-progress blocking read on the connection.
+      #
+      # @api private
+      def interrupt_socket
+        socket&.close
+      end
+
       private
 
       HELLO_DOC = BSON::Document.new({ hello: 1 }).freeze

--- a/lib/mongo/server/push_monitor.rb
+++ b/lib/mongo/server/push_monitor.rb
@@ -72,7 +72,7 @@ module Mongo
             # Interrupt any in-progress exhausted hello reads by
             # disconnecting the connection.
             begin
-              @connection.send(:socket).close
+              @connection.interrupt_socket
             rescue StandardError
               nil
             end

--- a/lib/mongo/server_selector/base.rb
+++ b/lib/mongo/server_selector/base.rb
@@ -687,8 +687,7 @@ module Mongo
         msg = ''
         dead_monitors = []
         cluster.servers_list.each do |server|
-          thread = server.monitor.instance_variable_get(:@thread)
-          dead_monitors << server if thread.nil? || !thread.alive?
+          dead_monitors << server unless server.monitor&.running?
         end
         if dead_monitors.any?
           msg += ". The following servers have dead monitor threads: #{dead_monitors.map(&:summary).join(', ')}"

--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -1312,8 +1312,6 @@ module Mongo
       @inside_with_transaction
     end
 
-    private
-
     # Get the read concern the session will use when starting a transaction.
     #
     # This is a driver style hash with underscore keys.
@@ -1324,10 +1322,23 @@ module Mongo
     # @return [ Hash ] The read concern used for starting transactions.
     #
     # @since 2.9.0
+    # @api private
     def txn_read_concern
       # Read concern is inherited from client but not db or collection.
       txn_options[:read_concern] || @client.read_concern
     end
+
+    # Returns causal consistency document if the last operation time is
+    # known and causal consistency is enabled, otherwise returns nil.
+    #
+    # @api private
+    def causal_consistency_doc
+      return unless operation_time && causal_consistency?
+
+      { afterClusterTime: operation_time }
+    end
+
+    private
 
     def within_states?(*states)
       states.include?(@state)
@@ -1344,14 +1355,6 @@ module Mongo
     def txn_write_concern
       txn_options[:write_concern] ||
         (@client.write_concern && @client.write_concern.options)
-    end
-
-    # Returns causal consistency document if the last operation time is
-    # known and causal consistency is enabled, otherwise returns nil.
-    def causal_consistency_doc
-      return unless operation_time && causal_consistency?
-
-      { afterClusterTime: operation_time }
     end
 
     def causal_consistency?

--- a/lib/mongo/socket/ssl.rb
+++ b/lib/mongo/socket/ssl.rb
@@ -421,13 +421,13 @@ module Mongo
         # https://github.com/jruby/jruby-openssl/issues/176
         if BSON::Environment.jruby?
           [ OpenSSL::PKey::RSA, OpenSSL::PKey::DSA ].each do |cls|
-            return cls.send(:new, *args)
+            return cls.new(*args)
           rescue OpenSSL::PKey::PKeyError
             # ignore
           end
           # Neither RSA nor DSA worked, fall through to trying PKey
         end
-        OpenSSL::PKey.send(:read, *args)
+        OpenSSL::PKey.read(*args)
       end
 
       def set_cert_verification(context, options)


### PR DESCRIPTION
## Description

The ticket named `instance_variable_set` in `Mongo::Cluster.create` as one example of a structural antipattern. This branch audits the driver for that broader class of "brittle or surprising" patterns and removes the ones that are safe, behavior-preserving cleanups. Every change replaces a metaprogramming reach-in — mutating another object's private state, or calling past method visibility with `send` — with straightforward, encapsulated OO.

No behavior changes: the affected methods keep their existing contracts. Each batch was linted and run against a local replica set.

The audit also looked at structural OO smells (god objects, long parameter lists) and thread-safety, and cataloged concurrency and metaprogramming sites that are better handled as follow-ups (see below). This branch is scoped to the low-risk encapsulation fixes.

## What changed

**Stop mutating a caller's private state (the ticket's named example)**

- `Cluster.create` and `Database.create` only ever mutated the client they were handed, via `instance_variable_set`, and were called only from `Client#with`. That behavior now lives on `Client` as `reset_cluster!` and `reset_database!`, and the two class factories are gone.
- `Message.deserialize_array` / `.deserialize_field` were class methods that set ivars on a passed-in message. They are now instance methods, so the ivar access is ordinary self-assignment.

**Call methods directly or via `public_send` instead of `send`**

- Several sites used `send` to invoke methods that are already public (`redacted.rb`, `sdam_flow.rb`, `crypt/handle.rb`, `socket/ssl.rb`, `cursor.rb`, `result_combiner.rb`). Switched to `public_send` or a direct call.
- `Client#with_session` is public, so three callers now call it directly.

**Promote genuinely-internal methods to `@api private` public**

Where `send` was reaching a private method on another object, the method is now a documented `@api private` public method and the call is direct:

- `Session#txn_read_concern`, `Session#causal_consistency_doc`
- `Client#monitoring` (dropped a redundant `private` marker)
- `Collection::View#with_session`, `Collection::View#server_selector`
- `Index::View#limit` (also needed by `Cursor#limit`, whose `@view` may be an index view)
- `FSBucket#ensure_indexes!`
- `Message#fields`, `Message#serialize_fields`

**Replace reach-ins with purpose-built accessors**

- `server_selection_diagnostic_message` read a monitor's private `@thread` ivar; it now uses the existing public `Monitor#running?` predicate (guarded with safe navigation, since a server's monitor may be nil).
- `PushMonitor#stop!` did `connection.send(:socket).close` to interrupt a blocking read; that is now `ConnectionCommon#interrupt_socket` (`@api private`).

## Testing

Each batch was checked with RuboCop and run against a local replica set (`spec/mongo/...` for every changed class, plus the relevant `spec/integration/` specs). All pass; no new failures.

One caught regression is worth calling out: an early swap changed `Cursor#limit` from `@view.send(:limit)` to `@view.limit`, but `@view` can be a `Mongo::Index::View`, where `limit` was private. The specs caught it, and the fix was to make `Index::View#limit` public `@api private` (matching `Collection::View`). General lesson for reviewers: replacing a metaprogramming reach with a real call can surface polymorphic or nil cases that `send`/`instance_variable_get` silently tolerated.