### PR TITLE
RUBY-3903 Fix libmongocrypt version floor, ClientEncryption timeout_ms and missing range_opts

### DIFF
--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -50,7 +50,8 @@ module Mongo
         key_vault_client,
         options[:key_vault_namespace],
         Crypt::KMS::Credentials.new(options[:kms_providers]),
-        Crypt::KMS::Validations.validate_tls_options(options[:kms_tls_options])
+        Crypt::KMS::Validations.validate_tls_options(options[:kms_tls_options]),
+        options[:timeout_ms]
       )
     end
 

--- a/lib/mongo/crypt/binding.rb
+++ b/lib/mongo/crypt/binding.rb
@@ -81,7 +81,7 @@ module Mongo
       # will cause a `LoadError`.
       #
       # @api private
-      MIN_LIBMONGOCRYPT_VERSION = Gem::Version.new('1.12.0')
+      MIN_LIBMONGOCRYPT_VERSION = Gem::Version.new('1.20.0')
 
       # @!method self.mongocrypt_version(len)
       #   @api private

--- a/lib/mongo/crypt/explicit_encryption_context.rb
+++ b/lib/mongo/crypt/explicit_encryption_context.rb
@@ -148,6 +148,8 @@ module Mongo
       end
 
       def convert_range_opts(range_opts)
+        raise ArgumentError.new(':range_opts is required for the "Range" algorithm') if range_opts.nil?
+
         range_opts.dup.tap do |opts|
           opts[:sparsity] = BSON::Int64.new(opts[:sparsity]) if opts[:sparsity] && !opts[:sparsity].is_a?(BSON::Int64)
           opts[:trimFactor] = opts.delete(:trim_factor) if opts[:trim_factor]

--- a/spec/mongo/client_encryption_spec.rb
+++ b/spec/mongo/client_encryption_spec.rb
@@ -61,6 +61,20 @@ describe Mongo::ClientEncryption do
       it_behaves_like 'a functioning ClientEncryption'
     end
 
+    context 'with timeout_ms' do
+      include_context 'with local kms_providers'
+
+      it 'passes the timeout to the encrypter' do
+        client_encryption = described_class.new(client, {
+                                                  key_vault_namespace: key_vault_namespace,
+                                                  kms_providers: kms_providers,
+                                                  timeout_ms: 5_000
+                                                })
+        encrypter = client_encryption.instance_variable_get(:@encrypter)
+        expect(encrypter.instance_variable_get(:@timeout_ms)).to eq(5_000)
+      end
+    end
+
     context 'with invalid KMS provider information' do
       let(:kms_providers) { { random_key: {} } }
 

--- a/spec/mongo/crypt/explicit_encryption_context_spec.rb
+++ b/spec/mongo/crypt/explicit_encryption_context_spec.rb
@@ -204,6 +204,57 @@ describe Mongo::Crypt::ExplicitEncryptionContext do
         end
       end
 
+      context 'with Range algorithm' do
+        let(:algorithm) { 'Range' }
+        let(:key_alt_name) { nil }
+        let(:value) { { v: 123 } }
+
+        let(:range_opts) do
+          { min: 0, max: 200, sparsity: 1, trim_factor: 1 }
+        end
+
+        it 'initializes context' do
+          expect do
+            described_class.new(
+              mongocrypt,
+              io,
+              value,
+              options.merge(contention_factor: 0, range_opts: range_opts)
+            )
+          end.not_to raise_error
+        end
+
+        context 'with trim_factor of 0' do
+          let(:range_opts) do
+            { min: 0, max: 200, sparsity: 1, trim_factor: 0 }
+          end
+
+          it 'passes the trim factor through' do
+            expect do
+              described_class.new(
+                mongocrypt,
+                io,
+                value,
+                options.merge(contention_factor: 0, range_opts: range_opts)
+              )
+            end.not_to raise_error
+          end
+        end
+
+        context 'without range_opts' do
+          it 'raises an exception' do
+            expect do
+              described_class.new(
+                mongocrypt,
+                io,
+                value,
+                options.merge(contention_factor: 0)
+              )
+            end.to raise_error(ArgumentError, /:range_opts is required for the "Range" algorithm/)
+          end
+        end
+      end
+
       context 'with String algorithm' do
         let(:algorithm) { 'String' }
         let(:key_alt_name) { nil }


### PR DESCRIPTION
Three small QE fixes found while auditing the driver against the client-side-encryption
spec. Each is a separate commit.

## Require libmongocrypt 1.20.0

#3088 attaches `mongocrypt_ctx_setopt_algorithm_text` unconditionally, but
`MIN_LIBMONGOCRYPT_VERSION` stayed at 1.12.0. The version check runs at
`binding.rb:136`, well before that `attach_function` at line 1891, so an older
libmongocrypt passes the gate and then dies with

```
FFI::NotFoundError: Function 'mongocrypt_ctx_setopt_algorithm_text' not found
```

instead of the intended "libmongocrypt version X or above is required". 1.20.0 is what
the GA text fixtures require (`QE-Text-substring.yml`, MONGOCRYPT-936) and matches the
`libmongocrypt-helper ~> 1.20.1` pin. `version_spec.rb` derives its cases from the
constant, so it needs no change.

## Pass timeout_ms from ClientEncryption to the encrypter

`ClientEncryption#initialize` documents `:timeout_ms` but called
`ExplicitEncrypter.new` with four arguments, leaving the fifth (`timeout_ms`) nil.
`ExplicitEncrypter` threads `@timeout_ms` into every key management call, so CSOT on
`ClientEncryption` was silently dead. The new spec fails on master and passes here.

## Raise ArgumentError when range_opts is missing

`encrypt(algorithm: 'Range')` without `:range_opts` raised
`NoMethodError: undefined method '[]' for nil` out of `nil.dup.tap`. Now it reports the
missing option, matching how the `String` algorithm handles a missing `:string_opts`.

The same commit adds a spec pinning `trim_factor: 0`. The guard
`if opts[:trim_factor]` reads like it would drop 0, but 0 is truthy in Ruby, so the
value is passed through — the spec keeps it that way.