### PR TITLE
RUBY-3829 Update libmongocrypt download references

### DIFF
--- a/.evergreen/run-tests.sh
+++ b/.evergreen/run-tests.sh
@@ -224,31 +224,19 @@ if test -n "$FLE"; then
   if [[ "$FLE" == "helper" || "$FLE" == "mongocryptd" ]]; then
     echo "Using helper gem"
   elif test "$FLE" = path; then
-    if false; then
-      # We would ideally like to use the actual libmongocrypt binary here,
-      # however there isn't a straightforward way to obtain a binary that
-      # 1) is of a release version and 2) doesn't contain crypto.
-      # These could be theoretically spelunked out of libmongocrypt's
-      # evergreen tasks.
-      curl --retry 3 -fLo libmongocrypt-all.tar.gz "https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz"
-      tar xf libmongocrypt-all.tar.gz
+    # Install the helper gem to obtain the libmongocrypt binary.
+    gem install libmongocrypt-helper --pre
 
-      export LIBMONGOCRYPT_PATH=`pwd`/rhel-70-64-bit/nocrypto/lib64/libmongocrypt.so
-    else
-      # So, install the helper for the binary.
-      gem install libmongocrypt-helper --pre
-
-      # https://stackoverflow.com/questions/19072070/how-to-find-where-gem-files-are-installed
-      path=$(find `gem env |grep INSTALLATION |awk -F: '{print $2}'` -name libmongocrypt.so |head -1 || true)
-      if test -z "$path"; then
-        echo Failed to find libmongocrypt.so in installed gems 1>&2
-        exit 1
-      fi
-      cp $path .
-      export LIBMONGOCRYPT_PATH=`pwd`/libmongocrypt.so
-
-      gem uni libmongocrypt-helper
+    # https://stackoverflow.com/questions/19072070/how-to-find-where-gem-files-are-installed
+    path=$(find `gem env |grep INSTALLATION |awk -F: '{print $2}'` -name libmongocrypt.so |head -1 || true)
+    if test -z "$path"; then
+      echo Failed to find libmongocrypt.so in installed gems 1>&2
+      exit 1
     fi
+    cp $path .
+    export LIBMONGOCRYPT_PATH=`pwd`/libmongocrypt.so
+
+    gem uni libmongocrypt-helper
     test -f "$LIBMONGOCRYPT_PATH"
     ldd "$LIBMONGOCRYPT_PATH"
   else

--- a/spec/README.md
+++ b/spec/README.md
@@ -414,15 +414,13 @@ Install and Configure mongocryptd: https://www.mongodb.com/docs/manual/core/quer
 Install libmongocrypt on your machine:
 
 Option 1: Download a pre-built binary
-- Download a tarball of all libmongocrypt variations from this link:
-    https://s3.amazonaws.com/mciuploads/libmongocrypt/all/master/latest/libmongocrypt-all.tar.gz
-- Unzip the file you downloaded. You will see a list of folders, each
-    corresponding to an operating system. Find the folder that matches
-    your operating system and open it.
-- Inside that folder, open the folder called "nocrypto." In either the
-    lib or lb64 folder, you will find the libmongocrypt.so or
-    libmongocrypt.dylib or libmongocrypt.dll file, depending on your OS.
-- Move that file to wherever you want to keep it on your machine.
+- Follow the install steps in the MongoDB documentation:
+    https://www.mongodb.com/docs/manual/core/csfle/reference/libmongocrypt
+- Alternatively, download a pre-built binary tarball from the libmongocrypt
+    GitHub releases page: https://github.com/mongodb/libmongocrypt/releases/latest
+- Extract the tarball. Find the libmongocrypt.so, libmongocrypt.dylib, or
+    libmongocrypt.dll file (depending on your OS) and move it to wherever you
+    want to keep it on your machine.
 
 Option 2: Build from source
 - To build libmongocrypt from source, follow the instructions in the README on the libmongocrypt GitHub repo: https://github.com/mongodb/libmongocrypt


### PR DESCRIPTION
## Description

Updates the Ruby driver's references to the libmongocrypt download URL per RUBY-3829 (split from DRIVERS-3441). MONGOCRYPT-841 moved libmongocrypt binaries off the old `s3.amazonaws.com/mciuploads/...libmongocrypt-all.tar.gz` location.

The driver itself does not download libmongocrypt binaries; it depends on the `libmongocrypt-helper` gem. The only occurrences of the old URL in this repo were:

- `.evergreen/run-tests.sh` — a dead download block guarded by `if false`. Removed it, leaving the live helper-gem path intact.
- `spec/README.md` — documentation. Now points to the MongoDB install docs and the libmongocrypt GitHub releases page instead of the direct S3 link.

## Out of scope

- `spec/shared/share/Dockerfile.erb` still references the old URL, but `spec/shared` is a git submodule shared across the Ruby driver projects and needs a separate PR in that repo.
- The actual binary-packaging update lives in the `libmongocrypt-helper` gem repo.
