### PR TITLE
Document Range and String algorithms in ClientEncryption#encrypt

### DIFF
--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -106,19 +106,31 @@ module Mongo
     #   encryption key.
     # @option options [ String ] :algorithm The algorithm used to encrypt the value.
     #   Valid algorithms are "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-    #   "AEAD_AES_256_CBC_HMAC_SHA_512-Random", "Indexed", "Unindexed", "String".
+    #   "AEAD_AES_256_CBC_HMAC_SHA_512-Random", "Indexed", "Unindexed", "Range",
+    #   "String".
     # @option options [ Integer | nil ] :contention_factor Contention factor
-    #   to be applied if encryption algorithm is set to "Indexed" or "String".
-    #   If not provided, it defaults to a value of 0. Contention factor should be
-    #   set only if encryption algorithm is set to "Indexed" or "String".
+    #   to be applied if encryption algorithm is set to "Indexed", "Range", or
+    #   "String". If not provided, it defaults to a value of 0. Contention factor
+    #   should be set only if encryption algorithm is set to "Indexed", "Range",
+    #   or "String".
     # @option options [ String | nil ] query_type Query type to be applied
-    #   if encryption algorithm is set to "Indexed" or "String". Allowed values
-    #   are "equality" (for "Indexed") and "prefix", "suffix", "substring"
-    #   (for "String").
+    #   if encryption algorithm is set to "Indexed", "Range", or "String".
+    #   Allowed values are "equality" (for "Indexed"), "range" (for "Range"),
+    #   and "prefix", "suffix", "substring" (for "String").
+    # @option options [ Hash | nil ] :range_opts Specifies index options for a
+    #   Queryable Encryption field supporting "range" queries. Required when
+    #   algorithm is "Range". Allowed options are :min, :max, :trim_factor,
+    #   :sparsity, :precision.
     # @option options [ Hash | nil ] :string_opts Specifies index options for a
     #   Queryable Encryption field supporting "prefix", "suffix", or "substring"
     #   queries. Required when algorithm is "String". Allowed options are
     #   :case_sensitive, :diacritic_sensitive, :prefix, :suffix, :substring.
+    #
+    # @note The result of explicit encryption with the "Indexed", "Range", or
+    #   "String" algorithm must be processed by the server to insert or query.
+    #   To insert or query with such a payload, use a Mongo::Client configured
+    #   with :auto_encryption_options. The :bypass_query_analysis option may be
+    #   true; the :bypass_auto_encryption option must be false.
     #
     # @note The "substring" query type is unstable and subject to backwards
     #   breaking changes.
@@ -129,8 +141,8 @@ module Mongo
     # @return [ BSON::Binary ] A BSON Binary object of subtype 6 (ciphertext)
     #   representing the encrypted value.
     #
-    # @raise [ ArgumentError ] if either contention_factor or query_type
-    #   is set, and algorithm is not "Indexed".
+    # @raise [ ArgumentError ] if either contention_factor or query_type is set,
+    #   and algorithm is not "Indexed", "Range", or "String".
     def encrypt(value, options = {})
       @encrypter.encrypt(value, options)
     end

--- a/lib/mongo/client_encryption.rb
+++ b/lib/mongo/client_encryption.rb
@@ -173,7 +173,7 @@ module Mongo
     #   expression. The only allowed value is "Range"
     # @option options [ Integer | nil ] :contention_factor Contention factor
     #   to be applied If not  provided, it defaults to a value of 0.
-    # @option options [ String | nil ] query_type Query type to be applied.
+    # @option options [ String | nil ] :query_type Query type to be applied.
     #   The only allowed value is "range".
     #
     # @note The :key_id and :key_alt_name options are mutually exclusive. Only

--- a/lib/mongo/crypt/explicit_encrypter.rb
+++ b/lib/mongo/crypt/explicit_encrypter.rb
@@ -100,23 +100,31 @@ module Mongo
       #   encryption key.
       # @option options [ String ] :algorithm The algorithm used to encrypt the value.
       #   Valid algorithms are "AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic",
-      #   "AEAD_AES_256_CBC_HMAC_SHA_512-Random", "Indexed", "Unindexed".
+      #   "AEAD_AES_256_CBC_HMAC_SHA_512-Random", "Indexed", "Unindexed",
+      #   "Range", "String".
       # @option options [ Integer | nil ] :contention_factor Contention factor
-      #   to be applied if encryption algorithm is set to "Indexed". If not
-      #   provided, it defaults to a value of 0. Contention factor should be set
-      #   only if encryption algorithm is set to "Indexed".
+      #   to be applied if encryption algorithm is set to "Indexed", "Range", or
+      #   "String". If not provided, it defaults to a value of 0. Contention
+      #   factor should be set only if encryption algorithm is set to "Indexed",
+      #   "Range", or "String".
       # @option options [ String | nil ] query_type Query type to be applied
-      # if encryption algorithm is set to "Indexed". Query type should be set
-      #   only if encryption algorithm is set to "Indexed". The only allowed
-      #   value is "equality".
+      #   if encryption algorithm is set to "Indexed", "Range", or "String".
+      #   Allowed values are "equality" (for "Indexed"), "range" (for "Range"),
+      #   and "prefix", "suffix", "substring" (for "String").
+      # @option options [ Hash | nil ] :range_opts Specifies index options for a
+      #   Queryable Encryption field supporting "range" queries. Required when
+      #   algorithm is "Range".
+      # @option options [ Hash | nil ] :string_opts Specifies index options for a
+      #   Queryable Encryption field supporting "prefix", "suffix", or
+      #   "substring" queries. Required when algorithm is "String".
       #
       # @note The :key_id and :key_alt_name options are mutually exclusive. Only
       #   one is required to perform explicit encryption.
       #
       # @return [ BSON::Binary ] A BSON Binary object of subtype 6 (ciphertext)
       #   representing the encrypted value
-      # @raise [ ArgumentError ] if either contention_factor or query_type
-      #   is set, and algorithm is not "Indexed".
+      # @raise [ ArgumentError ] if either contention_factor or query_type is
+      #   set, and algorithm is not "Indexed", "Range", or "String".
       def encrypt(value, options)
         Crypt::ExplicitEncryptionContext.new(
           @crypt_handle,

--- a/lib/mongo/crypt/explicit_encrypter.rb
+++ b/lib/mongo/crypt/explicit_encrypter.rb
@@ -107,7 +107,7 @@ module Mongo
       #   "String". If not provided, it defaults to a value of 0. Contention
       #   factor should be set only if encryption algorithm is set to "Indexed",
       #   "Range", or "String".
-      # @option options [ String | nil ] query_type Query type to be applied
+      # @option options [ String | nil ] :query_type Query type to be applied
       #   if encryption algorithm is set to "Indexed", "Range", or "String".
       #   Allowed values are "equality" (for "Indexed"), "range" (for "Range"),
       #   and "prefix", "suffix", "substring" (for "String").


### PR DESCRIPTION
Documentation only, no behaviour change.

`ClientEncryption#encrypt` still described only the `Indexed` and `Unindexed` algorithms, even though `Range` and `String` have both been supported for a while. As a result:

- `Range` was missing from the list of valid `:algorithm` values.
- `:range_opts` and `:string_opts` were not documented at all.
- `:contention_factor` and `query_type` were described as applying only to `Indexed`.
- The `@raise` clause claimed `ArgumentError` is raised unless the algorithm is `Indexed`, while the code accepts `Indexed`, `Range` and `String`.

This also adds the note the client-side encryption spec requires drivers to document ([spec](https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.md#algorithm)): a payload produced by the `Indexed`, `Range` or `String` algorithm has to be inserted or queried through a client configured with `:auto_encryption_options`, where `:bypass_query_analysis` may be true but `:bypass_auto_encryption` must be false.

The same corrections are applied to `Mongo::Crypt::ExplicitEncrypter#encrypt`, which `ClientEncryption#encrypt` delegates to and whose docs had drifted further.

Verified with RuboCop and by running `spec/mongo/client_encryption_spec.rb`, `spec/mongo/crypt/explicit_encryption_context_spec.rb` and `spec/integration/client_side_encryption/string_explicit_encryption_prose_spec.rb` against a local 9.0 replica set.
