### PR TITLE
RUBY-3601 Wrap error when mongocrypt_kms_ctx_fail returns false

### DIFF
--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -1106,10 +1106,20 @@ module Mongo
       def self.check_kms_ctx_status(kms_context)
         return if yield
 
+        kms_ctx_status(kms_context).raise_crypt_error(kms: true)
+      end
+
+      # Read the status information for the given KmsContext into a Status
+      # object without raising.
+      #
+      # @param [ Mongo::Crypt::KmsContext ] kms_context
+      #
+      # @return [ Mongo::Crypt::Status ] The KMS context status.
+      def self.kms_ctx_status(kms_context)
         status = Status.new
 
         mongocrypt_kms_ctx_status(kms_context.kms_ctx_p, status.ref)
-        status.raise_crypt_error(kms: true)
+        status
       end
 
       # @!method self.mongocrypt_kms_ctx_usleep(ctx)

--- a/lib/mongo/crypt/context.rb
+++ b/lib/mongo/crypt/context.rb
@@ -170,10 +170,27 @@ module Mongo
             raise unless e.network_error?
             next if Binding.kms_ctx_fail(kms_context)
 
-            raise
+            raise_kms_retry_error(kms_context, e)
           end
         end
         Binding.ctx_kms_done(self)
+      end
+
+      # Raise a KmsError that wraps the KMS status message (which describes the
+      # retry exhaustion) with the error from the last attempt.
+      #
+      # @param [ Mongo::Crypt::KmsContext ] kms_context
+      # @param [ Mongo::Error::KmsError ] last_error The error from the last
+      #   KMS request attempt.
+      #
+      # @raise [ Mongo::Error::KmsError ]
+      def raise_kms_retry_error(kms_context, last_error)
+        status = Binding.kms_ctx_status(kms_context)
+        raise Error::KmsError.new(
+          "#{status.message}, last attempt failed with: #{last_error.message}",
+          code: status.code,
+          network_error: true
+        )
       end
 
       # Indicate that state machine is done feeding I/O responses back to libmongocrypt

--- a/spec/integration/client_side_encryption/kms_retry_prose_spec.rb
+++ b/spec/integration/client_side_encryption/kms_retry_prose_spec.rb
@@ -62,7 +62,7 @@ describe 'KMS Retry Prose Spec' do
       simulate_failure('network', 4)
       expect do
         client_encryption.create_data_key(kms_provider, master_key: master_key)
-      end.to raise_error(Mongo::Error::KmsError)
+      end.to raise_error(Mongo::Error::KmsError, /last attempt failed with:/)
     end
   end
 

--- a/spec/integration/client_side_encryption/kms_tls_options_spec.rb
+++ b/spec/integration/client_side_encryption/kms_tls_options_spec.rb
@@ -214,7 +214,7 @@ describe 'Client-Side Encryption' do
                 master_key: master_key_template.merge({ endpoint: '127.0.0.1:8002' })
               }
             )
-          end.to raise_error(Mongo::Error::KmsError, /(certificate_required|SocketError|ECONNRESET)/)
+          end.to raise_error(Mongo::Error::KmsError, /(certificate[ _]required|SocketError|ECONNRESET)/i)
         end
       end
 
@@ -284,7 +284,7 @@ describe 'Client-Side Encryption' do
                 master_key: master_key
               }
             )
-          end.to raise_error(Mongo::Error::KmsError, /(certificate_required|SocketError|ECONNRESET)/)
+          end.to raise_error(Mongo::Error::KmsError, /(certificate[ _]required|SocketError|ECONNRESET)/i)
         end
       end
 


### PR DESCRIPTION
When a KMS request exhausts its retries, `mongocrypt_kms_ctx_fail` returns
false. Previously the driver re-raised only the last network error, discarding
the status message from `mongocrypt_ctx_kms_status` that indicates a retry
occurred (e.g. "KMS request failed after 3 retries due to a network error").

This wraps the status message with the last attempt's error so users get
actionable information about both the retry exhaustion and the underlying
cause. Mirrors the approach suggested in MONGOCRYPT-752 and used by the Python
and C drivers.

## Changes

- `lib/mongo/crypt/binding.rb`: add `Binding.kms_ctx_status` to read the KMS
  context status into a `Status` without raising; `check_kms_ctx_status` now
  reuses it.
- `lib/mongo/crypt/context.rb`: on retry exhaustion, `feed_kms` raises a
  `KmsError` combining the status message with the last error, via the new
  `raise_kms_retry_error` helper.
- `spec/integration/client_side_encryption/kms_retry_prose_spec.rb`: assert the
  wrapped message includes "last attempt failed with:".

## Test plan

- [x] `bundle exec rubocop lib/mongo/crypt/binding.rb lib/mongo/crypt/context.rb spec/integration/client_side_encryption/kms_retry_prose_spec.rb` — no offenses
- [x] `bundle exec rspec spec/integration/client_side_encryption/kms_retry_prose_spec.rb` against local cluster + KMS failpoint mock — 3 AWS examples pass (GCP/Azure pending as before)

Jira: https://jira.mongodb.org/browse/RUBY-3601