### PR TITLE
RUBY-3922 Skip interruptInUse-pool-clear tests broken by SERVER-128517

### DIFF
--- a/spec/spec_tests/data/client_side_operations_timeout/command-execution.yml
+++ b/spec/spec_tests/data/client_side_operations_timeout/command-execution.yml
@@ -28,6 +28,7 @@ initialData:
 
 tests:
   - description: "maxTimeMS value in the command is less than timeoutMS"
+    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor changing RTT measurement"
     operations:
       # Artificially increase the server RTT to ~50ms.
       - name: failPoint
@@ -100,6 +101,7 @@ tests:
                 maxTimeMS: { $$lte: 450 }
 
   - description: "command is not sent if RTT is greater than timeoutMS"
+    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor changing RTT measurement"
     operations:
       # Artificially increase the server RTT to ~50ms.
       - name: failPoint

--- a/spec/spec_tests/data/sdam_unified/interruptInUse-pool-clear.yml
+++ b/spec/spec_tests/data/sdam_unified/interruptInUse-pool-clear.yml
@@ -21,6 +21,7 @@ initialData: &initialData
 
 tests:
   - description: Connection pool clear uses interruptInUseConnections=true after monitor timeout
+    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor"
     operations:
       - name: createEntities
         object: testRunner
@@ -124,6 +125,7 @@ tests:
           - _id: 1
 
   - description: Error returned from connection pool clear with interruptInUseConnections=true is retryable
+    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor"
     operations:
       - name: createEntities
         object: testRunner
@@ -230,6 +232,7 @@ tests:
         documents:
           - _id: 1
   - description: Error returned from connection pool clear with interruptInUseConnections=true is retryable for write
+    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor"
     operations:
       - name: createEntities
         object: testRunner


### PR DESCRIPTION
The three `sdam_unified/interruptInUse-pool-clear.yml` tests started failing on master (green 2026-07-22, red 2026-07-24) with no driver change. The same server change also breaks two RTT-dependent `client_side_operations_timeout/command-execution.yml` tests.

## Root cause

[SERVER-128517](https://jira.mongodb.org/browse/SERVER-128517) "Add configurable minimum timeout for pre-auth streamable hello" introduces the server parameter `minWaitForStreamingHelloMillis` (default 10000 ms), flooring the wait for pre-auth streamable hello commands. The monitor's streamable hello is pre-auth, so it is now held up to 10 s. The scenario relies on the monitor detecting the failpoint-induced failure and clearing the pool with `interruptInUseConnections=true` quickly; with the floor it no longer reacts in time, so the in-use operation hits its own ~5 s socket timeout (`Mongo::Error::SocketTimeoutError`) before the interrupt-driven pool clear fires.

The same floor also changes RTT measurement: the `command-execution.yml` tests use a `blockConnection`/`blockTimeMS` failpoint on `hello` to inflate the measured RTT, then assert the driver reduces `maxTimeMS` (or short-circuits) accordingly. With the floor the inflated RTT is no longer observed, so:

- "maxTimeMS value in the command is less than timeoutMS" fails with `maxTimeMS` ~499 instead of `<= 450`.
- "command is not sent if RTT is greater than timeoutMS" no longer short-circuits, so the expected client-side timeout is not raised.

This is a server-side change, not a driver regression.

## Evidence

- Fails only on replica-set AND server >= 7.0. Sharded passes; standalone skips; replica-set on 4.4/5.0/6.0 passes.
- Matches SERVER-128517 fix versions exactly: 7.0.39, 8.0.28, 8.2.12, 8.3.7 (rapid), 9.0.0-rc1 (not 6.0).
- Local bisect: 8.0.4 PASS, 8.0.26 PASS, 8.0.28 FAIL.
- Reproduces on driver code from before the recent SDAM commits (RUBY-3909, RUBY-3822).

## Change

Skip the affected tests via `skipReason` in the fixtures, referencing RUBY-3922 (same pattern as the existing RUBY-3781 skip in `hello-network-error.yml`):

- three `interruptInUse-pool-clear.yml` tests
- two RTT-dependent `command-execution.yml` tests

RUBY-3922 tracks the long-term fix (set `minWaitForStreamingHelloMillis: 0` in the test environment and/or update the upstream spec fixtures; coordinate across drivers).

Verified locally against server 8.0.28:

- `bundle exec rspec spec/spec_tests/sdam_unified_spec.rb -e "interruptInUseConnections"` -> `3 examples, 0 failures, 3 pending`.
- `CSOT_SPEC_TESTS=1 bundle exec rspec spec/spec_tests/client_side_operations_timeout_spec.rb` -> `531 examples, 0 failures, 12 pending`.
