### PR TITLE
RUBY-3914 Fix multiple excluded cops

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -918,10 +918,6 @@ Style/RedundantArgument:
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: infinite?, nonzero?
-Style/RedundantCondition:
-  Exclude:
-    - 'lib/mongo/session.rb'
-
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/RedundantEach:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,11 +18,6 @@ Lint/NextWithoutAccumulator:
   Exclude:
     - 'lib/mongo/operation/shared/result/aggregatable.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-# Configuration parameters: AllowedMethods, InferNonNilReceiver, AdditionalNilMethods.
-# AllowedMethods: instance_of?, kind_of?, is_a?, eql?, respond_to?, equal?
-# AdditionalNilMethods: present?, blank?, try, try!
 # Offense count: 12
 Lint/RescueException:
   Exclude:
@@ -748,7 +743,6 @@ Style/GlobalVars:
     - 'spec/runners/unified/test.rb'
     - 'spec/support/sdam_formatter_integration.rb'
 
-# Offense count: 1
 # Offense count: 10
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowSplatArgument.
@@ -914,10 +908,6 @@ Style/RedundantArgument:
     - 'lib/mongo/auth/scram_conversation_base.rb'
     - 'lib/mongo/auth/stringprep/unicode_normalize/normalize.rb'
 
-# Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: infinite?, nonzero?
 # Offense count: 2
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/RedundantEach:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -804,12 +804,6 @@ Style/IfWithBooleanLiteralBranches:
     - 'lib/mongo/cluster_time.rb'
     - 'lib/mongo/error/sdam_error_detection.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/InfiniteLoop:
-  Exclude:
-    - 'lib/mongo/crypt/context.rb'
-
 # Offense count: 10
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: InverseMethods, InverseBlocks.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -834,11 +834,6 @@ Style/MapToHash:
     - 'spec/runners/transactions/test.rb'
     - 'spec/runners/unified/test.rb'
 
-# Offense count: 1
-Style/MixinUsage:
-  Exclude:
-    - 'bin/mongo_console'
-
 # Offense count: 12
 Style/MultilineBlockChain:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -815,11 +815,6 @@ Style/InverseMethods:
     - 'spec/spec_tests/sdam_spec.rb'
     - 'spec/support/spec_config.rb'
 
-# Offense count: 1
-Style/ItAssignment:
-  Exclude:
-    - 'spec/integration/cursor_pinning_spec.rb'
-
 # Offense count: 153
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/LineEndConcatenation:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -749,12 +749,6 @@ Style/GlobalVars:
     - 'spec/support/sdam_formatter_integration.rb'
 
 # Offense count: 1
-# This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: MinBodyLength, AllowConsecutiveConditionals.
-Style/GuardClause:
-  Exclude:
-    - 'lib/mongo/srv/result.rb'
-
 # Offense count: 10
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowSplatArgument.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -827,12 +827,6 @@ Style/MapIntoArray:
     - 'spec/integration/query_cache_spec.rb'
     - 'spec/mongo/session/session_pool_spec.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/MapJoin:
-  Exclude:
-    - 'spec/runners/crud/requirement.rb'
-
 # Offense count: 3
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/MapToHash:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -877,11 +877,6 @@ Style/OneClassPerFile:
     - 'spec/support/background_thread_registry.rb'
     - 'spec/support/client_registry.rb'
 
-# Offense count: 1
-Style/OpenStructUse:
-  Exclude:
-    - 'spec/support/background_thread_registry.rb'
-
 # Offense count: 3
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/PredicateWithKind:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -906,12 +906,6 @@ Style/PreferredHashMethods:
 Style/RaiseArgs:
   Enabled: false
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/ReduceToHash:
-  Exclude:
-    - 'spec/mongo/monitoring/command_log_subscriber_spec.rb'
-
 # Offense count: 3
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: Methods.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -648,12 +648,6 @@ Style/ClassVars:
   Exclude:
     - 'lib/mongo/id.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/CommentedKeyword:
-  Exclude:
-    - 'lib/mongo/auth/stringprep/unicode_normalize/normalize.rb'
-
 # Offense count: 16
 # Configuration parameters: AllowedConstants.
 Style/Documentation:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -19,11 +19,6 @@ Lint/NextWithoutAccumulator:
     - 'lib/mongo/operation/shared/result/aggregatable.rb'
 
 # Offense count: 1
-Lint/NonLocalExitFromIterator:
-  Exclude:
-    - 'lib/mongo/uri/options_mapper.rb'
-
-# Offense count: 1
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: AllowedMethods, InferNonNilReceiver, AdditionalNilMethods.
 # AllowedMethods: instance_of?, kind_of?, is_a?, eql?, respond_to?, equal?

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,10 +23,6 @@ Lint/NextWithoutAccumulator:
 # Configuration parameters: AllowedMethods, InferNonNilReceiver, AdditionalNilMethods.
 # AllowedMethods: instance_of?, kind_of?, is_a?, eql?, respond_to?, equal?
 # AdditionalNilMethods: present?, blank?, try, try!
-Lint/RedundantSafeNavigation:
-  Exclude:
-    - 'lib/mongo/uri/options_mapper.rb'
-
 # Offense count: 12
 Lint/RescueException:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,11 +13,6 @@ Lint/IncompatibleIoSelectWithFiberScheduler:
     - 'lib/mongo/socket/ssl.rb'
     - 'lib/mongo/socket/tcp.rb'
 
-# Offense count: 1
-Lint/MixedRegexpCaptureTypes:
-  Exclude:
-    - 'lib/mongo/crypt/binding.rb'
-
 # Offense count: 2
 Lint/NextWithoutAccumulator:
   Exclude:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -967,12 +967,6 @@ Style/SelectByKind:
     - 'spec/integration/step_down_spec.rb'
     - 'spec/mongo/server/connection_pool_spec.rb'
 
-# Offense count: 1
-# This cop supports unsafe autocorrection (--autocorrect-all).
-Style/SelectByRegexp:
-  Exclude:
-    - 'spec/spec_tests/transactions_unified_spec.rb'
-
 # Offense count: 13
 # This cop supports unsafe autocorrection (--autocorrect-all).
 Style/SlicingWithRange:

--- a/bin/mongo_console
+++ b/bin/mongo_console
@@ -4,8 +4,8 @@
 $LOAD_PATH[0, 0] = File.join(File.dirname(__FILE__), '..', 'lib')
 
 require 'mongo'
-# include the mongo namespace
-include Mongo
+# include the mongo namespace so its constants are available unqualified
+Object.include(Mongo)
 
 begin
   require 'pry'

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -106,7 +106,7 @@ module Mongo
       def self.parse_version(version)
         Gem::Version.new(version)
       rescue ArgumentError
-        match = version.match(/\A(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)?(-[A-Za-z+\d]+)?\z/)
+        match = version.match(/\A(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)?(?:-[A-Za-z+\d]+)?\z/)
         raise ArgumentError.new("Malformed version number string #{version}") if match.nil?
 
         Gem::Version.new(

--- a/lib/mongo/crypt/context.rb
+++ b/lib/mongo/crypt/context.rb
@@ -76,7 +76,7 @@ module Mongo
       # This method is not currently unit tested. It is integration tested
       # in spec/integration/explicit_encryption_spec.rb
       def run_state_machine(timeout_holder)
-        while true
+        loop do
           timeout_ms = timeout_holder.remaining_timeout_ms!
           case state
           when :error

--- a/lib/mongo/session.rb
+++ b/lib/mongo/session.rb
@@ -459,13 +459,9 @@ module Mongo
       @inside_with_transaction = true
       @with_transaction_timeout_ms = options&.dig(:timeout_ms) || @options[:default_timeout_ms] || @client.timeout_ms
       @with_transaction_deadline = calculate_with_transaction_deadline(options)
-      deadline = if @with_transaction_deadline
-                   # CSOT enabled, so we have a customer defined deadline.
-                   @with_transaction_deadline
-                 else
-                   # CSOT not enabled, so we use the default deadline, 120 seconds.
-                   Utils.monotonic_time + 120
-                 end
+      # When CSOT is enabled we have a customer defined deadline; otherwise
+      # fall back to the default deadline, 120 seconds.
+      deadline = @with_transaction_deadline || (Utils.monotonic_time + 120)
       transaction_in_progress = false
       transaction_attempt = 0
       last_error = nil

--- a/lib/mongo/srv/result.rb
+++ b/lib/mongo/srv/result.rb
@@ -123,9 +123,11 @@ module Mongo
           raise Error::MismatchedDomain.new(format(MISMATCHED_DOMAINNAME, record_host, srv_host_domain))
         end
 
-        unless (record_host_parts.size > srv_host_domain.size) && (srv_host_domain == record_host_parts[-srv_host_domain.size..-1])
-          raise Error::MismatchedDomain.new(format(MISMATCHED_DOMAINNAME, record_host, srv_host_domain))
-        end
+        record_matches_domain = (record_host_parts.size > srv_host_domain.size) &&
+                                (srv_host_domain == record_host_parts[-srv_host_domain.size..-1])
+        return if record_matches_domain
+
+        raise Error::MismatchedDomain.new(format(MISMATCHED_DOMAINNAME, record_host, srv_host_domain))
       end
     end
   end

--- a/lib/mongo/uri/options_mapper.rb
+++ b/lib/mongo/uri/options_mapper.rb
@@ -391,7 +391,7 @@ module Mongo
       # @return [ Array<true | false> | nil ] The string.
       def stringify_repeated_bool(value)
         rep = revert_repeated_bool(value)
-        if rep&.is_a?(Array)
+        if rep.is_a?(Array)
           rep.join(',')
         else
           rep

--- a/lib/mongo/uri/options_mapper.rb
+++ b/lib/mongo/uri/options_mapper.rb
@@ -87,7 +87,7 @@ module Mongo
           strategy = URI_OPTION_MAP[key.downcase]
           if strategy.nil?
             log_warn("Unsupported URI option '#{key}' on URI '#{@string}'. It will be ignored.")
-            return
+            next
           end
 
           group = strategy[:group]

--- a/spec/integration/cursor_pinning_spec.rb
+++ b/spec/integration/cursor_pinning_spec.rb
@@ -72,7 +72,7 @@ describe 'Cursor pinning' do
         enum = view.to_enum
         expect_any_instance_of(Mongo::Cursor).to receive(:check_in_connection)
         # Drain the cursor
-        enum.each { |it| it.nil? }
+        enum.each { |doc| doc.nil? }
       end
     end
 

--- a/spec/mongo/monitoring/command_log_subscriber_spec.rb
+++ b/spec/mongo/monitoring/command_log_subscriber_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 describe Mongo::Monitoring::CommandLogSubscriber do
   describe '#started' do
     let(:filter) do
-      (1...100).each_with_object({}) do |i, hash|
-        hash[i] = i
+      (1...100).to_h do |i|
+        [ i, i ]
       end
     end
 

--- a/spec/runners/crud/requirement.rb
+++ b/spec/runners/crud/requirement.rb
@@ -126,7 +126,7 @@ module Mongo
       def description
         versions = [ min_server_version, max_server_version ].compact
         versions = (versions.join('-') if versions.any?)
-        topologies = (self.topologies.map(&:to_s).join(',') if self.topologies)
+        topologies = (self.topologies.join(',') if self.topologies)
         [ versions, topologies ].compact.join('/')
       end
     end

--- a/spec/spec_tests/transactions_unified_spec.rb
+++ b/spec/spec_tests/transactions_unified_spec.rb
@@ -6,7 +6,7 @@ require 'runners/unified'
 
 base = "#{CURRENT_PATH}/spec_tests/data/transactions_unified"
 # See https://jira.mongodb.org/browse/RUBY-3502 for more details
-TRANSACTIONS_UNIFIED_TESTS = Dir.glob("#{base}/**/*.yml").sort.reject { |name| name =~ /.*mongos-unpin.yml$/ }
+TRANSACTIONS_UNIFIED_TESTS = Dir.glob("#{base}/**/*.yml").sort.grep_v(/mongos-unpin\.yml$/)
 
 describe 'Transactions unified spec tests' do
   define_unified_spec_tests(base, TRANSACTIONS_UNIFIED_TESTS)

--- a/spec/support/background_thread_registry.rb
+++ b/spec/support/background_thread_registry.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'singleton'
-require 'ostruct'
 
 module Mongo
   module BackgroundThread
@@ -18,6 +17,8 @@ end
 class BackgroundThreadRegistry
   include Singleton
 
+  Record = Struct.new(:thread, :object, :example, keyword_init: true)
+
   def initialize
     @lock = Mutex.new
     @records = []
@@ -25,7 +26,7 @@ class BackgroundThreadRegistry
 
   def register(object, thread)
     @lock.synchronize do
-      @records << OpenStruct.new(
+      @records << Record.new(
         thread: thread,
         object: object,
         # When rake spec:prepare is run, the current_example method is not defined


### PR DESCRIPTION
Each of the following cops were being excluded by our rubocop todo file. Each had only a single recorded violation, so this PR tackles them all in one batch.

- Lint/MixedRegexpCaptureTypes
- Lint/NonLocalExitFromIterator
- Lint/RedundantSafeNavigation
- Style/CommentedKeyword
- Style/GuardClause
- Style/InfiniteLoop
- Style/ItAssignment
- Style/MapJoin
- Style/MixinUsage
- Style/OpenStructUse
- Style/ReduceToHash
- Style/RedundantCondition
- Style/SelectByRegexp