### PR TITLE
RUBY-3912 Fix Lint/MissingSuper violations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,11 +13,6 @@ Lint/IncompatibleIoSelectWithFiberScheduler:
     - 'lib/mongo/socket/ssl.rb'
     - 'lib/mongo/socket/tcp.rb'
 
-# Offense count: 31
-# Configuration parameters: AllowedParentClasses.
-Lint/MissingSuper:
-  Enabled: false
-
 # Offense count: 1
 Lint/MixedRegexpCaptureTypes:
   Exclude:

--- a/lib/mongo/monitoring/event/cmap/connection_check_out_failed.rb
+++ b/lib/mongo/monitoring/event/cmap/connection_check_out_failed.rb
@@ -62,6 +62,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address, reason)
+            super()
             @reason = reason
             @address = address
           end

--- a/lib/mongo/monitoring/event/cmap/connection_check_out_started.rb
+++ b/lib/mongo/monitoring/event/cmap/connection_check_out_started.rb
@@ -35,6 +35,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address)
+            super()
             @address = address
           end
 

--- a/lib/mongo/monitoring/event/cmap/connection_checked_in.rb
+++ b/lib/mongo/monitoring/event/cmap/connection_checked_in.rb
@@ -47,6 +47,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address, id, pool)
+            super()
             @address = address
             @connection_id = id
             @pool = pool

--- a/lib/mongo/monitoring/event/cmap/connection_checked_out.rb
+++ b/lib/mongo/monitoring/event/cmap/connection_checked_out.rb
@@ -48,6 +48,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address, id, pool)
+            super()
             @address = address
             @connection_id = id
             @pool = pool

--- a/lib/mongo/monitoring/event/cmap/connection_closed.rb
+++ b/lib/mongo/monitoring/event/cmap/connection_closed.rb
@@ -79,6 +79,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address, id, reason)
+            super()
             @reason = reason
             @address = address
             @connection_id = id

--- a/lib/mongo/monitoring/event/cmap/connection_created.rb
+++ b/lib/mongo/monitoring/event/cmap/connection_created.rb
@@ -41,6 +41,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address, id)
+            super()
             @address = address
             @connection_id = id
           end

--- a/lib/mongo/monitoring/event/cmap/connection_ready.rb
+++ b/lib/mongo/monitoring/event/cmap/connection_ready.rb
@@ -41,6 +41,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address, id)
+            super()
             @address = address
             @connection_id = id
           end

--- a/lib/mongo/monitoring/event/cmap/pool_cleared.rb
+++ b/lib/mongo/monitoring/event/cmap/pool_cleared.rb
@@ -43,6 +43,7 @@ module Mongo
           #
           # @api private
           def initialize(address, service_id: nil, interrupt_in_use_connections: nil)
+            super()
             @address = address
             @service_id = service_id
             @options = {}

--- a/lib/mongo/monitoring/event/cmap/pool_closed.rb
+++ b/lib/mongo/monitoring/event/cmap/pool_closed.rb
@@ -42,6 +42,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address, pool)
+            super()
             @address = address
             @pool = pool
           end

--- a/lib/mongo/monitoring/event/cmap/pool_created.rb
+++ b/lib/mongo/monitoring/event/cmap/pool_created.rb
@@ -48,6 +48,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address, options, pool)
+            super()
             @address = address
             @options = options.dup.freeze
             @pool = pool

--- a/lib/mongo/monitoring/event/cmap/pool_ready.rb
+++ b/lib/mongo/monitoring/event/cmap/pool_ready.rb
@@ -41,6 +41,7 @@ module Mongo
           # @since 2.9.0
           # @api private
           def initialize(address, options, pool)
+            super()
             @address = address
             @options = options.dup.freeze
             @pool = pool

--- a/lib/mongo/monitoring/event/command_failed.rb
+++ b/lib/mongo/monitoring/event/command_failed.rb
@@ -83,6 +83,7 @@ module Mongo
         def initialize(command_name, database_name, address,
                        request_id, operation_id, message, failure, duration,
                        started_event:, server_connection_id: nil, service_id: nil)
+          super()
           @command_name = command_name.to_s
           @database_name = database_name
           @address = address

--- a/lib/mongo/monitoring/event/command_started.rb
+++ b/lib/mongo/monitoring/event/command_started.rb
@@ -84,6 +84,7 @@ module Mongo
                        operation_id, command, socket_object_id: nil, connection_id: nil,
                        connection_generation: nil, server_connection_id: nil,
                        service_id: nil)
+          super()
           @command_name = command_name.to_s
           @database_name = database_name
           @address = address

--- a/lib/mongo/monitoring/event/command_succeeded.rb
+++ b/lib/mongo/monitoring/event/command_succeeded.rb
@@ -76,6 +76,7 @@ module Mongo
         def initialize(command_name, database_name, address, request_id,
                        operation_id, reply, duration, started_event:,
                        server_connection_id: nil, service_id: nil)
+          super()
           @command_name = command_name.to_s
           @database_name = database_name
           @address = address

--- a/lib/mongo/monitoring/event/server_closed.rb
+++ b/lib/mongo/monitoring/event/server_closed.rb
@@ -37,6 +37,7 @@ module Mongo
         #
         # @since 2.4.0
         def initialize(address, topology)
+          super()
           @address = address
           @topology = topology
         end

--- a/lib/mongo/monitoring/event/server_description_changed.rb
+++ b/lib/mongo/monitoring/event/server_description_changed.rb
@@ -58,6 +58,7 @@ module Mongo
         # @api private
         def initialize(address, topology, previous_description, new_description,
                        awaited: false)
+          super()
           @address = address
           @topology = topology
           @previous_description = previous_description

--- a/lib/mongo/monitoring/event/server_heartbeat_failed.rb
+++ b/lib/mongo/monitoring/event/server_heartbeat_failed.rb
@@ -35,6 +35,7 @@ module Mongo
         # @since 2.7.0
         # @api private
         def initialize(address, round_trip_time, error, started_event:, awaited: false)
+          super()
           @address = address
           @round_trip_time = round_trip_time
           @error = error

--- a/lib/mongo/monitoring/event/server_heartbeat_started.rb
+++ b/lib/mongo/monitoring/event/server_heartbeat_started.rb
@@ -40,6 +40,7 @@ module Mongo
         # @since 2.7.0
         # @api private
         def initialize(address, awaited: false)
+          super()
           @address = address
           @awaited = !!awaited
         end

--- a/lib/mongo/monitoring/event/server_heartbeat_succeeded.rb
+++ b/lib/mongo/monitoring/event/server_heartbeat_succeeded.rb
@@ -35,6 +35,7 @@ module Mongo
         # @since 2.7.0
         # @api private
         def initialize(address, round_trip_time, started_event:, awaited: false)
+          super()
           @address = address
           @round_trip_time = round_trip_time
           @awaited = !!awaited

--- a/lib/mongo/monitoring/event/server_opening.rb
+++ b/lib/mongo/monitoring/event/server_opening.rb
@@ -37,6 +37,7 @@ module Mongo
         #
         # @since 2.4.0
         def initialize(address, topology)
+          super()
           @address = address
           @topology = topology
         end

--- a/lib/mongo/monitoring/event/topology_changed.rb
+++ b/lib/mongo/monitoring/event/topology_changed.rb
@@ -37,6 +37,7 @@ module Mongo
         #
         # @since 2.4.0
         def initialize(previous_topology, new_topology)
+          super()
           @previous_topology = previous_topology
           @new_topology = new_topology
         end

--- a/lib/mongo/monitoring/event/topology_closed.rb
+++ b/lib/mongo/monitoring/event/topology_closed.rb
@@ -33,6 +33,7 @@ module Mongo
         #
         # @since 2.4.0
         def initialize(topology)
+          super()
           @topology = topology
         end
 

--- a/lib/mongo/monitoring/event/topology_opening.rb
+++ b/lib/mongo/monitoring/event/topology_opening.rb
@@ -33,6 +33,7 @@ module Mongo
         #
         # @since 2.4.0
         def initialize(topology)
+          super()
           @topology = topology
         end
 

--- a/lib/mongo/operation/insert/bulk_result.rb
+++ b/lib/mongo/operation/insert/bulk_result.rb
@@ -47,9 +47,7 @@ module Mongo
         # @since 2.0.0
         # @api private
         def initialize(replies, connection_description, connection_global_id, ids)
-          @replies = [ *replies ] if replies
-          @connection_description = connection_description
-          @connection_global_id = connection_global_id
+          super(replies, connection_description, connection_global_id)
           if replies && replies.first && (doc = replies.first.documents.first)
             if (errors = doc['writeErrors'])
               # some documents were potentially inserted

--- a/lib/mongo/protocol/compressed.rb
+++ b/lib/mongo/protocol/compressed.rb
@@ -74,12 +74,15 @@ module Mongo
       #
       # @since 2.5.0
       def initialize(message, compressor, zlib_compression_level = nil)
+        super()
         @original_message = message
         @original_op_code = message.op_code
         @uncompressed_size = 0
         @compressor_id = COMPRESSOR_ID_MAP[compressor]
         @compressed_message = ''
         @zlib_compression_level = zlib_compression_level if zlib_compression_level && zlib_compression_level != -1
+        # A compressed message must reuse the wrapped message's request id,
+        # overriding the fresh id assigned by the superclass initializer.
         @request_id = message.request_id
       end
 

--- a/lib/mongo/server/connection.rb
+++ b/lib/mongo/server/connection.rb
@@ -88,6 +88,7 @@ module Mongo
       #
       # @since 2.0.0
       def initialize(server, options = {})
+        super()
         if server.load_balancer? && options[:generation]
           raise ArgumentError, 'Generation cannot be set when server is a load balancer'
         end

--- a/lib/mongo/server/monitor/connection.rb
+++ b/lib/mongo/server/monitor/connection.rb
@@ -54,6 +54,7 @@ module Mongo
         #
         # @since 2.0.0
         def initialize(address, options = {})
+          super()
           @address = address
           @options = options.dup.freeze
           raise ArgumentError, 'App metadata is required' unless (@app_metadata = options[:app_metadata])

--- a/lib/mongo/server/pending_connection.rb
+++ b/lib/mongo/server/pending_connection.rb
@@ -23,6 +23,7 @@ module Mongo
       extend Forwardable
 
       def initialize(socket, server, monitoring, options = {})
+        super()
         @socket = socket
         @options = options
         @server = server

--- a/spec/runners/change_streams/test.rb
+++ b/spec/runners/change_streams/test.rb
@@ -22,6 +22,7 @@ module Mongo
   module ChangeStreams
     class ChangeStreamsTest < Mongo::CRUD::CRUDTestBase
       def initialize(crud_spec, test, collection_name, collection2_name, database_name, database2_name)
+        super()
         @spec = crud_spec
         @description = test['description']
 

--- a/spec/runners/crud/test.rb
+++ b/spec/runners/crud/test.rb
@@ -25,6 +25,7 @@ module Mongo
       #
       # @since 2.0.0
       def initialize(crud_spec, data, test)
+        super()
         @spec = crud_spec
         @data = data
         @description = test['description']

--- a/spec/runners/transactions/test.rb
+++ b/spec/runners/transactions/test.rb
@@ -42,6 +42,7 @@ module Mongo
       #
       # @since 2.6.0
       def initialize(crud_spec, data, test, expectations_bson_types: true)
+        super()
         test = IceNine.deep_freeze(test)
         @spec = crud_spec
         @data = data || []


### PR DESCRIPTION
## Description

Removes the `Lint/MissingSuper` exclusion from `.rubocop_todo.yml` and brings the code into compliance. Every subclass `initialize` now calls `super`.

Most cases were mechanical: the class descends from a parent with no meaningful `initialize` (`Mongo::Event::Base`, `ConnectionCommon`, `CRUDTestBase` — all effectively `Object`), so `super()` was added at the top of the initializer.

Two cases warranted more thought and turned out not to need `rubocop:disable`:

- **`Operation::Insert::BulkResult`** — its custom `initialize` duplicated the parent's reply/connection assignment. Tracing every construction site shows `BulkResult` is only built from a `Result` subclass's `bulk_result` method, which passes an already-validated single-element `@replies` array. The "must support multi-reply arrays" premise was vestigial, so it now simply delegates to `super`.
- **`Protocol::Compressed`** — the parent `Message#initialize` assigns a fresh request id, but a compressed message must reuse the wrapped message's id. It now calls `super()` and overrides `@request_id` afterward (last write wins).

## Testing

- `rubocop --only Lint/MissingSuper`: clean across 1048 files, no `rubocop:disable` comments.
- Ran the affected specs against a local replica set: monitoring events, protocol/compressed, server connection/monitor, bulk write, CRUD spec-runner suite, and zlib compression — all green.
