### PR TITLE
RUBY-3910 Skip time-sensitive CSOT change stream tests on 9.0+ sharded

### DIFF
--- a/spec/spec_tests/data/client_side_operations_timeout/override-collection-timeoutMS.yml
+++ b/spec/spec_tests/data/client_side_operations_timeout/override-collection-timeoutMS.yml
@@ -717,6 +717,13 @@ tests:
                 listIndexes: *collectionName
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured on a MongoCollection - createChangeStream on collection"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: createEntities
         object: testRunner

--- a/spec/spec_tests/data/client_side_operations_timeout/override-database-timeoutMS.yml
+++ b/spec/spec_tests/data/client_side_operations_timeout/override-database-timeoutMS.yml
@@ -377,6 +377,13 @@ tests:
                 ping: 1
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured on a MongoDatabase - createChangeStream on database"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: createEntities
         object: testRunner
@@ -1207,6 +1214,13 @@ tests:
                 listIndexes: *collectionName
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured on a MongoDatabase - createChangeStream on collection"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: createEntities
         object: testRunner

--- a/spec/spec_tests/data/client_side_operations_timeout/override-operation-timeoutMS.yml
+++ b/spec/spec_tests/data/client_side_operations_timeout/override-operation-timeoutMS.yml
@@ -160,6 +160,13 @@ tests:
                 listDatabases: 1
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured for an operation - createChangeStream on client"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -452,6 +459,13 @@ tests:
                 ping: 1
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured for an operation - createChangeStream on database"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1028,6 +1042,13 @@ tests:
                 listIndexes: *collectionName
                 maxTimeMS: { $$exists: false }
   - description: "timeoutMS can be configured for an operation - createChangeStream on collection"
+    runOnRequirements:
+    - minServerVersion: "4.4"
+      topologies: ["replicaset"]
+    - minServerVersion: "4.4"
+      maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+      # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+      topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner

--- a/spec/spec_tests/data/client_side_operations_timeout/retryability-legacy-timeouts.yml
+++ b/spec/spec_tests/data/client_side_operations_timeout/retryability-legacy-timeouts.yml
@@ -770,6 +770,13 @@ tests:
               command:
                 listDatabases: 1
   - description: "operation succeeds after one socket timeout - createChangeStream on client"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+        topologies: ["replicaset"]
+      - minServerVersion: "4.4"
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1030,6 +1037,13 @@ tests:
               command:
                 listCollections: 1
   - description: "operation succeeds after one socket timeout - createChangeStream on database"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+        topologies: ["replicaset"]
+      - minServerVersion: "4.4"
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1609,6 +1623,13 @@ tests:
               command:
                 listIndexes: *collectionName
   - description: "operation succeeds after one socket timeout - createChangeStream on collection"
+    runOnRequirements:
+      - minServerVersion: "4.4"
+        topologies: ["replicaset"]
+      - minServerVersion: "4.4"
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner

--- a/spec/spec_tests/data/client_side_operations_timeout/retryability-timeoutMS.yml
+++ b/spec/spec_tests/data/client_side_operations_timeout/retryability-timeoutMS.yml
@@ -1315,6 +1315,11 @@ tests:
   - description: "operation is retried multiple times for non-zero timeoutMS - createChangeStream on client"
     runOnRequirements:
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -1755,6 +1760,11 @@ tests:
   - description: "operation is retried multiple times for non-zero timeoutMS - createChangeStream on database"
     runOnRequirements:
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner
@@ -2740,6 +2750,11 @@ tests:
   - description: "operation is retried multiple times for non-zero timeoutMS - createChangeStream on collection"
     runOnRequirements:
       - minServerVersion: "4.3.1" # failCommand errorLabels option
+        topologies: ["replicaset"]
+      - minServerVersion: "4.3.1" # failCommand errorLabels option
+        maxServerVersion: "8.99" # Skip sharded 9.0+ due to reasons noted in DRIVERS-3556.
+        # Removing the skip may be desired in the future if this test migrates from timeoutMS to maxTimeMS. See DRIVERS-3556 for a suggested approach: add a unified test runner option to advance the config server's cluster time immediately before opening a change stream. Otherwise, existing tests using maxTimeMS < periodicNoopIntervalSecs on 9.0+ sharded clusters may unexpectedly fail with server timeouts.
+        topologies: ["sharded"]
     operations:
       - name: failPoint
         object: testRunner


### PR DESCRIPTION
## Description

Sync the CSOT spec fixtures from DRIVERS-3556 (spec PRs [#1962](https://github.com/mongodb/specifications/pull/1962) and [#1964](https://github.com/mongodb/specifications/pull/1964)).

On 9.0+ sharded clusters, opening a current-time change stream can block until the config server's cluster time advances past the open time (intentional SPM-1941 behavior). This races against the sub-1s `timeoutMS` values these tests use, producing spurious failures in CI. The spec addressed it by splitting the affected `createChangeStream` tests' `runOnRequirements` into a replicaset entry and a sharded entry capped at `maxServerVersion: "8.99"`, so they no longer run on 9.0+ sharded topologies.

This PR mirrors those changes into `spec/spec_tests/data/client_side_operations_timeout/` — 11 test cases across 5 files:

- `override-operation-timeoutMS.yml` (client, database, collection)
- `override-collection-timeoutMS.yml` (collection)
- `override-database-timeoutMS.yml` (database, collection)
- `retryability-legacy-timeouts.yml` (client, database, collection)
- `retryability-timeoutMS.yml` (client, database, collection)

The driver consumes these `.yml` fixtures directly, so no runner or template changes are needed.

## Testing

Ran the full CSOT suite against a local 9.0.0-rc0 replica set (`CSOT_SPEC_TESTS=1`). The edited change-stream tests still run on the replica set (skips only apply to sharded) and pass. The one unrelated failure (`deprecated-options.yml` maxTimeMS/aggregate) is pre-existing and independent of these changes.