### PR TITLE
RUBY-3482 Disallow comma in authMechanismProperties connection string value

### DIFF
--- a/lib/mongo/client.rb
+++ b/lib/mongo/client.rb
@@ -242,7 +242,11 @@ module Mongo
     #   printed to the mongod logs upon establishing a connection
     # @option options [ Symbol ] :auth_mech The authentication mechanism to
     #   use. One of :mongodb_cr, :mongodb_x509, :plain, :scram, :scram256
-    # @option options [ Hash ] :auth_mech_properties
+    # @option options [ Hash ] :auth_mech_properties When passed in a
+    #   connection string as authMechanismProperties, key-value pairs are
+    #   delimited by commas, so a value containing a comma (",") must not be
+    #   provided as part of the connection string. Such a value must be passed
+    #   through this option instead. Values may contain colons (":").
     # @option options [ String ] :auth_source The source to authenticate from.
     # @option options [ true | false | nil | Integer ] :bg_error_backtrace
     #   Experimental. Set to true to log complete backtraces for errors in

--- a/lib/mongo/uri/options_mapper.rb
+++ b/lib/mongo/uri/options_mapper.rb
@@ -614,7 +614,7 @@ module Mongo
       #
       # @return [ Hash | nil ] The auth mechanism properties hash.
       def convert_auth_mech_props(_name, value)
-        properties = hash_extractor('authMechanismProperties', value)
+        properties = hash_extractor('authMechanismProperties', value, invalidate_on_error: true)
         if properties
           properties.each do |k, v|
             properties[k] = (v.downcase == 'true') if k.to_s.downcase == 'canonicalize_host_name' && v
@@ -863,16 +863,27 @@ module Mongo
 
       # Extract values from the string and put them into a nested hash.
       #
+      # Multiple key-value pairs are delimited by a comma. Within each pair,
+      # the key is everything up to the first colon and the value is everything
+      # after it, so values may themselves contain colons (for example
+      # TOKEN_RESOURCE:mongodb://host).
+      #
       # @param [ String ] name Name of the URI option being processed.
       # @param [ String ] value The string to build a hash from.
+      # @param [ true | false ] invalidate_on_error When a pair is malformed
+      #   (has no value), discard the whole option and return nil instead of
+      #   skipping just that pair. Used for options such as
+      #   authMechanismProperties whose values must not contain commas.
       #
-      # @return [ Hash ] The hash built from the string.
-      def hash_extractor(name, value)
+      # @return [ Hash | nil ] The hash built from the string, or nil.
+      def hash_extractor(name, value, invalidate_on_error: false)
         h = {}
         value.split(',').each do |tag|
-          k, v = tag.split(':')
+          k, v = tag.split(':', 2)
           if v.nil?
             log_warn("Invalid hash value for #{name}: key `#{k}` does not have a value: #{value}")
+            return nil if invalidate_on_error
+
             next
           end
 

--- a/spec/mongo/uri/options_mapper_spec.rb
+++ b/spec/mongo/uri/options_mapper_spec.rb
@@ -817,15 +817,23 @@ describe Mongo::URI::OptionsMapper do
       end
     end
 
+    context 'when a value contains a colon' do
+      let(:value) { 'TOKEN_RESOURCE:mongodb://test-cluster,ENVIRONMENT:azure' }
+
+      it 'keeps the whole value after the first colon' do
+        expect(converted).to eq(TOKEN_RESOURCE: 'mongodb://test-cluster', ENVIRONMENT: 'azure')
+      end
+    end
+
     context 'when including items without a colon' do
       let(:value) { 'k1:v1,k2,v2' }
 
-      it 'drops those items' do
-        expect(converted).to eq(k1: 'v1')
+      it 'discards the whole option' do
+        expect(converted).to be_nil
       end
 
       it 'warns' do
-        expect(options_mapper).to receive(:log_warn).twice
+        expect(options_mapper).to receive(:log_warn).once
         converted
       end
     end

--- a/spec/spec_tests/data/connection_string/valid-options.yml
+++ b/spec/spec_tests/data/connection_string/valid-options.yml
@@ -28,3 +28,18 @@ tests:
         auth: ~
         options:
               tls: true
+    -
+        description: Colon in a key value pair
+        uri: mongodb://example.com/?authMechanismProperties=TOKEN_RESOURCE:mongodb://test-cluster,ENVIRONMENT:azure
+        valid: true
+        warning: false
+        hosts:
+            -
+                type: hostname
+                host: example.com
+                port: ~
+        auth: ~
+        options:
+            authmechanismproperties:
+                token_resource: 'mongodb://test-cluster'
+                environment: azure

--- a/spec/spec_tests/data/connection_string/valid-warnings.yml
+++ b/spec/spec_tests/data/connection_string/valid-warnings.yml
@@ -73,3 +73,15 @@ tests:
                 port: ~
         auth: ~
         options: ~
+    -
+        description: Comma in a key value pair causes a warning
+        uri: mongodb://localhost/?authMechanismProperties=TOKEN_RESOURCE:mongodb://host1%2Chost2,ENVIRONMENT:azure
+        valid: true
+        warning: true
+        hosts:
+            -
+                type: "hostname"
+                host: "localhost"
+                port: ~
+        auth: ~
+        options: ~


### PR DESCRIPTION
Handles colons in connection-string key-value option values and disallows commas in authMechanismProperties values, per [DRIVERS-2915](https://jira.mongodb.org/browse/RUBY-3482) / connection-string spec.

## Changes

Source:
- `lib/mongo/uri/options_mapper.rb` — `hash_extractor` splits each pair on the first colon only (`split(':', 2)`), so a value may contain colons (e.g. `TOKEN_RESOURCE:mongodb://host`). New `invalidate_on_error:` kwarg: for `authMechanismProperties`, a comma-broken pair (a value that contained a comma) discards the whole option and logs a warning instead of keeping a partial hash. `readPreferenceTags` keeps its prior per-pair skip behavior.
- `lib/mongo/client.rb` — document that a value containing a comma must be passed via the `:auth_mech_properties` option, not the connection string.

Tests:
- `spec/spec_tests/data/connection_string/valid-options.yml` — colon-in-value case.
- `spec/spec_tests/data/connection_string/valid-warnings.yml` — comma-causes-warning case.
- `spec/mongo/uri/options_mapper_spec.rb` — updated to the new discard-whole-option behavior; added colon-in-value case.

Fixtures are adapted for Ruby: the driver has no MONGODB-OIDC mechanism, and `client.rb` downcases auth mechanism property keys, so the OIDC mechanism is dropped and expected keys are lowercased.

## Test plan

- [x] `bundle exec rspec spec/spec_tests/connection_string_spec.rb spec/spec_tests/uri_options_spec.rb spec/mongo/uri/options_mapper_spec.rb` — 758 examples, 0 failures
- [x] `bundle exec rubocop` on all touched files — no offenses
- [x] Spec-compliance review (connection-string spec, key value pairs section)

Jira: https://jira.mongodb.org/browse/RUBY-3482