### PR TITLE
RUBY-3351 Don't append read/write concerns to search index helpers

### DIFF
--- a/lib/mongo/collection/view/builder/aggregation.rb
+++ b/lib/mongo/collection/view/builder/aggregation.rb
@@ -105,7 +105,7 @@ module Mongo
               raise ArgumentError, "Unknown view class: #{view}"
             end
             command[:pipeline] = pipeline
-            if (read_concern = view.read_concern)
+            if (read_concern = view.read_concern) && !read_concern.empty?
               command[:readConcern] = Options::Mapper.transform_values_to_strings(
                 read_concern
               )

--- a/spec/spec_tests/data/index_management/searchIndexIgnoresReadWriteConcern.yml
+++ b/spec/spec_tests/data/index_management/searchIndexIgnoresReadWriteConcern.yml
@@ -97,28 +97,27 @@ tests:
                 writeConcern: { $$exists: false }
                 readConcern: { $$exists: false }
 
-  # https://jira.mongodb.org/browse/RUBY-3351
-  #- description: "listSearchIndexes ignores read and write concern"
-  #  operations:
-  #    - name: listSearchIndexes
-  #      object: *collection0
-  #      expectError:
-  #        # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
-  #        # that the driver constructs and sends the correct command.
-  #        # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
-  #        isError: true
-  #        errorContains: Atlas
-  #  expectEvents:
-  #    - client: *client0
-  #      events:
-  #        - commandStartedEvent:
-  #            command:
-  #              aggregate: *collection0
-  #              pipeline:
-  #                - $listSearchIndexes: {}
-  #              # Expect no writeConcern or readConcern to be sent.
-  #              writeConcern: { $$exists: false }
-  #              readConcern: { $$exists: false }
+  - description: "listSearchIndexes ignores read and write concern"
+    operations:
+      - name: listSearchIndexes
+        object: *collection0
+        expectError:
+          # This test always errors in a non-Atlas environment.  The test functions as a unit test  by asserting
+          # that the driver constructs and sends the correct command.
+          # The expected error message was changed in SERVER-83003. Check for the substring "Atlas" shared by both error messages.
+          isError: true
+          errorContains: Atlas
+    expectEvents:
+      - client: *client0
+        events:
+          - commandStartedEvent:
+              command:
+                aggregate: *collection0
+                pipeline:
+                  - $listSearchIndexes: {}
+                # Expect no writeConcern or readConcern to be sent.
+                writeConcern: { $$exists: false }
+                readConcern: { $$exists: false }
 
   - description: "updateSearchIndex ignores the read and write concern"
     operations:


### PR DESCRIPTION
Fix empty read concern being appended to the "list indexes" helper; besides that, the driver is already compliant with RUBY-3351.