### PR TITLE
Release candidate for 2.25.0

### DIFF
--- a/lib/mongo/version.rb
+++ b/lib/mongo/version.rb
@@ -5,5 +5,5 @@ module Mongo
   #
   # Note that this file is automatically updated via `rake candidate:create`.
   # Manual changes to this file will be overwritten by that rake task.
-  VERSION = '2.24.1'
+  VERSION = '2.25.0'
 end

--- a/product.yml
+++ b/product.yml
@@ -5,5 +5,5 @@ description: a pure-Ruby driver for connecting to, querying, and manipulating Mo
 package: mongo
 jira: https://jira.mongodb.org/projects/RUBY
 version:
-  number: 2.24.1
+  number: 2.25.0
   file: lib/mongo/version.rb


### PR DESCRIPTION
The MongoDB Ruby team is pleased to announce version 2.25.0 of the `mongo` gem - a pure-Ruby driver for connecting to, querying, and manipulating MongoDB databases. This is a new minor release in the 2.x series of the MongoDB Ruby Driver.

Install this release using [RubyGems](https://rubygems.org/) via the command line as follows: 

~~~
gem install -v 2.25.0 mongo
~~~

Or simply add it to your `Gemfile`:

~~~
gem 'mongo', '2.25.0'
~~~

Have any feedback? Click on through to MongoDB's JIRA and [open a new ticket](https://jira.mongodb.org/projects/RUBY) to let us know what's on your mind 🧠.

# New Features

### Support $lookup in CSFLE/QE ([RUBY-3611](https://jira.mongodb.org/browse/RUBY-3611) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3054))

You can now use `$lookup` in aggregation pipelines that reference CSFLE- and QE-enabled collections.

### Allow keyAltName in encrypted fields map ([RUBY-3773](https://jira.mongodb.org/browse/RUBY-3773) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3056))

When defining the encrypted fields for a collection (for use with Queryable Encryption), you may now specify the key via the `keyAltName` field, instead of by directly referencing a `keyId`.

### Deprecate legacy retry tuning options ([RUBY-3703](https://jira.mongodb.org/browse/RUBY-3703) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3057))

The following options are deprecated when set on a `Mongo::Client`:

- `:max_read_retries`
- `:read_retry_interval`
- `:max_write_retries`

These relate only to the _legacy_ retry feature, which is itself deprecated and slated for removal. Modern
retryable reads and writes are enabled by default and ignore these options.

### Deprecate server version 4.2 ([RUBY-3811](https://jira.mongodb.org/browse/RUBY-3811) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3060))

MongoDB server version 4.2 is EOL, and support for it will be **removed from the driver** in a future driver release. If you are using MongoDB server version 4.2, please upgrade to a newer version soon.


### Other New Features

* Add Database#cursor_command to create a cursor from a command response ([RUBY-3213](https://jira.mongodb.org/browse/RUBY-3213) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3055))
* Support delegated protocol for CSFLE/QE KMIP ([RUBY-3383](https://jira.mongodb.org/browse/RUBY-3383) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3058))
* Support named KMS providers (type:name format) ([RUBY-3363](https://jira.mongodb.org/browse/RUBY-3363) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3062))
* Raise on invalid tls/ssl boolean URI option ([RUBY-3832](https://jira.mongodb.org/browse/RUBY-3832) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3064))
* Wrap error when mongocrypt_kms_ctx_fail returns false ([RUBY-3601](https://jira.mongodb.org/browse/RUBY-3601) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3082))

# Bug Fixes

* redact credentials in URI rendering and InvalidURI errors ([RUBY-3835](https://jira.mongodb.org/browse/RUBY-3835) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3039))
* Fix raise_on_invalid handling and protect SRV monitor thread ([RUBY-3838](https://jira.mongodb.org/browse/RUBY-3838) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3040))
* Don't leak connections in load-balanced topology ([PR](https://github.com/mongodb/mongo-ruby-driver/pull/3041))
* Fix secondaryPreferred non-compliance with server selection spec ([RUBY-3768](https://jira.mongodb.org/browse/RUBY-3768) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3050))
* Keep MemoryPointer alive in Binary.wrap_string ([RUBY-3840](https://jira.mongodb.org/browse/RUBY-3840) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3063))
* Stop publishing SDAM events from the Monitor's RTT checks ([RUBY-3822](https://jira.mongodb.org/browse/RUBY-3822) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3069))
* Send afterClusterTime on writes in causally-consistent sessions ([RUBY-3820](https://jira.mongodb.org/browse/RUBY-3820) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3075))
* Close monitoring connection when server marked Unknown from network error ([RUBY-3909](https://jira.mongodb.org/browse/RUBY-3909) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3076))
* Don't append read/write concerns to search index helpers ([RUBY-3351](https://jira.mongodb.org/browse/RUBY-3351) | [PR](https://github.com/mongodb/mongo-ruby-driver/pull/3083))
