### PR TITLE
Revert "RUBY-3922 Skip interruptInUse-pool-clear tests broken by SERV…

### DIFF
--- a/spec/spec_tests/data/client_side_operations_timeout/command-execution.yml
+++ b/spec/spec_tests/data/client_side_operations_timeout/command-execution.yml
@@ -28,7 +28,6 @@ initialData:
 
 tests:
   - description: "maxTimeMS value in the command is less than timeoutMS"
-    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor changing RTT measurement"
     operations:
       # Artificially increase the server RTT to ~50ms.
       - name: failPoint
@@ -101,7 +100,6 @@ tests:
                 maxTimeMS: { $$lte: 450 }
 
   - description: "command is not sent if RTT is greater than timeoutMS"
-    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor changing RTT measurement"
     operations:
       # Artificially increase the server RTT to ~50ms.
       - name: failPoint

--- a/spec/spec_tests/data/sdam_unified/interruptInUse-pool-clear.yml
+++ b/spec/spec_tests/data/sdam_unified/interruptInUse-pool-clear.yml
@@ -21,7 +21,6 @@ initialData: &initialData
 
 tests:
   - description: Connection pool clear uses interruptInUseConnections=true after monitor timeout
-    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor"
     operations:
       - name: createEntities
         object: testRunner
@@ -125,7 +124,6 @@ tests:
           - _id: 1
 
   - description: Error returned from connection pool clear with interruptInUseConnections=true is retryable
-    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor"
     operations:
       - name: createEntities
         object: testRunner
@@ -232,7 +230,6 @@ tests:
         documents:
           - _id: 1
   - description: Error returned from connection pool clear with interruptInUseConnections=true is retryable for write
-    skipReason: "RUBY-3922: fails on server 7.0.39+/8.0.28+ due to SERVER-128517 pre-auth streamable hello 10s floor"
     operations:
       - name: createEntities
         object: testRunner


### PR DESCRIPTION
…ER-128517 (#3093)"

This reverts commit a725d15e03ca23c40ce9724d81df58959b498002.