### PR TITLE
RUBY-3785 Add SDAM tests for constant setVersion (disaggregated storage)

### DIFF
--- a/spec/spec_tests/data/sdam/rs/disaggregated_storage_setversion.yml
+++ b/spec/spec_tests/data/sdam/rs/disaggregated_storage_setversion.yml
@@ -1,0 +1,118 @@
+# Disaggregated storage clusters use a constant setVersion (typically 1) instead of
+# incrementing it on each reconfig. This test validates that primary staleness detection
+# works correctly using electionId when setVersion doesn't change.
+description: Static setVersion (DSC) is compatible with both pre and post DRIVERS-2412
+uri: "mongodb://a/?replicaSet=rs"
+phases:
+  # Phase 1: Initial state - A is primary with electionId=5, setVersion=1
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000005"}
+          minWireVersion: 0
+          maxWireVersion: 17
+      -
+        - "b:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: false
+          secondary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000005"}
+        b:27017:
+          type: RSSecondary
+          setName: rs
+          setVersion: 1
+          electionId: null
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1
+      maxElectionId: {"$oid": "000000000000000000000005"}
+  # Phase 2: B becomes primary with newer electionId=6, but setVersion stays at 1
+  # The driver should accept B as the new primary and mark A as Unknown
+  - responses:
+      -
+        - "b:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000006"}
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: Unknown
+          setName: null
+          setVersion: null
+          electionId: null
+        b:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000006"}
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1
+      maxElectionId: {"$oid": "000000000000000000000006"}
+  # Phase 3: Old primary A tries to come back with stale electionId=5
+  # Even though setVersion is still 1 (unchanged), the driver should reject A
+  # because its electionId is older than the current maxElectionId=6
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000005"}
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: Unknown
+          setName: null
+          setVersion: null
+          electionId: null
+        b:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000006"}
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1
+      maxElectionId: {"$oid": "000000000000000000000006"}

--- a/spec/spec_tests/data/sdam/rs/member_list_update_with_unchanged_setversion_and_electionid.yml
+++ b/spec/spec_tests/data/sdam/rs/member_list_update_with_unchanged_setversion_and_electionid.yml
@@ -1,0 +1,161 @@
+# This test validates that the member list (hosts) is updated even when
+# setVersion and electionId remain unchanged.
+description: Member list is updated when setVersion and electionId remain the same
+uri: "mongodb://a/?replicaSet=rs"
+phases:
+  # Phase 1: Initial state - A is primary with two members (a, b)
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000001"}
+          minWireVersion: 0
+          maxWireVersion: 17
+      -
+        - "b:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: false
+          secondary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000001"}
+        b:27017:
+          type: RSSecondary
+          setName: rs
+          setVersion: 1
+          electionId: null
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1
+      maxElectionId: {"$oid": "000000000000000000000001"}
+  # Phase 2: Primary reports a new member c has been added, but setVersion and
+  # electionId remain unchanged. The driver should add c to the topology.
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+            - "c:27017"
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000001"}
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000001"}
+        b:27017:
+          type: RSSecondary
+          setName: rs
+          setVersion: 1
+          electionId: null
+        c:27017:
+          type: Unknown
+          setName: null
+          setVersion: null
+          electionId: null
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1
+      maxElectionId: {"$oid": "000000000000000000000001"}
+  # Phase 3: c responds and becomes a secondary
+  - responses:
+      -
+        - "c:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: false
+          secondary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+            - "c:27017"
+          setName: rs
+          setVersion: 1
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000001"}
+        b:27017:
+          type: RSSecondary
+          setName: rs
+          setVersion: 1
+          electionId: null
+        c:27017:
+          type: RSSecondary
+          setName: rs
+          setVersion: 1
+          electionId: null
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1
+      maxElectionId: {"$oid": "000000000000000000000001"}
+  # Phase 4: Primary reports c has been removed, but setVersion and
+  # electionId remain unchanged. The driver should remove c from the topology.
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000001"}
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000001"}
+        b:27017:
+          type: RSSecondary
+          setName: rs
+          setVersion: 1
+          electionId: null
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1
+      maxElectionId: {"$oid": "000000000000000000000001"}
+

--- a/spec/spec_tests/data/sdam/rs/migration_from_disaggregated_storage.yml
+++ b/spec/spec_tests/data/sdam/rs/migration_from_disaggregated_storage.yml
@@ -1,0 +1,119 @@
+# When migrating from disaggregated storage (constant setVersion) back to a
+# traditional replica set (incrementing setVersion), a force reconfig is used
+# with a high setVersion value to ensure the driver accepts the new primary.
+description: DSC to ASC reverse migration - ASC primary with higher setVersion is accepted
+uri: "mongodb://a/?replicaSet=rs"
+phases:
+  # Phase 1: Disaggregated storage cluster with constant setVersion=1
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000005"}
+          minWireVersion: 0
+          maxWireVersion: 17
+      -
+        - "b:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: false
+          secondary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000005"}
+        b:27017:
+          type: RSSecondary
+          setName: rs
+          setVersion: 1
+          electionId: null
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1
+      maxElectionId: {"$oid": "000000000000000000000005"}
+  # Phase 2: After migration to traditional replica set, B becomes primary with
+  # setVersion=1000 (force reconfig with high value) and newer electionId=6
+  # The driver should accept B as the new primary due to higher setVersion
+  - responses:
+      -
+        - "b:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1000
+          electionId: {"$oid": "000000000000000000000006"}
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: Unknown
+          setName: null
+          setVersion: null
+          electionId: null
+        b:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1000
+          electionId: {"$oid": "000000000000000000000006"}
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1000
+      maxElectionId: {"$oid": "000000000000000000000006"}
+  # Phase 3: Old disaggregated storage primary A tries to come back
+  # The driver should reject it because both setVersion (1 < 1000) and
+  # electionId (5 < 6) are stale
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 1
+          electionId: {"$oid": "000000000000000000000005"}
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: Unknown
+          setName: null
+          setVersion: null
+          electionId: null
+        b:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 1000
+          electionId: {"$oid": "000000000000000000000006"}
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 1000
+      maxElectionId: {"$oid": "000000000000000000000006"}

--- a/spec/spec_tests/data/sdam/rs/migration_to_disaggregated_storage.yml
+++ b/spec/spec_tests/data/sdam/rs/migration_to_disaggregated_storage.yml
@@ -1,0 +1,85 @@
+# When migrating from a traditional replica set (incrementing setVersion) to
+# disaggregated storage (constant setVersion), the migration uses setVersionASC + 1
+# to prevent the driver from incorrectly marking the new primary as stale.
+description: ASC to DSC forward migration - DSC uses setVersionASC + 1 to prevent false stale detection
+uri: "mongodb://a/?replicaSet=rs"
+phases:
+  # Phase 1: Traditional replica set with incrementing setVersion=10
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 10
+          electionId: {"$oid": "000000000000000000000005"}
+          minWireVersion: 0
+          maxWireVersion: 17
+      -
+        - "b:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: false
+          secondary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 10
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 10
+          electionId: {"$oid": "000000000000000000000005"}
+        b:27017:
+          type: RSSecondary
+          setName: rs
+          setVersion: 10
+          electionId: null
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 10
+      maxElectionId: {"$oid": "000000000000000000000005"}
+  # Phase 2: After migration to disaggregated storage, setVersion becomes 11 (10 + 1)
+  # This ensures the driver sees a newer setVersion and accepts the new primary,
+  # even though future reconfigs will keep setVersion constant at 11
+  - responses:
+      -
+        - "a:27017"
+        - ok: 1
+          helloOk: true
+          isWritablePrimary: true
+          hosts:
+            - "a:27017"
+            - "b:27017"
+          setName: rs
+          setVersion: 11
+          electionId: {"$oid": "000000000000000000000006"}
+          minWireVersion: 0
+          maxWireVersion: 17
+    outcome:
+      servers:
+        a:27017:
+          type: RSPrimary
+          setName: rs
+          setVersion: 11
+          electionId: {"$oid": "000000000000000000000006"}
+        b:27017:
+          type: RSSecondary
+          setName: rs
+          setVersion: 10
+          electionId: null
+      topologyType: ReplicaSetWithPrimary
+      logicalSessionTimeoutMinutes: null
+      setName: rs
+      maxSetVersion: 11
+      maxElectionId: {"$oid": "000000000000000000000006"}


### PR DESCRIPTION
## Description

RUBY-3785 (split from DRIVERS-3397). Syncs four SDAM `rs` test scenarios from the
specifications repo covering replica sets that use a constant `setVersion` instead
of incrementing it on reconfig, as used by clusters backed by disaggregated storage:

- **Static setVersion** — compatible with both pre- and post-DRIVERS-2412 behavior
  (stale primary rejected via `electionId` when `setVersion` is unchanged).
- **Member list update** — hosts are added/removed even when `setVersion` and
  `electionId` remain the same.
- **Migration to disaggregated storage** — uses `setVersionASC + 1` to prevent
  false stale-primary detection.
- **Migration from disaggregated storage** — force reconfig with a high `setVersion`
  so the new primary is accepted.

These use only fields already present in existing SDAM fixtures, and the behavior
they exercise (DRIVERS-2412) is already implemented in the driver. No driver or
test-runner changes are required; the existing SDAM runner loads the fixtures
automatically.

Source: specifications commit `1bcb8edf68`.

## Testing

`bundle exec rspec spec/spec_tests/sdam_spec.rb` — 4684 examples, 0 failures. The
four new scenarios are confirmed loaded and executed. The suite uses mocked hello
responses, so no live cluster is needed.
